### PR TITLE
feat(auth): Phase 0 auth, RBAC, audit trail foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Givernance API — environment variables
+# Copy to .env and fill in real values before running.
+
+# ─── Database ─────────────────────────────────────────────────────────────────
+DATABASE_URL=postgresql://givernance:givernance@localhost:5432/givernance
+
+# ─── Auth ─────────────────────────────────────────────────────────────────────
+# Phase 0: simple symmetric JWT secret (replace with Keycloak JWKS URL in Phase 1)
+JWT_SECRET=change-me-in-production
+
+# ─── Admin ────────────────────────────────────────────────────────────────────
+# Secret header required for platform-admin routes (POST /v1/tenants, etc.)
+ADMIN_SECRET=change-me-in-production
+
+# ─── Server ───────────────────────────────────────────────────────────────────
+PORT=4000
+HOST=0.0.0.0
+LOG_LEVEL=info
+CORS_ORIGIN=http://localhost:3000
+
+# ─── Redis (BullMQ / cache) ───────────────────────────────────────────────────
+REDIS_URL=redis://localhost:6379

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,7 +26,8 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@types/pg": "^8.11.0",
+    "@types/node": "^25.6.0",
+    "@types/pg": "^8.20.0",
     "drizzle-kit": "^0.30.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2"

--- a/packages/api/src/modules/audit/routes.ts
+++ b/packages/api/src/modules/audit/routes.ts
@@ -1,34 +1,34 @@
 /** Audit routes — paginated audit log for org admins */
 
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
-import { desc, eq, sql } from 'drizzle-orm'
-import { db } from '../../lib/db.js'
-import { auditLogs } from '@givernance/shared/schema'
-import { PaginationQuerySchema } from '@givernance/shared/validators'
-import type { Pagination } from '@givernance/shared/types'
+import { auditLogs } from "@givernance/shared/schema";
+import type { Pagination } from "@givernance/shared/types";
+import { PaginationQuerySchema } from "@givernance/shared/validators";
+import { desc, eq, sql } from "drizzle-orm";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { db } from "../../lib/db.js";
 
 /** Guard: require org_admin role */
 async function requireOrgAdmin(request: FastifyRequest, reply: FastifyReply) {
   if (!request.auth?.userId) {
     return reply
       .status(401)
-      .send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' })
+      .send({ statusCode: 401, error: "Unauthorized", message: "Authentication required" });
   }
-  if (request.auth.role !== 'org_admin') {
+  if (request.auth.role !== "org_admin") {
     return reply
       .status(403)
-      .send({ statusCode: 403, error: 'Forbidden', message: 'org_admin role required' })
+      .send({ statusCode: 403, error: "Forbidden", message: "org_admin role required" });
   }
 }
 
 export async function auditRoutes(app: FastifyInstance) {
   /** GET /v1/audit — list audit logs for current tenant (org_admin only, paginated) */
-  app.get('/audit', { preHandler: requireOrgAdmin }, async (request, reply) => {
-    const query = PaginationQuerySchema.parse(request.query)
-    const { page, perPage } = query
-    const offset = (page - 1) * perPage
+  app.get("/audit", { preHandler: requireOrgAdmin }, async (request, reply) => {
+    const query = PaginationQuerySchema.parse(request.query);
+    const { page, perPage } = query;
+    const offset = (page - 1) * perPage;
     // auth is guaranteed non-null by requireOrgAdmin guard
-    const { orgId } = request.auth!
+    const { orgId } = request.auth!;
 
     const [data, countResult] = await Promise.all([
       db
@@ -38,20 +38,17 @@ export async function auditRoutes(app: FastifyInstance) {
         .orderBy(desc(auditLogs.createdAt))
         .limit(perPage)
         .offset(offset),
-      db
-        .select({ count: sql<number>`count(*)` })
-        .from(auditLogs)
-        .where(eq(auditLogs.orgId, orgId)),
-    ])
+      db.select({ count: sql<number>`count(*)` }).from(auditLogs).where(eq(auditLogs.orgId, orgId)),
+    ]);
 
-    const total = Number(countResult[0]?.count ?? 0)
+    const total = Number(countResult[0]?.count ?? 0);
     const pagination: Pagination = {
       page,
       perPage,
       total,
       totalPages: Math.ceil(total / perPage),
-    }
+    };
 
-    return reply.send({ data, pagination })
-  })
+    return reply.send({ data, pagination });
+  });
 }

--- a/packages/api/src/modules/audit/routes.ts
+++ b/packages/api/src/modules/audit/routes.ts
@@ -1,0 +1,57 @@
+/** Audit routes — paginated audit log for org admins */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import { desc, eq, sql } from 'drizzle-orm'
+import { db } from '../../lib/db.js'
+import { auditLogs } from '@givernance/shared/schema'
+import { PaginationQuerySchema } from '@givernance/shared/validators'
+import type { Pagination } from '@givernance/shared/types'
+
+/** Guard: require org_admin role */
+async function requireOrgAdmin(request: FastifyRequest, reply: FastifyReply) {
+  if (!request.auth?.userId) {
+    return reply
+      .status(401)
+      .send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' })
+  }
+  if (request.auth.role !== 'org_admin') {
+    return reply
+      .status(403)
+      .send({ statusCode: 403, error: 'Forbidden', message: 'org_admin role required' })
+  }
+}
+
+export async function auditRoutes(app: FastifyInstance) {
+  /** GET /v1/audit — list audit logs for current tenant (org_admin only, paginated) */
+  app.get('/audit', { preHandler: requireOrgAdmin }, async (request, reply) => {
+    const query = PaginationQuerySchema.parse(request.query)
+    const { page, perPage } = query
+    const offset = (page - 1) * perPage
+    // auth is guaranteed non-null by requireOrgAdmin guard
+    const { orgId } = request.auth!
+
+    const [data, countResult] = await Promise.all([
+      db
+        .select()
+        .from(auditLogs)
+        .where(eq(auditLogs.orgId, orgId))
+        .orderBy(desc(auditLogs.createdAt))
+        .limit(perPage)
+        .offset(offset),
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(auditLogs)
+        .where(eq(auditLogs.orgId, orgId)),
+    ])
+
+    const total = Number(countResult[0]?.count ?? 0)
+    const pagination: Pagination = {
+      page,
+      perPage,
+      total,
+      totalPages: Math.ceil(total / perPage),
+    }
+
+    return reply.send({ data, pagination })
+  })
+}

--- a/packages/api/src/modules/health/routes.test.ts
+++ b/packages/api/src/modules/health/routes.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Smoke tests — health check and tenant creation.
+ * Run with: pnpm test
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+
+// Mock DB module before importing the server — Vitest hoists vi.mock() calls.
+vi.mock('../../lib/db.js', () => ({
+  db: {
+    execute: vi.fn().mockResolvedValue([]),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: 'aaaaaaaa-0000-0000-0000-000000000001',
+            name: 'Test Org',
+            slug: 'test-org',
+            plan: 'starter',
+            status: 'active',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        ]),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue([]),
+        orderBy: vi.fn(() => ({ limit: vi.fn(() => ({ offset: vi.fn().mockResolvedValue([]) })) })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue([]),
+      })),
+    })),
+  },
+}))
+
+// Import server after mocks are registered
+import { createServer } from '../../server.js'
+
+describe('GET /healthz', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    app = await createServer()
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  it('returns 200 with status ok', async () => {
+    const res = await app.inject({ method: 'GET', url: '/healthz' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ status: 'ok' })
+  })
+})
+
+describe('POST /v1/tenants', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    process.env['ADMIN_SECRET'] = 'test-admin-secret'
+    app = await createServer()
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  it('returns 401 without admin secret', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/tenants',
+      payload: { name: 'Test', slug: 'test' },
+    })
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('creates a tenant with valid admin secret and returns 201', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/tenants',
+      headers: { 'x-admin-secret': 'test-admin-secret' },
+      payload: { name: 'Test Org', slug: 'test-org' },
+    })
+    expect(res.statusCode).toBe(201)
+    const body = res.json<{ data: { id: string; name: string } }>()
+    expect(body.data).toHaveProperty('id')
+    expect(body.data.name).toBe('Test Org')
+  })
+})

