### PR TITLE
feat(agents): add feature-flag-engineer agent + feature flag strategy

### DIFF
--- a/.claude/agents/feature-flag-engineer.md
+++ b/.claude/agents/feature-flag-engineer.md
@@ -1,0 +1,324 @@
+# Feature Flag Engineer — Givernance NPO Platform
+
+You are the feature flag specialist for Givernance. You own the full feature flag lifecycle: schema design, API, backend enforcement, frontend integration, tenant targeting, plan-gating, GDPR implications, and gradual rollout strategy. You ensure every new feature ships behind a flag so it can be tested on a test tenant before general availability.
+
+## Your role
+
+- Define and maintain the canonical flag registry (names, defaults, scopes, plan gates)
+- Design the flag storage, cache, and evaluation layers (PostgreSQL + Redis + in-process)
+- Specify backend enforcement patterns (Fastify middleware, service-layer guards)
+- Specify frontend enforcement patterns (Next.js context, React hooks, SSR-safe evaluation)
+- Design per-tenant and per-plan flag overrides
+- Audit new features to ensure a flag exists and is correctly scoped
+- Review PRs for missing flag gates, hardcoded feature toggles, or premature flag removal
+- Produce the feature flag analysis doc for new spikes
+
+## Technical context
+
+| Layer | Technology | Flag integration |
+|---|---|---|
+| API | Fastify 5, Node.js 22 LTS | Middleware guard + service-layer check |
+| Frontend | Next.js 15 (React, TypeScript) | React context + SSR-safe hook |
+| Flag storage | **PostgreSQL 16** (`feature_flags` + `tenant_flag_overrides` tables) | Source of truth |
+| Flag cache | **Redis 7** (Scaleway Managed Redis EU) | TTL 60s, loaded on startup, refreshed on change |
+| ORM | Drizzle ORM (`@givernance/shared`) | All table definitions live here |
+| Auth | Keycloak 24 — JWT with `tenantId`, `plan`, `roles` claims | Used in flag evaluation context |
+| Monorepo | pnpm workspaces — `shared`, `api`, `worker`, `web` | Flag client shared package |
+
+## Flag taxonomy
+
+### Scopes
+
+| Scope | Description | Who controls |
+|---|---|---|
+| `global` | Platform-wide on/off (infrastructure, experimental) | `super_admin` only |
+| `tenant` | Per-organisation override | `super_admin` (force) or `org_admin` (within plan allowance) |
+| `plan` | Automatically on/off based on subscription tier | Entitlement system (not a manual flag) |
+| `user` | Per-user within a tenant (A/B, beta opt-in) | `org_admin` or user self-service |
+
+### Naming convention
+
+```
+ff.<domain>.<feature>          # e.g. ff.payments.sepa_direct_debit
+ff.<domain>.<feature>.<sub>    # e.g. ff.ai.segment_builder.v2
+```
+
+Prefix `ff.` is mandatory. Domain matches the module name from `packages/api/src/modules/`.
+
+### Registry (canonical list — update when adding flags)
+
+| Flag | Default | Scope | Plan gate | Description |
+|---|---|---|---|---|
+| `ff.payments.sepa_direct_debit` | `off` | tenant | Starter+ | SEPA DD collection via Mollie |
+| `ff.integrations.xero` | `off` | tenant | Pro+ | Xero GL push |
+| `ff.comms.sms_notifications` | `off` | tenant | Starter+ | SMS via Twilio |
+| `ff.portals.volunteer` | `off` | tenant | Starter+ | Volunteer self-service login |
+| `ff.portals.beneficiary` | `off` | tenant | Pro+ | Beneficiary self-service login |
+| `ff.impact.toc_builder` | `off` | tenant | Pro+ | Theory of Change visual builder |
+| `ff.impact.sroi_calculator` | `off` | tenant | Pro+ | SROI calculation helper |
+| `ff.ai.segment_builder` | `off` | tenant | Pro+ | AI-assisted constituent segmentation |
+
+## Data model
+
+### `feature_flags` table (platform registry)
+
+```typescript
+export const featureFlags = pgTable('feature_flags', {
+  id: uuid('id').primaryKey().$defaultFn(() => uuidv7()),
+  key: text('key').notNull().unique(),          // 'ff.payments.sepa_direct_debit'
+  defaultValue: boolean('default_value').notNull().default(false),
+  scope: text('scope').notNull(),               // 'global' | 'tenant' | 'user'
+  planGate: text('plan_gate'),                  // 'starter' | 'pro' | 'enterprise' | null (all plans)
+  description: text('description').notNull(),
+  deprecated: boolean('deprecated').notNull().default(false),
+  deprecatedAt: timestamp('deprecated_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});
+```
+
+### `tenant_flag_overrides` table (per-org overrides)
+
+```typescript
+export const tenantFlagOverrides = pgTable('tenant_flag_overrides', {
+  id: uuid('id').primaryKey().$defaultFn(() => uuidv7()),
+  tenantId: uuid('tenant_id').notNull().references(() => tenants.id),
+  flagKey: text('flag_key').notNull().references(() => featureFlags.key),
+  value: boolean('value').notNull(),
+  setBy: uuid('set_by').references(() => users.id),    // null = system/plan
+  reason: text('reason'),                               // free-text, why this override exists
+  expiresAt: timestamp('expires_at', { withTimezone: true }),  // null = permanent
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => ({
+  uniquePerTenant: uniqueIndex('uq_tenant_flag').on(t.tenantId, t.flagKey),
+}));
+```
+
+### Redis cache structure
+
+```
+ff:tenant:{tenantId}            → JSON hash of all evaluated flags for that tenant
+ff:global                       → JSON hash of global defaults
+ff:ttl                          → 60 seconds (refresh interval)
+```
+
+## Evaluation algorithm
+
+Flag resolution follows this precedence (highest wins):
+
+```
+1. Tenant override (tenant_flag_overrides)     ← explicit per-org setting
+2. Plan entitlement (tenant.plan vs planGate)  ← automatic, not a manual flag
+3. Global default (feature_flags.defaultValue) ← platform default
+```
+
+Implementation:
+
+```typescript
+// packages/shared/src/flags/evaluate.ts
+export function evaluateFlag(
+  key: string,
+  context: { tenantId: string; plan: TenantPlan; overrides: Record<string, boolean> },
+  registry: Record<string, FlagDefinition>
+): boolean {
+  const flag = registry[key];
+  if (!flag || flag.deprecated) return false;
+
+  // 1. Tenant override (explicit)
+  if (key in context.overrides) return context.overrides[key];
+
+  // 2. Plan gate
+  if (flag.planGate && !planIncludes(context.plan, flag.planGate)) return false;
+
+  // 3. Global default
+  return flag.defaultValue;
+}
+```
+
+## Backend enforcement patterns
+
+### Fastify middleware (route-level guard)
+
+```typescript
+// packages/api/src/lib/flags/flag-guard.ts
+export function requireFlag(flagKey: string): preHandlerHookHandler {
+  return async (req, reply) => {
+    const enabled = await getFlagForTenant(flagKey, req.tenant.id);
+    if (!enabled) {
+      return reply.status(404).send({ error: 'Feature not available' });
+      // 404 > 403: avoids confirming feature existence to unauthorised tenants
+    }
+  };
+}
+
+// Usage in routes.ts:
+fastify.get('/payments/sepa', {
+  preHandler: [requireFlag('ff.payments.sepa_direct_debit')],
+}, handler);
+```
+
+### Service-layer guard (business logic)
+
+For complex flows where a flag may need to be checked mid-operation:
+
+```typescript
+const enabled = await flagService.isEnabled('ff.ai.segment_builder', tenantId);
+if (!enabled) throw new FeatureNotAvailableError('ff.ai.segment_builder');
+```
+
+**Rule**: API routes use middleware guard for simple cases. Service layer checks are used when the flag gates a sub-operation within a larger flow.
+
+## Frontend enforcement patterns
+
+### Flag context (Next.js)
+
+```typescript
+// packages/web/src/lib/flags/FlagProvider.tsx
+// Flags are fetched once at page/layout level (SSR-safe), stored in context.
+// Never call the flags API from a client component directly — always use the hook.
+
+const { isEnabled } = useFlags();
+const showSepa = isEnabled('ff.payments.sepa_direct_debit');
+```
+
+### SSR guard (layout/page)
+
+```typescript
+// In a Next.js server component:
+const flags = await getFlagsForTenant(tenantId);
+if (!flags['ff.portals.volunteer']) notFound();
+```
+
+**Rule**: Flags that gate entire pages are enforced at the server component level (`notFound()`). Flags that toggle UI elements within a page use the `useFlags()` hook.
+
+## Flag lifecycle
+
+```
+1. PROPOSED    → spike branch, doc + agent definition, no code
+2. ACTIVE      → off by default, feature behind the gate in production
+3. TEST_TENANT → enabled for one or more test tenants to validate
+4. GA_ROLLOUT  → enabled progressively (10% → 50% → 100%)
+5. DEPRECATED  → flag.deprecated = true, all tenants already on (or feature removed)
+6. REMOVED     → flag deleted from registry + all code gates removed
+```
+
+**Naming in code**: Use the flag key string directly (`'ff.payments.sepa_direct_debit'`), never a magic constant. The registry is the single source of truth.
+
+## GDPR considerations
+
+| Concern | Mitigation |
+|---|---|
+| Flag overrides store `setBy` (user UUID) | Included in tenant data export (GDPR Art. 15), cleared on erasure of that user |
+| Flag evaluation logs | Log `flagKey` + `tenantId` + result only — never user PII |
+| `reason` field | Free-text; do not write PII into reason (e.g. "testing for org X's user Y") |
+| `expiresAt` on overrides | Use for time-limited test access; prevents forgotten "temporary" overrides becoming permanent |
+| Flag audit trail | Every `tenant_flag_overrides` change must be recorded in `audit_logs` with action `feature_flag.override_set` / `feature_flag.override_removed` |
+
+## How you work
+
+### Analysing a new feature spike
+
+1. **Identify flag candidates** — read the feature spec, list every behaviour that should be gated
+2. **Define flag keys** — naming convention, scope, plan gate
+3. **Design data model** — are new columns needed on `feature_flags` or `tenant_flag_overrides`?
+4. **Backend enforcement points** — list every API route and worker job that must check the flag
+5. **Frontend enforcement points** — list every page, layout, and UI component that must check
+6. **Flag lifecycle** — proposed state, who enables for test tenants, GA criteria
+7. **GDPR impact** — any PII in flag metadata? audit trail required?
+8. **Cross-agent rules** — how does this flag interact with other agents (MVP Engineer, Security Architect, QA Engineer)?
+9. **Produce analysis doc** — structured markdown in `docs/`
+
+### Reviewing a PR
+
+1. **Check flag gate exists** — new feature route must have a `requireFlag()` preHandler
+2. **Check frontend gate exists** — new page/component must use `useFlags()` or SSR guard
+3. **Check registry updated** — new flag must be in the canonical registry table in this doc
+4. **Check audit event** — flag changes must emit `feature_flag.override_set` to `audit_logs`
+5. **Check no hardcoded booleans** — `if (true)` / `if (false)` as flag substitutes are forbidden
+6. **Check deprecation path** — any flag removal PR must also remove all code gates
+
+## Output format
+
+### Feature flag analysis report
+
+```markdown
+## Feature Flag Analysis — [Feature Name]
+
+### Summary
+[1–2 sentences: what the feature is and why it needs a flag]
+
+### Flag definitions
+
+| Flag key | Default | Scope | Plan gate | Enforcement layers |
+|----------|---------|-------|-----------|-------------------|
+| `ff.<domain>.<name>` | off | tenant | Pro+ | API route, frontend page |
+
+### Backend enforcement points
+
+| Route / Worker | Method | Flag | Guard type |
+|---|---|---|---|
+| `GET /api/payments/sepa` | route | `ff.payments.sepa_direct_debit` | middleware |
+
+### Frontend enforcement points
+
+| Page / Component | Guard type | Behaviour when off |
+|---|---|---|
+| `/settings/payments/sepa` | SSR `notFound()` | 404 page |
+| `<SepaPaymentButton />` | `useFlags()` hook | hidden |
+
+### Data model changes
+[New columns or tables, if any]
+
+### Lifecycle plan
+- **Test tenant**: [who and when]
+- **GA criteria**: [what must be true before enabling by default]
+
+### GDPR notes
+[Any PII-adjacent concerns]
+
+### Cross-agent rules
+[Rules for MVP Engineer, Security Architect, QA Engineer]
+
+### Open questions
+- [ ] Question 1
+```
+
+## Anti-patterns to avoid
+
+| Anti-pattern | Correct approach |
+|---|---|
+| `if (process.env.ENABLE_SEPA === 'true')` | Use flag registry + Redis evaluation |
+| `if (tenant.plan === 'pro')` in route handler | Plan gate is a property of the flag, evaluated in `evaluateFlag()` |
+| Flag key as magic string duplicated across files | Single source of truth in `packages/shared/src/flags/registry.ts` |
+| Removing a flag by just deleting the code gate | Mark `deprecated: true` first, wait one release cycle, then remove code + DB row |
+| Evaluating flags in every request directly from PostgreSQL | Always use Redis cache; DB is only queried on cache miss or startup |
+| Frontend fetching flags from API on every render | Fetch once per page load in server component, propagate via context |
+| Flags that gate entire product domains forever | Flags are temporary by nature — plan for removal at GA |
+| Hardcoding test tenant IDs in flag evaluation logic | Use `tenant_flag_overrides` with a `reason` and `expiresAt` |
+| Logging flag evaluation results with user PII | Log `flagKey`, `tenantId`, result only — never email, name, userId |
+
+## Cross-agent rules
+
+These rules apply to all agents working on feature-flagged code:
+
+### MVP Engineer
+- Every new Fastify route for a non-MVP feature MUST include `requireFlag()` in `preHandler`
+- Every BullMQ processor that implements a gated feature MUST check the flag at job start
+- Drizzle schema changes for gated features SHOULD still run in migrations (flag gates logic, not schema)
+- Flag keys MUST be imported from `@givernance/shared/flags/registry` — no inline strings
+
+### QA Engineer
+- Integration tests MUST test the "flag off" path (route returns 404 when flag disabled)
+- Integration tests MUST test the "flag on" path (feature works when flag enabled for tenant)
+- RLS isolation tests MUST verify flag overrides for tenant A don't affect tenant B
+- Test fixture helper: `enableFlag(tenantId, flagKey)` / `disableFlag(tenantId, flagKey)`
+
+### Security Architect
+- Flag override endpoints (super_admin only) MUST be behind `RBAC.SUPER_ADMIN` + audit logged
+- Tenant flag override endpoints MUST verify the flag's `scope` allows tenant-level control
+- A `plan` gate MUST NOT be bypassable by a tenant override for flags marked `planGate: 'strict'`
+
+### Data Architect
+- `feature_flags` and `tenant_flag_overrides` are platform tables (not tenant-scoped, no RLS row-level isolation needed beyond RBAC)
+- `tenant_flag_overrides` rows MUST be included in tenant data export (GDPR Art. 15)
+- On tenant deletion: cascade-delete `tenant_flag_overrides` rows for that tenant

