### PR TITLE
feat(infra): Phase 0 Scaleway SaaS + local dev docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# =============================================================================
+# Givernance — Local Development Environment
+# Copy to .env and adjust as needed:  cp .env.example .env
+# =============================================================================
+
+# --- PostgreSQL -------------------------------------------------
+POSTGRES_DB=givernance
+POSTGRES_USER=givernance
+POSTGRES_PASSWORD=givernance_dev
+POSTGRES_PORT=5432
+DATABASE_URL=postgresql://givernance:givernance_dev@localhost:5432/givernance
+
+# --- Redis (cache / rate-limiting) ------------------------------
+REDIS_PORT=6379
+REDIS_URL=redis://localhost:6379
+
+# --- Keycloak (OIDC / SAML) ------------------------------------
+KEYCLOAK_PORT=8080
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin
+KEYCLOAK_ISSUER=http://localhost:8080/realms/givernance
+
+# --- MinIO (S3-compatible object storage) -----------------------
+MINIO_API_PORT=9000
+MINIO_CONSOLE_PORT=9001
+MINIO_ROOT_USER=givernance
+MINIO_ROOT_PASSWORD=givernance_dev
+S3_ENDPOINT=http://localhost:9000
+S3_BUCKET=givernance
+S3_ACCESS_KEY=givernance
+S3_SECRET_KEY=givernance_dev
+S3_REGION=us-east-1
+
+# --- Mailpit (local SMTP testing) ------------------------------
+MAILPIT_SMTP_PORT=1025
+MAILPIT_UI_PORT=8025
+SMTP_HOST=localhost
+SMTP_PORT=1025
+
+# --- App --------------------------------------------------------
+NODE_ENV=development
+PORT=4000
+LOG_LEVEL=debug

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,12 @@
+# Givernance — local reverse proxy (optional)
+# Activated with: docker compose --profile proxy up -d
+
+:3000 {
+	# API server (Fastify)
+	reverse_proxy host.docker.internal:4000
+}
+
+:3001 {
+	# Web app (Next.js dev server)
+	reverse_proxy host.docker.internal:3100
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,20 @@
 ## Givernance — local development stack
 ## Usage: docker compose up -d
+## Docs:  docs/infra/README.md
 
 services:
   postgres:
     image: postgres:16-alpine
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     environment:
-      POSTGRES_DB: givernance
-      POSTGRES_USER: givernance
-      POSTGRES_PASSWORD: givernance_dev
+      POSTGRES_DB: ${POSTGRES_DB:-givernance}
+      POSTGRES_USER: ${POSTGRES_USER:-givernance}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-givernance_dev}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U givernance"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-givernance}"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -21,7 +22,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redisdata:/data
     healthcheck:
@@ -31,41 +32,50 @@ services:
       retries: 5
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.0
+    image: quay.io/keycloak/keycloak:24.0
     ports:
-      - "8080:8080"
+      - "${KEYCLOAK_PORT:-8080}:8080"
     environment:
-      KC_BOOTSTRAP_ADMIN_USERNAME: admin
-      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
       KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://postgres:5432/givernance
-      KC_DB_USERNAME: givernance
-      KC_DB_PASSWORD: givernance_dev
+      KC_DB_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-givernance}
+      KC_DB_USERNAME: ${POSTGRES_USER:-givernance}
+      KC_DB_PASSWORD: ${POSTGRES_PASSWORD:-givernance_dev}
     command: start-dev
     depends_on:
       postgres:
         condition: service_healthy
 
-  nats:
-    image: nats:2-alpine
-    ports:
-      - "4222:4222"
-      - "8222:8222"
-    command: --jetstream --store_dir /data
-    volumes:
-      - natsdata:/data
-
   minio:
     image: minio/minio:latest
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "${MINIO_API_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
     environment:
-      MINIO_ROOT_USER: givernance
-      MINIO_ROOT_PASSWORD: givernance_dev
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-givernance}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-givernance_dev}
     command: server /data --console-address ":9001"
     volumes:
       - miniodata:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "${MAILPIT_SMTP_PORT:-1025}:1025"
+      - "${MAILPIT_UI_PORT:-8025}:8025"
+    volumes:
+      - mailpitdata:/data
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8025/api/v1/info"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
 
   caddy:
     image: caddy:2-alpine
@@ -74,6 +84,8 @@ services:
       - "3001:3001"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddydata:/data