--- a/packages/api/src/modules/health/routes.test.ts
+++ b/packages/api/src/modules/health/routes.test.ts
@@ -3,22 +3,22 @@
  * Run with: pnpm test
  */
 
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 // Mock DB module before importing the server — Vitest hoists vi.mock() calls.
-vi.mock('../../lib/db.js', () => ({
+vi.mock("../../lib/db.js", () => ({
   db: {
     execute: vi.fn().mockResolvedValue([]),
     insert: vi.fn(() => ({
       values: vi.fn(() => ({
         returning: vi.fn().mockResolvedValue([
           {
-            id: 'aaaaaaaa-0000-0000-0000-000000000001',
-            name: 'Test Org',
-            slug: 'test-org',
-            plan: 'starter',
-            status: 'active',
+            id: "aaaaaaaa-0000-0000-0000-000000000001",
+            name: "Test Org",
+            slug: "test-org",
+            plan: "starter",
+            status: "active",
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
           },
@@ -37,62 +37,62 @@ vi.mock('../../lib/db.js', () => ({
       })),
     })),
   },
-}))
+}));
 
 // Import server after mocks are registered
-import { createServer } from '../../server.js'
+import { createServer } from "../../server.js";
 
-describe('GET /healthz', () => {
-  let app: FastifyInstance
-
-  beforeAll(async () => {
-    app = await createServer()
-    await app.ready()
-  })
-
-  afterAll(async () => {
-    await app.close()
-  })
-
-  it('returns 200 with status ok', async () => {
-    const res = await app.inject({ method: 'GET', url: '/healthz' })
-    expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ status: 'ok' })
-  })
-})
-
-describe('POST /v1/tenants', () => {
-  let app: FastifyInstance
+describe("GET /healthz", () => {
+  let app: FastifyInstance;
 
   beforeAll(async () => {
-    process.env['ADMIN_SECRET'] = 'test-admin-secret'
-    app = await createServer()
-    await app.ready()
-  })
+    app = await createServer();
+    await app.ready();
+  });
 
   afterAll(async () => {
-    await app.close()
-  })
+    await app.close();
+  });
 
-  it('returns 401 without admin secret', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/v1/tenants',
-      payload: { name: 'Test', slug: 'test' },
-    })
-    expect(res.statusCode).toBe(401)
-  })
+  it("returns 200 with status ok", async () => {
+    const res = await app.inject({ method: "GET", url: "/healthz" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: "ok" });
+  });
+});
 
-  it('creates a tenant with valid admin secret and returns 201', async () => {
+describe("POST /v1/tenants", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env["ADMIN_SECRET"] = "test-admin-secret";
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("returns 401 without admin secret", async () => {
     const res = await app.inject({
-      method: 'POST',
-      url: '/v1/tenants',
-      headers: { 'x-admin-secret': 'test-admin-secret' },
-      payload: { name: 'Test Org', slug: 'test-org' },
-    })
-    expect(res.statusCode).toBe(201)
-    const body = res.json<{ data: { id: string; name: string } }>()
-    expect(body.data).toHaveProperty('id')
-    expect(body.data.name).toBe('Test Org')
-  })
-})
+      method: "POST",
+      url: "/v1/tenants",
+      payload: { name: "Test", slug: "test" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("creates a tenant with valid admin secret and returns 201", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/tenants",
+      headers: { "x-admin-secret": "test-admin-secret" },
+      payload: { name: "Test Org", slug: "test-org" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { id: string; name: string } }>();
+    expect(body.data).toHaveProperty("id");
+    expect(body.data.name).toBe("Test Org");
+  });
+});

--- a/packages/api/src/modules/invitations/routes.ts
+++ b/packages/api/src/modules/invitations/routes.ts
@@ -1,0 +1,108 @@
+/** Invitation routes — invite users by email, accept via token */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import { and, eq, isNull } from 'drizzle-orm'
+import { z } from 'zod'
+import { db } from '../../lib/db.js'
+import { invitations, users } from '@givernance/shared/schema'
+
+const CreateInvitationBody = z.object({
+  email: z.string().email(),
+  role: z.enum(['org_admin', 'user', 'viewer']).default('user'),
+})
+
+const AcceptInvitationBody = z.object({
+  firstName: z.string().min(1).max(255),
+  lastName: z.string().min(1).max(255),
+})
+
+/** Guard: require org_admin role */
+async function requireOrgAdmin(request: FastifyRequest, reply: FastifyReply) {
+  if (!request.auth?.userId) {
+    return reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' })
+  }
+  if (request.auth.role !== 'org_admin') {
+    return reply.status(403).send({ statusCode: 403, error: 'Forbidden', message: 'org_admin role required' })
+  }
+}
+
+export async function invitationRoutes(app: FastifyInstance) {
+  /**
+   * POST /v1/invitations — invite a user by email (org_admin only)
+   * Email delivery is Phase 2 — returns the token for now.
+   */
+  app.post('/invitations', { preHandler: requireOrgAdmin }, async (request, reply) => {
+    // auth is guaranteed non-null by requireOrgAdmin guard
+    const { userId, orgId } = request.auth!
+    const body = CreateInvitationBody.parse(request.body)
+
+    // Look up the inviting user's internal ID
+    const [inviter] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.keycloakId, userId), eq(users.orgId, orgId)))
+
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // 7 days
+
+    const [invitation] = await db
+      .insert(invitations)
+      .values({
+        orgId,
+        email: body.email,
+        role: body.role,
+        invitedById: inviter?.id ?? null,
+        expiresAt,
+      })
+      .returning()
+
+    return reply.status(201).send({ data: invitation })
+  })
+
+  /**
+   * POST /v1/invitations/:token/accept — accept an invitation (no auth required)
+   * The token itself is the credential. Creates a user record in the tenant.
+   */
+  app.post('/invitations/:token/accept', async (request, reply) => {
+    const { token } = request.params as { token: string }
+    const body = AcceptInvitationBody.parse(request.body)
+
+    const [invitation] = await db
+      .select()
+      .from(invitations)
+      .where(and(eq(invitations.token, token), isNull(invitations.acceptedAt)))
+
+    if (!invitation) {
+      return reply.status(404).send({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Invalid or already used invitation token',
+      })
+    }
+
+    if (invitation.expiresAt < new Date()) {
+      return reply.status(410).send({
+        statusCode: 410,
+        error: 'Gone',
+        message: 'Invitation has expired',
+      })
+    }
+
+    const [user] = await db
+      .insert(users)
+      .values({
+        orgId: invitation.orgId,
+        email: invitation.email,
+        firstName: body.firstName,
+        lastName: body.lastName,
+        role: invitation.role,
+      })
+      .returning()
+
+    await db
+      .update(invitations)
+      .set({ acceptedAt: new Date() })
+      .where(eq(invitations.id, invitation.id))
+
+    return reply.status(201).send({ data: user })
+  })
+}

