### PR TITLE
fix(dev): wait for Keycloak schema init before patching ssl_required

### DIFF
--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -51,9 +51,19 @@ echo "Running migrations on test database..."
 DATABASE_URL="postgresql://${POSTGRES_USER:-givernance}:${POSTGRES_PASSWORD:-givernance_dev}@localhost:5432/givernance_test" \
   pnpm --filter @givernance/api db:migrate
 
+echo "Waiting for Keycloak to initialize its database schema..."
+until docker compose exec -T postgres psql \
+  -U "${POSTGRES_USER:-givernance}" \
+  -d "${POSTGRES_DB:-givernance}" \
+  -tc "SELECT 1 FROM realm WHERE name='master'" 2>/dev/null | grep -q 1; do
+  sleep 2
+done
+
 echo "Relaxing Keycloak SSL requirement for local dev..."
-docker compose exec -T postgres psql -U "${POSTGRES_USER:-givernance}" -d "${POSTGRES_DB:-givernance}" \
-  -c "UPDATE realm SET ssl_required='NONE' WHERE name='master';" > /dev/null 2>&1 || true
+docker compose exec -T postgres psql \
+  -U "${POSTGRES_USER:-givernance}" \
+  -d "${POSTGRES_DB:-givernance}" \
+  -c "UPDATE realm SET ssl_required='NONE' WHERE name='master';"
 docker compose restart keycloak > /dev/null
 
 echo ""


### PR DESCRIPTION
## Problem

`dev-up.sh` ran the `UPDATE realm SET ssl_required='NONE'` immediately after PostgreSQL became ready, but Keycloak initialises its own database schema (including the `realm` table and the `master` realm row) asynchronously at first boot — a process that takes 15–60 seconds.

The UPDATE silently affected 0 rows, and `|| true` swallowed the error without any feedback. Keycloak restarted with `ssl_required = 'EXTERNAL'` unchanged, causing the "HTTPS required" error in the admin console.

## Fix

Poll the `realm` table until the `master` row exists before running the UPDATE, then restart Keycloak:

```bash
until docker compose exec -T postgres psql \
  -U "${POSTGRES_USER:-givernance}" \
  -d "${POSTGRES_DB:-givernance}" \
  -tc "SELECT 1 FROM realm WHERE name='master'" 2>/dev/null | grep -q 1; do
  sleep 2
done
```

Also removed the `|| true` so failures are visible.

## Test plan

- [ ] `./scripts/dev-up.sh` on a fresh clone (no existing Docker volumes)
- [ ] Keycloak admin console accessible at `http://localhost:8080` without HTTPS redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)