### PR TITLE
feat(constituents): Phase 1 - full CRUD, search, filtering and soft-delete

### DIFF
--- a/packages/api/migrations/0006_constituents_soft_delete.sql
+++ b/packages/api/migrations/0006_constituents_soft_delete.sql
@@ -1,0 +1,4 @@
+-- Migration: 0006_constituents_soft_delete
+-- Adds deleted_at column for soft-delete support on constituents
+
+ALTER TABLE constituents ADD COLUMN deleted_at TIMESTAMPTZ;

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1744502404000,
       "tag": "0005_rls_app_role",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1744502405000,
+      "tag": "0006_constituents_soft_delete",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/modules/constituents/routes.ts
+++ b/packages/api/src/modules/constituents/routes.ts
@@ -1,42 +1,211 @@
-/** Constituent routes — GET /v1/constituents, POST /v1/constituents */
+/** Constituent routes — full CRUD with search, filtering, and soft-delete */
 
-import type { ApiResponse } from "@givernance/shared/types";
-import { ConstituentCreateSchema, PaginationQuerySchema } from "@givernance/shared/validators";
+import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
-import { createConstituent, listConstituents } from "./service.js";
+import { requireAuth } from "../../lib/guards.js";
+import {
+  createConstituent,
+  deleteConstituent,
+  getConstituent,
+  listConstituents,
+  updateConstituent,
+} from "./service.js";
+
+const ConstituentCreateBody = Type.Object({
+  firstName: Type.String({ minLength: 1, maxLength: 255 }),
+  lastName: Type.String({ minLength: 1, maxLength: 255 }),
+  email: Type.Optional(Type.String({ maxLength: 255 })),
+  phone: Type.Optional(Type.String({ maxLength: 50 })),
+  type: Type.Optional(
+    Type.Union([
+      Type.Literal("donor"),
+      Type.Literal("volunteer"),
+      Type.Literal("member"),
+      Type.Literal("beneficiary"),
+      Type.Literal("partner"),
+    ]),
+  ),
+  tags: Type.Optional(Type.Array(Type.String())),
+});
+
+const ConstituentUpdateBody = Type.Partial(ConstituentCreateBody);
+
+const IdParams = Type.Object({
+  id: Type.String({ pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" }),
+});
+
+const ListQuery = Type.Object({
+  page: Type.Optional(Type.Integer({ minimum: 1, default: 1 })),
+  perPage: Type.Optional(Type.Integer({ minimum: 1, maximum: 100, default: 20 })),
+  search: Type.Optional(Type.String()),
+  tags: Type.Optional(Type.Union([Type.Array(Type.String()), Type.String()])),
+  type: Type.Optional(
+    Type.Union([
+      Type.Literal("donor"),
+      Type.Literal("volunteer"),
+      Type.Literal("member"),
+      Type.Literal("beneficiary"),
+      Type.Literal("partner"),
+    ]),
+  ),
+  includeDeleted: Type.Optional(Type.Boolean({ default: false })),
+});
 
 export async function constituentRoutes(app: FastifyInstance) {
-  /** List constituents with pagination */
-  app.get("/constituents", async (request, reply) => {
-    const query = PaginationQuerySchema.parse(request.query);
-    const orgId = request.auth?.orgId;
+  /** List constituents with pagination, search, and filtering */
+  app.get(
+    "/constituents",
+    { preHandler: requireAuth, schema: { querystring: ListQuery } },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply
+          .status(401)
+          .send({ statusCode: 401, error: "Unauthorized", message: "Missing auth context" });
+      }
 
-    if (!orgId) {
-      return reply
-        .status(401)
-        .send({ statusCode: 401, error: "Unauthorized", message: "Missing auth context" });
-    }
+      const query = request.query as {
+        page?: number;
+        perPage?: number;
+        search?: string;
+        tags?: string[] | string;
+        type?: string;
+        includeDeleted?: boolean;
+      };
 
-    const result = await listConstituents(orgId, query);
-    const response: ApiResponse<typeof result.data> = {
-      data: result.data,
-      pagination: result.pagination,
-    };
-    return response;
-  });
+      const tags = query.tags ? (Array.isArray(query.tags) ? query.tags : [query.tags]) : undefined;
+
+      const result = await listConstituents(orgId, {
+        page: query.page ?? 1,
+        perPage: query.perPage ?? 20,
+        search: query.search,
+        tags,
+        type: query.type,
+        includeDeleted: query.includeDeleted,
+      });
+
+      return { data: result.data, pagination: result.pagination };
+    },
+  );
+
+  /** Get a single constituent by ID */
+  app.get(
+    "/constituents/:id",
+    { preHandler: requireAuth, schema: { params: IdParams } },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply
+          .status(401)
+          .send({ statusCode: 401, error: "Unauthorized", message: "Missing auth context" });
+      }
+
+      const { id } = request.params as { id: string };
+      const constituent = await getConstituent(orgId, id);
+
+      if (!constituent) {
+        return reply.status(404).send({
+          type: "https://httpproblems.com/http-status/404",
+          title: "Not Found",
+          status: 404,
+          detail: "Constituent not found",
+        });
+      }
+
+      return { data: constituent };
+    },
+  );
 
   /** Create a new constituent */