--- a/.claude/agents/feature-flag-engineer.md
+++ b/.claude/agents/feature-flag-engineer.md
@@ -73,7 +73,7 @@ export const featureFlags = pgTable('feature_flags', {
   deprecated: boolean('deprecated').notNull().default(false),
   deprecatedAt: timestamp('deprecated_at', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull().$onUpdateFn(() => new Date()),
 });
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── 15-infra-adr.md           — Architecture Decision Records (ADR-001, ADR-002, ADR-003)
 │   ├── 16-greg-field-insights.md — Field insights: fundraising channels, migration, pricing (Greg)
 │   ├── 17-log-management.md      — Log management strategy, structured logging, audit trail, GDPR
+│   ├── 18-feature-flags.md        — Feature flag strategy: schema, evaluation, backend/frontend enforcement, lifecycle
 │   ├── vision/
 │   │   └── conversational-mode.md — Future conversational AI mode (2026-2028)
 │   └── design/                    — 86 interactive HTML mockups
@@ -79,6 +80,7 @@ Use these agents for domain-specific tasks via Claude Code:
 | API Contract Designer | `.claude/agents/api-contract-designer.md` | REST API contracts, TypeBox schemas, OpenAPI 3.1, RFC 7807 errors |
 | QA Engineer | `.claude/agents/qa-engineer.md` | Integration tests, RLS isolation, GDPR compliance, Stripe webhooks |
 | Log Analyst | `.claude/agents/log-analyst.md` | Structured logging, distributed tracing, audit trail, GDPR log compliance, performance diagnostics |
+| Feature Flag Engineer | `.claude/agents/feature-flag-engineer.md` | Feature flags: schema, evaluation, backend/frontend enforcement, lifecycle, plan-gating |
 
 ## Implementation Status
 
@@ -95,4 +97,4 @@ HTML mockups are in `docs/design/`. Open `docs/design/index.html` locally or vie
 - Project name: **Givernance** (not "Libero", not "givernance-npo-platform")
 - Terminology: **NPO** (nonprofit organization), not "NGO"
 - GDPR in English docs, RGPD in French docs
-- All docs are in `docs/`, numbered 01-17 for architecture specs
+- All docs are in `docs/`, numbered 01-18 for architecture specs

--- a/docs/18-feature-flags.md
+++ b/docs/18-feature-flags.md
@@ -77,6 +77,9 @@ Every API request evaluates flags. PostgreSQL round-trips on every request are n
 - Populated on API startup + refreshed on every `tenant_flag_overrides` write
 - Invalidated immediately on override change (via BullMQ job or direct `DEL`)
 
+**SaaS deployment**: Scaleway Managed Redis EU (single GDPR DPA, no cluster to operate).
+**Self-hosted NPO deployment**: Redis 7 / Valkey via Docker Compose.
+
 ### 3.3 Evaluation: `@givernance/shared/flags`
 
 A pure TypeScript module in the `shared` package resolves flags with no external I/O:

--- a/docs/18-feature-flags.md
+++ b/docs/18-feature-flags.md
@@ -1,0 +1,388 @@
+# 18 — Feature Flag Strategy
+
+> **Status**: Spike / Analysis — Phase 1 implementation target
+> **Owner**: Feature Flag Engineer agent (`.claude/agents/feature-flag-engineer.md`)
+> **Related**: `02-reference-architecture.md`, `03-data-model.md`, `04-business-capabilities.md`, `06-security-compliance.md`, `07-delivery-roadmap.md`
+
+## 1. Goals
+
+The feature flag strategy must enable:
+
+- **Safe test-tenant validation** — any new feature can be activated for a single org before general availability, with zero code changes
+- **Plan-based entitlement** — features automatically on/off based on subscription tier, without custom billing logic in route handlers
+- **Emergency kill-switch** — disable a broken feature instantly across all tenants without a deploy
+- **Gradual rollout** — go from 0% to 100% by enabling overrides incrementally
+- **Clean removal** — flags have a defined lifecycle; they are never permanent unless they represent permanent plan gates
+
+## 2. Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         Givernance API (Fastify 5)                       │
+│                                                                           │
+│  inbound request                                                          │
+│       │                                                                   │
+│       ▼                                                                   │
+│  ┌─────────────────────────┐                                             │
+│  │  requireFlag() preHandler│  ← flag off → 404 (silent denial)          │
+│  └─────────────┬───────────┘                                             │
+│                │ flag on                                                  │
+│                ▼                                                          │
+│         route handler / service                                          │
+└────────────────┬────────────────────────────────────────────────────────┘
+                 │
+      ┌──────────▼────────────┐
+      │  FlagService.isEnabled │
+      │  (packages/shared)     │
+      └──────────┬────────────┘
+                 │
+     ┌───────────┴────────────────┐
+     │                            │
+┌────▼────┐               ┌───────▼──────┐
+│  Redis  │  cache miss   │  PostgreSQL  │
+│  Cache  │ ──────────────│  (source of  │
+│  TTL 60s│               │   truth)     │
+└─────────┘               └──────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                       Next.js 15 (SSR + React)                           │
+│                                                                           │
+│  server component (layout/page)                                          │
+│       │  getFlagsForTenant(tenantId) → flags map                         │
+│       │                                                                   │
+│       ├─ page gated → notFound() if flag off                             │
+│       │                                                                   │
+│       └─ <FlagProvider flags={flags}>                                    │
+│               │                                                           │
+│               └─ client component → const { isEnabled } = useFlags()     │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## 3. Technology Choices
+
+### 3.1 Flag Storage: PostgreSQL (source of truth)
+
+The `feature_flags` table holds the platform registry. `tenant_flag_overrides` holds per-org exceptions. PostgreSQL is the authoritative store because:
+
+- GDPR Art. 15 compliance: flag overrides per tenant must be included in data exports
+- Audit trail: every override change is an `audit_logs` entry
+- Admin UI: super_admin needs a queryable, structured store (not a config file)
+
+### 3.2 Flag Cache: Redis (evaluation layer)
+
+Every API request evaluates flags. PostgreSQL round-trips on every request are not acceptable. Redis provides:
+
+- Sub-millisecond reads from a hash keyed per `tenantId`
+- 60-second TTL (acceptable staleness for feature flags)
+- Populated on API startup + refreshed on every `tenant_flag_overrides` write
+- Invalidated immediately on override change (via BullMQ job or direct `DEL`)
+
+### 3.3 Evaluation: `@givernance/shared/flags`
+
+A pure TypeScript module in the `shared` package resolves flags with no external I/O:
+
+```
+Input:  flagKey + { tenantId, plan, overrides: Record<string, boolean> }
+Output: boolean
+```
+
+This keeps flag evaluation testable without Redis/PostgreSQL in unit tests.
+
+### 3.4 Frontend: React context + SSR
+
+Next.js 15 server components fetch the flag map once per request from the API. The map is passed via `<FlagProvider>` context to client components. This ensures:
+
+- No client-side API calls for flags (no waterfall, no flash of wrong content)
+- SSR-safe: server components can call `notFound()` before sending HTML
+- Type-safe: flag keys are typed from the shared registry
+
+## 4. Data Model
+
+### 4.1 `feature_flags` table
+
+Source of truth for all flag definitions.
+
+```sql
+CREATE TABLE feature_flags (
+  id            UUID PRIMARY KEY,
+  key           TEXT NOT NULL UNIQUE,        -- 'ff.payments.sepa_direct_debit'
+  default_value BOOLEAN NOT NULL DEFAULT false,
+  scope         TEXT NOT NULL,               -- 'global' | 'tenant' | 'user'
+  plan_gate     TEXT,                        -- 'starter' | 'pro' | 'enterprise' | NULL
+  description   TEXT NOT NULL,
+  deprecated    BOOLEAN NOT NULL DEFAULT false,
+  deprecated_at TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+### 4.2 `tenant_flag_overrides` table
+
+Per-organisation overrides. Highest precedence in evaluation.
+
+```sql
+CREATE TABLE tenant_flag_overrides (
+  id         UUID PRIMARY KEY,
+  tenant_id  UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  flag_key   TEXT NOT NULL REFERENCES feature_flags(key),
+  value      BOOLEAN NOT NULL,
+  set_by     UUID REFERENCES users(id) ON DELETE SET NULL,
+  reason     TEXT,                           -- free-text, why this override exists
+  expires_at TIMESTAMPTZ,                    -- NULL = permanent
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, flag_key)
+);
+```
+
+### 4.3 Audit integration
+
+Every `tenant_flag_overrides` INSERT/UPDATE/DELETE MUST emit an `audit_logs` entry:
+
+| Action | `action` field | `resource_type` |
+|--------|----------------|-----------------|
+| Override created | `feature_flag.override_set` | `feature_flag` |
+| Override updated | `feature_flag.override_updated` | `feature_flag` |
+| Override deleted | `feature_flag.override_removed` | `feature_flag` |
+| Flag deprecated | `feature_flag.deprecated` | `feature_flag` |
+
+## 5. Evaluation Algorithm
+
+Flag resolution precedence (highest wins):
+
+```
+1. tenant_flag_overrides         → explicit per-org value
+2. plan entitlement              → flag.plan_gate vs tenant.plan
+3. feature_flags.default_value   → platform default
+```
+
+If the flag does not exist in the registry → `false` (unknown flags are off by default).
+If the flag is `deprecated` → `false` (deprecated flags are always off).
+
+## 6. Backend Enforcement
+
+### 6.1 Fastify middleware guard (route-level)
+
+```typescript
+// packages/api/src/lib/flags/flag-guard.ts
+export function requireFlag(flagKey: string): preHandlerHookHandler {
+  return async (req, reply) => {
+    const enabled = await req.flagService.isEnabled(flagKey, req.tenant.id);
+    if (!enabled) {
+      // 404 not 403: silent denial, does not confirm feature existence
+      return reply.status(404).send({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Route not found',
+      });
+    }
+  };
+}
+```
+
+**Usage in `routes.ts`:**
+
+```typescript
+fastify.post('/payments/sepa/mandates', {
+  preHandler: [authenticate, requireFlag('ff.payments.sepa_direct_debit')],
+  schema: CreateSepaMandateSchema,
+}, createSepaMandateHandler);
+```
+
+### 6.2 Service-layer guard (sub-operation)
+
+For flags that gate a step within a larger operation (not the whole route):
+
+```typescript
+if (!await flagService.isEnabled('ff.ai.segment_builder', tenantId)) {
+  throw new FeatureNotAvailableError('ff.ai.segment_builder');
+}
+```
+
+### 6.3 BullMQ processor guard
+
+Worker jobs must also check the flag at the start of processing, because the flag may have been disabled between job enqueue and processing:
+
+```typescript
+// packages/worker/src/processors/sepa-mandate.processor.ts
+async function processSepaMandateJob(job: Job) {
+  const enabled = await flagService.isEnabled('ff.payments.sepa_direct_debit', job.data.tenantId);
+  if (!enabled) {
+    await job.discard(); // Drop silently — flag was disabled after enqueue
+    return;
+  }
+  // ... rest of processor
+}
+```
+
+## 7. Frontend Enforcement
+
+### 7.1 Server-side: page/layout gate
+
+Pages dedicated to a gated feature are enforced at the server component level:
+
+```typescript
+// app/(tenant)/settings/payments/sepa/page.tsx
+export default async function SepaSettingsPage() {
+  const flags = await getFlagsForTenant(tenantId);
+  if (!flags['ff.payments.sepa_direct_debit']) notFound();
+  return <SepaSettingsContent />;
+}
+```
+
+### 7.2 Client-side: UI element toggle
+
+UI elements within mixed pages use the `useFlags()` hook:
+
+```tsx
+const { isEnabled } = useFlags();
+
+return (
+  <PaymentMethodList>
+    {isEnabled('ff.payments.sepa_direct_debit') && <SepaPaymentOption />}
+    <StripeCardOption />   {/* always visible */}
+  </PaymentMethodList>
+);
+```
+
+### 7.3 Navigation menu
+
+Menu items for gated features must be hidden when the flag is off. Enforce in the server component that builds the sidebar nav config, not client-side:
+
+```typescript
+// Server component — builds nav items
+const navItems = buildNavItems({ flags });
+// SepaSettings item omitted from navItems when flag is off
+```
+
+## 8. Flag Lifecycle
+
+```
+PROPOSED → ACTIVE (off) → TEST_TENANT → GA_ROLLOUT → GA (on by default) → DEPRECATED → REMOVED
+```
+
+| Stage | DB state | Code state | Who can change |
+|---|---|---|---|
+| `PROPOSED` | Not in DB yet | Not in code yet | — |
+| `ACTIVE` | `default_value = false` | Gate in place | `super_admin` activates for test tenants via override |
+| `TEST_TENANT` | Override row for test tenant(s), `default = false` | Gate in place | `super_admin` |
+| `GA_ROLLOUT` | Overrides for consenting orgs, `default = false` | Gate in place | `super_admin` |
+| `GA` | `default_value = true` | Gate in place | `super_admin` |
+| `DEPRECATED` | `deprecated = true`, `deprecated_at` set | Gate still in place (returns false) | `super_admin` |
+| `REMOVED` | Row deleted | Code gates and flag key removed | Developer (PR) |
+
+**GA criteria** (minimum before setting `default_value = true`):
+- ✅ Tested on at least 1 production test tenant for ≥ 2 weeks without critical bug
+- ✅ QA test suite includes both "flag on" and "flag off" paths
+- ✅ No open HIGH issues in the feature's spike doc
+- ✅ Security Architect sign-off if the feature handles PII or payments
+
+## 9. Flag Administration API
+
+### Super-admin endpoints
+
+```
+GET    /admin/feature-flags               → list all flags with defaults
+GET    /admin/feature-flags/:key          → single flag detail
+PATCH  /admin/feature-flags/:key          → update default_value, plan_gate, deprecated
+
+GET    /admin/tenants/:id/feature-flags   → list all overrides for a tenant
+PUT    /admin/tenants/:id/feature-flags/:key   → create/update override
+DELETE /admin/tenants/:id/feature-flags/:key   → remove override (revert to default)
+```
+
+All endpoints: `RBAC.SUPER_ADMIN` required + audit logged.
+
+### Tenant self-service (within plan allowance)
+
+```
+GET    /org/feature-flags                 → list flags this org can toggle
+PATCH  /org/feature-flags/:key            → toggle flag (only scope=tenant flags within plan)
+```
+
+`RBAC.ORG_ADMIN` required + audit logged.
+
+## 10. GDPR Considerations
+
+| Concern | Mitigation |
+|---|---|
+| `set_by` (user UUID in `tenant_flag_overrides`) | Included in tenant data export (GDPR Art. 15); cleared (`SET NULL`) on user erasure |
+| `reason` field | Free-text field — document rule: **do not write constituent names, emails, or other PII into `reason`** |
+| `expires_at` | Always set for temporary test access; prevents forgotten "test" overrides becoming permanent |
+| Flag evaluation logs | Log `flagKey` + `tenantId` + boolean result only — never userId, email, or other PII |
+| Audit trail | Every override change → `audit_logs` entry (see §4.3) |
+| Tenant deletion | `tenant_flag_overrides` rows cascade-delete on tenant deletion |
+| Data portability | `tenant_flag_overrides` included in GDPR Art. 15 data export for that tenant |
+
+## 11. Cross-Agent Rules
+
+### For MVP Engineer
+
+- Every new Fastify route for a non-MVP feature **MUST** include `requireFlag()` in `preHandler`
+- Every BullMQ processor implementing a gated feature **MUST** check the flag at job start (see §6.3)
+- Flag keys **MUST** be imported from `@givernance/shared/flags/registry` — no inline strings in route files
+- Drizzle schema changes for gated features **SHOULD** still run in migrations (flag gates logic, not schema)
+- The `packages/shared/src/flags/registry.ts` file is the single source of truth; update it in the same PR as the flag gate
+
+### For QA Engineer
+
+- Integration tests **MUST** cover the "flag off" path: route returns 404 when `requireFlag()` blocks
+- Integration tests **MUST** cover the "flag on" path: feature works correctly for a flag-enabled tenant
+- RLS isolation: flag override for tenant A **MUST NOT** affect tenant B (test this explicitly)
+- Add test fixture helpers: `enableFlag(tenantId, flagKey)` / `disableFlag(tenantId, flagKey)` in `packages/api/test/helpers/`
+- Frontend: add Playwright test that verifies the flagged page returns 404 when flag is off
+
+### For Security Architect
+
+- Override endpoints (super_admin) **MUST** be behind `RBAC.SUPER_ADMIN` + audit logged
+- Tenant override endpoints **MUST** verify the flag's `scope` allows tenant-level control (reject requests to override `global` flags)
+- Plan gate **MUST NOT** be bypassable by a tenant override for flags with `planGate: 'strict'` (future enhancement; track as open question)
+- Redis cache keys **MUST NOT** include user identifiers — only `tenantId`
+
+### For Data Architect
+
+- `feature_flags` and `tenant_flag_overrides` are platform tables — no tenant-scoped RLS needed (no `tenant_id` partitioning on `feature_flags` itself)
+- `tenant_flag_overrides` rows **MUST** be included in tenant data export (GDPR Art. 15)
+- On tenant deletion: cascade-delete `tenant_flag_overrides` rows automatically (FK + `ON DELETE CASCADE`)
+- Add both tables to the Drizzle schema in `packages/shared/src/schema/`
+
+### For Log Analyst
+
+- Flag evaluation **MUST NOT** log PII — only `flagKey`, `tenantId`, and the boolean result
+- Override changes **MUST** be logged at `info` level with `audit: true` in the structured log + written to `audit_logs`
+- Redis cache miss events are `debug` level only (high volume, not business-relevant)
+- Add `ff.override_set`, `ff.override_removed` to the audit events catalog in `docs/17-log-management.md`
+
+## 12. Open Questions
+
+- [ ] **Strict plan gate** — should super_admin be able to override a `planGate` for a tenant on a free tier? (e.g. demo access). Proposal: add a `strict` boolean on `feature_flags`. If `strict = true`, plan gate cannot be overridden even by super_admin.
+- [ ] **User-scoped flags** — scope `user` is defined but not implemented in Phase 1. Is there a Phase 1 use case (beta opt-in UI)? If not, defer to Phase 2.
+- [ ] **Flag analytics** — should we track flag evaluation counts per tenant to understand adoption before GA? Proposal: increment a Redis counter per flag per tenant per day, flush to PG nightly.
+- [ ] **Frontend type safety** — flag keys are strings today. Should we generate a TypeScript enum from the registry at build time to catch typos at compile time?
+- [ ] **Webhook/outbound event gate** — if a webhook integration is behind a flag (e.g. Xero), should the flag also suppress domain events that would trigger that webhook, or let the webhook processor handle it?
+- [ ] **Migration tool** — does `givernance-migrate` need to respect feature flags? (e.g. skip migrating SEPA mandates if the flag is off for the target tenant)
+
+## 13. Implementation Phases
+
+### Phase 1 (Skeleton sprint — no feature-specific flags yet)
+
+- [ ] `feature_flags` + `tenant_flag_overrides` Drizzle schema in `packages/shared`
+- [ ] `packages/shared/src/flags/registry.ts` — typed registry module
+- [ ] `packages/shared/src/flags/evaluate.ts` — pure evaluation function (no I/O)
+- [ ] `FlagService` in `packages/api/src/lib/flags/` — Redis cache + PG fallback
+- [ ] `requireFlag()` Fastify preHandler in `packages/api/src/lib/flags/`
+- [ ] Super-admin CRUD API for `feature_flags` and `tenant_flag_overrides`
+- [ ] Redis warm-up on API startup (load all flags from PG into Redis)
+- [ ] Redis invalidation on override change (BullMQ job or direct `DEL`)
+- [ ] Audit log integration for all override mutations
+- [ ] `FlagProvider` + `useFlags()` in `packages/web/src/lib/flags/`
+- [ ] Test fixture helpers in `packages/api/test/helpers/flags.ts`
+- [ ] Integration tests: flag off → 404, flag on → 200, tenant isolation
+
+### Phase 1+ (First gated feature — SEPA Direct Debit)
+
+- [ ] Register `ff.payments.sepa_direct_debit` in the registry
+- [ ] Add `requireFlag('ff.payments.sepa_direct_debit')` to all SEPA routes
+- [ ] Add SSR gate to `/settings/payments/sepa` Next.js page
+- [ ] Add `isEnabled` check to SEPA BullMQ processor
+- [ ] Enable on test tenant; validate end-to-end

--- a/docs/18-feature-flags.md
+++ b/docs/18-feature-flags.md
@@ -107,16 +107,16 @@ Source of truth for all flag definitions.
 
 ```sql
 CREATE TABLE feature_flags (
-  id            UUID PRIMARY KEY,
+  id            UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
   key           TEXT NOT NULL UNIQUE,        -- 'ff.payments.sepa_direct_debit'
   default_value BOOLEAN NOT NULL DEFAULT false,
   scope         TEXT NOT NULL,               -- 'global' | 'tenant' | 'user'
-  plan_gate     TEXT,                        -- 'starter' | 'pro' | 'enterprise' | NULL
+  plan_gate     TEXT,                        -- matches tenants.plan_id values (e.g. 'starter', 'pro', 'enterprise') — align with doc-08 when tiers are finalised
   description   TEXT NOT NULL,
   deprecated    BOOLEAN NOT NULL DEFAULT false,
   deprecated_at TIMESTAMPTZ,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
-  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()  -- must be kept current via Drizzle $onUpdateFn(() => new Date()) or a DB trigger
 );
 ```
 
@@ -126,7 +126,7 @@ Per-organisation overrides. Highest precedence in evaluation.
 
 ```sql
 CREATE TABLE tenant_flag_overrides (
-  id         UUID PRIMARY KEY,
+  id         UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
   tenant_id  UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
   flag_key   TEXT NOT NULL REFERENCES feature_flags(key),
   value      BOOLEAN NOT NULL,
@@ -140,7 +140,7 @@ CREATE TABLE tenant_flag_overrides (
 
 ### 4.3 Audit integration
 
-Every `tenant_flag_overrides` INSERT/UPDATE/DELETE MUST emit an `audit_logs` entry:
+Every `tenant_flag_overrides` INSERT/UPDATE/DELETE MUST emit an `audit_log` entry (note: doc-03 uses `audit_log` singular — align table name during Phase 1 schema reconciliation):
 
 | Action | `action` field | `resource_type` |
 |--------|----------------|-----------------|
@@ -211,7 +211,8 @@ Worker jobs must also check the flag at the start of processing, because the fla
 async function processSepaMandateJob(job: Job) {
   const enabled = await flagService.isEnabled('ff.payments.sepa_direct_debit', job.data.tenantId);
   if (!enabled) {
-    await job.discard(); // Drop silently — flag was disabled after enqueue
+    await job.moveToCompleted('flag-disabled', true); // Drop silently — flag was disabled after enqueue
+    // Note: job.discard() was removed in BullMQ 5; use moveToCompleted or simply return
     return;
   }
   // ... rest of processor
@@ -290,7 +291,7 @@ GET    /admin/feature-flags/:key          → single flag detail
 PATCH  /admin/feature-flags/:key          → update default_value, plan_gate, deprecated
 
 GET    /admin/tenants/:id/feature-flags   → list all overrides for a tenant
-PUT    /admin/tenants/:id/feature-flags/:key   → create/update override
+PUT    /admin/tenants/:id/feature-flags/:key   → upsert override (PUT semantics: full replacement; use PATCH if partial update needed)
 DELETE /admin/tenants/:id/feature-flags/:key   → remove override (revert to default)
 ```
 
@@ -313,7 +314,7 @@ PATCH  /org/feature-flags/:key            → toggle flag (only scope=tenant fla
 | `reason` field | Free-text field — document rule: **do not write constituent names, emails, or other PII into `reason`** |
 | `expires_at` | Always set for temporary test access; prevents forgotten "test" overrides becoming permanent |
 | Flag evaluation logs | Log `flagKey` + `tenantId` + boolean result only — never userId, email, or other PII |
-| Audit trail | Every override change → `audit_logs` entry (see §4.3) |
+| Audit trail | Every override change → `audit_log` entry (see §4.3) |
 | Tenant deletion | `tenant_flag_overrides` rows cascade-delete on tenant deletion |
 | Data portability | `tenant_flag_overrides` included in GDPR Art. 15 data export for that tenant |
 
@@ -352,7 +353,7 @@ PATCH  /org/feature-flags/:key            → toggle flag (only scope=tenant fla
 ### For Log Analyst
 
 - Flag evaluation **MUST NOT** log PII — only `flagKey`, `tenantId`, and the boolean result
-- Override changes **MUST** be logged at `info` level with `audit: true` in the structured log + written to `audit_logs`
+- Override changes **MUST** be logged at `info` level with `audit: true` in the structured log + written to `audit_log`
 - Redis cache miss events are `debug` level only (high volume, not business-relevant)
 - Add `ff.override_set`, `ff.override_removed` to the audit events catalog in `docs/17-log-management.md`
 


### PR DESCRIPTION
## Summary

- New **Feature Flag Engineer** subagent (`.claude/agents/feature-flag-engineer.md`) — flag taxonomy, evaluation algorithm, backend enforcement (Fastify middleware + service layer + BullMQ), frontend enforcement (Next.js SSR + React context), flag lifecycle, GDPR considerations, cross-agent rules, anti-patterns
- New **doc 18** (`docs/18-feature-flags.md`) — comprehensive feature flag strategy: architecture, PostgreSQL schema, Redis cache, evaluation algorithm, admin API, GDPR, cross-agent rules, open questions, phased plan
- Updated `CLAUDE.md` with new agent and doc references

## Key decisions

| Component | Choice | Why |
|-----------|--------|-----|
| Storage | PostgreSQL `feature_flags` + `tenant_flag_overrides` | GDPR Art. 15 export, audit trail, queryable admin UI |
| Cache | Redis (TTL 60s) | Sub-ms evaluation without PG round-trip per request |
| Evaluation | Pure TS module in `@givernance/shared` | No I/O, fully unit-testable |
| Backend gate | `requireFlag()` Fastify preHandler | Uniform enforcement before handler runs |
| Frontend gate | Next.js server component `notFound()` + `useFlags()` hook | SSR-safe, no client-side waterfall |
| Flag denial | 404 (not 403) | Silent denial — does not confirm feature existence to wrong tenants |

## Architecture highlights

- **Precedence**: tenant override > plan entitlement > global default
- **Test-tenant workflow**: super_admin sets `tenant_flag_overrides` row — no deploy, no code change
- **BullMQ guard**: processors re-check flag at job start (flag may change between enqueue and processing)
- **GDPR**: `set_by` in Art. 15 export; `reason` field must not contain PII; full audit trail via `audit_logs`
- **Cross-agent rules** for MVP Engineer, QA Engineer, Security Architect, Data Architect, Log Analyst

## No production code

Analysis/design only. Implementation tracked in `docs/18-feature-flags.md §13`.

## Test plan

- [ ] Review feature-flag-engineer agent consistency with existing agents
- [ ] Verify doc 18 aligns with `02-reference-architecture.md` and `04-business-capabilities.md`
- [ ] Confirm cross-agent rules do not conflict with existing conventions
- [ ] Validate open questions in §12 are correctly scoped

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)