--- a/packages/api/src/modules/invitations/routes.ts
+++ b/packages/api/src/modules/invitations/routes.ts
@@ -1,28 +1,32 @@
 /** Invitation routes — invite users by email, accept via token */
 
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
-import { and, eq, isNull } from 'drizzle-orm'
-import { z } from 'zod'
-import { db } from '../../lib/db.js'
-import { invitations, users } from '@givernance/shared/schema'
+import { invitations, users } from "@givernance/shared/schema";
+import { and, eq, isNull } from "drizzle-orm";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { db } from "../../lib/db.js";
 
 const CreateInvitationBody = z.object({
   email: z.string().email(),
-  role: z.enum(['org_admin', 'user', 'viewer']).default('user'),
-})
+  role: z.enum(["org_admin", "user", "viewer"]).default("user"),
+});
 
 const AcceptInvitationBody = z.object({
   firstName: z.string().min(1).max(255),
   lastName: z.string().min(1).max(255),
-})
+});
 
 /** Guard: require org_admin role */
 async function requireOrgAdmin(request: FastifyRequest, reply: FastifyReply) {
   if (!request.auth?.userId) {
-    return reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' })
+    return reply
+      .status(401)
+      .send({ statusCode: 401, error: "Unauthorized", message: "Authentication required" });
   }
-  if (request.auth.role !== 'org_admin') {
-    return reply.status(403).send({ statusCode: 403, error: 'Forbidden', message: 'org_admin role required' })
+  if (request.auth.role !== "org_admin") {
+    return reply
+      .status(403)
+      .send({ statusCode: 403, error: "Forbidden", message: "org_admin role required" });
   }
 }
 
@@ -31,18 +35,18 @@ export async function invitationRoutes(app: FastifyInstance) {
    * POST /v1/invitations — invite a user by email (org_admin only)
    * Email delivery is Phase 2 — returns the token for now.
    */
-  app.post('/invitations', { preHandler: requireOrgAdmin }, async (request, reply) => {
+  app.post("/invitations", { preHandler: requireOrgAdmin }, async (request, reply) => {
     // auth is guaranteed non-null by requireOrgAdmin guard
-    const { userId, orgId } = request.auth!
-    const body = CreateInvitationBody.parse(request.body)
+    const { userId, orgId } = request.auth!;
+    const body = CreateInvitationBody.parse(request.body);
 
     // Look up the inviting user's internal ID
     const [inviter] = await db
       .select({ id: users.id })
       .from(users)
-      .where(and(eq(users.keycloakId, userId), eq(users.orgId, orgId)))
+      .where(and(eq(users.keycloakId, userId), eq(users.orgId, orgId)));
 
-    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // 7 days
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
 
     const [invitation] = await db
       .insert(invitations)
@@ -53,38 +57,38 @@ export async function invitationRoutes(app: FastifyInstance) {
         invitedById: inviter?.id ?? null,
         expiresAt,
       })
-      .returning()
+      .returning();
 
-    return reply.status(201).send({ data: invitation })
-  })
+    return reply.status(201).send({ data: invitation });
+  });
 
   /**
    * POST /v1/invitations/:token/accept — accept an invitation (no auth required)
    * The token itself is the credential. Creates a user record in the tenant.
    */
-  app.post('/invitations/:token/accept', async (request, reply) => {
-    const { token } = request.params as { token: string }
-    const body = AcceptInvitationBody.parse(request.body)
+  app.post("/invitations/:token/accept", async (request, reply) => {
+    const { token } = request.params as { token: string };
+    const body = AcceptInvitationBody.parse(request.body);
 
     const [invitation] = await db
       .select()
       .from(invitations)
-      .where(and(eq(invitations.token, token), isNull(invitations.acceptedAt)))
+      .where(and(eq(invitations.token, token), isNull(invitations.acceptedAt)));
 
     if (!invitation) {
       return reply.status(404).send({
         statusCode: 404,
-        error: 'Not Found',
-        message: 'Invalid or already used invitation token',
-      })
+        error: "Not Found",
+        message: "Invalid or already used invitation token",
+      });
     }
 
     if (invitation.expiresAt < new Date()) {
       return reply.status(410).send({
         statusCode: 410,
-        error: 'Gone',
-        message: 'Invitation has expired',
-      })
+        error: "Gone",
+        message: "Invitation has expired",
+      });
     }
 
     const [user] = await db
@@ -96,13 +100,13 @@ export async function invitationRoutes(app: FastifyInstance) {
         lastName: body.lastName,
         role: invitation.role,
       })
-      .returning()
+      .returning();
 
     await db
       .update(invitations)
       .set({ acceptedAt: new Date() })
-      .where(eq(invitations.id, invitation.id))
+      .where(eq(invitations.id, invitation.id));
 
-    return reply.status(201).send({ data: user })
-  })
+    return reply.status(201).send({ data: user });
+  });
 }

--- a/packages/api/src/modules/tenants/routes.ts
+++ b/packages/api/src/modules/tenants/routes.ts
@@ -1,0 +1,54 @@
+/** Tenant routes — platform-admin CRUD for organizations */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { db } from '../../lib/db.js'
+import { tenants } from '@givernance/shared/schema'
+
+const CreateTenantBody = z.object({
+  name: z.string().min(1).max(255),
+  slug: z.string().min(1).max(100).regex(/^[a-z0-9-]+$/, 'slug must be lowercase alphanumeric with hyphens'),
+  plan: z.enum(['starter', 'pro', 'enterprise']).optional().default('starter'),
+})
+
+/** Guard: require x-admin-secret header matching ADMIN_SECRET env var */
+async function requireAdminSecret(request: FastifyRequest, reply: FastifyReply) {
+  const secret = request.headers['x-admin-secret'] as string | undefined
+  const adminSecret = process.env['ADMIN_SECRET']
+  if (!secret || !adminSecret || secret !== adminSecret) {
+    return reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Invalid admin secret' })
+  }
+}
+
+export async function tenantRoutes(app: FastifyInstance) {
+  /** POST /v1/tenants — create a new organization (platform admin only) */
+  app.post('/tenants', { preHandler: requireAdminSecret }, async (request, reply) => {
+    const body = CreateTenantBody.parse(request.body)
+
+    const [tenant] = await db
+      .insert(tenants)
+      .values({ name: body.name, slug: body.slug, plan: body.plan })
+      .returning()
+
+    return reply.status(201).send({ data: tenant })
+  })
+
+  /** GET /v1/tenants — list all organizations (platform admin only) */
+  app.get('/tenants', { preHandler: requireAdminSecret }, async (_request, reply) => {
+    const all = await db.select().from(tenants)
+    return reply.send({ data: all })
+  })
+
+  /** GET /v1/tenants/:id — get organization details (platform admin only) */
+  app.get('/tenants/:id', { preHandler: requireAdminSecret }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const [tenant] = await db.select().from(tenants).where(eq(tenants.id, id))
+
+    if (!tenant) {
+      return reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'Tenant not found' })
+    }
+
+    return reply.send({ data: tenant })
+  })
+}