-  app.post("/constituents", async (request, reply) => {
-    const body = ConstituentCreateSchema.parse(request.body);
-    const orgId = request.auth?.orgId;
+  app.post(
+    "/constituents",
+    { preHandler: requireAuth, schema: { body: ConstituentCreateBody } },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply
+          .status(401)
+          .send({ statusCode: 401, error: "Unauthorized", message: "Missing auth context" });
+      }
 
-    if (!orgId) {
-      return reply
-        .status(401)
-        .send({ statusCode: 401, error: "Unauthorized", message: "Missing auth context" });
-    }
+      const body = request.body as {
+        firstName: string;
+        lastName: string;
+        email?: string;
+        phone?: string;
+        type?: string;
+        tags?: string[];
+      };
 
-    const constituent = await createConstituent(orgId, body);
-    return reply.status(201).send({ data: constituent });
-  });
+      const constituent = await createConstituent(orgId, body);
+      return reply.status(201).send({ data: constituent });
+    },
+  );
+
+  /** Update a constituent (partial update) */
+  app.put(
+    "/constituents/:id",
+    { preHandler: requireAuth, schema: { params: IdParams, body: ConstituentUpdateBody } },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply
+          .status(401)
+          .send({ statusCode: 401, error: "Unauthorized", message: "Missing auth context" });
+      }
+
+      const { id } = request.params as { id: string };
+      const body = request.body as {
+        firstName?: string;
+        lastName?: string;
+        email?: string;
+        phone?: string;
+        type?: string;
+        tags?: string[];
+      };
+
+      const updated = await updateConstituent(orgId, id, body, userId);
+
+      if (!updated) {
+        return reply.status(404).send({
+          type: "https://httpproblems.com/http-status/404",
+          title: "Not Found",
+          status: 404,
+          detail: "Constituent not found",
+        });
+      }
+
+      return { data: updated };
+    },
+  );
+
+  /** Soft-delete a constituent */
+  app.delete(
+    "/constituents/:id",
+    { preHandler: requireAuth, schema: { params: IdParams } },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply
+          .status(401)
+          .send({ statusCode: 401, error: "Unauthorized", message: "Missing auth context" });
+      }
+
+      const { id } = request.params as { id: string };
+      const deleted = await deleteConstituent(orgId, id, userId);
+
+      if (!deleted) {
+        return reply.status(404).send({
+          type: "https://httpproblems.com/http-status/404",
+          title: "Not Found",
+          status: 404,
+          detail: "Constituent not found",
+        });
+      }
+
+      return { data: deleted };
+    },
+  );
 }

--- a/packages/api/src/modules/constituents/service.ts
+++ b/packages/api/src/modules/constituents/service.ts
@@ -1,28 +1,67 @@
 /** Constituent service — business logic for constituent operations */
 
-import { constituents } from "@givernance/shared/schema";
+import { constituents, outboxEvents } from "@givernance/shared/schema";
 import type { Pagination } from "@givernance/shared/types";
-import type { ConstituentCreate, PaginationQuery } from "@givernance/shared/validators";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, ilike, isNull, or, sql } from "drizzle-orm";
 import { withTenantContext } from "../../lib/db.js";
 