+      - caddyconfig:/config
     depends_on:
       - keycloak
     profiles:
@@ -82,5 +94,7 @@ services:
 volumes:
   pgdata:
   redisdata:
-  natsdata:
   miniodata:
+  mailpitdata:
+  caddydata:
+  caddyconfig:

--- a/docs/infra/README.md
+++ b/docs/infra/README.md
@@ -1,0 +1,110 @@
+# Givernance — Infrastructure
+
+This document describes the local development stack and the SaaS production architecture.
+
+## Local Development
+
+The local stack mirrors the SaaS production services using Docker Compose.
+
+### Prerequisites
+
+- Docker Engine 24+ with Compose V2
+- Node.js 22 LTS
+- pnpm 9+
+
+### Quick Start
+
+```bash
+# Copy environment file
+cp .env.example .env
+
+# Start all services
+./scripts/dev-up.sh
+
+# Stop all services
+./scripts/dev-down.sh
+```
+
+Or manually:
+
+```bash
+docker compose up -d
+```
+
+### Local Services
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| PostgreSQL 16 | `localhost:5432` | Primary database (`givernance` DB) |
+| Redis 7 | `localhost:6379` | Cache, rate limiting |
+| Keycloak 24 | `http://localhost:8080` | OIDC/SAML identity provider (admin: `admin`/`admin`) |
+| MinIO | `http://localhost:9000` (API), `http://localhost:9001` (Console) | S3-compatible object storage (user: `givernance`/`givernance_dev`) |
+| Mailpit | `localhost:1025` (SMTP), `http://localhost:8025` (UI) | Local email capture and testing |
+| Caddy | `localhost:3000`, `localhost:3001` | Reverse proxy (optional, `--profile proxy`) |
+
+### Connecting the App
+
+The application reads connection strings from environment variables. See `.env.example` for defaults:
+
+```
+DATABASE_URL=postgresql://givernance:givernance_dev@localhost:5432/givernance
+REDIS_URL=redis://localhost:6379
+S3_ENDPOINT=http://localhost:9000
+SMTP_HOST=localhost
+SMTP_PORT=1025
+```
+
+---
+
+## SaaS Architecture (Scaleway EU)
+
+The managed SaaS offering runs entirely on **Scaleway**, a French cloud provider with datacenters in Paris (PAR) and Amsterdam (AMS). All infrastructure is under a **single Scaleway GDPR Data Processing Agreement (DPA)** — 100% EU data residency.
+
+See [ADR-009](../15-infra-adr.md#adr-009--scaleway-as-primary-saas-managed-cloud-provider) for the full decision record.
+
+### Managed Services
+
+| Component | Scaleway Product | Local Equivalent |
+|-----------|-----------------|------------------|
+| Database | Managed PostgreSQL EU (PAR/AMS) | PostgreSQL 16 (Docker) |
+| Cache / Rate Limiting | Managed Redis EU | Redis 7 (Docker) |
+| Object Storage | Scaleway Object Storage (S3-compatible) | MinIO (Docker) |
+| Auth | Keycloak on Scaleway VM | Keycloak (Docker) |
+| Observability | Cockpit (Grafana + Loki + Mimir + Tempo) | — (local: stdout logs) |
+| AI Inference | Scaleway Generative APIs (Mistral, Llama 3.1) | — (optional, not in local stack) |
+| Deployment | Kamal + Scaleway EU VMs | Docker Compose |
+
+### GDPR Compliance
+
+- **Data residency**: All data stored and processed in EU (France / Netherlands).
+- **Single DPA**: One contract with Scaleway covers compute, database, storage, cache, inference, and observability.
+- **Art. 9 special category data**: Beneficiary case notes and medical/social status processed via Scaleway Generative APIs — EU-only inference, no data leaves EU jurisdiction.
+- **Self-hosted option**: NPOs requiring on-premises deployment use the same Docker Compose stack with their own PostgreSQL, Redis, MinIO, and Keycloak instances.
+
+### Cost Estimates
+
+| Phase | Config | Monthly Cost |
+|-------|--------|-------------|
+| Phase 0 (dev/staging) | Minimal VMs + managed DB | ~67 EUR |
+| Phase 1 (1 NPO pilot) | API x2, Worker, Web, DB + replica, Redis, Keycloak HA | ~281 EUR |
+| Phase 1 extended (5-10 NPOs) | Scaled Phase 1 | ~458 EUR |
+
+---
+
+## Self-Hosted Deployment
+
+For NPOs that need on-premises infrastructure, the same Docker Compose file serves as the deployment baseline:
+
+```
+PostgreSQL 16 + PgBouncer
+Redis 7
+MinIO (S3-compatible storage)
+Keycloak 24 (OIDC/SAML)
+Caddy (reverse proxy + TLS)
+```
+
+Production self-hosted deployments should add:
+- TLS certificates (Caddy handles automatic HTTPS via Let's Encrypt)
+- Database backups (pg_dump cron or WAL archiving)
+- Redis persistence configuration
+- MinIO replication for storage durability

--- a/scripts/dev-down.sh
+++ b/scripts/dev-down.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$ROOT_DIR"
+
+echo "Stopping Givernance local dev stack..."
+docker compose --profile proxy down
+
+echo ""
+echo "Stack stopped. Data volumes preserved."
+echo "To remove volumes: docker compose down -v"

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$ROOT_DIR"
+
+# Copy .env if it doesn't exist
+if [ ! -f .env ]; then
+  echo "No .env file found — copying from .env.example"
+  cp .env.example .env
+fi
+
+echo "Starting Givernance local dev stack..."
+docker compose up -d
+
+echo ""
+echo "Waiting for PostgreSQL..."
+until docker compose exec -T postgres pg_isready -U "${POSTGRES_USER:-givernance}" -q 2>/dev/null; do
+  sleep 1
+done
+echo "PostgreSQL is ready."
+
+echo ""
+echo "Waiting for Redis..."
+until docker compose exec -T redis redis-cli ping 2>/dev/null | grep -q PONG; do
+  sleep 1
+done
+echo "Redis is ready."
+
+echo ""
+echo "====================================="
+echo " Givernance — Local Dev Stack"
+echo "====================================="
+echo ""
+echo " PostgreSQL   localhost:${POSTGRES_PORT:-5432}   (DB: ${POSTGRES_DB:-givernance})"
+echo " Redis        localhost:${REDIS_PORT:-6379}"
+echo " Keycloak     http://localhost:${KEYCLOAK_PORT:-8080}   (admin/admin)"
+echo " MinIO API    http://localhost:${MINIO_API_PORT:-9000}"
+echo " MinIO UI     http://localhost:${MINIO_CONSOLE_PORT:-9001}   (givernance/givernance_dev)"
+echo " Mailpit SMTP localhost:${MAILPIT_SMTP_PORT:-1025}"
+echo " Mailpit UI   http://localhost:${MAILPIT_UI_PORT:-8025}"
+echo ""
+echo " Caddy proxy (optional): docker compose --profile proxy up -d"
+echo ""
+echo "====================================="


### PR DESCRIPTION
## Summary

- **Docker Compose stack** updated for local development: PostgreSQL 16, Redis 7, Keycloak 24, MinIO, Mailpit, Caddy (optional proxy). NATS removed (deferred to Phase 4 per ADR-005).
- **`.env.example`** added with all connection strings and service ports.
- **`docs/infra/README.md`** documents local dev setup, SaaS architecture (Scaleway EU under single GDPR DPA), cost estimates, and self-hosted deployment notes.
- **`scripts/dev-up.sh` / `scripts/dev-down.sh`** for one-command stack lifecycle with readiness checks.

## Alignment with ADR-009

All local services mirror the Scaleway SaaS managed equivalents:
| Local | SaaS (Scaleway EU) |
|-------|-------------------|
| PostgreSQL 16 (Docker) | Managed PostgreSQL EU |
| Redis 7 (Docker) | Managed Redis EU |
| MinIO (Docker) | Scaleway Object Storage (S3-compatible) |
| Keycloak 24 (Docker) | Keycloak on Scaleway VM |
| Mailpit (Docker) | Resend/Brevo (production) |

NATS JetStream intentionally excluded — reintroduced at Phase 4 per ADR-005.

## Test plan

- [ ] `docker compose config` validates without errors
- [ ] `./scripts/dev-up.sh` starts all services and reports readiness
- [ ] `./scripts/dev-down.sh` stops all services cleanly
- [ ] PostgreSQL accepts connections on port 5432
- [ ] Keycloak admin console accessible at http://localhost:8080
- [ ] MinIO console accessible at http://localhost:9001
- [ ] Mailpit UI accessible at http://localhost:8025

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)