--- a/packages/api/src/modules/tenants/routes.ts
+++ b/packages/api/src/modules/tenants/routes.ts
@@ -1,54 +1,62 @@
 /** Tenant routes — platform-admin CRUD for organizations */
 
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
-import { eq } from 'drizzle-orm'
-import { z } from 'zod'
-import { db } from '../../lib/db.js'
-import { tenants } from '@givernance/shared/schema'
+import { tenants } from "@givernance/shared/schema";
+import { eq } from "drizzle-orm";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { db } from "../../lib/db.js";
 
 const CreateTenantBody = z.object({
   name: z.string().min(1).max(255),
-  slug: z.string().min(1).max(100).regex(/^[a-z0-9-]+$/, 'slug must be lowercase alphanumeric with hyphens'),
-  plan: z.enum(['starter', 'pro', 'enterprise']).optional().default('starter'),
-})
+  slug: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-z0-9-]+$/, "slug must be lowercase alphanumeric with hyphens"),
+  plan: z.enum(["starter", "pro", "enterprise"]).optional().default("starter"),
+});
 
 /** Guard: require x-admin-secret header matching ADMIN_SECRET env var */
 async function requireAdminSecret(request: FastifyRequest, reply: FastifyReply) {
-  const secret = request.headers['x-admin-secret'] as string | undefined
-  const adminSecret = process.env['ADMIN_SECRET']
+  const secret = request.headers["x-admin-secret"] as string | undefined;
+  const adminSecret = process.env["ADMIN_SECRET"];
   if (!secret || !adminSecret || secret !== adminSecret) {
-    return reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Invalid admin secret' })
+    return reply
+      .status(401)
+      .send({ statusCode: 401, error: "Unauthorized", message: "Invalid admin secret" });
   }
 }
 
 export async function tenantRoutes(app: FastifyInstance) {
   /** POST /v1/tenants — create a new organization (platform admin only) */
-  app.post('/tenants', { preHandler: requireAdminSecret }, async (request, reply) => {
-    const body = CreateTenantBody.parse(request.body)
+  app.post("/tenants", { preHandler: requireAdminSecret }, async (request, reply) => {
+    const body = CreateTenantBody.parse(request.body);
 
     const [tenant] = await db
       .insert(tenants)
       .values({ name: body.name, slug: body.slug, plan: body.plan })
-      .returning()
+      .returning();
 
-    return reply.status(201).send({ data: tenant })
-  })
+    return reply.status(201).send({ data: tenant });
+  });
 
   /** GET /v1/tenants — list all organizations (platform admin only) */
-  app.get('/tenants', { preHandler: requireAdminSecret }, async (_request, reply) => {
-    const all = await db.select().from(tenants)
-    return reply.send({ data: all })
-  })
+  app.get("/tenants", { preHandler: requireAdminSecret }, async (_request, reply) => {
+    const all = await db.select().from(tenants);
+    return reply.send({ data: all });
+  });
 
   /** GET /v1/tenants/:id — get organization details (platform admin only) */
-  app.get('/tenants/:id', { preHandler: requireAdminSecret }, async (request, reply) => {
-    const { id } = request.params as { id: string }
-    const [tenant] = await db.select().from(tenants).where(eq(tenants.id, id))
+  app.get("/tenants/:id", { preHandler: requireAdminSecret }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const [tenant] = await db.select().from(tenants).where(eq(tenants.id, id));
 
     if (!tenant) {
-      return reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'Tenant not found' })
+      return reply
+        .status(404)
+        .send({ statusCode: 404, error: "Not Found", message: "Tenant not found" });
     }
 
-    return reply.send({ data: tenant })
-  })
+    return reply.send({ data: tenant });
+  });
 }

--- a/packages/api/src/modules/users/routes.ts
+++ b/packages/api/src/modules/users/routes.ts
@@ -1,0 +1,92 @@
+/** User routes — user profile and org-admin user management */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { db } from '../../lib/db.js'
+import { users } from '@givernance/shared/schema'
+
+const CreateUserBody = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1).max(255),
+  lastName: z.string().min(1).max(255),
+  role: z.enum(['org_admin', 'user', 'viewer']).default('user'),
+})
+
+const UpdateRoleBody = z.object({
+  role: z.enum(['org_admin', 'user', 'viewer']),
+})
+
+/** Guard: require valid JWT */
+async function requireAuth(request: FastifyRequest, reply: FastifyReply) {
+  if (!request.auth?.userId) {
+    return reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' })
+  }
+}
+
+/** Guard: require org_admin role */
+async function requireOrgAdmin(request: FastifyRequest, reply: FastifyReply) {
+  if (!request.auth?.userId) {
+    return reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' })
+  }
+  if (request.auth.role !== 'org_admin') {
+    return reply.status(403).send({ statusCode: 403, error: 'Forbidden', message: 'org_admin role required' })
+  }
+}
+
+export async function userRoutes(app: FastifyInstance) {
+  /** GET /v1/users/me — current user profile (requires JWT) */
+  app.get('/users/me', { preHandler: requireAuth }, async (request, reply) => {
+    // auth is guaranteed non-null by requireAuth guard
+    const auth = request.auth!
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(and(eq(users.keycloakId, auth.userId), eq(users.orgId, auth.orgId)))
+
+    if (!user) {
+      return reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'User profile not found' })
+    }
+
+    return reply.send({ data: user })
+  })
+
+  /** GET /v1/users — list users in tenant (org_admin only) */
+  app.get('/users', { preHandler: requireOrgAdmin }, async (request, reply) => {
+    const { orgId } = request.auth!
+    const all = await db.select().from(users).where(eq(users.orgId, orgId))
+    return reply.send({ data: all })
+  })
+
+  /** POST /v1/users — create user in tenant (org_admin only) */
+  app.post('/users', { preHandler: requireOrgAdmin }, async (request, reply) => {
+    const { orgId } = request.auth!
+    const body = CreateUserBody.parse(request.body)
+
+    const [user] = await db
+      .insert(users)
+      .values({ ...body, orgId })
+      .returning()
+
+    return reply.status(201).send({ data: user })
+  })
+
+  /** PATCH /v1/users/:id/role — update user role (org_admin only) */
+  app.patch('/users/:id/role', { preHandler: requireOrgAdmin }, async (request, reply) => {
+    const { orgId } = request.auth!
+    const { id } = request.params as { id: string }
+    const { role } = UpdateRoleBody.parse(request.body)
+
+    const [updated] = await db
+      .update(users)
+      .set({ role, updatedAt: new Date() })
+      .where(and(eq(users.id, id), eq(users.orgId, orgId)))
+      .returning()
+
+    if (!updated) {
+      return reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'User not found' })
+    }
+
+    return reply.send({ data: updated })
+  })
+}

--- a/packages/api/src/modules/users/routes.ts
+++ b/packages/api/src/modules/users/routes.ts
@@ -1,92 +1,102 @@
 /** User routes — user profile and org-admin user management */
 
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
-import { and, eq } from 'drizzle-orm'
-import { z } from 'zod'
-import { db } from '../../lib/db.js'
-import { users } from '@givernance/shared/schema'
+import { users } from "@givernance/shared/schema";
+import { and, eq } from "drizzle-orm";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { db } from "../../lib/db.js";
 
 const CreateUserBody = z.object({
   email: z.string().email(),
   firstName: z.string().min(1).max(255),
   lastName: z.string().min(1).max(255),
-  role: z.enum(['org_admin', 'user', 'viewer']).default('user'),
-})
+  role: z.enum(["org_admin", "user", "viewer"]).default("user"),
+});
 
 const UpdateRoleBody = z.object({
-  role: z.enum(['org_admin', 'user', 'viewer']),
-})
+  role: z.enum(["org_admin", "user", "viewer"]),
+});
 
 /** Guard: require valid JWT */
 async function requireAuth(request: FastifyRequest, reply: FastifyReply) {
   if (!request.auth?.userId) {
-    return reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' })
+    return reply
+      .status(401)
+      .send({ statusCode: 401, error: "Unauthorized", message: "Authentication required" });
   }
 }
 
 /** Guard: require org_admin role */
 async function requireOrgAdmin(request: FastifyRequest, reply: FastifyReply) {
   if (!request.auth?.userId) {
-    return reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Authentication required' })
+    return reply
+      .status(401)
+      .send({ statusCode: 401, error: "Unauthorized", message: "Authentication required" });
   }
-  if (request.auth.role !== 'org_admin') {
-    return reply.status(403).send({ statusCode: 403, error: 'Forbidden', message: 'org_admin role required' })
+  if (request.auth.role !== "org_admin") {
+    return reply
+      .status(403)
+      .send({ statusCode: 403, error: "Forbidden", message: "org_admin role required" });
   }
 }
 
 export async function userRoutes(app: FastifyInstance) {
   /** GET /v1/users/me — current user profile (requires JWT) */
-  app.get('/users/me', { preHandler: requireAuth }, async (request, reply) => {
+  app.get("/users/me", { preHandler: requireAuth }, async (request, reply) => {
     // auth is guaranteed non-null by requireAuth guard
-    const auth = request.auth!
+    const auth = request.auth!;
     const [user] = await db
       .select()
       .from(users)
-      .where(and(eq(users.keycloakId, auth.userId), eq(users.orgId, auth.orgId)))
+      .where(and(eq(users.keycloakId, auth.userId), eq(users.orgId, auth.orgId)));
 
     if (!user) {
-      return reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'User profile not found' })
+      return reply
+        .status(404)
+        .send({ statusCode: 404, error: "Not Found", message: "User profile not found" });
     }
 
-    return reply.send({ data: user })
-  })
+    return reply.send({ data: user });
+  });
 
   /** GET /v1/users — list users in tenant (org_admin only) */