-/** List constituents for an organization with pagination */
-export async function listConstituents(orgId: string, query: PaginationQuery) {
-  const { page, perPage } = query;
+export interface ListConstituentsQuery {
+  page: number;
+  perPage: number;
+  search?: string;
+  tags?: string[];
+  type?: string;
+  includeDeleted?: boolean;
+}
+
+export interface ConstituentInput {
+  firstName: string;
+  lastName: string;
+  email?: string;
+  phone?: string;
+  type?: string;
+  tags?: string[];
+}
+
+/** List constituents for an organization with pagination, search, and filtering */
+export async function listConstituents(orgId: string, query: ListConstituentsQuery) {
+  const { page, perPage, search, tags, type, includeDeleted } = query;
   const offset = (page - 1) * perPage;
 
   return withTenantContext(orgId, async (tx) => {
+    const conditions = [eq(constituents.orgId, orgId)];
+
+    if (!includeDeleted) {
+      conditions.push(isNull(constituents.deletedAt));
+    }
+
+    if (search) {
+      const pattern = `%${search}%`;
+      const searchCondition = or(
+        ilike(constituents.firstName, pattern),
+        ilike(constituents.lastName, pattern),
+        ilike(constituents.email, pattern),
+      );
+      if (searchCondition) {
+        conditions.push(searchCondition);
+      }
+    }
+
+    if (type) {
+      conditions.push(eq(constituents.type, type));
+    }
+
+    if (tags && tags.length > 0) {
+      conditions.push(
+        sql`${constituents.tags} && ${sql.raw(`ARRAY[${tags.map((t) => `'${t.replace(/'/g, "''")}'`).join(",")}]::text[]`)}`,
+      );
+    }
+
+    const where = and(...conditions);
+
     const [data, countResult] = await Promise.all([
-      tx
-        .select()
-        .from(constituents)
-        .where(eq(constituents.orgId, orgId))
-        .limit(perPage)
-        .offset(offset),
-      tx
-        .select({ count: sql<number>`count(*)` })
-        .from(constituents)
-        .where(eq(constituents.orgId, orgId)),
+      tx.select().from(constituents).where(where).limit(perPage).offset(offset),
+      tx.select({ count: sql<number>`count(*)` }).from(constituents).where(where),
     ]);
 
     const total = Number(countResult[0]?.count ?? 0);
@@ -37,8 +76,24 @@ export async function listConstituents(orgId: string, query: PaginationQuery) {
   });
 }
 
+/** Get a single constituent by ID */
+export async function getConstituent(orgId: string, id: string) {
+  return withTenantContext(orgId, async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(constituents)
+      .where(
+        and(eq(constituents.id, id), eq(constituents.orgId, orgId), isNull(constituents.deletedAt)),
+      );
+
+    if (!row) return null;
+
+    return { ...row, activities: [] };
+  });
+}
+
 /** Create a new constituent in an organization */
-export async function createConstituent(orgId: string, input: ConstituentCreate) {
+export async function createConstituent(orgId: string, input: ConstituentInput) {
   return withTenantContext(orgId, async (tx) => {
     const [result] = await tx
       .insert(constituents)
@@ -46,5 +101,67 @@ export async function createConstituent(orgId: string, input: ConstituentCreate)
       .returning();
 
     return result;
+  });
+}
+
+/** Update a constituent */
+export async function updateConstituent(
+  orgId: string,
+  id: string,
+  input: Partial<ConstituentInput>,
+  userId: string,
+) {
+  return withTenantContext(orgId, async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(constituents)
+      .where(
+        and(eq(constituents.id, id), eq(constituents.orgId, orgId), isNull(constituents.deletedAt)),
+      );
+
+    if (!existing) return null;
+
+    const [updated] = await tx
+      .update(constituents)
+      .set({ ...input, updatedAt: new Date() })
+      .where(eq(constituents.id, id))
+      .returning();
+
+    await tx.insert(outboxEvents).values({
+      tenantId: orgId,
+      type: "constituent.updated",
+      payload: { constituentId: id, changes: input, updatedBy: userId },
+    });
+
+    return updated;
+  });
+}
+
+/** Soft-delete a constituent */
+export async function deleteConstituent(orgId: string, id: string, userId: string) {
+  return withTenantContext(orgId, async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(constituents)
+      .where(
+        and(eq(constituents.id, id), eq(constituents.orgId, orgId), isNull(constituents.deletedAt)),
+      );
+
+    if (!existing) return null;
+
+    const now = new Date();
+    const [deleted] = await tx
+      .update(constituents)
+      .set({ deletedAt: now, updatedAt: now })
+      .where(eq(constituents.id, id))
+      .returning();
+
+    await tx.insert(outboxEvents).values({
+      tenantId: orgId,
+      type: "constituent.deleted",
+      payload: { constituentId: id, deletedBy: userId },
+    });
+
+    return deleted;
   });
 }

