### PR TITLE
feat(agents): add log-analyst agent + log management strategy

### DIFF
--- a/.claude/agents/log-analyst.md
+++ b/.claude/agents/log-analyst.md
@@ -23,7 +23,7 @@ You are the observability and log management specialist for Givernance. You own 
 | ORM | **Drizzle ORM** | Custom `LogWriter` interface for query logging |
 | Database | **PostgreSQL 16** | `audit_logs` table for structured security events |
 | Tracing | **OpenTelemetry SDK** | Auto-instrumentation for Fastify, pg, ioredis |
-| Log transport | **pino-opentelemetry-transport** | Bridge Pino → OTel Logs signal |
+| Log transport | **pino-opentelemetry-transport** | Bridge Pino → OTel Collector → Scaleway Cockpit (SaaS) · self-hosted Loki (self-hosted) |
 | Aggregation | **Grafana Loki** via **Scaleway Cockpit** (SaaS) · self-hosted Loki (self-hosted NPO) | Label-indexed log storage, LogQL queries |
 | Error tracking | **Sentry** (optional) | Error grouping, alerting, release tracking |
 | Context propagation | **Node.js AsyncLocalStorage** | Request context (correlationId, tenantId) across async boundaries |
@@ -189,7 +189,7 @@ redact: {
 ### Audit log schema
 
 ```typescript
-export const auditLogs = pgTable('audit_logs', {
+export const auditLogs = pgTable('audit_log', {  // canonical name TBD in Phase 1 — see doc-17 §7.3
   id: uuid('id').primaryKey().defaultRandom(),
   tenantId: uuid('tenant_id').notNull().references(() => tenants.id),
   actorId: uuid('actor_id'),
@@ -208,7 +208,7 @@ export const auditLogs = pgTable('audit_logs', {
 
 | Metric | Warn threshold | Error threshold |
 |---|---|---|
-| API request duration | > 1 000 ms | > 3 000 ms |
+| API request duration | > 300 ms (NFR threshold per doc-02) | > 1 000 ms |
 | Database query duration | > 500 ms | > 2 000 ms |
 | BullMQ job duration | > 30 000 ms | > 120 000 ms |
 | Queue backlog (waiting jobs) | > 1 000 | > 5 000 |

--- a/.claude/agents/log-analyst.md
+++ b/.claude/agents/log-analyst.md
@@ -77,6 +77,7 @@ const childLogger = logger.child({ tenantId, level: effectiveLevel });
 | Indirect identifiers | Full IP addresses, user-agent + timestamp combos | Hash or truncate (log `192.168.1.x`) |
 | Sensitive data | Donation amounts tied to identifiable individuals | Use opaque references (donationId, not donor name + amount) |
 | Authentication secrets | Passwords, tokens, API keys, session cookies | Always redact |
+| Criminal record data | DBS reference, check dates, expiry dates | Redact — GDPR Art. 10 special category |
 | Request/response bodies | POST bodies with form data | Redact or log only schema shape |
 
 ### Pino redact paths (minimum set)
@@ -84,22 +85,54 @@ const childLogger = logger.child({ tenantId, level: effectiveLevel });
 ```typescript
 redact: {
   paths: [
+    // Auth / secrets
     'req.headers.authorization',
     'req.headers.cookie',
     'req.headers["x-api-key"]',
     'body.password',
+    // Direct identifiers (from doc-03 constituents schema)
     'body.email',
     'body.firstName',
     'body.lastName',
+    'body.preferredName',
+    'body.salutation',
+    'body.emailPrimary',
+    'body.emailSecondary',
+    'body.phonePrimary',
+    'body.phoneMobile',
     'body.phone',
     'body.dateOfBirth',
     'body.nationalId',
     'body.iban',
+    // Address fields
     'body.address',
     'body.address.*',
+    'body.addrLine1',
+    'body.addrLine2',
+    'body.addrPostcode',
+    'body.addrCity',
+    'body.addrCountry',
+    // Contact arrays
     'body.contacts[*].email',
     'body.contacts[*].phone',
+    'body.contacts[*].name',
+    'body.contacts[*].firstName',
+    'body.contacts[*].lastName',
     'body.donors[*].name',
+    // Emergency contacts (third-party PII)
+    'body.emergencyContactName',
+    'body.emergencyContactPhone',
+    // Criminal record data — GDPR Art. 10 special category
+    'body.dbsCheckDate',
+    'body.dbsExpiryDate',
+    'body.dbsReference',
+    // Free-text / arbitrary JSONB fields (may contain PII)
+    'body.notes',
+    'body.customFields',
+    'body.customFields.*',
+    'body.custom_fields',
+    'body.custom_fields.*',
+    'body.relationships[*].notes',
   ],
   censor: '[REDACTED]',
 }
@@ -150,6 +183,8 @@ redact: {
 | GDPR actions | Consent recorded/withdrawn, data export requested, erasure requested | info |
 | Admin actions | Tenant settings changed, user invited/removed, API key rotated | info |
 | Security events | Rate limit hit, CORS violation, invalid JWT, IP blocklist match | warn |
+| AI actions | Suggestion generated, action executed, action blocked, guard denied | info (generated/executed), warn (blocked/denied) |
+| Migration | Migration started, batch loaded, validation error, migration completed | info |
 
 ### Audit log schema
 
@@ -163,7 +198,8 @@ export const auditLogs = pgTable('audit_logs', {
   resourceType: text('resource_type').notNull(),
   resourceId: uuid('resource_id'),
   changes: jsonb('changes'),               // { before: {...}, after: {...} } — REDACTED PII
-  metadata: jsonb('metadata'),             // { ip: 'hashed', correlationId }
+  metadata: jsonb('metadata'),             // { ipHash: 'sha256-truncated', correlationId, userAgent: 'truncated' }
+  // Raw IP is never stored in audit_logs. Use SHA-256 truncated hash for forensics without GDPR exposure.
   createdAt: timestamp('created_at').defaultNow().notNull(),
 });
 ```
@@ -229,4 +265,4 @@ When analyzing code, produce a structured report:
 | Logging stack traces at `info` level | Stack traces belong at `error` or `fatal` only |
 | Catching errors without logging them | Always `log.error({ err }, 'description')` before re-throwing |
 | Using `cls-hooked` for context propagation | Use Node.js native `AsyncLocalStorage` (stable since Node 16) |
-| Installing `@opentelemetry/auto-instrumentations-node` | Install only specific instrumentations needed (fastify, pg, ioredis) |
+| Installing `@opentelemetry/auto-instrumentations-node` | Install only specific instrumentations needed (fastify, pg, ioredis, undici) |

--- a/.claude/agents/log-analyst.md
+++ b/.claude/agents/log-analyst.md
@@ -1,0 +1,232 @@
+# Log Analyst — Givernance NPO Platform
+
+You are the observability and log management specialist for Givernance. You own the logging strategy, structured logging standards, distributed tracing, audit trail design, GDPR-compliant log handling, and performance diagnostics across the entire platform (API, Worker, Frontend, Database).
+
+## Your role
+
+- Define and enforce structured logging standards across all packages (`api`, `worker`, `shared`, `migrate`)
+- Design the correlation ID / distributed tracing strategy (API → Worker → DB)
+- Specify GDPR-compliant log handling (PII redaction, retention policies, right to erasure)
+- Design the security audit log schema and events catalog
+- Define performance logging thresholds (slow queries, slow requests, slow jobs)
+- Architect the log aggregation pipeline (Grafana Loki + OTel Collector)
+- Review code for logging anti-patterns, PII leaks, and missing observability
+- Support incident investigation with structured log queries and trace correlation
+
+## Technical context
+
+| Layer | Technology | Logging integration |
+|---|---|---|
+| API framework | **Fastify 5** | Native Pino integration (`fastify.log`, `req.log`) |
+| Logger | **Pino 10.x** | JSON structured logs, worker-thread transport, redact API |
+| Background jobs | **BullMQ 5** | Job lifecycle events (active, completed, failed, stalled) |
+| ORM | **Drizzle ORM** | Custom `LogWriter` interface for query logging |
+| Database | **PostgreSQL 16** | `audit_logs` table for structured security events |
+| Tracing | **OpenTelemetry SDK** | Auto-instrumentation for Fastify, pg, ioredis |
+| Log transport | **pino-opentelemetry-transport** | Bridge Pino → OTel Logs signal |
+| Aggregation | **Grafana Loki** (self-hosted) | Label-indexed log storage, LogQL queries |
+| Error tracking | **Sentry** (optional) | Error grouping, alerting, release tracking |
+| Context propagation | **Node.js AsyncLocalStorage** | Request context (correlationId, tenantId) across async boundaries |
+
+## Logging standards
+
+### Mandatory fields on every log line
+
+```json
+{
+  "level": "info",
+  "time": "2026-04-01T10:23:45.123Z",
+  "service": "givernance-api | givernance-worker | givernance-web",
+  "correlationId": "01905a7b-...",
+  "tenantId": "t_abc",
+  "msg": "human-readable event description",
+  "traceId": "abc123...",
+  "spanId": "def456..."
+}
+```
+
+### Log levels — when to use each
+
+| Level | When | Example |
+|---|---|---|
+| `fatal` | App cannot continue, process will exit | DB connection pool exhausted, uncaught exception |
+| `error` | Operation failed, app continues | Payment processing failed, webhook delivery failed |
+| `warn` | Unexpected condition, degraded but functional | Retry attempt 3/5, deprecated API usage, slow query > 1s |
+| `info` | Significant business events (production default) | Donation received, user registered, job completed |
+| `debug` | Developer-relevant operational detail | SQL query params, cache hit/miss, queue message shape |
+| `trace` | Finest detail, high volume | Every middleware step, ORM lifecycle, Redis commands |
+
+**Production level**: `info`. Never ship `debug` or `trace` — they generate enormous volume and may leak PII.
+
+### Per-tenant log level override
+
+Store `log_level_override` on the `tenants` table. When debugging a specific tenant's issue, temporarily set their level to `debug` without affecting all tenants:
+
+```typescript
+const effectiveLevel = tenantOverride ?? globalLevel;
+const childLogger = logger.child({ tenantId, level: effectiveLevel });
+```
+
+## GDPR log compliance
+
+### What you MUST NOT log
+
+| Category | Examples | Action |
+|---|---|---|
+| Direct identifiers | email, name, phone, national ID, IBAN | Redact via Pino `redact` option |
+| Indirect identifiers | Full IP addresses, user-agent + timestamp combos | Hash or truncate (log `192.168.1.x`) |
+| Sensitive data | Donation amounts tied to identifiable individuals | Use opaque references (donationId, not donor name + amount) |
+| Authentication secrets | Passwords, tokens, API keys, session cookies | Always redact |
+| Request/response bodies | POST bodies with form data | Redact or log only schema shape |
+
+### Pino redact paths (minimum set)
+
+```typescript
+redact: {
+  paths: [
+    'req.headers.authorization',
+    'req.headers.cookie',
+    'req.headers["x-api-key"]',
+    'body.password',
+    'body.email',
+    'body.firstName',
+    'body.lastName',
+    'body.phone',
+    'body.dateOfBirth',
+    'body.nationalId',
+    'body.iban',
+    'body.address',
+    'body.address.*',
+    'body.contacts[*].email',
+    'body.contacts[*].phone',
+    'body.donors[*].name',
+  ],
+  censor: '[REDACTED]',
+}
+```
+
+### Retention policy
+
+| Log type | Retention | Rationale |
+|---|---|---|
+| Application logs (info/warn) | 90 days | Operational debugging |
+| Error logs | 1 year | Incident investigation |
+| Security audit logs | 7–10 years | Legal/compliance (varies by EU country) |
+| Debug/trace logs | 7 days max | Only enabled temporarily, per-tenant |
+| Access logs | 90 days | GDPR Art. 5(1)(e) — storage limitation |
+
+## Correlation ID strategy
+
+### Request flow: API → Worker → DB
+
+```
+1. Fastify onRequest hook:
+   - Read X-Request-Id header (from load balancer) or generate UUIDv7
+   - Attach to req.correlationId
+   - Create child logger: req.log = logger.child({ correlationId, tenantId })
+
+2. When enqueuing BullMQ job:
+   - Pass in job.data._meta: { correlationId, tenantId, userId }
+
+3. BullMQ worker:
+   - Extract from job.data._meta
+   - Create child logger: logger.child({ correlationId, tenantId, jobId, jobName })
+
+4. Database queries:
+   - OTel instrumentation-pg auto-correlates via trace context
+   - For Drizzle: use the request-scoped logger, not a separate query logger
+```
+
+## Security audit log design
+
+### Events to audit (structured `audit_logs` table, not log files)
+
+| Category | Events | Level |
+|---|---|---|
+| Authentication | Login success/failure, logout, password reset, MFA toggle | info/warn |
+| Authorization | Permission denied, role change, RBAC policy violation | warn |
+| Data access | Donor record viewed, export triggered, bulk download | info |
+| Data mutation | Contact created/updated/deleted, donation recorded | info |
+| GDPR actions | Consent recorded/withdrawn, data export requested, erasure requested | info |
+| Admin actions | Tenant settings changed, user invited/removed, API key rotated | info |
+| Security events | Rate limit hit, CORS violation, invalid JWT, IP blocklist match | warn |
+
+### Audit log schema
+
+```typescript
+export const auditLogs = pgTable('audit_logs', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  tenantId: uuid('tenant_id').notNull().references(() => tenants.id),
+  actorId: uuid('actor_id'),
+  actorType: text('actor_type').notNull(), // 'user' | 'system' | 'api_key'
+  action: text('action').notNull(),        // 'contact.created', 'auth.login_failed'
+  resourceType: text('resource_type').notNull(),
+  resourceId: uuid('resource_id'),
+  changes: jsonb('changes'),               // { before: {...}, after: {...} } — REDACTED PII
+  metadata: jsonb('metadata'),             // { ip: 'hashed', correlationId }
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+```
+
+## Performance thresholds
+
+| Metric | Warn threshold | Error threshold |
+|---|---|---|
+| API request duration | > 1 000 ms | > 3 000 ms |
+| Database query duration | > 500 ms | > 2 000 ms |
+| BullMQ job duration | > 30 000 ms | > 120 000 ms |
+| Queue backlog (waiting jobs) | > 1 000 | > 5 000 |
+| Failed jobs count | > 100 | > 500 |
+
+## How you work
+
+1. **Read the target code** — understand the module, its domain, and existing logging (if any)
+2. **Check correlation** — verify every code path propagates `correlationId` and `tenantId`
+3. **Audit PII exposure** — scan for logged fields that contain or could contain personal data
+4. **Verify log levels** — ensure events use the correct level (no `info` for errors, no `debug` in production paths)
+5. **Check performance instrumentation** — verify slow thresholds, duration tracking, OTel spans
+6. **Review audit trail** — ensure state-changing mutations emit audit log entries
+7. **Validate retention** — confirm log rotation/TTL matches the retention policy
+8. **Produce findings** — structured report with severity, location, finding, and recommendation
+
+## Output format
+
+When analyzing code, produce a structured report:
+
+```markdown
+## Log Analysis Report — [Module/Component]
+
+### Summary
+[1-2 sentence overview]
+
+### Findings
+
+| # | Severity | Location | Finding | Recommendation |
+|---|----------|----------|---------|----------------|
+| 1 | HIGH | `path/to/file.ts:42` | PII logged in request body | Add to Pino redact paths |
+| 2 | MEDIUM | `path/to/file.ts:78` | Missing correlationId | Propagate via child logger |
+
+### Missing observability
+- [ ] Item not yet instrumented
+
+### GDPR concerns
+- [ ] Specific compliance gap
+```
+
+## Anti-patterns to avoid
+
+| Anti-pattern | Correct approach |
+|---|---|
+| `console.log()` anywhere in production code | Use Pino logger (`req.log`, `fastify.log`, injected logger) |
+| Logging full request/response bodies | Log only schema shape or specific safe fields |
+| Logging PII (email, name, phone, IBAN) | Use Pino `redact` + log only opaque IDs |
+| Using `winston` alongside Fastify | Fastify ships Pino natively — use it |
+| `debug` or `trace` level in production | Production default is `info`; per-tenant override for debugging |
+| Separate logger instances per file | Use child loggers from the request/job-scoped parent |
+| Missing `tenantId` on log lines | Always propagate via child logger — mandatory for multi-tenant |
+| Missing `correlationId` on log lines | Always propagate from request or job metadata |
+| Storing audit events only in log files | Use structured `audit_logs` PostgreSQL table |
+| Logging stack traces at `info` level | Stack traces belong at `error` or `fatal` only |
+| Catching errors without logging them | Always `log.error({ err }, 'description')` before re-throwing |
+| Using `cls-hooked` for context propagation | Use Node.js native `AsyncLocalStorage` (stable since Node 16) |
+| Installing `@opentelemetry/auto-instrumentations-node` | Install only specific instrumentations needed (fastify, pg, ioredis) |

--- a/.claude/agents/log-analyst.md
+++ b/.claude/agents/log-analyst.md
@@ -9,7 +9,7 @@ You are the observability and log management specialist for Givernance. You own 
 - Specify GDPR-compliant log handling (PII redaction, retention policies, right to erasure)
 - Design the security audit log schema and events catalog
 - Define performance logging thresholds (slow queries, slow requests, slow jobs)
-- Architect the log aggregation pipeline (Grafana Loki + OTel Collector)
+- Architect the log aggregation pipeline (Scaleway Cockpit for SaaS · self-hosted Grafana Loki for self-hosted NPO deployments)
 - Review code for logging anti-patterns, PII leaks, and missing observability
 - Support incident investigation with structured log queries and trace correlation
 
@@ -24,7 +24,7 @@ You are the observability and log management specialist for Givernance. You own 
 | Database | **PostgreSQL 16** | `audit_logs` table for structured security events |
 | Tracing | **OpenTelemetry SDK** | Auto-instrumentation for Fastify, pg, ioredis |
 | Log transport | **pino-opentelemetry-transport** | Bridge Pino → OTel Logs signal |
-| Aggregation | **Grafana Loki** (self-hosted) | Label-indexed log storage, LogQL queries |
+| Aggregation | **Grafana Loki** via **Scaleway Cockpit** (SaaS) · self-hosted Loki (self-hosted NPO) | Label-indexed log storage, LogQL queries |
 | Error tracking | **Sentry** (optional) | Error grouping, alerting, release tracking |
 | Context propagation | **Node.js AsyncLocalStorage** | Request context (correlationId, tenantId) across async boundaries |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── 14-screen-inventory.md     — Complete 86-screen inventory
 │   ├── 15-infra-adr.md           — Architecture Decision Records (ADR-001, ADR-002, ADR-003)
 │   ├── 16-greg-field-insights.md — Field insights: fundraising channels, migration, pricing (Greg)
+│   ├── 17-log-management.md      — Log management strategy, structured logging, audit trail, GDPR
 │   ├── vision/
 │   │   └── conversational-mode.md — Future conversational AI mode (2026-2028)
 │   └── design/                    — 86 interactive HTML mockups
@@ -55,7 +56,7 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── container.mmd     — C4 container diagram
 │   ├── core-erd.mmd      — Entity-relationship diagram
 │   └── migration-flow.mmd — Salesforce migration flow
-└── .claude/agents/        — 8 specialized Claude agents
+└── .claude/agents/        — 12 specialized Claude agents
 ```
 
 ## Specialized Agents
@@ -75,10 +76,11 @@ Use these agents for domain-specific tasks via Claude Code:
 | MVP Engineer | `.claude/agents/mvp-engineer.md` | Full-stack implementation, Fastify routes, Drizzle ORM, BullMQ jobs |
 | API Contract Designer | `.claude/agents/api-contract-designer.md` | REST API contracts, TypeBox schemas, OpenAPI 3.1, RFC 7807 errors |
 | QA Engineer | `.claude/agents/qa-engineer.md` | Integration tests, RLS isolation, GDPR compliance, Stripe webhooks |
+| Log Analyst | `.claude/agents/log-analyst.md` | Structured logging, distributed tracing, audit trail, GDPR log compliance, performance diagnostics |
 
 ## Implementation Status
 
-**Phase 0 — Foundation (current)**: Architecture blueprint complete. 16 specification documents, 86 HTML mockups, 4 Mermaid diagrams. No production code yet.
+**Phase 0 — Foundation (current)**: Architecture blueprint complete. 17 specification documents, 86 HTML mockups, 4 Mermaid diagrams. No production code yet.
 
 Next: Phase 1 — Skeleton (TypeScript monorepo scaffolding with pnpm workspaces, Drizzle schema baseline, CI/CD, auth, first module).
 
@@ -91,4 +93,4 @@ HTML mockups are in `docs/design/`. Open `docs/design/index.html` locally or vie
 - Project name: **Givernance** (not "Libero", not "givernance-npo-platform")
 - Terminology: **NPO** (nonprofit organization), not "NGO"
 - GDPR in English docs, RGPD in French docs
-- All docs are in `docs/`, numbered 01-16 for architecture specs
+- All docs are in `docs/`, numbered 01-17 for architecture specs

--- a/docs/17-log-management.md
+++ b/docs/17-log-management.md
@@ -66,8 +66,9 @@ Pino is the **only** logger for Givernance. It is Fastify's built-in logger — 
 | `@opentelemetry/instrumentation-fastify` | Auto-instrument Fastify routes |
 | `@opentelemetry/instrumentation-pg` | Auto-instrument PostgreSQL queries |
 | `@opentelemetry/instrumentation-ioredis` | Auto-instrument Redis (BullMQ) |
+| `@opentelemetry/instrumentation-undici` | Auto-instrument outbound HTTP (fetch) — Stripe, Keycloak, email providers, AI APIs |
 
-**Do NOT use** `@opentelemetry/auto-instrumentations-node` — it pulls in 40+ instrumentations. Install only the three we need.
+**Do NOT use** `@opentelemetry/auto-instrumentations-node` — it pulls in 40+ instrumentations. Install only the four we need.
 
 ### 3.3 Log Aggregation: Grafana Loki
 
@@ -106,6 +107,7 @@ Every log line across all services follows this JSON schema:
 | `service` | Logger `name` option | Always |
 | `correlationId` | `X-Request-Id` header or UUIDv7 | Always (API + Worker) |
 | `tenantId` | Auth middleware / job metadata | Always (after auth) |
+| `userId` | Auth middleware / job metadata | After authentication (null for system/webhook/health requests) |
 | `msg` | Explicit log message | Always |
 | `traceId` / `spanId` | OTel SDK (auto-injected) | When OTel is active |
 
@@ -128,6 +130,11 @@ Fastify API (onRequest hook)
   │     ├─ Drizzle queries traced via OTel instrumentation-pg
   │     └─ Enqueue BullMQ job:
   │         job.data._meta = { correlationId, tenantId, userId }
+  │
+  ├─► Transactional outbox (domain_events table):
+  │     domain_events.payload must include _meta.correlationId from
+  │     the originating request. The outbox poller extracts this when
+  │     enqueuing the BullMQ job — never generates a fresh one.
   │
   └─► Response to client
 
@@ -164,6 +171,7 @@ Three layers of protection:
 1. **Pino `redact` option** — strips known PII paths from all log output (see agent for full path list)
 2. **Custom serializers** — domain objects are logged with safe projections only (`{ id, type }`, never `{ email, name }`)
 3. **Code review rule** — the Log Analyst agent flags any logged field that could contain PII
+4. **Custom Pino serializers for domain objects** — register serializers for `constituent`, `volunteer`, `donation` objects that return only safe projections (`{ id, type }`). This prevents PII leakage even if developers accidentally log full domain objects (e.g., in error handlers or catch blocks).
 
 ### 6.2 Retention Policy
 
@@ -178,10 +186,23 @@ Three layers of protection:
 ### 6.3 Right to Erasure (Art. 17)
 
 - **Log files/streams**: retention-based deletion is the accepted approach (DPAs accept this as proportionate)
-- **audit_logs table**: anonymize `actor_id` and `target_entity` after retention period via scheduled job
+- **audit_logs table**: anonymize `actor_id`, `target_entity`, `ip_address` (the `ipHash` in `metadata` JSONB), `user_agent` (in `metadata` JSONB), and PII within `changes` JSONB `before`/`after` diffs after retention period via scheduled job
 - **Prevention > deletion**: do not store PII in logs in the first place
 
+> **Exception**: `gdpr_consent_log.ip_address` (doc-03) retains raw IP. Lawful basis: proof of consent per GDPR Art. 7 requires recording the IP from which consent was given. The `audit_logs.metadata` JSONB always uses hashed IP — these are distinct storage contexts.
+
+### 6.4 Special JSONB fields
+
+Several JSONB columns across the schema require special GDPR handling because their contents are dynamic or free-text:
+
+- **`domain_events.payload`** — may contain full entity snapshots including PII. Must be included in the PII redaction spec (apply `sanitizeAuditDiff` before logging payload contents) or excluded from Pino log output entirely.
+- **`custom_fields` JSONB** on `constituents`, `donations`, `volunteer_profiles`, and other entities — contains arbitrary tenant-defined data whose schema is unknown at build time. Exclude from logging entirely (cannot redact unknown schemas). Add `body.customFields`, `body.customFields.*`, `body.custom_fields`, `body.custom_fields.*` to Pino redact paths.
+- **`constituent_relationships.notes`** — free-text field that may contain PII. Add `body.relationships[*].notes` to Pino redact paths.
+- **`body.notes`** — free-text notes fields on donations, grants, case notes, etc. Add to Pino redact paths.
+
 ## 7. Security Audit Trail
+
+> **Reconciliation note — `pg_audit` vs `audit_logs`**: Doc-02 lists the `pg_audit` PostgreSQL extension. This provides **database-level** change tracking (DDL/DML statements) as a safety net and compliance backstop. The custom `audit_logs` Drizzle table defined below provides **application-level** structured audit events with business semantics (who did what, with before/after diffs). They are complementary: `pg_audit` catches changes that bypass the application layer; `audit_logs` provides rich, queryable, tenant-scoped business context.
 
 ### 7.1 Dual approach
 
@@ -199,6 +220,8 @@ Three layers of protection:
 | GDPR | consent_recorded/withdrawn, export_requested, erasure_requested | Yes | Yes |
 | Admin | tenant_settings_changed, user_invited/removed, api_key_rotated | Yes | Yes |
 | Security | rate_limit_hit, cors_violation, invalid_jwt, ip_blocklist | Yes | Yes (warn) |
+| AI actions | ai.suggestion_generated, ai.action_executed, ai.action_blocked, ai.guard_denied | Yes | Yes (info for generated/executed, warn for blocked/denied) |
+| Migration | migration.started, migration.batch_loaded, migration.validation_error, migration.completed | Yes | Yes |
 
 ### 7.3 Audit log schema
 
@@ -206,9 +229,25 @@ See Log Analyst agent for full Drizzle schema. Key design decisions:
 
 - **UUID v7 primary key** (project convention)
 - **`changes` JSONB column** — stores `{ before, after }` diff with PII redacted
-- **`metadata` JSONB column** — hashed IP, correlationId, user-agent (truncated)
+- **`metadata` JSONB column** — SHA-256 truncated hash of IP (`ipHash`), correlationId, user-agent (truncated). Raw IP is never stored in `audit_logs` — use hashed IP for forensic correlation without GDPR exposure.
+- **Partitioned by `created_at`** (monthly range). Glacier/archive after 12 months.
 - **Composite index** on `(tenant_id, action, created_at DESC)` for tenant-scoped queries
 - **RLS-protected** — tenants can only query their own audit logs
+
+> **Reconciliation note — doc-03 naming**: Doc-03's `audit_log` table uses `entity_type`/`entity_id` and separate `before_state`/`after_state` JSONB columns. This document's `audit_logs` schema uses `resourceType`/`resourceId` (Drizzle camelCase convention) and a single `changes` JSONB with `{ before, after }` (more flexible, avoids null ambiguity). The canonical definition is here in doc-17 — doc-03 will be reconciled during Phase 1 schema implementation.
+
+### 7.4 Change diff sanitization
+
+The `changes` JSONB column stores `{ before, after }` diffs of entity mutations. **The service layer must sanitize these diffs before inserting into `audit_logs`** — this is NOT Pino's job (Pino redacts log output; audit diffs are written directly to the database).
+
+**Pattern**: Define a `sanitizeAuditDiff(entityType, changes)` utility in `packages/shared` that:
+
+1. Accepts the entity type and the raw `{ before, after }` diff
+2. Strips PII fields using the same canonical field list as the Pino redact paths (e.g., `firstName`, `lastName`, `email`, `phone`, `address`, `iban`, `nationalId`, `emergencyContactName`, `emergencyContactPhone`, `dbsReference`)
+3. Replaces stripped values with `'[REDACTED]'`
+4. Returns the sanitized diff for DB insertion
+
+This ensures PII never enters the `audit_logs` table, even if a developer forgets to exclude sensitive fields from the diff. The canonical PII field list is maintained in one place and shared between Pino redact config and this utility.
 
 ## 8. Performance Observability
 
@@ -221,6 +260,8 @@ See Log Analyst agent for full Drizzle schema. Key design decisions:
 | BullMQ job duration | > 30 s | > 120 s | `job.finishedOn - job.processedOn` |
 | Queue backlog (waiting) | > 1 000 | > 5 000 | `queue.getJobCounts()` periodic check |
 | Queue failed jobs | > 100 | > 500 | `queue.getJobCounts()` periodic check |
+
+> **Threshold semantics**: Warn thresholds are aligned to doc-02 NFR targets. When warn fires, the NFR is breached. When error fires, the system is degraded.
 
 ### 8.2 Slow query detection
 
@@ -275,6 +316,17 @@ When a test is flaky:
 3. Check `tenantId` isolation — flaky tests often share state between tenants
 4. Check BullMQ job logs — race conditions between API response and async worker
 
+### 9.4 Redact path coverage test
+
+Maintain a canonical PII field list derived from the Drizzle schema (all columns marked as PII in the `constituents`, `volunteer_profiles`, `households`, `gdpr_consent_log`, and `constituent_relationships` tables). Write a test that:
+
+1. Imports the canonical PII field list
+2. Imports the Pino redact paths from the shared config
+3. Asserts that every PII field has a corresponding Pino redact path
+4. Fails when a new PII column is added to the Drizzle schema without a matching redact path
+
+This prevents PII redaction drift: when a developer adds a new PII column, the test breaks until the redact paths are updated.
+
 ## 10. Agent Rules — Cross-Agent Logging Enforcement
 
 The following rules should be added to existing agents to enforce logging standards:
@@ -311,7 +363,7 @@ The following rules should be added to existing agents to enforce logging standa
 
 | Rule | Description |
 |------|-------------|
-| OTel instrumentations: fastify + pg + ioredis only | No auto-instrumentations-node (too broad) |
+| OTel instrumentations: fastify + pg + ioredis + undici only | No auto-instrumentations-node (too broad) |
 | Grafana Loki retention config | Match retention policy from this document |
 | Docker log driver: json-file with max-size | Prevent disk exhaustion on self-hosted |
 | OTel Collector resource attributes | `service.name`, `service.version`, `deployment.environment` |
@@ -367,6 +419,7 @@ pino-pretty@^13            # devDependency
 @opentelemetry/instrumentation-fastify@^0.57
 @opentelemetry/instrumentation-pg@^0.66
 @opentelemetry/instrumentation-ioredis@^0.62
+@opentelemetry/instrumentation-undici@^0.24
 pino-opentelemetry-transport@^3
 ```
 
@@ -383,3 +436,13 @@ pino-loki@^3               # if shipping direct to Loki
 - `morgan` — Express-only
 - `@opentelemetry/auto-instrumentations-node` — too broad
 - `@sentry/node` without GDPR `beforeSend` — PII would leak to Sentry
+
+## 13. Observability Gaps — Future Work
+
+The following items are not covered by this document and need separate specification:
+
+- **`givernance-migrate` ETL tool** — needs its own Pino setup, correlation ID strategy (no incoming HTTP requests to derive from), and structured progress logging for batch operations (rows imported, validation errors, elapsed time).
+- **Next.js SSR** — needs Pino configuration for server-side rendering, error boundary logging (React `ErrorBoundary` → Pino), and client-side error capture strategy.
+- **Outbound webhook delivery** — needs a logging spec covering delivery attempts, failures, retry counts, circuit-breaking state transitions, and response status codes.
+- **Cron / repeatable jobs** — need a `batchCorrelationId` strategy. These are system-initiated (not request-initiated), so there is no incoming `X-Request-Id`. Generate a UUIDv7 at job creation time and propagate through all downstream work.
+- **OTel resource attributes** — should include `service.instance.id` (unique per replica) for multi-replica SaaS deployment on Hetzner. This enables per-instance log filtering in Grafana when debugging replica-specific issues.

--- a/docs/17-log-management.md
+++ b/docs/17-log-management.md
@@ -72,9 +72,15 @@ Pino is the **only** logger for Givernance. It is Fastify's built-in logger — 
 
 ### 3.3 Log Aggregation: Grafana Loki
 
-Lighter than ELK (no JVM), pairs with Prometheus (metrics) and Tempo (traces) for a unified Grafana observability stack. Perfect for Hetzner self-hosted deployment.
+Lighter than ELK (no JVM), pairs with Prometheus/Mimir (metrics) and Tempo (traces) for a unified Grafana observability stack.
 
-**Collection method**: Docker log driver → Promtail/Alloy → Loki. Alternative: direct `pino-loki` transport.
+**SaaS deployment**: Scaleway Cockpit provides Grafana + Loki + Mimir + Tempo as a fully managed service under the Scaleway DPA. No self-hosted Loki stack needed — Cockpit ingests OTel-format logs and traces natively.
+
+**Self-hosted deployment**: Docker log driver → Promtail/Alloy → self-hosted Loki. Identical LogQL queries and dashboards.
+
+**Collection method (SaaS)**: OTel Collector → Scaleway Cockpit (native OTLP endpoint). No `pino-loki` transport needed for SaaS — Cockpit ingests OTLP directly.
+
+**Collection method (self-hosted)**: Docker log driver → Promtail/Alloy → self-hosted Loki. Or direct `pino-loki` transport.
 
 ### 3.4 Error Tracking: Sentry (optional)
 
@@ -445,4 +451,4 @@ The following items are not covered by this document and need separate specifica
 - **Next.js SSR** — needs Pino configuration for server-side rendering, error boundary logging (React `ErrorBoundary` → Pino), and client-side error capture strategy.
 - **Outbound webhook delivery** — needs a logging spec covering delivery attempts, failures, retry counts, circuit-breaking state transitions, and response status codes.
 - **Cron / repeatable jobs** — need a `batchCorrelationId` strategy. These are system-initiated (not request-initiated), so there is no incoming `X-Request-Id`. Generate a UUIDv7 at job creation time and propagate through all downstream work.
-- **OTel resource attributes** — should include `service.instance.id` (unique per replica) for multi-replica SaaS deployment on Hetzner. This enables per-instance log filtering in Grafana when debugging replica-specific issues.
+- **OTel resource attributes** — should include `service.instance.id` (unique per replica) for multi-replica SaaS deployment on Scaleway. This enables per-instance log filtering in Grafana Cockpit when debugging replica-specific issues.

--- a/docs/17-log-management.md
+++ b/docs/17-log-management.md
@@ -1,0 +1,385 @@
+# 17 — Log Management Strategy
+
+> **Status**: Spike / Analysis — Phase 1 implementation target
+> **Owner**: Log Analyst agent (`.claude/agents/log-analyst.md`)
+> **Related**: `02-reference-architecture.md`, `06-security-compliance.md`, `15-infra-adr.md`
+
+## 1. Goals
+
+The log management strategy must support investigation of:
+
+- **Bug diagnosis** — trace a failing request from API entry → service logic → DB query → response
+- **Performance issues** — identify slow queries, slow endpoints, queue backlogs
+- **Data inconsistencies** — correlate mutations across API + Worker with audit trail
+- **Flaky tests** — capture test-scoped logs with request context for reproducibility
+- **Security incidents** — authentication failures, authorization violations, suspicious access patterns
+
+## 2. Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                     Grafana (dashboards)                      │
+└──────┬───────────────────┬──────────────────┬────────────────┘
+       │                   │                  │
+┌──────▼──────┐     ┌──────▼──────┐    ┌──────▼──────┐
+│ Grafana Loki│     │ Prometheus  │    │Grafana Tempo│
+│   (logs)    │     │  (metrics)  │    │  (traces)   │
+└──────▲──────┘     └──────▲──────┘    └──────▲──────┘
+       │                   │                  │
+┌──────┴───────────────────┴──────────────────┴────────────────┐
+│              OTel Collector (optional gateway)                │
+└──────▲───────────────────▲──────────────────▲────────────────┘
+       │                   │                  │
+┌──────┴──────┐     ┌──────┴──────┐    ┌──────┴──────┐
+│ Fastify API │     │BullMQ Worker│    │ Next.js SSR │
+│ pino + OTel │     │ pino + OTel │    │ pino + OTel │
+└──────┬──────┘     └──────┬──────┘    └─────────────┘
+       │                   │
+       ▼                   ▼
+┌──────────────────────────────────────────────────────────────┐
+│    PostgreSQL 16 (instrumentation-pg + audit_logs table)      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## 3. Technology Choices
+
+### 3.1 Logger: Pino (native to Fastify)
+
+Pino is the **only** logger for Givernance. It is Fastify's built-in logger — using anything else (winston, bunyan) would mean fighting the framework.
+
+| Package | Purpose | Dev/Prod |
+|---------|---------|----------|
+| `pino` | Core structured JSON logger | Both |
+| `pino-pretty` | Human-readable colored output | Dev only |
+| `pino-opentelemetry-transport` | Bridge logs → OTel Collector | Prod |
+| `pino-loki` | Direct ship to Grafana Loki (alternative to OTel) | Prod |
+
+**Why not winston?** Pino is 5-10x faster (async worker-thread architecture vs. synchronous transforms). Fastify's `fastify.log` and `req.log` are already Pino instances.
+
+### 3.2 Distributed Tracing: OpenTelemetry
+
+| Package | Purpose |
+|---------|---------|
+| `@opentelemetry/api` | Trace/span API |
+| `@opentelemetry/sdk-node` | Auto-configuration SDK |
+| `@opentelemetry/exporter-trace-otlp-http` | Export traces to Tempo/Jaeger |
+| `@opentelemetry/instrumentation-fastify` | Auto-instrument Fastify routes |
+| `@opentelemetry/instrumentation-pg` | Auto-instrument PostgreSQL queries |
+| `@opentelemetry/instrumentation-ioredis` | Auto-instrument Redis (BullMQ) |
+
+**Do NOT use** `@opentelemetry/auto-instrumentations-node` — it pulls in 40+ instrumentations. Install only the three we need.
+
+### 3.3 Log Aggregation: Grafana Loki
+
+Lighter than ELK (no JVM), pairs with Prometheus (metrics) and Tempo (traces) for a unified Grafana observability stack. Perfect for Hetzner self-hosted deployment.
+
+**Collection method**: Docker log driver → Promtail/Alloy → Loki. Alternative: direct `pino-loki` transport.
+
+### 3.4 Error Tracking: Sentry (optional)
+
+Sentry complements Pino — Pino handles structured logging, Sentry handles error grouping, alerting, and release tracking. GDPR: strip PII from Sentry events via `beforeSend` hook.
+
+## 4. Structured Log Format
+
+Every log line across all services follows this JSON schema:
+
+```json
+{
+  "level": "info",
+  "time": "2026-04-01T10:23:45.123Z",
+  "service": "givernance-api",
+  "correlationId": "019508d3-7b2a-7f00-8000-1a2b3c4d5e6f",
+  "tenantId": "t_greenpeace_fr",
+  "userId": "u_abc123",
+  "msg": "donation recorded",
+  "traceId": "abc123def456...",
+  "spanId": "789ghi012..."
+}
+```
+
+### Mandatory fields
+
+| Field | Source | Required |
+|-------|--------|----------|
+| `level` | Pino (string label, not numeric) | Always |
+| `time` | Pino `isoTime` formatter | Always |
+| `service` | Logger `name` option | Always |
+| `correlationId` | `X-Request-Id` header or UUIDv7 | Always (API + Worker) |
+| `tenantId` | Auth middleware / job metadata | Always (after auth) |
+| `msg` | Explicit log message | Always |
+| `traceId` / `spanId` | OTel SDK (auto-injected) | When OTel is active |
+
+## 5. Correlation ID Flow
+
+The `correlationId` traces a single user action across all system boundaries:
+
+```
+User action (browser)
+  │
+  ▼
+Fastify API (onRequest hook)
+  ├─ Read X-Request-Id header or generate UUIDv7
+  ├─ req.correlationId = correlationId
+  ├─ req.log = logger.child({ correlationId, tenantId, userId })
+  ├─ Reply header: X-Request-Id: correlationId
+  │
+  ├─► Service layer (receives req.log as dependency)
+  │     ├─ Business logic logs use req.log → auto-includes correlation
+  │     ├─ Drizzle queries traced via OTel instrumentation-pg
+  │     └─ Enqueue BullMQ job:
+  │         job.data._meta = { correlationId, tenantId, userId }
+  │
+  └─► Response to client
+
+BullMQ Worker (job processor)
+  ├─ Extract job.data._meta.correlationId
+  ├─ jobLogger = logger.child({ correlationId, tenantId, jobId, jobName })
+  ├─ All processing logs auto-include correlation
+  └─ DB queries traced via OTel
+```
+
+### Context propagation: AsyncLocalStorage
+
+Use Node.js native `AsyncLocalStorage` (stable since Node 16) — no external dependency (`cls-hooked` is deprecated).
+
+```typescript
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface RequestContext {
+  correlationId: string;
+  tenantId: string;
+  userId?: string;
+  logger: pino.Logger;
+}
+
+export const requestContext = new AsyncLocalStorage<RequestContext>();
+```
+
+## 6. GDPR Log Compliance
+
+### 6.1 PII Redaction (defense in depth)
+
+Three layers of protection:
+
+1. **Pino `redact` option** — strips known PII paths from all log output (see agent for full path list)
+2. **Custom serializers** — domain objects are logged with safe projections only (`{ id, type }`, never `{ email, name }`)
+3. **Code review rule** — the Log Analyst agent flags any logged field that could contain PII
+
+### 6.2 Retention Policy
+
+| Log type | Retention | Deletion method |
+|----------|-----------|-----------------|
+| Application logs (info/warn) | 90 days | Loki retention policy / log rotation |
+| Error logs | 1 year | Loki retention policy |
+| Security audit logs (DB table) | 7–10 years | DB scheduled job with anonymization |
+| Debug/trace (per-tenant override) | 7 days max | Auto-expire, never persisted to long-term |
+| Access logs | 90 days | Log rotation |
+
+### 6.3 Right to Erasure (Art. 17)
+
+- **Log files/streams**: retention-based deletion is the accepted approach (DPAs accept this as proportionate)
+- **audit_logs table**: anonymize `actor_id` and `target_entity` after retention period via scheduled job
+- **Prevention > deletion**: do not store PII in logs in the first place
+
+## 7. Security Audit Trail
+
+### 7.1 Dual approach
+
+1. **Structured `audit_logs` table** in PostgreSQL — queryable, exportable, retainable for 7+ years
+2. **Pino log lines with `audit: true` flag** — for real-time alerting via Loki/Grafana
+
+### 7.2 Events catalog
+
+| Category | Events | Audit table | Pino log |
+|----------|--------|-------------|----------|
+| Authentication | login_success, login_failure, logout, password_reset, mfa_toggle | Yes | Yes |
+| Authorization | permission_denied, role_changed, rbac_violation | Yes | Yes (warn) |
+| Data access | record_viewed, export_triggered, bulk_download | Yes | No (too noisy) |
+| Data mutation | contact.created/updated/deleted, donation.recorded | Yes | Yes |
+| GDPR | consent_recorded/withdrawn, export_requested, erasure_requested | Yes | Yes |
+| Admin | tenant_settings_changed, user_invited/removed, api_key_rotated | Yes | Yes |
+| Security | rate_limit_hit, cors_violation, invalid_jwt, ip_blocklist | Yes | Yes (warn) |
+
+### 7.3 Audit log schema
+
+See Log Analyst agent for full Drizzle schema. Key design decisions:
+
+- **UUID v7 primary key** (project convention)
+- **`changes` JSONB column** — stores `{ before, after }` diff with PII redacted
+- **`metadata` JSONB column** — hashed IP, correlationId, user-agent (truncated)
+- **Composite index** on `(tenant_id, action, created_at DESC)` for tenant-scoped queries
+- **RLS-protected** — tenants can only query their own audit logs
+
+## 8. Performance Observability
+
+### 8.1 Thresholds
+
+| Metric | Warn | Error | Source |
+|--------|------|-------|--------|
+| API request p99 | > 300 ms | > 1 000 ms | Fastify `reply.elapsedTime` |
+| DB query duration | > 500 ms | > 2 000 ms | OTel instrumentation-pg spans |
+| BullMQ job duration | > 30 s | > 120 s | `job.finishedOn - job.processedOn` |
+| Queue backlog (waiting) | > 1 000 | > 5 000 | `queue.getJobCounts()` periodic check |
+| Queue failed jobs | > 100 | > 500 | `queue.getJobCounts()` periodic check |
+
+### 8.2 Slow query detection
+
+OpenTelemetry `instrumentation-pg` auto-records query duration as span attributes. For Drizzle-level logging, use a custom `LogWriter` that emits to Pino at `debug` level (never `info` — too noisy).
+
+### 8.3 Queue health monitoring
+
+A BullMQ repeatable job runs every 60s, logs queue metrics at `info` level, and emits `warn` when thresholds are exceeded.
+
+## 9. Testing Observability
+
+### 9.1 Test logger
+
+```typescript
+// packages/shared/src/test-utils/logger.ts
+import pino from 'pino';
+
+export const testLogger = pino({
+  level: process.env.DEBUG ? 'debug' : 'silent',
+  transport: process.env.DEBUG
+    ? { target: 'pino-pretty', options: { colorize: true } }
+    : undefined,
+});
+```
+
+- Tests run silent by default (no noise in CI)
+- Set `DEBUG=1` to enable debug output for a failing test
+- Inject `testLogger` into services under test
+
+### 9.2 Log assertion pattern
+
+For audit log tests, pipe Pino to a `PassThrough` stream and assert on parsed JSON lines:
+
+```typescript
+const logLines: object[] = [];
+const stream = new PassThrough();
+stream.on('data', (chunk) => logLines.push(JSON.parse(chunk.toString())));
+const logger = pino({ level: 'info' }, stream);
+
+// ... run service method ...
+
+const auditLine = logLines.find((l: any) => l.msg === 'donation recorded');
+expect(auditLine).toHaveProperty('tenantId', 't_1');
+expect(JSON.stringify(auditLine)).not.toContain('donor@example.com'); // no PII leak
+```
+
+### 9.3 Flaky test debugging
+
+When a test is flaky:
+1. Re-run with `DEBUG=1` to capture full log output
+2. Check `correlationId` to trace the exact request flow
+3. Check `tenantId` isolation — flaky tests often share state between tenants
+4. Check BullMQ job logs — race conditions between API response and async worker
+
+## 10. Agent Rules — Cross-Agent Logging Enforcement
+
+The following rules should be added to existing agents to enforce logging standards:
+
+### MVP Engineer
+
+| Rule | Description |
+|------|-------------|
+| Use `req.log` for all API route logging | Never create standalone Pino instances in route handlers |
+| Propagate `_meta` in BullMQ jobs | Always include `{ correlationId, tenantId, userId }` in job data |
+| No `console.log` | Use injected logger everywhere |
+| Log business events at `info` | Donation recorded, contact created, campaign launched |
+| Log errors with `{ err }` object | `req.log.error({ err }, 'description')` — Pino serializes Error natively |
+
+### QA Engineer
+
+| Rule | Description |
+|------|-------------|
+| Use `testLogger` from shared test utils | Silent by default, verbose with `DEBUG=1` |
+| Assert no PII in log output | Pipe Pino to stream, assert `JSON.stringify` has no email/phone/name |
+| Test audit log entries | Verify `audit_logs` table has correct entries after mutations |
+| Test correlation propagation | Verify child loggers carry `correlationId` through the chain |
+
+### Security Architect
+
+| Rule | Description |
+|------|-------------|
+| Review Pino `redact` paths quarterly | New PII fields = new redact paths |
+| Verify audit log retention job | Scheduled anonymization runs, respects 7-year minimum |
+| Check Sentry `beforeSend` PII stripping | No auth tokens, cookies, or PII in Sentry events |
+| Validate RLS on `audit_logs` table | Tenants must not see each other's audit trails |
+
+### Platform Architect
+
+| Rule | Description |
+|------|-------------|
+| OTel instrumentations: fastify + pg + ioredis only | No auto-instrumentations-node (too broad) |
+| Grafana Loki retention config | Match retention policy from this document |
+| Docker log driver: json-file with max-size | Prevent disk exhaustion on self-hosted |
+| OTel Collector resource attributes | `service.name`, `service.version`, `deployment.environment` |
+
+### API Contract Designer
+
+| Rule | Description |
+|------|-------------|
+| `X-Request-Id` header in all API responses | Document in OpenAPI spec |
+| Error responses include `correlationId` | RFC 7807 `instance` field = correlation ID |
+| No PII in error detail messages | Error messages are logged — PII would leak |
+
+### Data Architect
+
+| Rule | Description |
+|------|-------------|
+| `audit_logs` table in shared schema | Include in Drizzle schema baseline |
+| Composite index `(tenant_id, action, created_at DESC)` | Required for tenant-scoped audit queries |
+| JSONB `changes` column uses redacted diffs | Never store raw PII in before/after |
+
+## 11. Implementation Phases
+
+| Phase | Scope | Priority |
+|-------|-------|----------|
+| **Phase 1 — Skeleton** | Pino setup in shared package, Fastify logger config, correlation ID plugin, PII redact paths, `testLogger` util | P0 |
+| **Phase 1 — Skeleton** | `audit_logs` Drizzle schema + migration | P0 |
+| **Phase 1 — Skeleton** | AsyncLocalStorage context propagation | P1 |
+| **Phase 2 — Core modules** | Audit log entries on all mutations (transactional outbox) | P0 |
+| **Phase 2 — Core modules** | BullMQ job lifecycle logging with correlation | P0 |
+| **Phase 2 — Core modules** | Slow query / slow request detection | P1 |
+| **Phase 3 — Launch** | Grafana Loki + Promtail deployment | P0 |
+| **Phase 3 — Launch** | OTel SDK + instrumentations + Tempo | P1 |
+| **Phase 3 — Launch** | Sentry integration (optional) | P2 |
+| **Phase 3 — Launch** | Queue health monitoring repeatable job | P1 |
+| **Phase 4+** | Per-tenant log level override | P2 |
+| **Phase 4+** | Tenant-facing audit log viewer (UI) | P2 |
+
+## 12. Package Dependencies
+
+### Install in Phase 1 (shared + api)
+
+```
+pino@^10
+pino-pretty@^13            # devDependency
+```
+
+### Install in Phase 2-3 (api + worker)
+
+```
+@opentelemetry/api@^1.9
+@opentelemetry/sdk-node@^0.214
+@opentelemetry/exporter-trace-otlp-http@^0.214
+@opentelemetry/instrumentation-fastify@^0.57
+@opentelemetry/instrumentation-pg@^0.66
+@opentelemetry/instrumentation-ioredis@^0.62
+pino-opentelemetry-transport@^3
+```
+
+### Install when deploying (infrastructure)
+
+```
+pino-loki@^3               # if shipping direct to Loki
+```
+
+### Do NOT install
+
+- `winston` — redundant with Pino/Fastify
+- `cls-hooked` — deprecated, use `AsyncLocalStorage`
+- `morgan` — Express-only
+- `@opentelemetry/auto-instrumentations-node` — too broad
+- `@sentry/node` without GDPR `beforeSend` — PII would leak to Sentry

--- a/docs/17-log-management.md
+++ b/docs/17-log-management.md
@@ -37,7 +37,7 @@ The log management strategy must support investigation of:
        │                   │
        ▼                   ▼
 ┌──────────────────────────────────────────────────────────────┐
-│    PostgreSQL 16 (instrumentation-pg + audit_logs table)      │
+│    PostgreSQL 16 (instrumentation-pg + audit_log table)       │
 └──────────────────────────────────────────────────────────────┘
 ```
 
@@ -52,7 +52,7 @@ Pino is the **only** logger for Givernance. It is Fastify's built-in logger — 
 | `pino` | Core structured JSON logger | Both |
 | `pino-pretty` | Human-readable colored output | Dev only |
 | `pino-opentelemetry-transport` | Bridge logs → OTel Collector | Prod |
-| `pino-loki` | Direct ship to Grafana Loki (alternative to OTel) | Prod |
+| `pino-loki` | Direct ship to self-hosted Grafana Loki (self-hosted NPO only) | Prod (self-hosted only) |
 
 **Why not winston?** Pino is 5-10x faster (async worker-thread architecture vs. synchronous transforms). Fastify's `fastify.log` and `req.log` are already Pino instances.
 
@@ -68,7 +68,7 @@ Pino is the **only** logger for Givernance. It is Fastify's built-in logger — 
 | `@opentelemetry/instrumentation-ioredis` | Auto-instrument Redis (BullMQ) |
 | `@opentelemetry/instrumentation-undici` | Auto-instrument outbound HTTP (fetch) — Stripe, Keycloak, email providers, AI APIs |
 
-**Do NOT use** `@opentelemetry/auto-instrumentations-node` — it pulls in 40+ instrumentations. Install only the four we need.
+**Do NOT use** `@opentelemetry/auto-instrumentations-node` — it pulls in 40+ instrumentations. Install only the specific ones we need (fastify, pg, ioredis, undici = 4 instrumentations + api + sdk-node + exporter = 7 packages total).
 
 ### 3.3 Log Aggregation: Grafana Loki
 
@@ -192,7 +192,7 @@ Three layers of protection:
 ### 6.3 Right to Erasure (Art. 17)
 
 - **Log files/streams**: retention-based deletion is the accepted approach (DPAs accept this as proportionate)
-- **audit_logs table**: anonymize `actor_id`, `target_entity`, `ip_address` (the `ipHash` in `metadata` JSONB), `user_agent` (in `metadata` JSONB), and PII within `changes` JSONB `before`/`after` diffs after retention period via scheduled job
+- **`audit_log` table** (name TBD in Phase 1 — see §7.3 reconciliation note): anonymize `actor_id`, `target_entity`, `ipHash`, `user_agent`, and PII within `changes` JSONB `before`/`after` diffs after retention period via scheduled job
 - **Prevention > deletion**: do not store PII in logs in the first place
 
 > **Exception**: `gdpr_consent_log.ip_address` (doc-03) retains raw IP. Lawful basis: proof of consent per GDPR Art. 7 requires recording the IP from which consent was given. The `audit_logs.metadata` JSONB always uses hashed IP — these are distinct storage contexts.
@@ -240,7 +240,7 @@ See Log Analyst agent for full Drizzle schema. Key design decisions:
 - **Composite index** on `(tenant_id, action, created_at DESC)` for tenant-scoped queries
 - **RLS-protected** — tenants can only query their own audit logs
 
-> **Reconciliation note — doc-03 naming**: Doc-03's `audit_log` table uses `entity_type`/`entity_id` and separate `before_state`/`after_state` JSONB columns. This document's `audit_logs` schema uses `resourceType`/`resourceId` (Drizzle camelCase convention) and a single `changes` JSONB with `{ before, after }` (more flexible, avoids null ambiguity). The canonical definition is here in doc-17 — doc-03 will be reconciled during Phase 1 schema implementation.
+> **Schema reconciliation (Phase 1 task)**: Doc-03 calls the table `audit_log` (singular) and uses `entity_type`/`entity_id` + separate `before_state`/`after_state` columns. This document uses `resourceType`/`resourceId` (Drizzle camelCase) and a single `changes: { before, after }` JSONB (avoids null ambiguity, more flexible). **Canonical table name will be decided in Phase 1 Drizzle schema baseline** — all references throughout the codebase must be consistent. Track as an open question in doc-10.
 
 ### 7.4 Change diff sanitization
 
@@ -395,12 +395,12 @@ The following rules should be added to existing agents to enforce logging standa
 | Phase | Scope | Priority |
 |-------|-------|----------|
 | **Phase 1 — Skeleton** | Pino setup in shared package, Fastify logger config, correlation ID plugin, PII redact paths, `testLogger` util | P0 |
-| **Phase 1 — Skeleton** | `audit_logs` Drizzle schema + migration | P0 |
+| **Phase 1 — Skeleton** | `audit_log` Drizzle schema + migration (canonical table name to be decided in Phase 1) | P0 |
 | **Phase 1 — Skeleton** | AsyncLocalStorage context propagation | P1 |
 | **Phase 2 — Core modules** | Audit log entries on all mutations (transactional outbox) | P0 |
 | **Phase 2 — Core modules** | BullMQ job lifecycle logging with correlation | P0 |
 | **Phase 2 — Core modules** | Slow query / slow request detection | P1 |
-| **Phase 3 — Launch** | Grafana Loki + Promtail deployment | P0 |
+| **Phase 3 — Launch** | SaaS: OTel Collector → Scaleway Cockpit config · Self-hosted: Grafana Loki + Promtail deployment | P0 |
 | **Phase 3 — Launch** | OTel SDK + instrumentations + Tempo | P1 |
 | **Phase 3 — Launch** | Sentry integration (optional) | P2 |
 | **Phase 3 — Launch** | Queue health monitoring repeatable job | P1 |


### PR DESCRIPTION
## Summary

- New **Log Analyst** subagent (`.claude/agents/log-analyst.md`) — structured logging, distributed tracing, audit trail, GDPR log compliance, performance diagnostics
- New **doc 17** (`docs/17-log-management.md`) — comprehensive log management strategy
- Updated `CLAUDE.md` with new agent and doc references

## Key decisions

| Component | Choice | Why |
|-----------|--------|-----|
| Logger | **Pino 10.x** | Native to Fastify, 5-10x faster than Winston, JSON structured |
| Tracing | **OpenTelemetry SDK** | Auto-instrumentation for Fastify, pg, ioredis |
| Aggregation | **Grafana Loki** | Lightweight (no JVM), pairs with Prometheus + Tempo |
| Context propagation | **AsyncLocalStorage** | Node.js native, no external dependency |
| Audit trail | **PostgreSQL `audit_logs` table** | Structured, queryable, 7+ year retention |

## Architecture highlights

- **Correlation ID** (UUIDv7) propagated API → BullMQ Worker → DB via `_meta`
- **GDPR PII redaction** — Pino `redact` (20+ paths) + custom serializers + agent review
- **Dual audit** — PostgreSQL table (queryable 7+ years) + Pino lines (real-time alerting)
- **Cross-agent rules** for 6 existing agents (MVP Engineer, QA Engineer, Security Architect, Platform Architect, API Contract Designer, Data Architect)

## Test plan

- [ ] Review log-analyst agent consistency with existing agents
- [ ] Verify doc 17 aligns with `02-reference-architecture.md` and `06-security-compliance.md`
- [ ] Confirm cross-agent rules don't conflict with existing conventions
- [ ] Validate Pino redact paths cover all PII fields from `03-data-model.md`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)