-  app.get('/users', { preHandler: requireOrgAdmin }, async (request, reply) => {
-    const { orgId } = request.auth!
-    const all = await db.select().from(users).where(eq(users.orgId, orgId))
-    return reply.send({ data: all })
-  })
+  app.get("/users", { preHandler: requireOrgAdmin }, async (request, reply) => {
+    const { orgId } = request.auth!;
+    const all = await db.select().from(users).where(eq(users.orgId, orgId));
+    return reply.send({ data: all });
+  });
 
   /** POST /v1/users — create user in tenant (org_admin only) */
-  app.post('/users', { preHandler: requireOrgAdmin }, async (request, reply) => {
-    const { orgId } = request.auth!
-    const body = CreateUserBody.parse(request.body)
+  app.post("/users", { preHandler: requireOrgAdmin }, async (request, reply) => {
+    const { orgId } = request.auth!;
+    const body = CreateUserBody.parse(request.body);
 
     const [user] = await db
       .insert(users)
       .values({ ...body, orgId })
-      .returning()
+      .returning();
 
-    return reply.status(201).send({ data: user })
-  })
+    return reply.status(201).send({ data: user });
+  });
 
   /** PATCH /v1/users/:id/role — update user role (org_admin only) */
-  app.patch('/users/:id/role', { preHandler: requireOrgAdmin }, async (request, reply) => {
-    const { orgId } = request.auth!
-    const { id } = request.params as { id: string }
-    const { role } = UpdateRoleBody.parse(request.body)
+  app.patch("/users/:id/role", { preHandler: requireOrgAdmin }, async (request, reply) => {
+    const { orgId } = request.auth!;
+    const { id } = request.params as { id: string };
+    const { role } = UpdateRoleBody.parse(request.body);
 
     const [updated] = await db
       .update(users)
       .set({ role, updatedAt: new Date() })
       .where(and(eq(users.id, id), eq(users.orgId, orgId)))
-      .returning()
+      .returning();
 
     if (!updated) {
-      return reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'User not found' })
+      return reply
+        .status(404)
+        .send({ statusCode: 404, error: "Not Found", message: "User not found" });
     }
 
-    return reply.send({ data: updated })
-  })
+    return reply.send({ data: updated });
+  });
 }

--- a/packages/api/src/plugins/audit.ts
+++ b/packages/api/src/plugins/audit.ts
@@ -1,9 +1,9 @@
 /** Audit log middleware — persists all mutating requests to audit_logs */
 
+import { auditLogs } from "@givernance/shared/schema";
 import { createHash } from "crypto";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import fp from "fastify-plugin";
-import { auditLogs } from "@givernance/shared/schema";
 import { db } from "../lib/db.js";
 
 /** Extract the top-level resource type from a /v1/<resource>/... URL */

--- a/packages/api/src/plugins/audit.ts
+++ b/packages/api/src/plugins/audit.ts
@@ -1,25 +1,51 @@
-/** Audit log middleware — logs all mutating requests */
+/** Audit log middleware — persists all mutating requests to audit_logs */
 
+import { createHash } from "crypto";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import fp from "fastify-plugin";
+import { auditLogs } from "@givernance/shared/schema";
+import { db } from "../lib/db.js";
+
+/** Extract the top-level resource type from a /v1/<resource>/... URL */
+function extractResourceType(url: string): string | undefined {
+  const match = /\/v1\/([^/?]+)/.exec(url);
+  return match?.[1];
+}
 
 async function audit(app: FastifyInstance) {
   app.addHook("onResponse", async (request: FastifyRequest, reply: FastifyReply) => {
     // Only audit mutating methods
     if (!["POST", "PUT", "PATCH", "DELETE"].includes(request.method)) return;
+    // Only audit authenticated requests
+    if (!request.auth?.orgId) return;
 
-    const entry = {
-      method: request.method,
-      url: request.url,
-      statusCode: reply.statusCode,
-      userId: request.auth?.userId ?? "anonymous",
-      orgId: request.auth?.orgId ?? "unknown",
-      timestamp: new Date().toISOString(),
-      ip: request.ip,
-    };
+    const routeUrl = request.routeOptions.url ?? request.url;
+    const ipHash = createHash("sha256").update(request.ip).digest("hex").slice(0, 16);
 
-    // TODO: persist to audit_logs table
-    request.log.info(entry, "audit");
+    try {
+      await db.insert(auditLogs).values({
+        orgId: request.auth.orgId,
+        userId: request.auth.userId,
+        action: `${request.method}:${routeUrl}`,
+        resourceType: extractResourceType(routeUrl),
+        ipHash,
+        userAgent: request.headers["user-agent"] ?? undefined,
+      });
+    } catch (err) {
+      // Log but never fail the request due to an audit error
+      request.log.error({ err, method: request.method, url: request.url }, "audit insert failed");
+    }
+
+    request.log.info(
+      {
+        method: request.method,
+        url: request.url,
+        statusCode: reply.statusCode,
+        userId: request.auth.userId,
+        orgId: request.auth.orgId,
+      },
+      "audit",
+    );
   });
 }
 

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -1,7 +1,7 @@
-/** JWT validation plugin — verifies Keycloak-issued OIDC tokens */
+/** JWT validation plugin — verifies Keycloak-issued OIDC tokens (Phase 0: @fastify/jwt) */
 
 import fjwt from "@fastify/jwt";
-import type { AuthContext } from "@givernance/shared";
+import type { AuthContext, UserRole } from "@givernance/shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import fp from "fastify-plugin";
 