--- a/packages/api/src/tests/integration/constituents.test.ts
+++ b/packages/api/src/tests/integration/constituents.test.ts
@@ -1,0 +1,367 @@
+import { sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { createServer } from "../../server.js";
+
+let app: FastifyInstance;
+
+const ORG_A = "00000000-0000-0000-0000-000000000001";
+const ORG_B = "00000000-0000-0000-0000-000000000002";
+const USER_A = "00000000-0000-0000-0000-000000000099";
+const USER_B = "00000000-0000-0000-0000-000000000098";
+
+function signToken(app: FastifyInstance, claims: Record<string, unknown> = {}) {
+  return app.jwt.sign({
+    sub: USER_A,
+    org_id: ORG_A,
+    realm_access: { roles: ["admin"] },
+    email: "user-a@example.org",
+    role: "org_admin",
+    ...claims,
+  });
+}
+
+function authHeader(token: string) {
+  return { authorization: `Bearer ${token}` };
+}
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+
+  // Ensure test tenants exist with specific IDs (upsert via ON CONFLICT)
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug) VALUES (${ORG_A}, 'Org A', 'test-org-a') ON CONFLICT (id) DO NOTHING`,
+  );
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug) VALUES (${ORG_B}, 'Org B', 'test-org-b') ON CONFLICT (id) DO NOTHING`,
+  );
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+// ─── CRUD Operations ────────────────────────────────────────────────────────
+
+describe("Constituents CRUD", () => {
+  let constituentId: string;
+
+  it("POST /v1/constituents creates a constituent", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/constituents",
+      headers: authHeader(tokenA),
+      payload: {
+        firstName: "Alice",
+        lastName: "Dupont",
+        email: "alice@example.org",
+        type: "donor",
+        tags: ["major-donor", "annual"],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { id: string; firstName: string } }>();
+    expect(body.data).toHaveProperty("id");
+    expect(body.data.firstName).toBe("Alice");
+    constituentId = body.data.id;
+  });
+
+  it("GET /v1/constituents/:id returns the constituent with activities stub", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/constituents/${constituentId}`,
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { id: string; activities: unknown[] } }>();
+    expect(body.data.id).toBe(constituentId);
+    expect(body.data.activities).toEqual([]);
+  });
+
+  it("PUT /v1/constituents/:id updates the constituent", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "PUT",
+      url: `/v1/constituents/${constituentId}`,
+      headers: authHeader(tokenA),
+      payload: { lastName: "Martin" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { lastName: string } }>();
+    expect(body.data.lastName).toBe("Martin");
+  });
+
+  it("GET /v1/constituents/:id returns 404 for non-existent ID", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents/00000000-0000-0000-0000-ffffffffffff",
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("PUT /v1/constituents/:id returns 404 for non-existent ID", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "PUT",
+      url: "/v1/constituents/00000000-0000-0000-0000-ffffffffffff",
+      headers: authHeader(tokenA),
+      payload: { firstName: "Ghost" },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("DELETE /v1/constituents/:id soft-deletes the constituent", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/constituents/${constituentId}`,
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { deletedAt: string } }>();
+    expect(body.data.deletedAt).toBeTruthy();
+  });
+
+  it("GET /v1/constituents/:id returns 404 after soft-delete", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/constituents/${constituentId}`,
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("DELETE /v1/constituents/:id returns 404 for already-deleted constituent", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/constituents/${constituentId}`,
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ─── Search and Filtering ───────────────────────────────────────────────────
+
+describe("Constituents search and filtering", () => {
+  beforeAll(async () => {
+    const tokenA = signToken(app);
+    // Create a few constituents for searching
+    const entries = [
+      {
+        firstName: "Marie",
+        lastName: "Curie",
+        email: "marie@science.org",
+        type: "donor",
+        tags: ["vip"],
+      },
+      {
+        firstName: "Pierre",
+        lastName: "Curie",
+        email: "pierre@science.org",
+        type: "volunteer",
+        tags: ["vip", "board"],
+      },
+      {
+        firstName: "Ada",
+        lastName: "Lovelace",
+        email: "ada@tech.org",
+        type: "member",
+        tags: ["board"],
+      },
+    ];
+
+    for (const entry of entries) {
+      await app.inject({
+        method: "POST",
+        url: "/v1/constituents",
+        headers: authHeader(tokenA),
+        payload: entry,
+      });
+    }
+  });
+
+  it("search by name returns matching constituents", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents?search=Curie",
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { lastName: string }[]; pagination: { total: number } }>();
+    expect(body.data.length).toBe(2);
+    for (const c of body.data) {
+      expect(c.lastName).toBe("Curie");
+    }
+  });
+
+  it("search by email returns matching constituents", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents?search=ada@tech",
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: unknown[] }>();
+    expect(body.data.length).toBe(1);
+  });
+
+  it("filter by type returns only matching type", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents?type=volunteer",
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { type: string }[] }>();
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+    for (const c of body.data) {
+      expect(c.type).toBe("volunteer");
+    }
+  });
+
+  it("filter by tags returns constituents with matching tags", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents?tags=board",
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { tags: string[] }[] }>();
+    expect(body.data.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("soft-deleted constituents are excluded by default", async () => {
+    const tokenA = signToken(app);
+    // The constituent deleted in the CRUD tests above should NOT appear
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents",
+      headers: authHeader(tokenA),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { deletedAt: string | null }[] }>();
+    for (const c of body.data) {
+      expect(c.deletedAt).toBeNull();
+    }
+  });
+});
+
+// ─── RLS Tenant Isolation ───────────────────────────────────────────────────
+
+describe("Constituents RLS tenant isolation", () => {
+  let constituentInA: string;
+
+  beforeAll(async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/constituents",
+      headers: authHeader(tokenA),
+      payload: { firstName: "TenantA", lastName: "Only", type: "donor" },
+    });
+    constituentInA = res.json<{ data: { id: string } }>().data.id;
+  });
+
+  it("Tenant B cannot GET a constituent from Tenant A", async () => {
+    const tokenB = signToken(app, { sub: USER_B, org_id: ORG_B, email: "user-b@example.org" });
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/constituents/${constituentInA}`,
+      headers: authHeader(tokenB),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("Tenant B cannot PUT a constituent from Tenant A", async () => {
+    const tokenB = signToken(app, { sub: USER_B, org_id: ORG_B, email: "user-b@example.org" });
+    const res = await app.inject({
+      method: "PUT",
+      url: `/v1/constituents/${constituentInA}`,
+      headers: authHeader(tokenB),
+      payload: { firstName: "Hacked" },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("Tenant B cannot DELETE a constituent from Tenant A", async () => {
+    const tokenB = signToken(app, { sub: USER_B, org_id: ORG_B, email: "user-b@example.org" });
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/constituents/${constituentInA}`,
+      headers: authHeader(tokenB),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("Tenant B list does not include Tenant A constituents", async () => {
+    const tokenB = signToken(app, { sub: USER_B, org_id: ORG_B, email: "user-b@example.org" });
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents",
+      headers: authHeader(tokenB),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { id: string }[] }>();
+    const ids = body.data.map((c) => c.id);
+    expect(ids).not.toContain(constituentInA);
+  });
+});
+
+// ─── Unauthenticated Access ─────────────────────────────────────────────────
+
+describe("Constituents unauthenticated access", () => {
+  it("GET /v1/constituents/:id without token returns 401", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents/00000000-0000-0000-0000-000000000001",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("PUT /v1/constituents/:id without token returns 401", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/v1/constituents/00000000-0000-0000-0000-000000000001",
+      payload: { firstName: "Test" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("DELETE /v1/constituents/:id without token returns 401", async () => {
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/v1/constituents/00000000-0000-0000-0000-000000000001",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -125,6 +125,7 @@ export const constituents = pgTable("constituents", {
   phone: varchar("phone", { length: 50 }),
   type: varchar("type", { length: 50 }).notNull().default("donor"),
   tags: text("tags").array(),
+  deletedAt: timestamp("deleted_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });


### PR DESCRIPTION
Closes #32

## Summary
Completes the constituents API with all CRUD operations, search, and filtering required for Phase 1 Sprint 1.

## What's included
- **Soft-delete**: added `deleted_at` column and migration `0006`
- **`GET /v1/constituents`**: full-text search (`ILIKE`), `type`, `tags` array filtering, excludes soft-deleted by default
- **`GET /v1/constituents/:id`**: fetches single constituent with activity timeline stub (`activities: []`)
- **`PUT /v1/constituents/:id`**: partial update, emits `ConstituentUpdated` to outbox inside same Drizzle transaction
- **`DELETE /v1/constituents/:id`**: soft-delete, emits `ConstituentDeleted` to outbox
- **Validation**: completely migrated to `@sinclair/typebox` for fastify route schemas
- **Testing**: 20 new integration tests validating search logic, soft-delete visibility, and cross-tenant RLS isolation

🤖 Authored by Claude CLI