### PR TITLE
fix(agents): align all agents with Scaleway as SaaS cloud provider (ADR-009)

### DIFF
--- a/.claude/agents/mvp-engineer.md
+++ b/.claude/agents/mvp-engineer.md
@@ -23,7 +23,7 @@ You are the full-stack implementation engineer for Givernance Phase 1 MVP. You w
 | Background jobs | BullMQ 5 (Redis) |
 | Database | PostgreSQL 16, multi-tenant via RLS |
 | Auth | Keycloak 24 — JWT Bearer tokens validated in Fastify preHandler hooks |
-| Storage | Cloudflare R2 / MinIO (S3-compatible) |
+| Storage | Scaleway Object Storage EU (SaaS) / MinIO (self-hosted) — S3-compatible |
 | Email | Resend (primary), Brevo (bulk) |
 | Payments | Stripe Connect |
 | Monorepo | pnpm workspaces — packages: `shared`, `api`, `worker`, `migrate` |

--- a/.claude/agents/platform-architect.md
+++ b/.claude/agents/platform-architect.md
@@ -35,17 +35,17 @@ You are the principal platform architect for Givernance. You own the system arch
 |---|---|---|
 | Primary DB | **PostgreSQL 16** | RLS, JSONB, ltree, mature, self-hostable |
 | DB pooling | **PgBouncer** (transaction mode) | Required for connection-pooling in serverless/multi-instance deployments |
-| Cache / job broker | **Redis 7** | Session store, rate limiting, BullMQ job queues (SaaS: Upstash EU · Self-hosted: Redis 7) |
+| Cache / job broker | **Redis 7** | Session store, rate limiting, BullMQ job queues (SaaS: Scaleway Managed Redis EU · Self-hosted: Redis 7 / Valkey) |
 | Search | **PostgreSQL FTS + pg_trgm** | Sufficient for <1M constituents; Meilisearch add-on for larger |
-| File storage | **Cloudflare R2** (SaaS) · **MinIO** (self-hosted) | Documents, exports, receipts — S3-compatible API |
+| File storage | **Scaleway Object Storage EU** (SaaS) · **MinIO** (self-hosted) | Documents, exports, receipts — S3-compatible API |
 | Time-series (future) | **TimescaleDB** extension | Impact KPI trends, donation trends |
 
 ### Infrastructure
 | Layer | Choice | Rationale |
 |---|---|---|
 | Containers | **Docker** | Universal, predictable |
-| Orchestration (self-hosted) | **Docker Compose + Kamal** | One-click deploy on Hetzner EU for SME NPOs |
-| Orchestration (SaaS) | **Kamal + Hetzner EU** | Managed deploys with zero-downtime rolling updates |
+| Orchestration (self-hosted) | **Docker Compose + Kamal** | One-click deploy for SME NPOs |
+| Orchestration (SaaS) | **Kamal + Scaleway EU VMs** | Managed deploys with zero-downtime rolling updates |
 | IaC | **TBD** | Not yet defined; evaluate OpenTofu or Pulumi when multi-cloud needs emerge |
 | CI/CD | **GitHub Actions** | Free for nonprofits, widely understood |
 | Secrets | **TBD** | Not yet defined; avoid env file secrets in production — evaluate at deployment phase |


### PR DESCRIPTION
## Context

ADR-009 (2026-03-30) selected **Scaleway** as the sole SaaS managed cloud provider, superseding the tri-vendor Neon.tech + Upstash + Cloudflare R2 setup (ADR-006). The CLAUDE.md tech stack table was updated at that time, but two agents on main and three spike PRs still referenced the old vendors.

## Changes

| Agent | Old (ADR-006) | New (ADR-009) |
|-------|--------------|---------------|
| platform-architect | Redis SaaS: Upstash EU | Scaleway Managed Redis EU |
| platform-architect | Storage SaaS: Cloudflare R2 | Scaleway Object Storage EU |
| platform-architect | Orchestration SaaS: Kamal + Hetzner EU | Kamal + Scaleway EU VMs |
| mvp-engineer | Storage: Cloudflare R2 / MinIO | Scaleway Object Storage EU (SaaS) / MinIO (self-hosted) |

Spike PRs also updated (pushed to their branches):
- PR #3 spike/log-management: Scaleway Cockpit as SaaS log aggregation target
- PR #4 spike/feature-flags: Scaleway Managed Redis EU for flag cache
- PR #7 spike/impersonation: Scaleway Managed Redis EU for session store

Closes #9

Generated with Claude Code