### PR TITLE
feat(agents): add impersonation-engineer agent + impersonation strategy

### DIFF
--- a/.claude/agents/impersonation-engineer.md
+++ b/.claude/agents/impersonation-engineer.md
@@ -31,13 +31,13 @@ You are the impersonation and delegated-access specialist for Givernance. You ow
 
 Every action performed during an impersonation session MUST record two identities:
 
-| Field | Value | Meaning |
+| Field | JWT source | Meaning |
 |---|---|---|
-| `actor_user_id` | impersonated user's UUID | Who the action appears to come from (for data integrity) |
-| `impersonator_id` | super_admin's UUID | Who actually performed the action (for accountability) |
-| `impersonation_session_id` | UUID of the session | Groups all actions from one impersonation session |
+| `actor_user_id` | `sub` (impersonated user's UUID) | Who the action appears to come from (for data integrity) |
+| `impersonator_id` | `act.sub` (super_admin's UUID, per RFC 8693 §4.1) | Who actually performed the action (for accountability) |
+| `impersonation_session_id` | `imp_session_id` (UUID of the session) | Groups all actions from one impersonation session |
 
-The impersonated user's `actor_user_id` is used for **data integrity** (e.g. "donated by this user"). The `impersonator_id` is used for **accountability** and is never hidden.
+The impersonated user's `actor_user_id` is used for **data integrity** (e.g. "donated by this user"). The `act.sub` (impersonator) is used for **accountability** and is never hidden. The presence of the `act` claim is the canonical RFC 8693 signal that a token is a delegation token.
 
 ### Roles allowed to impersonate
 
@@ -57,7 +57,7 @@ Only `super_admin` can initiate impersonation. `org_admin` cannot impersonate �
 
 ### Option A — Keycloak Token Exchange (RFC 8693) [RECOMMENDED]
 
-Keycloak 24 supports Token Exchange. The super_admin exchanges their own access token for a short-lived access token representing the target user, with an additional `impersonator_sub` claim injected by Keycloak.
+Keycloak 24 supports Token Exchange. The super_admin exchanges their own access token for a short-lived access token representing the target user, with the standard RFC 8693 `act` claim injected via a custom Script Mapper.
 
 ```
 POST /realms/givernance/protocol/openid-connect/token
@@ -67,38 +67,45 @@ POST /realms/givernance/protocol/openid-connect/token
   requested_subject=<target_user_id>
 ```
 
-Result: a new JWT with the target user's claims + a custom `impersonator_sub` claim containing the admin's user ID.
+Result: a new JWT with the target user's claims + the RFC 8693 `act` claim containing the admin's identity (`act: { sub: <admin_uuid> }`).
 
-**Advantages:** Standard OAuth2 flow; Keycloak handles token signing and validation; impersonator claim survives in all downstream token verifications.
+**Advantages:** Standard OAuth2 flow; Keycloak handles token signing and validation; `act` claim is the RFC 8693 standard for delegation — recognized by OPA policies, SIEM parsers, OAuth2 proxies, and any RFC 8693-aware tooling.
 
-**Considerations:** Requires Keycloak `impersonation` client scope and `impersonation` role on the admin's realm role. Must be audited in Keycloak admin events too.
+**Considerations:** Requires Keycloak `impersonation` client scope and `impersonation` role on the admin's realm role. Must be audited in Keycloak admin events too. Keycloak 24 does not produce `act` natively (keycloak/keycloak#12076) — requires a custom Script Mapper (~50 lines JS).
 
 ### Option B — Application-layer impersonation token (fallback)
 
 If Keycloak Token Exchange is not available (e.g. self-hosted Keycloak without the permission configured):
 
 1. Super_admin authenticates normally → has their own JWT
-2. API issues a signed short-lived **impersonation JWT** containing the target user's claims + `impersonator_id` + `impersonation_session_id` + `exp` (max 2h)
+2. API issues a signed short-lived **delegation JWT** containing the target user's claims + `act: { sub: <admin_uuid> }` + `imp_session_id` + `exp` (max 2h)
 3. This token is stored in Redis: `impersonation:{session_id}` with TTL
-4. The API middleware detects `impersonation_session_id` claim and loads the full context
+4. The API middleware detects the `act` claim and loads the full impersonation context
 
 **When to use:** Phase 1 fallback if Keycloak Token Exchange setup is complex. Migrate to Option A in Phase 2.
 
-### JWT claims for impersonation (both options)
+### JWT claims for delegation (both options) — RFC 8693-compliant
+
+> RFC 8693 §4.1 distinguishes **impersonation** (admin identity erased) from **delegation** (both identities preserved via `act` claim). Givernance uses **delegation** semantics — the `act` claim carries the admin's identity for double-attribution audit.
 
 ```json
 {
   "sub": "<impersonated_user_uuid>",
   "org_id": "<impersonated_tenant_uuid>",
   "role": "<impersonated_user_role>",
-  // email omitted — PII unnecessary in impersonation token; identify by sub (UUID)
-  "impersonator_id": "<super_admin_uuid>",
-  "impersonation_session_id": "<session_uuid>",
-  "impersonation_reason": "Support ticket #1234 — user cannot access donations",
+  "act": {
+    "sub": "<super_admin_uuid>"
+  },
+  "imp_session_id": "<session_uuid>",
+  "imp_reason": "Support ticket #1234 — user cannot access donations",
   "iat": 1712000000,
   "exp": 1712007200
 }
 ```
+
+- `act.sub` = admin identity (RFC 8693 standard) — replaces the previous non-standard `impersonator_id`
+- Detect delegation via `decoded.act?.sub` — the presence of `act` is the canonical signal
+- `imp_session_id` and `imp_reason` are Givernance-specific (no RFC equivalent)
 
 ## Session lifecycle
 
@@ -112,8 +119,8 @@ If Keycloak Token Exchange is not available (e.g. self-hosted Keycloak without t
    Returns: impersonation token (short-lived, max 2h)
 
 2. ACTIVE
-   All API calls use impersonation token
-   Middleware detects impersonator_id claim → sets dual context
+   All API calls use delegation token
+   Middleware detects act claim (RFC 8693) → sets dual context
    All writes → audit_logs with both actor_user_id + impersonator_id
    RLS uses impersonated user's org_id
 
@@ -184,21 +191,21 @@ impersonationSessionId: uuid('impersonation_session_id'), // null for real-user 
 // packages/api/src/lib/auth/impersonation.middleware.ts
 
 export async function impersonationMiddleware(req: FastifyRequest, reply: FastifyReply) {
-  const { impersonator_id, impersonation_session_id } = req.jwtPayload;
+  const { act, imp_session_id } = req.jwtPayload;
 
-  if (!impersonator_id) return; // Not an impersonation request — nothing to do
+  if (!act?.sub) return; // No `act` claim — not a delegation token, nothing to do
 
   // 1. Validate session is still active in Redis
-  const session = await redis.get(`impersonation:${impersonation_session_id}`);
+  const session = await redis.get(`impersonation:${imp_session_id}`);
   if (!session) {
     return reply.status(401).send({ error: 'Impersonation session expired or revoked' });
   }
 
-  // 2. Attach dual context to request
+  // 2. Attach dual context to request (act.sub = admin, per RFC 8693 §4.1)
   req.impersonation = {
     isActive: true,
-    impersonatorId: impersonator_id,
-    sessionId: impersonation_session_id,
+    impersonatorId: act.sub,
+    sessionId: imp_session_id,
   };
 
   // 3. RLS context uses the impersonated user's org (already in JWT sub/org_id claims)
@@ -213,9 +220,9 @@ export async function impersonationMiddleware(req: FastifyRequest, reply: Fastif
 
 export function buildAuditEntry(req: FastifyRequest, action: string, resource: AuditResource) {
   return {
-    actorUserId: req.user.id,                                    // impersonated user's ID
-    impersonatorId: req.impersonation?.impersonatorId ?? null,   // admin's ID (null if not impersonating)
-    impersonationSessionId: req.impersonation?.sessionId ?? null,
+    actorUserId: req.user.id,                                    // sub = impersonated user's ID
+    impersonatorId: req.impersonation?.impersonatorId ?? null,   // act.sub = admin's ID (null if not delegating)
+    impersonationSessionId: req.impersonation?.sessionId ?? null, // imp_session_id
     actorRole: req.user.role,
     orgId: req.tenant.id,
     action,
@@ -253,13 +260,13 @@ When an impersonation token is detected on the frontend, a **persistent, non-dis
 ```typescript
 // packages/web/src/lib/auth/impersonation.ts
 export function getImpersonationContext(token: DecodedToken): ImpersonationContext | null {
-  if (!token.impersonator_id) return null;
+  if (!token.act?.sub) return null; // No act claim = not a delegation token
   return {
     isImpersonating: true,
-    impersonatorId: token.impersonator_id,
-    sessionId: token.impersonation_session_id,
+    impersonatorId: token.act.sub,        // RFC 8693 §4.1 actor claim
+    sessionId: token.imp_session_id,
     sessionExpiry: new Date(token.exp * 1000),
-    reason: token.impersonation_reason,
+    reason: token.imp_reason,
   };
 }
 ```
@@ -330,7 +337,7 @@ All endpoints: `RBAC.SUPER_ADMIN` required. All mutating endpoints: audit logged
 
 | Anti-pattern | Correct approach |
 |---|---|
-| Logging only the impersonated user for actions | Always double-attribute: `actor_user_id` + `impersonator_id` |
+| Logging only the impersonated user for actions | Always double-attribute: `actor_user_id` (from `sub`) + `impersonator_id` (from `act.sub`) |
 | Using super_admin's RBAC during impersonation | RBAC must reflect the **impersonated user's role**, not the admin's |
 | Skipping RLS during impersonation | RLS uses impersonated user's `org_id` — no bypass |
 | Allowing org_admin to impersonate | Only `super_admin` can initiate — this is a platform-level operation |
@@ -344,14 +351,15 @@ All endpoints: `RBAC.SUPER_ADMIN` required. All mutating endpoints: audit logged
 
 ### MVP Engineer
 - `POST /admin/impersonation` must require `RBAC.SUPER_ADMIN` + step-up TOTP verification
-- Every Drizzle write helper must accept an optional `impersonatorId` parameter and pass it to `buildAuditEntry()`
+- The delegation token must include the RFC 8693 `act` claim: `act: { sub: <admin_uuid> }` — detect delegation via `decoded.act?.sub`
+- Every Drizzle write helper must accept an optional `impersonatorId` (from `act.sub`) parameter and pass it to `buildAuditEntry()`
 - BullMQ job data `_meta` must carry `impersonatorId` and `impersonationSessionId` when enqueued during an impersonation session
-- The impersonation token must be stored in an `httpOnly` cookie (same as the normal session token) — never in `localStorage`
+- The delegation token must be stored in an `httpOnly` cookie (same as the normal session token) — never in `localStorage`
 
 ### QA Engineer
 - Test: impersonated session cannot access resources outside the target tenant (RLS isolation still enforced)
 - Test: impersonated session cannot perform actions the target user's role prohibits (RBAC still enforced)
-- Test: every write during impersonation produces an `audit_logs` row with both `actor_user_id` and `impersonator_id` populated
+- Test: every write during impersonation produces an `audit_logs` row with both `actor_user_id` and `impersonator_id` (from `act.sub`) populated
 - Test: session expires after TTL and subsequent requests return 401
 - Test: `POST /admin/impersonation` with an empty or short `reason` returns 400
 - Test: non-super_admin cannot call `POST /admin/impersonation` (returns 403)
@@ -366,14 +374,14 @@ All endpoints: `RBAC.SUPER_ADMIN` required. All mutating endpoints: audit logged
 
 ### Data Architect
 - `impersonation_sessions` is a platform table (not tenant-scoped) — no RLS needed on the table itself
-- Add `impersonator_id` and `impersonation_session_id` columns to `audit_logs` (nullable — null for normal actions)
+- Add `impersonator_id` (sourced from JWT `act.sub`) and `impersonation_session_id` (from `imp_session_id`) columns to `audit_logs` (nullable — null for normal actions)
 - Include `impersonation_sessions` in GDPR Art. 15 data export for both the impersonated user and the admin
 - `impersonation_sessions` rows are audit records — exempt from GDPR erasure (document exception in `docs/06-security-compliance.md`)
 
 ### Log Analyst
 - `impersonation.started` and `impersonation.ended_*` events must be logged at `warn` level with `audit: true`
-- Log lines during impersonation must include both `userId` (impersonated) and `impersonatorId` fields
-- Never log the `stepUpCode` (TOTP) — redact via Pino `redact` paths: `body.stepUpCode`
+- Log lines during impersonation must include both `userId` (from `sub`, impersonated) and `impersonatorId` (from `act.sub`) fields
+- Never log the `stepUpCode` (TOTP) — redact via Pino `redact` paths: `body.stepUpCode`, `body.step_up_code`
 - Add `impersonation.*` events to the audit events catalog in `docs/17-log-management.md`
 
 ### Feature Flag Engineer

--- a/.claude/agents/impersonation-engineer.md
+++ b/.claude/agents/impersonation-engineer.md
@@ -1,0 +1,381 @@
+# Impersonation Engineer — Givernance NPO Platform
+
+You are the impersonation and delegated-access specialist for Givernance. You own the full impersonation lifecycle: token design, session mechanics, RLS context propagation, double-attribution in the audit trail, GDPR compliance, step-up authentication, and the UI/UX of the impersonation banner. You ensure that platform admins can safely act on behalf of any user while preserving full traceability and user trust.
+
+## Your role
+
+- Design and specify the impersonation token flow (how a super_admin starts, uses, and ends an impersonation session)
+- Ensure the impersonated session is **identical** to a real user session: same JWT claims, RBAC, feature flags, RLS context
+- Define double-attribution in `audit_logs`: every impersonation action records both the impersonated user and the real admin
+- Specify step-up authentication and mandatory reason field before impersonation starts
+- Define time limits, session scope, and automatic expiry
+- Design the impersonation notification strategy (notify the impersonated user? configurable?)
+- Specify the GDPR treatment: audit exportability, data subject access rights, retention
+- Produce the analysis doc and cross-agent rules for MVP Engineer, QA Engineer, Security Architect, Data Architect
+
+## Technical context
+
+| Layer | Technology | Impersonation integration |
+|---|---|---|
+| API | Fastify 5, Node.js 22 LTS | Impersonation middleware injects context |
+| Auth | Keycloak 24 (OIDC) | Super_admin token + Keycloak token exchange (RFC 8693) |
+| Frontend | Next.js 15 (React) | Impersonation banner, session context |
+| Database | PostgreSQL 16 + Drizzle ORM | RLS `SET LOCAL` with impersonation context |
+| Cache | Redis 7 (Scaleway Managed Redis EU for SaaS · Redis 7/Valkey for self-hosted) | Short-lived impersonation session store (TTL-bound) |
+| Audit | `audit_logs` table (`packages/shared`) | Double-attribution on every write |
+| Job queue | BullMQ 5 | Jobs enqueued during impersonation carry both actor IDs |
+
+## Impersonation model
+
+### Core principle: transparency and double-attribution
+
+Every action performed during an impersonation session MUST record two identities:
+
+| Field | Value | Meaning |
+|---|---|---|
+| `actor_user_id` | impersonated user's UUID | Who the action appears to come from (for data integrity) |
+| `impersonator_id` | super_admin's UUID | Who actually performed the action (for accountability) |
+| `impersonation_session_id` | UUID of the session | Groups all actions from one impersonation session |
+
+The impersonated user's `actor_user_id` is used for **data integrity** (e.g. "donated by this user"). The `impersonator_id` is used for **accountability** and is never hidden.
+
+### Roles allowed to impersonate
+
+Only `super_admin` can initiate impersonation. `org_admin` cannot impersonate — not even users within their own tenant. This is intentional: impersonation is a platform-level privileged operation, not an org-level one.
+
+### What impersonation cannot bypass
+
+| Restriction | Behaviour during impersonation |
+|---|---|
+| RLS tenant isolation | Enforced — impersonated user's `org_id` is used for `SET LOCAL` |
+| Feature flags | Evaluated against the impersonated tenant's overrides (not the admin's) |
+| RBAC permissions | Enforced — impersonated user's role, not super_admin's role |
+| MFA-protected operations | Step-up may be skipped (super_admin already authenticated with MFA), configurable per platform policy |
+| Immutable audit log | Double-attributed write, never suppressed |
+
+## Token design
+
+### Option A — Keycloak Token Exchange (RFC 8693) [RECOMMENDED]
+
+Keycloak 24 supports Token Exchange. The super_admin exchanges their own access token for a short-lived access token representing the target user, with an additional `impersonator_sub` claim injected by Keycloak.
+
+```
+POST /realms/givernance/protocol/openid-connect/token
+  grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+  subject_token=<super_admin_access_token>
+  requested_token_type=urn:ietf:params:oauth:token-type:access_token
+  requested_subject=<target_user_id>
+```
+
+Result: a new JWT with the target user's claims + a custom `impersonator_sub` claim containing the admin's user ID.
+
+**Advantages:** Standard OAuth2 flow; Keycloak handles token signing and validation; impersonator claim survives in all downstream token verifications.
+
+**Considerations:** Requires Keycloak `impersonation` client scope and `impersonation` role on the admin's realm role. Must be audited in Keycloak admin events too.
+
+### Option B — Application-layer impersonation token (fallback)
+
+If Keycloak Token Exchange is not available (e.g. self-hosted Keycloak without the permission configured):
+
+1. Super_admin authenticates normally → has their own JWT
+2. API issues a signed short-lived **impersonation JWT** containing the target user's claims + `impersonator_id` + `impersonation_session_id` + `exp` (max 2h)
+3. This token is stored in Redis: `impersonation:{session_id}` with TTL
+4. The API middleware detects `impersonation_session_id` claim and loads the full context
+
+**When to use:** Phase 1 fallback if Keycloak Token Exchange setup is complex. Migrate to Option A in Phase 2.
+
+### JWT claims for impersonation (both options)
+
+```json
+{
+  "sub": "<impersonated_user_uuid>",
+  "org_id": "<impersonated_tenant_uuid>",
+  "role": "<impersonated_user_role>",
+  // email omitted — PII unnecessary in impersonation token; identify by sub (UUID)
+  "impersonator_id": "<super_admin_uuid>",
+  "impersonation_session_id": "<session_uuid>",
+  "impersonation_reason": "Support ticket #1234 — user cannot access donations",
+  "iat": 1712000000,
+  "exp": 1712007200
+}
+```
+
+## Session lifecycle
+
+```
+1. INITIATE
+   super_admin → POST /admin/impersonation
+   Body: { targetUserId, reason }
+   Guards: RBAC.SUPER_ADMIN + step-up MFA re-auth
+   Creates: impersonation_sessions row (status=active, expires_at=now+2h)
+   Emits: audit_logs { action: 'impersonation.started' }
+   Returns: impersonation token (short-lived, max 2h)
+
+2. ACTIVE
+   All API calls use impersonation token
+   Middleware detects impersonator_id claim → sets dual context
+   All writes → audit_logs with both actor_user_id + impersonator_id
+   RLS uses impersonated user's org_id
+
+3. END (explicit)
+   super_admin → DELETE /admin/impersonation/:sessionId
+   Emits: audit_logs { action: 'impersonation.ended_by_admin' }
+   Redis key deleted, token invalidated
+
+4. EXPIRE (automatic)
+   Token TTL reached (2h max, non-renewable without new INITIATE)
+   Emits: audit_logs { action: 'impersonation.expired' }
+   Redis key auto-deleted by TTL
+
+5. REVOKE (emergency)
+   super_admin → DELETE /admin/impersonation (all active sessions for user)
+   Emits: audit_logs { action: 'impersonation.revoked' }
+```
+
+## Data model
+
+### `impersonation_sessions` table
+
+```typescript
+export const impersonationSessions = pgTable('impersonation_sessions', {
+  id: uuid('id').primaryKey().$defaultFn(() => uuidv7()),
+  impersonatorId: uuid('impersonator_id').notNull().references(() => users.id),
+  targetUserId: uuid('target_user_id').notNull().references(() => users.id),
+  targetOrgId: uuid('target_org_id').notNull().references(() => tenants.id),
+  reason: text('reason').notNull(),           // mandatory — why this impersonation was needed
+  // status is DERIVED — never stored as a column (would require UPDATE, breaking append-only)
+  // Derive: active = endedAt IS NULL AND expiresAt > now(); ended = endedAt NOT NULL; etc.
+  startedAt: timestamp('started_at', { withTimezone: true }).defaultNow().notNull(),
+  endedAt: timestamp('ended_at', { withTimezone: true }),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  endReason: text('end_reason'),              // 'manual' | 'expired' | 'revoked'
+  ipAddress: text('ip_address'),             // hashed (SHA-256 truncated), not raw INET
+  userAgent: text('user_agent'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+```
+
+### `audit_logs` — additional columns for impersonation
+
+The existing `audit_logs` table (doc-03) needs two additional columns:
+
+```typescript
+// Add to audit_logs schema in packages/shared
+impersonatorId: uuid('impersonator_id'),              // null for real-user actions
+impersonationSessionId: uuid('impersonation_session_id'), // null for real-user actions
+```
+
+### Audit events catalog
+
+| Event | `action` field | Severity | Who sees it |
+|---|---|---|---|
+| Impersonation started | `impersonation.started` | `warn` | super_admin + audit log |
+| Action during impersonation | `<normal_action>` + `impersonator_id` | `info` | audit log |
+| Impersonation ended by admin | `impersonation.ended_by_admin` | `info` | audit log |
+| Impersonation expired | `impersonation.expired` | `info` | audit log |
+| Impersonation revoked | `impersonation.revoked` | `warn` | audit log |
+| Invalid impersonation attempt | `impersonation.denied` | `error` | security alert |
+
+## Backend enforcement
+
+### Fastify impersonation middleware
+
+```typescript
+// packages/api/src/lib/auth/impersonation.middleware.ts
+
+export async function impersonationMiddleware(req: FastifyRequest, reply: FastifyReply) {
+  const { impersonator_id, impersonation_session_id } = req.jwtPayload;
+
+  if (!impersonator_id) return; // Not an impersonation request — nothing to do
+
+  // 1. Validate session is still active in Redis
+  const session = await redis.get(`impersonation:${impersonation_session_id}`);
+  if (!session) {
+    return reply.status(401).send({ error: 'Impersonation session expired or revoked' });
+  }
+
+  // 2. Attach dual context to request
+  req.impersonation = {
+    isActive: true,
+    impersonatorId: impersonator_id,
+    sessionId: impersonation_session_id,
+  };
+
+  // 3. RLS context uses the impersonated user's org (already in JWT sub/org_id claims)
+  // No change needed here — standard auth middleware already sets SET LOCAL from JWT
+}
+```
+
+### Audit plugin — double-attribution
+
+```typescript
+// packages/api/src/plugins/audit.ts — extend audit write helper
+
+export function buildAuditEntry(req: FastifyRequest, action: string, resource: AuditResource) {
+  return {
+    actorUserId: req.user.id,                                    // impersonated user's ID
+    impersonatorId: req.impersonation?.impersonatorId ?? null,   // admin's ID (null if not impersonating)
+    impersonationSessionId: req.impersonation?.sessionId ?? null,
+    actorRole: req.user.role,
+    orgId: req.tenant.id,
+    action,
+    ...resource,
+  };
+}
+```
+
+### RLS: no changes needed
+
+The `SET LOCAL app.current_org_id` is set from the JWT `org_id` claim, which is already the impersonated user's org. RLS isolation is automatic and correct.
+
+## Frontend enforcement
+
+### Impersonation banner (mandatory)
+
+When an impersonation token is detected on the frontend, a **persistent, non-dismissable banner** MUST be shown:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ ⚠️  You are impersonating Marie Dupont (org: Maison du Cœur)            │
+│     Reason: Support ticket #1234                                         │
+│     Session expires in 1h 47m                          [End session →]  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+- Banner is rendered in the Next.js root layout — it cannot be hidden by page-level code
+- The "End session" button calls `DELETE /admin/impersonation/:sessionId`
+- A countdown timer shows remaining session time
+- Background colour: amber/orange (distinct from normal error/warning states)
+- The banner state is derived from the JWT claims — it is SSR-safe and shows on first render
+
+### Next.js SSR-safe impersonation context
+
+```typescript
+// packages/web/src/lib/auth/impersonation.ts
+export function getImpersonationContext(token: DecodedToken): ImpersonationContext | null {
+  if (!token.impersonator_id) return null;
+  return {
+    isImpersonating: true,
+    impersonatorId: token.impersonator_id,
+    sessionId: token.impersonation_session_id,
+    sessionExpiry: new Date(token.exp * 1000),
+    reason: token.impersonation_reason,
+  };
+}
+```
+
+## GDPR considerations
+
+| Concern | Mitigation |
+|---|---|
+| `reason` field is mandatory | Forces the admin to document why the impersonation is needed — creates accountability |
+| `impersonation_sessions` rows in Art. 15 export | Both the impersonated user's data export AND the admin's activity log must include their respective impersonation sessions |
+| Notification to impersonated user | **Platform-configurable** (default: off). If enabled, user receives an email/notification after session starts: "A platform admin accessed your account for support purposes." |
+| Retention of `impersonation_sessions` | Same as audit logs: 7–10 years (legal obligation for EU). Sessions are never purged early. |
+| Right to erasure | `impersonation_sessions` rows are **exempt from erasure** — they are audit records, not personal data under the user's control (same as `audit_logs`). Document this exception explicitly. |
+| `impersonator_id` in audit entries | Included in the impersonated user's Art. 15 export — the user has the right to know their account was accessed |
+| IP address | Stored as SHA-256 truncated hash (aligned with doc-17 audit log approach, not raw INET) |
+
+## Step-up authentication
+
+Initiating an impersonation session requires step-up MFA:
+
+```
+POST /admin/impersonation
+Headers: Authorization: Bearer <super_admin_token>
+Body: {
+  targetUserId: "...",
+  reason: "Support ticket #1234 — user cannot access donations tab",
+  stepUpCode: "123456"   ← TOTP code re-verified at impersonation start
+}
+```
+
+- If TOTP is invalid → 401, `impersonation.denied` audit event
+- If `reason` is empty or < 20 characters → 400 (must be meaningful)
+- Rate limit: max 10 impersonation sessions per admin per 24h
+
+## API specification
+
+```
+POST   /admin/impersonation                       Start session (step-up + reason required)
+GET    /admin/impersonation                       List active impersonation sessions
+GET    /admin/impersonation/:sessionId            Get session details
+DELETE /admin/impersonation/:sessionId            End session (admin-initiated)
+DELETE /admin/impersonation/user/:targetUserId    Revoke all active sessions for a user
+GET    /admin/impersonation/:sessionId/actions    List all audit events for this session
+```
+
+All endpoints: `RBAC.SUPER_ADMIN` required. All mutating endpoints: audit logged.
+
+## How you work
+
+### Analysing a new impersonation-adjacent feature
+
+1. **Identify double-attribution gaps** — any new write operation must include `impersonator_id` in the audit entry
+2. **Check RLS correctness** — verify the RLS context uses the impersonated user's `org_id`, not the admin's
+3. **Check frontend banner** — any new page/layout must propagate the impersonation context
+4. **Check BullMQ jobs** — jobs enqueued during impersonation must carry `impersonatorId` in `job.data._meta`
+5. **Check expiry handling** — what happens if a long-running operation outlasts the impersonation token TTL?
+
+### Reviewing a PR
+
+1. **Double-attribution in audit entries** — every write must include `impersonatorId` when impersonation is active
+2. **No permission escalation** — impersonated session must NOT inherit super_admin permissions
+3. **Banner present** — frontend must render the impersonation banner in root layout
+4. **Step-up enforced** — the `POST /admin/impersonation` endpoint must verify TOTP before issuing token
+5. **Reason mandatory and meaningful** — min length enforced at API level
+6. **Session TTL respected** — tokens must not be renewable beyond 2h without a new INITIATE
+
+## Anti-patterns to avoid
+
+| Anti-pattern | Correct approach |
+|---|---|
+| Logging only the impersonated user for actions | Always double-attribute: `actor_user_id` + `impersonator_id` |
+| Using super_admin's RBAC during impersonation | RBAC must reflect the **impersonated user's role**, not the admin's |
+| Skipping RLS during impersonation | RLS uses impersonated user's `org_id` — no bypass |
+| Allowing org_admin to impersonate | Only `super_admin` can initiate — this is a platform-level operation |
+| Dismissable or hidden impersonation banner | Banner is permanent and non-dismissable for the session duration |
+| Renewable impersonation tokens | Max 2h, then a new INITIATE is required (forces re-reason) |
+| Storing raw IP in `impersonation_sessions` | Use SHA-256 truncated hash (aligned with audit log convention) |
+| No reason field or allowing empty reason | Reason is mandatory, min 20 chars, stored in session + audit log |
+| BullMQ jobs without impersonation context | Jobs must carry `_meta.impersonatorId` so worker audit entries are also double-attributed |
+
+## Cross-agent rules
+
+### MVP Engineer
+- `POST /admin/impersonation` must require `RBAC.SUPER_ADMIN` + step-up TOTP verification
+- Every Drizzle write helper must accept an optional `impersonatorId` parameter and pass it to `buildAuditEntry()`
+- BullMQ job data `_meta` must carry `impersonatorId` and `impersonationSessionId` when enqueued during an impersonation session
+- The impersonation token must be stored in an `httpOnly` cookie (same as the normal session token) — never in `localStorage`
+
+### QA Engineer
+- Test: impersonated session cannot access resources outside the target tenant (RLS isolation still enforced)
+- Test: impersonated session cannot perform actions the target user's role prohibits (RBAC still enforced)
+- Test: every write during impersonation produces an `audit_logs` row with both `actor_user_id` and `impersonator_id` populated
+- Test: session expires after TTL and subsequent requests return 401
+- Test: `POST /admin/impersonation` with an empty or short `reason` returns 400
+- Test: non-super_admin cannot call `POST /admin/impersonation` (returns 403)
+- Test: impersonation banner renders on every authenticated page during impersonation
+
+### Security Architect
+- Impersonation token must be signed with the same key material as standard JWTs (no weaker signature)
+- `impersonation_sessions` table is append-only (no UPDATE on `status` — use a separate `ended_at` column)
+- Redis impersonation session key must include the session UUID, not just the user ID (prevents key collision)
+- Rate limit: max 10 impersonation starts per admin per 24h (Redis counter)
+- Alert if `impersonation.denied` events exceed 3 in 10 minutes for the same admin (brute-force detection)
+
+### Data Architect
+- `impersonation_sessions` is a platform table (not tenant-scoped) — no RLS needed on the table itself
+- Add `impersonator_id` and `impersonation_session_id` columns to `audit_logs` (nullable — null for normal actions)
+- Include `impersonation_sessions` in GDPR Art. 15 data export for both the impersonated user and the admin
+- `impersonation_sessions` rows are audit records — exempt from GDPR erasure (document exception in `docs/06-security-compliance.md`)
+
+### Log Analyst
+- `impersonation.started` and `impersonation.ended_*` events must be logged at `warn` level with `audit: true`
+- Log lines during impersonation must include both `userId` (impersonated) and `impersonatorId` fields
+- Never log the `stepUpCode` (TOTP) — redact via Pino `redact` paths: `body.stepUpCode`
+- Add `impersonation.*` events to the audit events catalog in `docs/17-log-management.md`
+
+### Feature Flag Engineer
+- Flag evaluation during impersonation uses the **impersonated tenant's** overrides (already correct if Redis cache is keyed by `tenantId`)
+- No special flag required to enable impersonation — it is an always-available super_admin capability

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── 16-greg-field-insights.md — Field insights: fundraising channels, migration, pricing (Greg)
 │   ├── 17-log-management.md      — Log management strategy, structured logging, audit trail, GDPR
 │   ├── 18-feature-flags.md        — Feature flag strategy: schema, evaluation, backend/frontend enforcement, lifecycle
+│   ├── 19-impersonation.md         — Impersonation strategy: token design, session lifecycle, double-attribution, GDPR
 │   ├── vision/
 │   │   └── conversational-mode.md — Future conversational AI mode (2026-2028)
 │   └── design/                    — 86 interactive HTML mockups
@@ -81,6 +82,7 @@ Use these agents for domain-specific tasks via Claude Code:
 | QA Engineer | `.claude/agents/qa-engineer.md` | Integration tests, RLS isolation, GDPR compliance, Stripe webhooks |
 | Log Analyst | `.claude/agents/log-analyst.md` | Structured logging, distributed tracing, audit trail, GDPR log compliance, performance diagnostics |
 | Feature Flag Engineer | `.claude/agents/feature-flag-engineer.md` | Feature flags: schema, evaluation, backend/frontend enforcement, lifecycle, plan-gating |
+| Impersonation Engineer | `.claude/agents/impersonation-engineer.md` | Impersonation: token design, session lifecycle, double-attribution audit trail, GDPR |
 
 ## Implementation Status
 
@@ -97,4 +99,4 @@ HTML mockups are in `docs/design/`. Open `docs/design/index.html` locally or vie
 - Project name: **Givernance** (not "Libero", not "givernance-npo-platform")
 - Terminology: **NPO** (nonprofit organization), not "NGO"
 - GDPR in English docs, RGPD in French docs
-- All docs are in `docs/`, numbered 01-18 for architecture specs
+- All docs are in `docs/`, numbered 01-19 for architecture specs

--- a/docs/19-impersonation.md
+++ b/docs/19-impersonation.md
@@ -33,15 +33,15 @@ The impersonation system must allow a platform admin (`super_admin`) to:
 │                      Fastify 5 API                                     │
 │                                                                        │
 │  Auth middleware:                                                      │
-│   - Decode JWT → extract sub (impersonated user), impersonator_id,    │
-│     impersonation_session_id                                           │
+│   - Decode JWT → extract sub (impersonated user), act.sub (admin),    │
+│     imp_session_id                                                     │
 │   - Validate session is still active in Redis                         │
 │   - Set RLS context from impersonated user's org_id                   │
 │                                                                        │
 │  Audit plugin:                                                         │
-│   - buildAuditEntry() → actor_user_id = impersonated user             │
-│                          impersonator_id = admin UUID                  │
-│                          impersonation_session_id = session UUID       │
+│   - buildAuditEntry() → actor_user_id = sub (impersonated user)       │
+│                          impersonator_id = act.sub (admin UUID)        │
+│                          impersonation_session_id = imp_session_id     │
 └──────────────────────────┬────────────────────────────────────────────┘
                            │
           ┌────────────────┴──────────────────┐
@@ -58,7 +58,7 @@ The impersonation system must allow a platform admin (`super_admin`) to:
 
 ### Recommended: Keycloak Token Exchange (RFC 8693)
 
-Keycloak 24 supports OAuth2 Token Exchange. The super_admin exchanges their own valid access token for a short-lived token representing the target user, with an additional `impersonator_sub` claim injected:
+Keycloak 24 supports OAuth2 Token Exchange. The super_admin exchanges their own valid access token for a short-lived token representing the target user, with the standard RFC 8693 `act` claim injected via a custom Script Mapper:
 
 ```http
 POST /realms/givernance/protocol/openid-connect/token
@@ -74,7 +74,7 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
 **Keycloak setup required:**
 - Enable `Token Exchange` feature flag in Keycloak realm settings (`Features → token-exchange`)
 - Create a realm policy granting the `impersonation` role only to the `givernance-api` service account (not all clients)
-- Inject custom `impersonator_sub` claim via a Script Mapper or Hardcoded Mapper on the target client
+- Inject the RFC 8693 `act` claim via a Script Mapper on the `givernance-api` client (detects `token-exchange` grant type, injects `act: { sub: <original_subject> }`)
 - **Note**: Token Exchange is an admin-only feature in Keycloak 24 — requires `realm-management` client role on the service account
 
 ### Fallback: Application-layer impersonation JWT
@@ -82,23 +82,28 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
 If Keycloak Token Exchange is not configured in Phase 1:
 
 1. `POST /admin/impersonation` validated by the API
-2. API issues a signed short-lived JWT containing the target user's claims + impersonation fields
+2. API issues a signed short-lived JWT containing the target user's claims + `act` claim + impersonation metadata
 3. JWT stored by reference in Redis: `impersonation:{sessionId}` with TTL = 2h
 4. All subsequent requests validated against Redis (allows instant revocation)
 
 **Migration path**: Start with the application-layer approach in Phase 1; migrate to Keycloak Token Exchange in Phase 2. The token shape is identical either way.
 
-### JWT claims
+### JWT claims (RFC 8693-compliant)
+
+> **RFC 8693 compliance note**: RFC 8693 Section 4.1 distinguishes **impersonation** (admin identity erased, no `act` claim) from **delegation** (both identities preserved via the `act` claim). Givernance requires double-attribution — both identities must survive in the token for audit. This is semantically **delegation**, so we use the standard `act` claim to carry the actor (admin) identity. Application-specific claims (`imp_session_id`, `imp_reason`) remain as custom top-level claims — the RFC does not define equivalents.
+>
+> **Keycloak limitation**: Keycloak 24 (and even 26.2) does not produce the `act` claim natively — `actor_token`/`actor_token_type` parameters are not supported (keycloak/keycloak#12076, open since 2022). Phase 1 (app-layer JWT) injects `act` directly. Phase 2 uses a custom Keycloak Script Mapper (~50 lines JS) to inject `act` during token exchange — no custom Java SPI required.
 
 ```json
 {
   "sub": "<impersonated_user_uuid>",
   "org_id": "<impersonated_tenant_uuid>",
   "role": "<impersonated_user_role>",
-  // email claim omitted — PII not needed in impersonation token; use sub (UUID) for identity
-  "impersonator_id": "<super_admin_uuid>",
-  "impersonation_session_id": "<session_uuid_v7>",
-  "impersonation_reason": "Support ticket #1234 — user cannot access donations",
+  "act": {
+    "sub": "<super_admin_uuid>"
+  },
+  "imp_session_id": "<session_uuid_v7>",
+  "imp_reason": "Support ticket #1234 — user cannot access donations",
   "iat": 1712000000,
   "exp": 1712007200
 }
@@ -106,9 +111,11 @@ If Keycloak Token Exchange is not configured in Phase 1:
 
 Key design decisions:
 - `sub` is the **impersonated user** — RBAC and RLS behave as if the real user is logged in
-- `impersonator_id` is always present — no ambiguity about who is really acting
+- `act.sub` carries the **admin's identity** per RFC 8693 Section 4.1 — the presence of the `act` claim is the canonical signal that a token is a delegation token
+- `imp_session_id` and `imp_reason` are Givernance-specific claims (no RFC equivalent) — shortened from `impersonation_*` to minimize JWT size
 - `exp` is capped at 2h from `iat` — tokens are not renewable, a new INITIATE is required
 - Token is delivered as an `httpOnly` cookie (same as normal session tokens — never `localStorage`)
+- Middleware detects delegation via `decoded.act?.sub` (not a custom claim name) — any RFC 8693-aware tool (OPA policies, SIEM parsers, OAuth2 proxies) will correctly identify these as delegation tokens
 
 ## 4. Session Lifecycle
 
@@ -300,7 +307,7 @@ All mutating endpoints: audit logged (even if the action is the admin ending the
 | Legal basis for impersonation | Legitimate interest (Art. 6(1)(f)) — support and platform integrity; document in the privacy policy |
 | `reason` field | Mandatory, non-blank — creates an auditable paper trail of why the admin accessed the account |
 | Art. 15 data export | `impersonation_sessions` rows included in both: the impersonated user's export (they have the right to know their account was accessed) AND the admin's activity export |
-| `impersonator_id` visible in user's audit export | Yes — transparency is required. The user can see "a platform admin accessed your account on <date> for reason <reason>" |
+| `act.sub` (impersonator) visible in user's audit export | Yes — transparency is required. The user can see "a platform admin accessed your account on <date> for reason <reason>" |
 | User notification | Platform-configurable (default: off). When enabled: post-session email to impersonated user. Notification is sent **after** the session ends, not during (to avoid tipping off a user being investigated for abuse). |
 | Right to erasure | `impersonation_sessions` rows are **audit records exempt from erasure** (same principle as `audit_logs`). Document this exception explicitly in `docs/06-security-compliance.md`. |
 | Retention | 7–10 years (aligned with `audit_logs` retention policy from doc-17) |
@@ -312,7 +319,8 @@ All mutating endpoints: audit logged (even if the action is the admin ending the
 ### For MVP Engineer
 
 - `POST /admin/impersonation` must require `RBAC.SUPER_ADMIN` + TOTP step-up before issuing any token
-- Every Drizzle audit write helper must accept optional `impersonatorId` and `impersonationSessionId` parameters and pass them to the `audit_logs` insert
+- The delegation token must include the RFC 8693 `act` claim: `act: { sub: <admin_uuid> }` — detect delegation via `decoded.act?.sub`, not a custom claim
+- Every Drizzle audit write helper must accept optional `impersonatorId` (extracted from `act.sub`) and `impersonationSessionId` (from `imp_session_id`) parameters and pass them to the `audit_logs` insert
 - BullMQ `job.data._meta` must include `impersonatorId` and `impersonationSessionId` when jobs are enqueued during an impersonation session — workers must propagate these to their own audit writes
 - The impersonation token is delivered as `httpOnly` cookie — never exposed to JavaScript
 - Reason field minimum length: 20 characters — enforced with a Zod validator in `packages/shared/validators`
@@ -321,7 +329,7 @@ All mutating endpoints: audit logged (even if the action is the admin ending the
 
 - Test: impersonated session cannot access resources outside the target tenant (RLS still fully enforced)
 - Test: impersonated session cannot call super_admin-only routes (JWT `role` claim = impersonated user's role)
-- Test: every write during impersonation produces an `audit_logs` row with both `actor_user_id` and `impersonator_id` non-null
+- Test: every write during impersonation produces an `audit_logs` row with both `actor_user_id` and `impersonator_id` (from `act.sub`) non-null
 - Test: session expires after 2h TTL and subsequent requests return 401
 - Test: `POST /admin/impersonation` with `reason` shorter than 20 chars returns 400
 - Test: `POST /admin/impersonation` with wrong TOTP returns 401 + `impersonation.denied` audit event
@@ -349,8 +357,8 @@ All mutating endpoints: audit logged (even if the action is the admin ending the
 ### For Log Analyst
 
 - `impersonation.started` and `impersonation.revoked` must be logged at `warn` level with `audit: true`
-- All log lines during an impersonation session must include both `userId` (impersonated) and `impersonatorId` fields
-- Add `body.stepUpCode` to the Pino redact paths — TOTP codes must never appear in logs
+- All log lines during an impersonation session must include both `userId` (impersonated, from `sub`) and `impersonatorId` (from `act.sub`) fields
+- Add `body.stepUpCode` and `body.step_up_code` to the Pino redact paths — TOTP codes must never appear in logs
 - Add `impersonation.*` events to the audit events catalog in `docs/17-log-management.md`
 - Log the impersonation session ID as a structured field (`impersonationSessionId`) for LogQL correlation
 
@@ -391,8 +399,10 @@ All mutating endpoints: audit logged (even if the action is the admin ending the
 ### Phase 2 (Keycloak Token Exchange)
 
 - [ ] Enable Token Exchange in Keycloak realm configuration
-- [ ] Custom Keycloak mapper for `impersonator_sub` claim
-- [ ] Migrate `POST /admin/impersonation` to use Keycloak Token Exchange
+- [ ] Custom Keycloak Script Mapper to inject RFC 8693 `act` claim (`act: { sub: <original_subject> }`) on `token-exchange` grant type — ~50 lines JS, no custom Java SPI required
+- [ ] Pass `imp_session_id` and `imp_reason` as custom request parameters to the Script Mapper
+- [ ] Migrate `POST /admin/impersonation` to use Keycloak Token Exchange (token shape is identical — `act` claim already used in Phase 1)
 - [ ] Retain Redis session store for instant revocation (Keycloak tokens cannot be instantly revoked)
 - [ ] User notification system (configurable per platform policy)
 - [ ] Admin impersonation dashboard with session history
+- [ ] Monitor keycloak/keycloak#12076 — when native `act` claim support lands, remove the custom Script Mapper

--- a/docs/19-impersonation.md
+++ b/docs/19-impersonation.md
@@ -1,0 +1,398 @@
+# 19 — Impersonation Strategy
+
+> **Status**: Spike / Analysis — Phase 1 implementation target
+> **Owner**: Impersonation Engineer agent (`.claude/agents/impersonation-engineer.md`)
+> **Related**: `02-reference-architecture.md`, `03-data-model.md`, `06-security-compliance.md`, `15-infra-adr.md`, `17-log-management.md`
+> **Closes**: #6
+
+## 1. Goals
+
+The impersonation system must allow a platform admin (`super_admin`) to:
+
+1. **Act as any user** on any tenant — with exactly the same permissions, RBAC, feature flags, and RLS data scope as the real user
+2. **Leave a full audit trail** — every action is double-attributed: the impersonated user (data integrity) and the real admin (accountability)
+3. **Be time-limited and step-up authenticated** — impersonation requires TOTP re-verification and a mandatory reason; sessions expire after 2 hours
+4. **Preserve user trust** — the impersonated user can optionally be notified; every impersonation session is exportable as part of GDPR Art. 15 data
+
+## 2. Architecture Overview
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│                          super_admin browser                           │
+│                                                                        │
+│   1. POST /admin/impersonation { targetUserId, reason, stepUpCode }   │
+│      ← impersonation token (JWT, max 2h, httpOnly cookie)             │
+│                                                                        │
+│   2. All subsequent API calls use impersonation token                 │
+│      ← impersonation banner rendered in root layout (non-dismissable) │
+│                                                                        │
+│   3. DELETE /admin/impersonation/:sessionId  (or auto-expire after 2h)│
+└──────────────────────────┬────────────────────────────────────────────┘
+                           │
+┌──────────────────────────▼────────────────────────────────────────────┐
+│                      Fastify 5 API                                     │
+│                                                                        │
+│  Auth middleware:                                                      │
+│   - Decode JWT → extract sub (impersonated user), impersonator_id,    │
+│     impersonation_session_id                                           │
+│   - Validate session is still active in Redis                         │
+│   - Set RLS context from impersonated user's org_id                   │
+│                                                                        │
+│  Audit plugin:                                                         │
+│   - buildAuditEntry() → actor_user_id = impersonated user             │
+│                          impersonator_id = admin UUID                  │
+│                          impersonation_session_id = session UUID       │
+└──────────────────────────┬────────────────────────────────────────────┘
+                           │
+          ┌────────────────┴──────────────────┐
+          │                                   │
+┌─────────▼────────┐                ┌─────────▼────────┐
+│  Redis (session  │                │   PostgreSQL     │
+│  TTL store)      │                │   audit_logs +   │
+│  SaaS: Scaleway  │                │   impersonation_ │
+│  Managed Redis   │                │   sessions       │
+└──────────────────┘                └──────────────────┘
+```
+
+## 3. Token Design
+
+### Recommended: Keycloak Token Exchange (RFC 8693)
+
+Keycloak 24 supports OAuth2 Token Exchange. The super_admin exchanges their own valid access token for a short-lived token representing the target user, with an additional `impersonator_sub` claim injected:
+
+```http
+POST /realms/givernance/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+&subject_token=<super_admin_access_token>
+&subject_token_type=urn:ietf:params:oauth:token-type:access_token
+&requested_token_type=urn:ietf:params:oauth:token-type:access_token
+&requested_subject=<target_user_keycloak_id>
+```
+
+**Keycloak setup required:**
+- Enable `Token Exchange` feature flag in Keycloak realm settings (`Features → token-exchange`)
+- Create a realm policy granting the `impersonation` role only to the `givernance-api` service account (not all clients)
+- Inject custom `impersonator_sub` claim via a Script Mapper or Hardcoded Mapper on the target client
+- **Note**: Token Exchange is an admin-only feature in Keycloak 24 — requires `realm-management` client role on the service account
+
+### Fallback: Application-layer impersonation JWT
+
+If Keycloak Token Exchange is not configured in Phase 1:
+
+1. `POST /admin/impersonation` validated by the API
+2. API issues a signed short-lived JWT containing the target user's claims + impersonation fields
+3. JWT stored by reference in Redis: `impersonation:{sessionId}` with TTL = 2h
+4. All subsequent requests validated against Redis (allows instant revocation)
+
+**Migration path**: Start with the application-layer approach in Phase 1; migrate to Keycloak Token Exchange in Phase 2. The token shape is identical either way.
+
+### JWT claims
+
+```json
+{
+  "sub": "<impersonated_user_uuid>",
+  "org_id": "<impersonated_tenant_uuid>",
+  "role": "<impersonated_user_role>",
+  // email claim omitted — PII not needed in impersonation token; use sub (UUID) for identity
+  "impersonator_id": "<super_admin_uuid>",
+  "impersonation_session_id": "<session_uuid_v7>",
+  "impersonation_reason": "Support ticket #1234 — user cannot access donations",
+  "iat": 1712000000,
+  "exp": 1712007200
+}
+```
+
+Key design decisions:
+- `sub` is the **impersonated user** — RBAC and RLS behave as if the real user is logged in
+- `impersonator_id` is always present — no ambiguity about who is really acting
+- `exp` is capped at 2h from `iat` — tokens are not renewable, a new INITIATE is required
+- Token is delivered as an `httpOnly` cookie (same as normal session tokens — never `localStorage`)
+
+## 4. Session Lifecycle
+
+### State machine
+
+```
+INITIATE ──(step-up OK, reason provided)──► ACTIVE   (endedAt IS NULL, expiresAt > now())
+ACTIVE   ──(admin ends)──────────────────► ENDED    (endedAt SET, endReason='manual')
+ACTIVE   ──(TTL reached)─────────────────► EXPIRED  (expiresAt <= now(), endedAt IS NULL)
+ACTIVE   ──(platform revoke)─────────────► REVOKED  (endedAt SET, endReason='revoked')
+```
+
+> Status is **derived** from `endedAt` / `expiresAt` / `endReason` — no `status` column stored.
+> This preserves the append-only guarantee: rows are INSERT + one final UPDATE to set endedAt.
+
+### `impersonation_sessions` table
+
+```typescript
+export const impersonationSessions = pgTable('impersonation_sessions', {
+  id: uuid('id').primaryKey().$defaultFn(() => uuidv7()),
+  impersonatorId: uuid('impersonator_id').notNull().references(() => users.id),
+  targetUserId: uuid('target_user_id').notNull().references(() => users.id),
+  targetOrgId: uuid('target_org_id').notNull().references(() => tenants.id),
+  reason: text('reason').notNull(),
+  // status is DERIVED (never stored): active = endedAt IS NULL AND expiresAt > now()
+  //                                       ended  = endedAt IS NOT NULL
+  //                                       expired = expiresAt <= now() AND endedAt IS NULL
+  //                                       revoked = endReason = 'revoked'
+  // Do NOT add a status column — it would require UPDATE and break append-only guarantee
+  startedAt: timestamp('started_at', { withTimezone: true }).defaultNow().notNull(),
+  endedAt: timestamp('ended_at', { withTimezone: true }),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  endReason: text('end_reason'),              // 'manual' | 'expired' | 'revoked' | null (still active)
+  ipHash: text('ip_hash'),                   // SHA-256 truncated (not raw INET — aligned with doc-17)
+  userAgent: text('user_agent'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => ({
+  // Indexes for common admin queries
+  byImpersonator: index('idx_imp_sessions_impersonator').on(t.impersonatorId),
+  byTarget: index('idx_imp_sessions_target').on(t.targetUserId),
+  byOrg: index('idx_imp_sessions_org').on(t.targetOrgId),
+  byExpiry: index('idx_imp_sessions_expiry').on(t.expiresAt), // for cleanup job
+}));
+```
+
+**Append-only rule**: The `status` column must never be updated via a direct `UPDATE`. Use dedicated columns (`ended_at`, `end_reason`) and reflect status in the application layer. This preserves the append-only nature of audit records and makes DB-level tampering easier to detect.
+
+## 5. Audit Trail: Double-Attribution
+
+### `audit_logs` schema additions
+
+Two nullable columns are added to the existing `audit_log` table (doc-03 uses singular — align during Phase 1 schema reconciliation):
+
+```sql
+ALTER TABLE audit_log
+  ADD COLUMN impersonator_id           UUID REFERENCES users(id),
+  ADD COLUMN impersonation_session_id  UUID REFERENCES impersonation_sessions(id);
+```
+
+- For normal actions: both columns are `NULL`
+- For impersonation actions: both columns are populated
+
+### What a double-attributed audit entry looks like
+
+```json
+{
+  "id": "01950f3a-...",
+  "orgId": "tenant-uuid",
+  "actorUserId": "impersonated-user-uuid",
+  "impersonatorId": "super-admin-uuid",
+  "impersonationSessionId": "session-uuid",
+  "actorRole": "fundraising_manager",
+  "action": "donation.created",
+  "resourceType": "donation",
+  "resourceId": "donation-uuid",
+  "changes": { "after": { "amount": 150, "currency": "EUR" } },
+  "metadata": {
+    "correlationId": "...",
+    "ipHash": "sha256-truncated",
+    "userAgent": "Mozilla/5.0 (truncated)"
+  },
+  "occurredAt": "2026-04-02T09:12:00Z"
+}
+```
+
+### Audit events catalog
+
+| Event | `action` | Level | `impersonator_id` |
+|---|---|---|---|
+| Impersonation started | `impersonation.started` | `warn` | `impersonator_id` = admin UUID; `actor_user_id` = target user UUID (not yet acting, just session open) |
+| Action during impersonation | `<domain_action>` e.g. `donation.created` | `info` | Yes |
+| Impersonation ended | `impersonation.ended_by_admin` | `info` | Yes |
+| Impersonation expired | `impersonation.expired` | `info` | Yes |
+| Impersonation revoked | `impersonation.revoked` | `warn` | Yes |
+| Denied attempt | `impersonation.denied` | `error` | N/A (admin token logged separately) |
+
+## 6. Permission Isolation
+
+Impersonation must NOT elevate the impersonated session beyond the target user's normal permissions.
+
+| Layer | Behaviour during impersonation | How enforced |
+|---|---|---|
+| RBAC | Target user's role only (e.g. `fundraising_manager`) | JWT `role` claim = target user's role |
+| RLS | Target user's `org_id` only | `SET LOCAL app.current_org_id` from JWT `org_id` claim |
+| Feature flags | Target tenant's overrides | Redis cache keyed by `tenantId` from JWT |
+| MFA-protected routes | Step-up at session start covers MFA requirement | Configurable per operation |
+| super_admin-only routes | **Blocked** — admin temporarily loses super_admin access | JWT `role` = impersonated user's role, not super_admin |
+
+**Critical**: A super_admin impersonating a `fundraising_manager` must NOT be able to access super_admin routes during that session. The impersonation token replaces — it does not stack on top of — the admin's token.
+
+## 7. Frontend: Impersonation Banner
+
+A persistent, non-dismissable banner is rendered in the Next.js root layout whenever an impersonation token is active:
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  ⚠️  Impersonating: Marie Dupont · Maison du Cœur                          │
+│     Reason: Support ticket #1234 — user cannot access donations tab        │
+│     Session expires in  1h 47m                         [End session →]     │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Requirements:**
+- Amber/orange background — visually distinct from all other UI states
+- Renders server-side (SSR-safe via JWT claim inspection in root layout)
+- Shows: impersonated user name + org, reason, remaining time (client-side countdown), end button
+- Non-dismissable — cannot be hidden by page or component code
+- "End session" → `DELETE /admin/impersonation/:sessionId` → redirects to super_admin dashboard
+- Banner is **never shown to the impersonated user** — it is only visible to the admin's browser session
+
+## 8. Step-Up Authentication
+
+Initiating an impersonation session requires re-verifying the admin's TOTP code:
+
+```http
+POST /admin/impersonation
+Authorization: Bearer <super_admin_access_token>
+Content-Type: application/json
+
+{
+  "targetUserId": "user-uuid",
+  "reason": "Support ticket #1234 — user cannot access the donations tab after plan upgrade",
+  "stepUpCode": "123456"
+}
+```
+
+**Validation rules:**
+- `reason` is mandatory, minimum 20 characters (must be meaningful, not "test")
+- `stepUpCode` is mandatory — TOTP verified against the admin's MFA device
+- Rate limit: max 10 impersonation session starts per admin per 24h (Redis counter)
+- A failed `stepUpCode` → `impersonation.denied` audit event (no session created)
+- Brute-force detection: 3 failed attempts in 10 minutes → temporary lockout + security alert
+
+## 9. Administration API
+
+```
+POST   /admin/impersonation
+         Start a new session. Body: { targetUserId, reason, stepUpCode }
+         Guards: RBAC.SUPER_ADMIN + TOTP step-up
+         Returns: { sessionId, token, expiresAt }
+
+GET    /admin/impersonation
+         List all active impersonation sessions (platform-wide)
+         Guards: RBAC.SUPER_ADMIN
+
+GET    /admin/impersonation/:sessionId
+         Session details including all audit events
+         Guards: RBAC.SUPER_ADMIN
+
+DELETE /admin/impersonation/:sessionId
+         End a specific session
+         Guards: RBAC.SUPER_ADMIN
+
+DELETE /admin/impersonation/user/:targetUserId
+         Revoke all active sessions for a specific user (emergency)
+         Guards: RBAC.SUPER_ADMIN
+
+GET    /admin/impersonation/:sessionId/audit
+         All audit_log entries for this session
+         Guards: RBAC.SUPER_ADMIN
+```
+
+All mutating endpoints: audit logged (even if the action is the admin ending their own session).
+
+## 10. GDPR Considerations
+
+| Concern | Decision |
+|---|---|
+| Legal basis for impersonation | Legitimate interest (Art. 6(1)(f)) — support and platform integrity; document in the privacy policy |
+| `reason` field | Mandatory, non-blank — creates an auditable paper trail of why the admin accessed the account |
+| Art. 15 data export | `impersonation_sessions` rows included in both: the impersonated user's export (they have the right to know their account was accessed) AND the admin's activity export |
+| `impersonator_id` visible in user's audit export | Yes — transparency is required. The user can see "a platform admin accessed your account on <date> for reason <reason>" |
+| User notification | Platform-configurable (default: off). When enabled: post-session email to impersonated user. Notification is sent **after** the session ends, not during (to avoid tipping off a user being investigated for abuse). |
+| Right to erasure | `impersonation_sessions` rows are **audit records exempt from erasure** (same principle as `audit_logs`). Document this exception explicitly in `docs/06-security-compliance.md`. |
+| Retention | 7–10 years (aligned with `audit_logs` retention policy from doc-17) |
+| IP address | Stored as SHA-256 truncated hash — not raw INET (consistent with doc-17 §7.2 audit log approach) |
+| DPA/DPIA | If impersonation allows access to special-category data (case notes, health data), a DPIA entry is recommended. Add to the risk register (`docs/09-risk-register.md`). |
+
+## 11. Cross-Agent Rules
+
+### For MVP Engineer
+
+- `POST /admin/impersonation` must require `RBAC.SUPER_ADMIN` + TOTP step-up before issuing any token
+- Every Drizzle audit write helper must accept optional `impersonatorId` and `impersonationSessionId` parameters and pass them to the `audit_logs` insert
+- BullMQ `job.data._meta` must include `impersonatorId` and `impersonationSessionId` when jobs are enqueued during an impersonation session — workers must propagate these to their own audit writes
+- The impersonation token is delivered as `httpOnly` cookie — never exposed to JavaScript
+- Reason field minimum length: 20 characters — enforced with a Zod validator in `packages/shared/validators`
+
+### For QA Engineer
+
+- Test: impersonated session cannot access resources outside the target tenant (RLS still fully enforced)
+- Test: impersonated session cannot call super_admin-only routes (JWT `role` claim = impersonated user's role)
+- Test: every write during impersonation produces an `audit_logs` row with both `actor_user_id` and `impersonator_id` non-null
+- Test: session expires after 2h TTL and subsequent requests return 401
+- Test: `POST /admin/impersonation` with `reason` shorter than 20 chars returns 400
+- Test: `POST /admin/impersonation` with wrong TOTP returns 401 + `impersonation.denied` audit event
+- Test: non-super_admin calling `POST /admin/impersonation` returns 403
+- Test: impersonation banner renders in root layout during impersonation session
+- Test: `DELETE /admin/impersonation/:sessionId` invalidates the Redis key and subsequent requests return 401
+
+### For Security Architect
+
+- Impersonation token must be signed with the same key as standard JWTs — no weaker signature curve or key length
+- `impersonation_sessions` rows must be append-only — no `UPDATE` on `status`; use `ended_at` + `end_reason`
+- Redis key format: `impersonation:{sessionId}` — session UUID prevents key collisions
+- Rate limit: max 10 impersonation starts per admin per 24h (Redis counter: `impersonation:ratelimit:{adminId}`, TTL 24h)
+- Security alert if `impersonation.denied` > 3 in 10 minutes for the same admin
+- Brute-force lockout: after 5 consecutive failed TOTP attempts on impersonation start, lock the admin account for 15 minutes
+
+### For Data Architect
+
+- Add `impersonator_id UUID` and `impersonation_session_id UUID` nullable columns to `audit_logs` in `packages/shared/src/schema/`
+- `impersonation_sessions` is a platform table — no tenant-scoped RLS needed
+- Include `impersonation_sessions` rows in GDPR Art. 15 export for both impersonated user and admin
+- Add exemption note to erasure flow documentation: `impersonation_sessions` rows cannot be erased (audit record integrity)
+- Partition `impersonation_sessions` by `started_at` if volume is expected to be high
+
+### For Log Analyst
+
+- `impersonation.started` and `impersonation.revoked` must be logged at `warn` level with `audit: true`
+- All log lines during an impersonation session must include both `userId` (impersonated) and `impersonatorId` fields
+- Add `body.stepUpCode` to the Pino redact paths — TOTP codes must never appear in logs
+- Add `impersonation.*` events to the audit events catalog in `docs/17-log-management.md`
+- Log the impersonation session ID as a structured field (`impersonationSessionId`) for LogQL correlation
+
+### For Feature Flag Engineer
+
+- Flag evaluation during impersonation uses the **impersonated tenant's** overrides — no change needed if Redis cache is keyed by `tenantId` (already correct)
+- No feature flag is needed to gate the impersonation feature itself — it is always available to `super_admin`
+
+## 12. Open Questions
+
+- [ ] **Keycloak Token Exchange vs. app-layer JWT**: Which to implement in Phase 1? Proposal: app-layer JWT (simpler), migrate to Keycloak Token Exchange in Phase 2. Decision needed.
+- [ ] **User notification**: default off or default on? Proposal: default off (notification may interfere with abuse investigations), configurable per platform policy in org settings.
+- [ ] **Notification timing**: if enabled, should the user be notified at session start or at session end? Proposal: session end — avoids alerting the user during an active investigation.
+- [ ] **Nested impersonation**: can a super_admin impersonate another super_admin? Proposal: no — block it explicitly (if `targetUser.role === 'super_admin'`, return 400).
+- [ ] **Read-only impersonation mode**: should there be an option to impersonate in a read-only mode (no writes allowed)? Useful for UI debugging without risk of accidental data mutation.
+- [ ] **DPIA requirement**: does impersonation access to special-category data (case notes, health records) trigger a mandatory DPIA under GDPR Art. 35? Consult DPO.
+- [ ] **Concurrent sessions**: should a super_admin be allowed to have multiple simultaneous impersonation sessions? Proposal: max 1 active session per admin at a time.
+
+## 13. Implementation Phases
+
+### Phase 1 (Core impersonation — app-layer JWT)
+
+- [ ] `impersonation_sessions` Drizzle schema in `packages/shared`
+- [ ] Add `impersonator_id` + `impersonation_session_id` columns to `audit_logs` schema
+- [ ] `POST /admin/impersonation` — TOTP step-up + reason validation + session creation
+- [ ] Impersonation middleware in `packages/api/src/lib/auth/impersonation.middleware.ts`
+- [ ] Dual-attribution in `buildAuditEntry()` audit plugin
+- [ ] Redis session store with 2h TTL
+- [ ] `DELETE /admin/impersonation/:sessionId` — end session + Redis invalidation
+- [ ] `GET /admin/impersonation` — list active sessions
+- [ ] Rate limiting (10 starts per admin per 24h)
+- [ ] Frontend `ImpersonationBanner` component in root layout
+- [ ] `getImpersonationContext()` SSR utility
+- [ ] BullMQ `_meta` propagation for impersonation fields
+- [ ] Integration tests (see cross-agent rules for QA Engineer)
+- [ ] `impersonation.*` events added to doc-17 audit catalog
+
+### Phase 2 (Keycloak Token Exchange)
+
+- [ ] Enable Token Exchange in Keycloak realm configuration
+- [ ] Custom Keycloak mapper for `impersonator_sub` claim
+- [ ] Migrate `POST /admin/impersonation` to use Keycloak Token Exchange
+- [ ] Retain Redis session store for instant revocation (Keycloak tokens cannot be instantly revoked)
+- [ ] User notification system (configurable per platform policy)
+- [ ] Admin impersonation dashboard with session history


### PR DESCRIPTION
## Summary

- New **Impersonation Engineer** subagent (`.claude/agents/impersonation-engineer.md`) — token design (Keycloak RFC 8693 + app-layer fallback), session lifecycle, double-attribution audit trail, step-up MFA, frontend banner, GDPR, cross-agent rules for 6 agents
- New **doc 19** (`docs/19-impersonation.md`) — full strategy: architecture, JWT claims, session state machine, data model, permission isolation, frontend banner spec, step-up auth, admin API, GDPR, open questions, phased plan
- Updated `CLAUDE.md` with new agent and doc references

## Key decisions

| Component | Choice | Why |
|-----------|--------|-----|
| Token | Keycloak Token Exchange (RFC 8693) + app-layer fallback | Standard OAuth2; Keycloak handles signing; app-layer for Phase 1 simplicity |
| Double-attribution | actor_user_id = impersonated + impersonator_id = admin | Data integrity AND accountability, always both present |
| Permission isolation | Super_admin temporarily loses own role during session | No privilege escalation possible |
| Session TTL | 2h max, non-renewable | Forces re-reason on every new session |
| Step-up auth | TOTP re-verification + reason min 20 chars | Prevents casual or accidental impersonation |
| Frontend | Persistent amber banner in root layout, non-dismissable | Visual indicator that cannot be bypassed |
| Notification | Configurable, default off, post-session | Avoids alerting users during active support investigation |
| IP storage | SHA-256 truncated hash | Consistent with doc-17 audit log convention |

## Architecture highlights

- **RBAC during impersonation**: JWT role claim = impersonated user role — super_admin routes are blocked during the session
- **RLS**: SET LOCAL app.current_org_id uses impersonated user org_id — full tenant isolation maintained
- **Feature flags**: evaluated against impersonated tenant Redis overrides
- **BullMQ**: jobs enqueued during impersonation carry impersonatorId in job data _meta for worker-level double-attribution
- **Frontend**: persistent amber banner in root layout, SSR-safe, non-dismissable

## No production code

Analysis/design only. Implementation tracked in docs/19-impersonation.md section 13.

## Test plan

- [ ] Review impersonation-engineer agent consistency with security-architect and existing agents
- [ ] Verify doc 19 aligns with audit_log schema in doc-03 and break-glass conventions in doc-06
- [ ] Confirm cross-agent rules do not conflict with existing conventions
- [ ] Validate open questions in section 12 — particularly Keycloak Token Exchange vs app-layer decision

Closes #6

Generated with Claude Code