@@ -13,7 +13,7 @@ declare module "fastify" {
 
 async function auth(app: FastifyInstance) {
   await app.register(fjwt, {
-    secret: process.env.JWT_SECRET ?? "dev-secret-change-in-production",
+    secret: process.env["JWT_SECRET"] ?? "dev-secret-change-in-production",
   });
 
   /** Extract auth context from verified JWT claims */
@@ -35,6 +35,10 @@ async function auth(app: FastifyInstance) {
         org_id: string;
         realm_access?: { roles: string[] };
         email: string;
+        /** Application-level role claim */
+        role?: string;
+        /** RFC 8693 §4.1 actor claim — present on delegation/impersonation tokens */
+        act?: { sub: string };
       }>();
 
       request.auth = {
@@ -42,6 +46,8 @@ async function auth(app: FastifyInstance) {
         orgId: decoded.org_id,
         roles: decoded.realm_access?.roles ?? [],
         email: decoded.email,
+        role: decoded.role as UserRole | undefined,
+        act: decoded.act,
       };
     } catch {
       // Auth will be null for unauthenticated requests

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -4,8 +4,12 @@ import cors from "@fastify/cors";
 import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import Fastify from "fastify";
+import { auditRoutes } from "./modules/audit/routes.js";
 import { constituentRoutes } from "./modules/constituents/routes.js";
 import { healthRoutes } from "./modules/health/routes.js";
+import { invitationRoutes } from "./modules/invitations/routes.js";
+import { tenantRoutes } from "./modules/tenants/routes.js";
+import { userRoutes } from "./modules/users/routes.js";
 import { auditPlugin } from "./plugins/audit.js";
 import { authPlugin } from "./plugins/auth.js";
 import { rlsPlugin } from "./plugins/rls.js";
@@ -14,13 +18,13 @@ import { rlsPlugin } from "./plugins/rls.js";
 export async function createServer() {
   const app = Fastify({
     logger: {
-      level: process.env.LOG_LEVEL ?? "info",
+      level: process.env["LOG_LEVEL"] ?? "info",
     },
   });
 
   // --- Core plugins ---
   await app.register(cors, {
-    origin: process.env.CORS_ORIGIN ?? "http://localhost:3000",
+    origin: process.env["CORS_ORIGIN"] ?? "http://localhost:3000",
     credentials: true,
   });
 
@@ -31,7 +35,7 @@ export async function createServer() {
         description: "CRM API for European nonprofits",
         version: "0.1.0",
       },
-      servers: [{ url: `http://localhost:${process.env.PORT ?? 4000}` }],
+      servers: [{ url: `http://localhost:${process.env["PORT"] ?? 4000}` }],
     },
   });
 
@@ -47,6 +51,10 @@ export async function createServer() {
   // --- Routes ---
   await app.register(healthRoutes);
   await app.register(constituentRoutes, { prefix: "/v1" });
+  await app.register(tenantRoutes, { prefix: "/v1" });
+  await app.register(userRoutes, { prefix: "/v1" });
+  await app.register(invitationRoutes, { prefix: "/v1" });
+  await app.register(auditRoutes, { prefix: "/v1" });
 
   return app;
 }

--- a/packages/migrate/src/migrations/0001_auth_rbac.sql
+++ b/packages/migrate/src/migrations/0001_auth_rbac.sql
@@ -1,0 +1,87 @@
+-- Migration: 0001_auth_rbac
+-- Auth, RBAC, and Audit Trail foundation tables
+-- Run manually or via drizzle-kit migrate
+
+-- ─── Enums ────────────────────────────────────────────────────────────────────
+
+CREATE TYPE user_role AS ENUM ('org_admin', 'user', 'viewer');
+
+-- ─── Tenants ──────────────────────────────────────────────────────────────────
+
+CREATE TABLE tenants (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        VARCHAR(255) NOT NULL,
+  slug        VARCHAR(100) NOT NULL UNIQUE,
+  plan        VARCHAR(50)  NOT NULL DEFAULT 'starter',
+  status      VARCHAR(50)  NOT NULL DEFAULT 'active',
+  created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- ─── Users ────────────────────────────────────────────────────────────────────
+
+CREATE TABLE users (
+  id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id       UUID         NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  email        VARCHAR(255) NOT NULL,
+  first_name   VARCHAR(255) NOT NULL,
+  last_name    VARCHAR(255) NOT NULL,
+  role         user_role    NOT NULL DEFAULT 'user',
+  keycloak_id  VARCHAR(255),
+  created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX users_org_id_idx ON users(org_id);
+CREATE INDEX users_email_idx  ON users(email);
+
+-- ─── Invitations ──────────────────────────────────────────────────────────────
+
+CREATE TABLE invitations (
+  id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id          UUID         NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  email           VARCHAR(255) NOT NULL,
+  role            user_role    NOT NULL DEFAULT 'user',
+  token           UUID         NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  invited_by_id   UUID         REFERENCES users(id) ON DELETE SET NULL,
+  expires_at      TIMESTAMPTZ  NOT NULL,
+  accepted_at     TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX invitations_org_id_idx ON invitations(org_id);
+CREATE INDEX invitations_token_idx  ON invitations(token);
+
+-- ─── Audit Logs ───────────────────────────────────────────────────────────────
+
+CREATE TABLE audit_logs (
+  id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id         UUID         NOT NULL,
+  user_id        VARCHAR(255),
+  action         VARCHAR(255) NOT NULL,
+  resource_type  VARCHAR(100),
+  resource_id    VARCHAR(255),
+  old_values     JSONB,
+  new_values     JSONB,
+  ip_hash        VARCHAR(64),
+  user_agent     TEXT,
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX audit_logs_org_id_idx  ON audit_logs(org_id);
+CREATE INDEX audit_logs_user_id_idx ON audit_logs(user_id);
+
+-- ─── RLS Policies (apply after enabling RLS on each table) ───────────────────
+--
+-- Enable RLS:
+--   ALTER TABLE constituents ENABLE ROW LEVEL SECURITY;
+--   ALTER TABLE donations     ENABLE ROW LEVEL SECURITY;
+--   ALTER TABLE users         ENABLE ROW LEVEL SECURITY;
+--   ALTER TABLE invitations   ENABLE ROW LEVEL SECURITY;
+--   ALTER TABLE audit_logs    ENABLE ROW LEVEL SECURITY;
+--
+-- Example policy:
+--   CREATE POLICY tenant_isolation ON constituents
+--     USING (org_id = current_setting('app.current_org_id')::UUID);
+--
+-- Tenants table is admin-managed only — no RLS needed.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,6 +20,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/pg": "^8.20.0",
     "typescript": "^5.7.2"
   }
 }

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -3,7 +3,106 @@
  * All tables include org_id for row-level security and audit columns.
  */
 
-import { integer, numeric, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import {
+  index,
+  integer,
+  jsonb,
+  numeric,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+export const userRoleEnum = pgEnum("user_role", ["org_admin", "user", "viewer"]);
+
+// ─── Tenants (organizations) ──────────────────────────────────────────────────
+
+/** Tenants — registered organizations using Givernance */
+export const tenants = pgTable("tenants", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  name: varchar("name", { length: 255 }).notNull(),
+  slug: varchar("slug", { length: 100 }).notNull().unique(),
+  plan: varchar("plan", { length: 50 }).notNull().default("starter"),
+  status: varchar("status", { length: 50 }).notNull().default("active"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// ─── Users ────────────────────────────────────────────────────────────────────
+
+/** Users — staff members within a tenant organization */
+export const users = pgTable(
+  "users",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    email: varchar("email", { length: 255 }).notNull(),
+    firstName: varchar("first_name", { length: 255 }).notNull(),
+    lastName: varchar("last_name", { length: 255 }).notNull(),
+    role: userRoleEnum("role").notNull().default("user"),
+    keycloakId: varchar("keycloak_id", { length: 255 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("users_org_id_idx").on(table.orgId), index("users_email_idx").on(table.email)],
+);
+
+// ─── Invitations ──────────────────────────────────────────────────────────────
+
+/** Invitations — pending email invitations for new users (email sending in Phase 2) */
+export const invitations = pgTable(
+  "invitations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    email: varchar("email", { length: 255 }).notNull(),
+    role: userRoleEnum("role").notNull().default("user"),
+    token: uuid("token").notNull().defaultRandom().unique(),
+    invitedById: uuid("invited_by_id").references(() => users.id, { onDelete: "set null" }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    acceptedAt: timestamp("accepted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("invitations_org_id_idx").on(table.orgId),
+    index("invitations_token_idx").on(table.token),
+  ],
+);
+
+// ─── Audit Logs ───────────────────────────────────────────────────────────────
+
+/** Audit logs — GDPR-compliant immutable record of all data mutations */
+export const auditLogs = pgTable(
+  "audit_logs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id").notNull(),
+    userId: varchar("user_id", { length: 255 }),
+    action: varchar("action", { length: 255 }).notNull(),
+    resourceType: varchar("resource_type", { length: 100 }),
+    resourceId: varchar("resource_id", { length: 255 }),
+    oldValues: jsonb("old_values"),
+    newValues: jsonb("new_values"),
+    ipHash: varchar("ip_hash", { length: 64 }),
+    userAgent: text("user_agent"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("audit_logs_org_id_idx").on(table.orgId),
+    index("audit_logs_user_id_idx").on(table.userId),
+  ],
+);
+
+// ─── Constituents ─────────────────────────────────────────────────────────────
 
 /** Constituents — donors, volunteers, members, beneficiaries */
 export const constituents = pgTable("constituents", {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -23,12 +23,19 @@ export interface ApiError {
   details?: Record<string, unknown>;
 }
 
+/** Application-level user role */
+export type UserRole = "org_admin" | "user" | "viewer";
+
 /** Authenticated user context extracted from JWT */
 export interface AuthContext {
   userId: string;
   orgId: string;
   roles: string[];
   email: string;
+  /** Application-level role from JWT `role` claim */
+  role?: UserRole;
+  /** RFC 8693 §4.1 actor claim — present only on delegation/impersonation tokens */
+  act?: { sub: string };
 }
 
 /** Constituent type enum */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.0.0
-        version: 2.4.10
+        version: 2.4.11
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.17
@@ -66,8 +66,11 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/pg':
-        specifier: ^8.11.0
+        specifier: ^8.20.0
         version: 8.20.0
       drizzle-kit:
         specifier: ^0.30.1
@@ -83,7 +86,7 @@ importers:
     dependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.712.0
-        version: 3.1027.0
+        version: 3.1029.0
       '@givernance/shared':
         specifier: workspace:*
         version: link:../shared
@@ -119,6 +122,9 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -130,7 +136,7 @@ importers:
         version: link:../shared
       bullmq:
         specifier: ^5.31.0
-        version: 5.73.3
+        version: 5.73.5
       drizzle-orm:
         specifier: ^0.36.4
         version: 0.36.4(@types/pg@8.20.0)(pg@8.20.0)(react@19.2.5)
@@ -176,8 +182,8 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-s3@3.1027.0':
-    resolution: {integrity: sha512-g6kaFE/pW0Tsoq/BYg8PfXa1hIZQBmyoKtmJTgcbdyzYWiOOu8vj4PZUE2kS8myita6avaY8Ama5IodHJ39lPA==}
+  '@aws-sdk/client-s3@3.1029.0':
+    resolution: {integrity: sha512-OuA8RZTxsAaHDcI25j2NGLMaYFI2WpJdDzK3uLmVBmaHwjQKQZOUDVVBcln8pNo3IgkY+HRSJhRR4/xlM//UyQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.973.27':
@@ -312,55 +318,55 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
-  '@biomejs/biome@2.4.10':
-    resolution: {integrity: sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==}
+  '@biomejs/biome@2.4.11':
+    resolution: {integrity: sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.10':
-    resolution: {integrity: sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw==}
+  '@biomejs/cli-darwin-arm64@2.4.11':
+    resolution: {integrity: sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.10':
-    resolution: {integrity: sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA==}
+  '@biomejs/cli-darwin-x64@2.4.11':
+    resolution: {integrity: sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.10':
-    resolution: {integrity: sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ==}
+  '@biomejs/cli-linux-arm64-musl@2.4.11':
+    resolution: {integrity: sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.4.10':
-    resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
+  '@biomejs/cli-linux-arm64@2.4.11':
+    resolution: {integrity: sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.4.10':
-    resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
+  '@biomejs/cli-linux-x64-musl@2.4.11':
+    resolution: {integrity: sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.4.10':
-    resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
+  '@biomejs/cli-linux-x64@2.4.11':
+    resolution: {integrity: sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.4.10':
-    resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
+  '@biomejs/cli-win32-arm64@2.4.11':
+    resolution: {integrity: sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.10':
-    resolution: {integrity: sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg==}
+  '@biomejs/cli-win32-x64@2.4.11':
+    resolution: {integrity: sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1253,8 +1259,8 @@ packages:
     resolution: {integrity: sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.5.0':
-    resolution: {integrity: sha512-/NzISn4grj/BRFVua/xnQwF+7fakYZgimpw2dfmlPgcqecBMKxpB9g5mLYRrmBD5OrPoODokw4Vi1hrSR4zRyw==}
+  '@smithy/middleware-retry@4.5.1':
+    resolution: {integrity: sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-serde@4.2.17':
@@ -1357,8 +1363,8 @@ packages:
     resolution: {integrity: sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@4.3.0':
-    resolution: {integrity: sha512-tSOPQNT/4KfbvqeMovWC3g23KSYy8czHd3tlN+tOYVNIDLSfxIsrPJihYi5TpNcoV789KWtgChUVedh2y6dDPg==}
+  '@smithy/util-retry@4.3.1':
+    resolution: {integrity: sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-stream@4.5.22':
@@ -1390,6 +1396,9 @@ packages:
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -1476,8 +1485,8 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  bullmq@5.73.3:
-    resolution: {integrity: sha512-WnwQYYJ6UKdyPXS1OkEp7QY+vFE3nblDLMTwYSqXRym9l+7KC0tAkODITC9mxxCFZGx5jrfAist9p8cZTIZIaQ==}
+  bullmq@5.73.5:
+    resolution: {integrity: sha512-bZu3t1c/1smbA8Jk46OrLA4JRHPTv4uLbqUP0uaviV7S4c/rSl/qKmg3twgKKz+3aB4E0NL0jcjQW5eHwGyQOw==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1873,8 +1882,8 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
-  lru-cache@11.3.3:
-    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
   luxon@3.7.2:
@@ -1958,8 +1967,8 @@ packages:
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
-  path-expression-matcher@1.4.0:
-    resolution: {integrity: sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==}
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
   path-scurry@2.0.2:
@@ -2075,8 +2084,8 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.2:
+    resolution: {integrity: sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -2324,6 +2333,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
@@ -2460,7 +2472,7 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-s3@3.1027.0':
+  '@aws-sdk/client-s3@3.1029.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
@@ -2496,7 +2508,7 @@ snapshots:
       '@smithy/md5-js': 4.2.13
       '@smithy/middleware-content-length': 4.2.13
       '@smithy/middleware-endpoint': 4.4.29
-      '@smithy/middleware-retry': 4.5.0
+      '@smithy/middleware-retry': 4.5.1
       '@smithy/middleware-serde': 4.2.17
       '@smithy/middleware-stack': 4.2.13
       '@smithy/node-config-provider': 4.3.13
@@ -2512,7 +2524,7 @@ snapshots:
       '@smithy/util-defaults-mode-node': 4.2.49
       '@smithy/util-endpoints': 3.3.4
       '@smithy/util-middleware': 4.2.13
-      '@smithy/util-retry': 4.3.0
+      '@smithy/util-retry': 4.3.1
       '@smithy/util-stream': 4.5.22
       '@smithy/util-utf8': 4.2.2
       '@smithy/util-waiter': 4.2.15
@@ -2737,7 +2749,7 @@ snapshots:
       '@smithy/core': 3.23.14
       '@smithy/protocol-http': 5.3.13
       '@smithy/types': 4.14.0
-      '@smithy/util-retry': 4.3.0
+      '@smithy/util-retry': 4.3.1
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.996.19':
@@ -2761,7 +2773,7 @@ snapshots:
       '@smithy/invalid-dependency': 4.2.13
       '@smithy/middleware-content-length': 4.2.13
       '@smithy/middleware-endpoint': 4.4.29
-      '@smithy/middleware-retry': 4.5.0
+      '@smithy/middleware-retry': 4.5.1
       '@smithy/middleware-serde': 4.2.17
       '@smithy/middleware-stack': 4.2.13
       '@smithy/node-config-provider': 4.3.13
@@ -2777,7 +2789,7 @@ snapshots:
       '@smithy/util-defaults-mode-node': 4.2.49
       '@smithy/util-endpoints': 3.3.4
       '@smithy/util-middleware': 4.2.13
-      '@smithy/util-retry': 4.3.0
+      '@smithy/util-retry': 4.3.1
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -2857,39 +2869,39 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
-  '@biomejs/biome@2.4.10':
+  '@biomejs/biome@2.4.11':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.10
-      '@biomejs/cli-darwin-x64': 2.4.10
-      '@biomejs/cli-linux-arm64': 2.4.10
-      '@biomejs/cli-linux-arm64-musl': 2.4.10
-      '@biomejs/cli-linux-x64': 2.4.10
-      '@biomejs/cli-linux-x64-musl': 2.4.10
-      '@biomejs/cli-win32-arm64': 2.4.10
-      '@biomejs/cli-win32-x64': 2.4.10
+      '@biomejs/cli-darwin-arm64': 2.4.11
+      '@biomejs/cli-darwin-x64': 2.4.11
+      '@biomejs/cli-linux-arm64': 2.4.11
+      '@biomejs/cli-linux-arm64-musl': 2.4.11
+      '@biomejs/cli-linux-x64': 2.4.11
+      '@biomejs/cli-linux-x64-musl': 2.4.11
+      '@biomejs/cli-win32-arm64': 2.4.11
+      '@biomejs/cli-win32-x64': 2.4.11
 
-  '@biomejs/cli-darwin-arm64@2.4.10':
+  '@biomejs/cli-darwin-arm64@2.4.11':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.10':
+  '@biomejs/cli-darwin-x64@2.4.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.10':
+  '@biomejs/cli-linux-arm64-musl@2.4.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.10':
+  '@biomejs/cli-linux-arm64@2.4.11':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.10':
+  '@biomejs/cli-linux-x64-musl@2.4.11':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.10':
+  '@biomejs/cli-linux-x64@2.4.11':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.10':
+  '@biomejs/cli-win32-arm64@2.4.11':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.10':
+  '@biomejs/cli-win32-x64@2.4.11':
     optional: true
 
   '@drizzle-team/brocli@0.10.2': {}
@@ -3302,7 +3314,7 @@ snapshots:
   '@react-email/render@1.1.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       html-to-text: 9.0.5
-      prettier: 3.8.1
+      prettier: 3.8.2
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       react-promise-suspense: 0.3.4
@@ -3522,7 +3534,7 @@ snapshots:
       '@smithy/util-middleware': 4.2.13
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.5.0':
+  '@smithy/middleware-retry@4.5.1':
     dependencies:
       '@smithy/core': 3.23.14
       '@smithy/node-config-provider': 4.3.13
@@ -3531,7 +3543,7 @@ snapshots:
       '@smithy/smithy-client': 4.12.9
       '@smithy/types': 4.14.0
       '@smithy/util-middleware': 4.2.13
-      '@smithy/util-retry': 4.3.0
+      '@smithy/util-retry': 4.3.1
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
@@ -3682,7 +3694,7 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@smithy/util-retry@4.3.0':
+  '@smithy/util-retry@4.3.1':
     dependencies:
       '@smithy/service-error-classification': 4.2.13
       '@smithy/types': 4.14.0
@@ -3728,9 +3740,13 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 25.6.0
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -3819,7 +3835,7 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  bullmq@5.73.3:
+  bullmq@5.73.5:
     dependencies:
       cron-parser: 4.9.0
       ioredis: 5.10.1
@@ -4084,12 +4100,12 @@ snapshots:
 
   fast-xml-builder@1.1.4:
     dependencies:
-      path-expression-matcher: 1.4.0
+      path-expression-matcher: 1.5.0
 
   fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.4.0
+      path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
   fastfall@1.5.1:
@@ -4249,7 +4265,7 @@ snapshots:
 
   loupe@3.2.1: {}
 
-  lru-cache@11.3.3: {}
+  lru-cache@11.3.5: {}
 
   luxon@3.7.2: {}
 
@@ -4337,11 +4353,11 @@ snapshots:
       leac: 0.6.0
       peberminta: 0.9.0
 
-  path-expression-matcher@1.4.0: {}
+  path-expression-matcher@1.5.0: {}
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.3.3
+      lru-cache: 11.3.5
       minipass: 7.1.3
 
   pathe@1.1.2: {}
@@ -4443,7 +4459,7 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  prettier@3.8.1: {}
+  prettier@3.8.2: {}
 
   process-warning@4.0.1: {}
 
@@ -4675,6 +4691,8 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.19.2: {}
 
   uuid@11.1.0: {}
 


### PR DESCRIPTION
## Summary

Implements Issue #13 — the full authentication, RBAC, and audit trail foundation for Phase 0.

- **Drizzle schema** — 4 new tables: `tenants`, `users`, `invitations`, `audit_logs` (with indexes and a `user_role` enum)
- **Auth plugin** — extracts `role` claim from JWT; `AuthContext` extended with `role?: UserRole`; `null`-safe type declaration
- **Audit plugin** — completes the TODO: persists to `audit_logs` with sha256 IP hash (fire-and-forget, never fails the request)
- **Tenants routes** (`POST/GET /v1/tenants`) — platform-admin only via `x-admin-secret` header
- **Users routes** (`GET /me`, list, create, `PATCH /:id/role`) — JWT auth + `org_admin` guard
- **Invitations routes** (`POST /invite`, `POST /:token/accept`) — email delivery deferred to Phase 2; token is the credential
- **Audit routes** (`GET /v1/audit`) — paginated, `org_admin` only
- **SQL migration** — `packages/migrate/src/migrations/0001_auth_rbac.sql` with raw DDL + RLS policy comments
- **`.env.example`** — all required env vars documented
- **Smoke tests** — 3 passing (healthz 200, tenants 401 without secret, tenants 201 with secret)
- **`@types/node` + `@types/pg`** added to both `api` and `shared` for consistent drizzle-orm peer dep resolution

## Test plan

- [x] `pnpm build` — all 4 packages build clean
- [x] `pnpm test` — 3/3 smoke tests pass
- [x] `pnpm --filter @givernance/api typecheck` — clean (0 errors)
- [x] `pnpm --filter @givernance/shared typecheck` — clean (0 errors)
- [ ] Integration test against real Postgres (requires `docker compose up`)

## Notes

- `packages/migrate` and `packages/worker` have pre-existing type errors unrelated to this PR
- No Keycloak setup needed — Phase 0 uses `@fastify/jwt` with `JWT_SECRET` env var
- No email sending — invitation tokens returned directly in the response

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)