### PR TITLE
docs: Align Architecture Docs with Phase 0 & 1 Reality

### DIFF
--- a/docs/02-reference-architecture.md
+++ b/docs/02-reference-architecture.md
@@ -1,6 +1,6 @@
 # 02 — Reference Architecture
 
-> Last updated: 2026-03-09
+> Last updated: 2026-04-14
 
 ---
 
@@ -57,10 +57,12 @@ See: /diagrams/container.mmd
 #### `givernance-api` (TypeScript, Fastify 5)
 - TypeScript ESM application running on Node.js 22 LTS
 - Domain modules: `auth`, `constituents`, `donations`, `campaigns`, `grants`, `programs`, `beneficiaries`, `volunteers`, `impact`, `finance`, `comms`, `reporting`, `gdpr`, `admin`, `platform`
-- Fastify 5 router + plugin stack (auth, audit, rate limit, tracing); TypeBox for OpenAPI schema validation + type-safe routes
-- Drizzle ORM for type-safe PostgreSQL queries; connects via PgBouncer (transaction mode, or directly to managed Neon.tech in SaaS deployment)
-- Zod for runtime input validation with inferred TypeScript types
-- Publishes domain events via transactional outbox → BullMQ job queue (NATS JetStream deferred to Phase 4+)
+- Fastify 5 router + plugin stack (auth, audit, rate limit, tracing); `@sinclair/typebox` for OpenAPI schema validation, JSON serialization, and type-safe routes (Zod was abandoned — see ADR-002 note)
+- Drizzle ORM for type-safe PostgreSQL queries; connects via PgBouncer (transaction mode) or directly to Scaleway Managed PostgreSQL in SaaS deployment
+- **TypeBox** for runtime input validation with inferred TypeScript types (replaces Zod for better Fastify JSON serialization performance and native Swagger/OpenAPI integration)
+- All API error responses conform to **RFC 7807** (`application/problem+json`) with strict `schema.response` on all routes to prevent PII leakage
+- Connects to PostgreSQL via `DATABASE_URL_APP` using the `givernance_app` role (NOBYPASSRLS) — see §6 Tenancy model
+- Publishes domain events via transactional outbox (`outbox_events` table) → `packages/relay` poller → BullMQ job queue (NATS JetStream deferred to Phase 4+)
 - Serves REST API on `:8080`; admin API on `:8081` (internal only)
 - Health: `GET /healthz`, `GET /readyz`
 
@@ -71,9 +73,18 @@ See: /diagrams/container.mmd
 - Auth: OIDC flow through Keycloak; JWT stored in httpOnly cookie
 - Static assets served from CDN (CloudFront / Cloudflare)
 
+#### `givernance-relay` (TypeScript, standalone)
+- Outbox relay microservice: polls the `outbox_events` table using `SELECT ... FOR UPDATE SKIP LOCKED` to prevent duplicate delivery across multiple relay instances
+- Enqueues events to BullMQ `givernance_events` queue, marks rows as `completed` or `failed`
+- Connects to PostgreSQL via `DATABASE_URL` using the `givernance` owner role (bypasses RLS — needs access to all tenant events)
+- Strict TypeBox environment validation; Pino structured logging with PII redaction
+
 #### `givernance-worker` (TypeScript, BullMQ 5)
 - Async job processor (BullMQ queues on Redis)
-- Jobs: PDF generation, bulk email send, import processing, scheduled reports, GL export, GDPR erasure execution, recurring donation installment creation
+- Jobs: PDF generation (streamed to S3 via `@aws-sdk/lib-storage` — no memory buffering), bulk email send, import processing, scheduled reports, GL export, GDPR erasure execution, recurring donation installment creation
+- Uses atomic receipt numbering via `INSERT ... ON CONFLICT ... UPDATE ... RETURNING next_val` on the `receipt_sequences` table (gapless, race-condition-safe, bounded by `UNIQUE(org_id, fiscal_year, receipt_number)`)
+- Connects to PostgreSQL via `DATABASE_URL` using the `givernance` owner role (bypasses RLS — workers process jobs across tenants)
+- Strict TypeBox environment validation; Pino structured logging with PII redaction (`authorization`, `cookie`, `password`, `token`, `iban`, `cardNumber`, `cvv`, `pan`)
 - Shares types and schemas with `givernance-api` via `@givernance/shared` package; separate process entry point
 
 #### `givernance-migrate` (TypeScript, Drizzle Kit)
@@ -148,7 +159,7 @@ packages/
 │   │   ├── types/           # Shared TypeScript types
 │   │   ├── events/          # Domain event types (CloudEvents)
 │   │   ├── jobs/            # BullMQ job type definitions
-│   │   └── validators/      # Zod schemas for API input validation
+│   │   └── validators/      # TypeBox schemas for API input validation
 │   └── package.json
 ├── api/                     # @givernance/api — Fastify API server
 │   ├── src/
@@ -172,9 +183,18 @@ packages/
 │   │   │   └── platform/    # Super-admin: org provisioning, feature flags
 │   │   └── lib/             # DB client (Drizzle), Redis client, NATS client, RLS helper
 │   └── package.json
+├── relay/                   # @givernance/relay — outbox event relay
+│   ├── src/
+│   │   ├── index.ts         # Outbox poller (SELECT ... FOR UPDATE SKIP LOCKED → BullMQ enqueue)
+│   │   ├── env.ts           # TypeBox environment validation
+│   │   └── lib/logger.ts    # Pino logger with PII redaction
+│   └── package.json
 ├── worker/                  # @givernance/worker — BullMQ job processor
 │   ├── src/
 │   │   ├── worker.ts        # BullMQ worker entry point
+│   │   ├── env.ts           # TypeBox environment validation
+│   │   ├── lib/logger.ts    # Pino logger with PII redaction
+│   │   ├── lib/s3.ts        # S3 streaming upload via @aws-sdk/lib-storage
 │   │   ├── queues/          # Queue definitions
 │   │   └── processors/      # Job processor handlers (one per job type)
 │   └── package.json
@@ -230,17 +250,40 @@ packages/
 
 **Model**: Shared database, shared schema, row-level isolation.
 
-```sql
--- RLS enforced via PostgreSQL policies
--- Connection context set per request by API middleware:
+### 6.1 PostgreSQL 3-Role Pattern
 
-BEGIN;
-SET LOCAL app.current_org_id   = '018e1234-...'; -- UUID v7
-SET LOCAL app.current_user_id  = '018e5678-...';
-SET LOCAL app.current_role     = 'fundraising_manager';
--- All queries in this transaction are automatically filtered by org_id
-COMMIT;
+We use a **3-role pattern** to enforce RLS at the database level:
+
+| Role | Attributes | Connection var | Used by |
+|------|-----------|----------------|---------|
+| `givernance` | Owner, `BYPASSRLS` | `DATABASE_URL` | Migrations, relay, workers (needs cross-tenant access) |
+| `givernance_app` | `NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS` | `DATABASE_URL_APP` | API server (subject to all RLS policies) |
+| `postgres` | Superuser | — | Infrastructure only (never used by application code) |
+
+> **Why not a global Fastify `preHandler` with `set_config`?** In earlier designs, we considered setting `app.current_org_id` in a Fastify `preHandler` hook. This is **unsafe with connection pooling**: `SET LOCAL` scoped to a transaction is safe, but `set_config` at session level leaks across pooled connections. The 3-role pattern eliminates this class of bug entirely — the `givernance_app` role physically cannot bypass RLS, regardless of application-layer mistakes.
+
+### 6.2 Tenant context per transaction
+
+The API **MUST** wrap all tenant-scoped queries in `withTenantContext`:
+
+```typescript
+// packages/api/src/lib/db.ts
+import { withTenantContext } from './db';
+
+// Inside a route handler:
+const result = await withTenantContext(orgId, async (tx) => {
+  // tx is a Drizzle transaction with app.current_org_id set via SET LOCAL
+  return tx.select().from(constituents).where(...);
+});
 ```
+
+Under the hood, `withTenantContext` opens a Drizzle transaction on the `givernance_app` connection and executes `set_config('app.current_org_id', orgId, true)` (the `true` flag scopes the setting to the current transaction). All RLS policies filter on `current_setting('app.current_org_id', true)::UUID`.
+
+### 6.3 FORCE ROW LEVEL SECURITY
+
+All tenant-scoped tables have `FORCE ROW LEVEL SECURITY` enabled (migration `0012_force_rls.sql`). This means RLS policies apply even to the table owner — an extra safety net ensuring that if any code accidentally uses the `givernance` owner connection for tenant queries, it still cannot bypass isolation. Tables covered: `users`, `invitations`, `audit_logs`, `constituents`, `donations`, `outbox_events`, `funds`, `donation_allocations`, `pledges`, `pledge_installments`, `receipts`, `campaigns`, `campaign_documents`, `campaign_qr_codes`.
+
+### 6.4 Schema rationale
 
 **Why shared schema over separate schemas**:
 - Simpler migrations (one migration file applies to all orgs)
@@ -248,7 +291,7 @@ COMMIT;
 - Lower DB overhead (no thousands of schema namespaces)
 - PgBouncer works correctly in transaction mode
 
-**Security boundary**: RLS policies are the only tenant boundary. All policies tested in integration test suite with cross-tenant access attempts. PgBouncer user does NOT have permission to bypass RLS (no `BYPASSRLS`).
+**Security boundary**: RLS policies are the primary tenant boundary. All policies tested in integration test suite with cross-tenant access attempts. The `givernance_app` role does NOT have `BYPASSRLS` — this is the role used by the API server for all user-facing requests.
 
 ---
 
@@ -258,15 +301,21 @@ COMMIT;
 
 ```
 1. API handler writes mutation to DB (e.g., INSERT INTO donations)
-2. In same DB transaction: INSERT INTO domain_events (event_type, payload, published=false)
-3. Transaction commits
-4. Background poller (every 500ms): SELECT unpublished events → enqueue BullMQ job → mark published
-5. BullMQ (Redis) delivers job to givernance-worker (at-least-once, with retries + dead-letter)
+2. In same Drizzle transaction: INSERT INTO outbox_events (type, tenant_id, payload, status='pending')
+3. Transaction commits atomically (mutation + event in one commit)
+4. givernance-relay (packages/relay) polls every 500ms:
+   SELECT ... FROM outbox_events WHERE status = 'pending'
+   ORDER BY created_at ASC LIMIT 100
+   FOR UPDATE SKIP LOCKED            ← prevents duplicate delivery across relay instances
+5. Relay enqueues to BullMQ `givernance_events` queue, marks row status = 'completed' (or 'failed')
+6. BullMQ (Redis) delivers job to givernance-worker (at-least-once, with retries + dead-letter)
 ```
+
+> **Implementation note**: The outbox table is named `outbox_events` (not `domain_events` as in the original design). The relay is a standalone microservice (`packages/relay`) — not a background poller inside the API process — so it can be scaled independently and doesn't compete with API request handling for resources.
 
 **Why outbox, not direct publish**: Guarantees job delivery even if Redis is temporarily unavailable; no dual-write problem. BullMQ provides at-least-once delivery, configurable retries, dead-letter queues, and job inspection — all natively.
 
-**Phase 4 migration path**: When NATS is introduced (see §7.4), the outbox poller will publish to NATS instead of enqueueing BullMQ directly. The domain event types and outbox table are unchanged — only `packages/shared/src/events/publisher.ts` is swapped.
+**Phase 4 migration path**: When NATS is introduced (see §7.4), the relay will publish to NATS instead of enqueueing BullMQ directly. The outbox table schema and domain event types are unchanged — only the relay's publish target is swapped.
 
 ### 7.2 Domain events (key examples)
 
@@ -363,6 +412,7 @@ All services run locally via Docker Compose. No managed cloud dependencies.
 services:
   api:         givernance/api:latest
   web:         givernance/web:latest
+  relay:       givernance/relay:latest   # outbox event relay
   worker:      givernance/worker:latest
   postgres:    postgres:16-alpine
   pgbouncer:   pgbouncer/pgbouncer:latest
@@ -409,7 +459,7 @@ Deployment: Kamal on Scaleway EU VMs. TLS via Caddy. All services under single S
 | Observability | Self-managed (Prometheus + Grafana) | Scaleway Cockpit (Grafana + Loki + Mimir + Tempo) | Scaleway Cockpit |
 | AI Inference (EU) | Ollama self-hosted | Scaleway Generative APIs (Mistral, Llama 3.1) | Scaleway Managed Inference or Generative APIs |
 | Deployment | Docker Compose + Caddy | Kamal + Scaleway EU VMs | Kamal + Scaleway EU VMs |
-| Services to operate | 8 | 4 (API, Worker, Web, Keycloak) | 5 (+NATS) |
+| Services to operate | 9 | 5 (API, Relay, Worker, Web, Keycloak) | 6 (+NATS) |
 | GDPR DPA | Self-managed | Single Scaleway DPA | Single Scaleway DPA |
 
 > See [ADR-005](./15-infra-adr.md#adr-005-nats-jetstream--deferred-to-phase-4) and [ADR-009](./15-infra-adr.md#adr-009--scaleway-as-primary-saas-managed-cloud-provider) for full rationale.

--- a/docs/03-data-model.md
+++ b/docs/03-data-model.md
@@ -1,6 +1,6 @@
 # 03 — Data Model
 
-> Last updated: 2026-02-24
+> Last updated: 2026-04-14
 
 ---
 
@@ -34,7 +34,7 @@ PARTY (constituents, households, organisations)
   └── IMPACT (indicators, readings)
   └── COMMS (email_sends, receipts, consent_log)
   └── FINANCE (funds, gl_batches, gl_export_lines)
-  └── PLATFORM (orgs, users, roles, audit_log, domain_events)
+  └── PLATFORM (orgs, users, roles, audit_log, outbox_events, receipt_sequences)
 ```
 
 ---
@@ -95,21 +95,48 @@ CREATE TABLE audit_log (
 -- Monthly partitions; Glacier archive after 12 months
 ```
 
-#### `domain_events` (transactional outbox)
+#### `outbox_events` (transactional outbox)
+
+> **Implementation note**: This table was originally designed as `domain_events` with a `published` boolean. The implemented table is named `outbox_events` with a `status` enum (`pending` / `completed` / `failed`) and a `processed_at` timestamp, which provides richer operational visibility.
+
 ```sql
-CREATE TABLE domain_events (
+CREATE TABLE outbox_events (
     id              UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
-    org_id          UUID NOT NULL,
-    event_type      TEXT NOT NULL,
-    aggregate_type  TEXT NOT NULL,
-    aggregate_id    UUID NOT NULL,
+    tenant_id       UUID NOT NULL,                    -- org_id (named tenant_id for clarity)
+    type            TEXT NOT NULL,                     -- e.g. 'DonationCreated', 'ConstituentUpdated'
     payload         JSONB NOT NULL,
-    published       BOOLEAN NOT NULL DEFAULT false,
-    published_at    TIMESTAMPTZ,
+    status          TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'completed', 'failed')),
+    processed_at    TIMESTAMPTZ,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX ON domain_events (published, created_at) WHERE published = false;
+CREATE INDEX ON outbox_events (status, created_at) WHERE status = 'pending';
 ```
+
+The `packages/relay` microservice polls this table using `SELECT ... FOR UPDATE SKIP LOCKED` and enqueues to BullMQ. See [02-reference-architecture.md §7.1](./02-reference-architecture.md) for the full flow.
+
+#### `receipt_sequences` (atomic receipt numbering)
+
+```sql
+CREATE TABLE receipt_sequences (
+    org_id          UUID NOT NULL REFERENCES orgs(id),
+    fiscal_year     INTEGER NOT NULL,
+    next_val        INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (org_id, fiscal_year)
+);
+```
+
+Used by the receipt generation worker to produce gapless, race-condition-safe receipt numbers via:
+
+```sql
+INSERT INTO receipt_sequences (org_id, fiscal_year, next_val)
+VALUES ($1, $2, 1)
+ON CONFLICT ON CONSTRAINT receipt_sequences_pkey
+DO UPDATE SET next_val = receipt_sequences.next_val + 1
+RETURNING next_val;
+```
+
+Receipt numbers follow the format `REC-YYYY-NNNN` (zero-padded). Uniqueness is enforced by a separate constraint on the `receipts` table: `UNIQUE(org_id, fiscal_year, receipt_number)`.
 
 ---
 
@@ -727,15 +754,56 @@ CREATE TABLE gl_export_lines (
 
 ---
 
-## 4. Row-level security policies (representative)
+## 4. Row-level security policies
+
+### 4.1 PostgreSQL 3-Role Pattern
+
+Givernance uses a **3-role pattern** for database access:
+
+| Role | Attributes | Used by | RLS behavior |
+|------|-----------|---------|-------------|
+| `givernance` | Owner, `BYPASSRLS` | Migrations, relay, workers | Bypasses RLS (needs cross-tenant access) |
+| `givernance_app` | `NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS` | API server | **Subject to all RLS policies** |
+| `postgres` | Superuser | Infrastructure only | Never used by application code |
+
+The API server connects via `DATABASE_URL_APP` (the `givernance_app` role). Workers and the relay connect via `DATABASE_URL` (the `givernance` owner role) because they process jobs across tenants.
+
+### 4.2 FORCE ROW LEVEL SECURITY
+
+All tenant-scoped tables have both `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY`. The `FORCE` keyword ensures that RLS policies apply even to the table owner — an extra safety net in case application code accidentally uses the wrong connection.
 
 ```sql
--- Enable RLS on all tenant tables
+-- Migration 0004: Enable RLS + create policies
 ALTER TABLE constituents ENABLE ROW LEVEL SECURITY;
 
+-- Migration 0012: FORCE RLS on all tenant tables
+ALTER TABLE constituents FORCE ROW LEVEL SECURITY;
+ALTER TABLE users FORCE ROW LEVEL SECURITY;
+ALTER TABLE donations FORCE ROW LEVEL SECURITY;
+ALTER TABLE outbox_events FORCE ROW LEVEL SECURITY;
+-- ... (all 14 tenant-scoped tables)
+```
+
+### 4.3 Tenant context per transaction
+
+The API sets the tenant context inside a Drizzle transaction using `withTenantContext()`:
+
+```sql
+-- Executed by withTenantContext(orgId, callback) in packages/api/src/lib/db.ts:
+BEGIN;
+SELECT set_config('app.current_org_id', '018e1234-...', true);  -- true = transaction-scoped
+-- All queries within this transaction are filtered by RLS policies
+COMMIT;
+```
+
+> **Why `set_config(..., true)` instead of `SET LOCAL`?** Both are transaction-scoped. `set_config` returns a value and integrates cleanly with Drizzle's `sql` template tag. The `true` parameter ensures the setting is discarded at transaction end — safe with connection pooling.
+
+### 4.4 Representative policies
+
+```sql
 -- Policy: users can only see their own org's data
 CREATE POLICY constituent_org_isolation ON constituents
-    USING (org_id = current_setting('app.current_org_id')::UUID);
+    USING (org_id = current_setting('app.current_org_id', true)::UUID);
 
 -- Policy: erased constituents visible only to gdpr_admin role
 CREATE POLICY constituent_erasure_visibility ON constituents
@@ -795,4 +863,4 @@ Financial records (donations, GL lines) are RETAINED with the constituent ID poi
 | Tag filtering | GIN on array | `constituents.tags` |
 | Custom field queries | GIN on JSONB | `constituents`, `donations` |
 | Soft-delete exclusion | Partial index `WHERE deleted_at IS NULL` | `constituents`, `donations` |
-| Event outbox poll | Partial index `WHERE published = false` | `domain_events` |
+| Event outbox poll | Partial index `WHERE status = 'pending'` | `outbox_events` |

--- a/docs/06-security-compliance.md
+++ b/docs/06-security-compliance.md
@@ -1,12 +1,38 @@
 # 06 — Security & Compliance (EU/GDPR)
 
+> Last updated: 2026-04-14
+
 ## Control baseline
 - Data residency: EU-only regions by default
 - Encryption at rest (AES-256) + in transit (TLS 1.3 minimum)
-- Tenant isolation via `org_id` + Postgres RLS
+- Tenant isolation via PostgreSQL RLS with **3-role pattern** (see below)
 - RBAC + permission scopes by capability
 - Immutable audit log for privileged actions
 - Secrets in vault; no plaintext secrets in DB
+- All API error responses use **RFC 7807** (`application/problem+json`) with strict `schema.response` on all routes to prevent PII leakage
+- Structured logging via **Pino** with built-in PII redaction (defense in depth)
+
+## Database role model (3-role pattern)
+
+| Role | Attributes | Connection | Used by |
+|------|-----------|------------|---------|
+| `givernance` | Owner, `BYPASSRLS` | `DATABASE_URL` | Migrations, relay, workers |
+| `givernance_app` | `NOBYPASSRLS`, `NOSUPERUSER`, `NOCREATEDB` | `DATABASE_URL_APP` | API server |
+| `postgres` | Superuser | — | Infrastructure only |
+
+The API server **always** connects via the `givernance_app` role, which is subject to all RLS policies. All tenant-scoped tables have `FORCE ROW LEVEL SECURITY` enabled, so even the table owner cannot bypass policies accidentally.
+
+The API wraps all tenant queries in `withTenantContext(orgId, callback)`, which sets `app.current_org_id` via transaction-scoped `set_config`. This ensures tenant context never leaks across pooled connections.
+
+> A global Fastify `preHandler` with session-level `set_config` was explicitly rejected — it is unsafe with connection pooling (PgBouncer transaction mode). See [03-data-model.md §4](./03-data-model.md) for full details.
+
+## PII redaction (defense in depth)
+
+Three layers prevent PII from appearing in logs or error responses:
+
+1. **Pino `redact` option**: All service loggers (API, relay, worker) strip known PII paths: `authorization`, `cookie`, `password`, `token`, `iban`, `cardNumber`, `cvv`, `pan`
+2. **Custom serializers**: Domain objects are logged with safe projections only (`{ id, type }`, never `{ email, name }`)
+3. **RFC 7807 strict response schemas**: All routes define explicit `schema.response` — only declared fields are serialized. Undeclared PII fields on internal objects are never exposed to clients.
 
 ## GDPR-by-design
 - Lawful basis per contact/communication

--- a/docs/09-risk-register.md
+++ b/docs/09-risk-register.md
@@ -9,4 +9,4 @@
 | Integration fragility | M | M | Adapter pattern + retry/idempotency |
 | Support burden at launch | M | M | Onboarding playbooks + knowledge base |
 | Node.js TypeScript performance vs compiled languages | L | M | Fastify 5 (one of fastest Node.js frameworks), connection pooling via PgBouncer, horizontal scaling |
-| Type safety at runtime | M | M | Zod validation at API boundaries + Drizzle ORM type-safe queries |
+| Type safety at runtime | M | M | TypeBox validation at API boundaries + Drizzle ORM type-safe queries |

--- a/docs/15-infra-adr.md
+++ b/docs/15-infra-adr.md
@@ -60,13 +60,15 @@ Use **TypeScript (Node.js 22 LTS + Fastify 5)** for the backend, creating a full
 ### Rationale
 
 - **Single language across the stack** → eliminates context switching for a solo/small team
-- **Shared types** between frontend (Next.js) and backend (Fastify) via `packages/shared` — a single Zod schema defines API contract, request validation, and form validation
-- **TypeScript type safety + Zod runtime validation** covers Go's compile-time safety advantage with the added benefit of runtime enforcement
+- **Shared types** between frontend (Next.js) and backend (Fastify) via `packages/shared` — a single TypeBox schema defines API contract, request validation, OpenAPI generation, and form validation
+- **TypeScript type safety + TypeBox runtime validation** covers Go's compile-time safety advantage with the added benefit of runtime enforcement and native Fastify JSON serialization performance
 - **Fastify 5 benchmarks at ~77,000 req/s** on Node.js 22 — well above the target NPO workload of ~500 req/s at peak (200-staff org, 50 concurrent users)
 - **BullMQ** (TypeScript-native) is a direct functional equivalent to Asynq (Go) — both Redis-backed, both support cron, retries, and concurrency control
 - **Drizzle ORM** provides Go-like type safety for SQL queries in TypeScript, with explicit SQL semantics (no magic)
 - **Ecosystem advantage**: TypeScript has a significantly larger developer pool than Go; easier hiring for a European NPO-focused startup
-- **Immediate benefit**: Zod schemas reused from API validation in Next.js forms create a single source of truth for data contracts
+- **Immediate benefit**: TypeBox schemas reused from API validation in Next.js forms create a single source of truth for data contracts
+
+> **Implementation note (2026-04-14)**: Zod was initially selected but **abandoned during Phase 1** in favor of `@sinclair/typebox`. TypeBox provides native Fastify integration (JSON serialization + OpenAPI 3.1 schema generation without conversion), better performance (no runtime Zod→JSON Schema transformation), and direct Swagger/OpenAPI compatibility. All validators in `packages/shared/src/validators/` and all route schemas in `packages/api/` use TypeBox exclusively.
 
 ### Tradeoffs
 
@@ -122,9 +124,9 @@ Use **Drizzle ORM** for database access and **Drizzle Kit** for schema migration
 
 ### Consequences
 
-- Schema definitions live in `packages/db/schema/` as TypeScript files — these are the source of truth for both migrations and application types
+- Schema definitions live in `packages/shared/src/schema/` as TypeScript files — these are the source of truth for both migrations and application types
 - Migration workflow: modify schema → `drizzle-kit generate` → review SQL → `drizzle-kit migrate`
-- RLS enforcement pattern: Fastify request hook calls `SET LOCAL app.tenant_id = $1` at transaction start — must be tested in Phase 1 integration tests
+- RLS enforcement pattern: The API uses the `givernance_app` PostgreSQL role (NOBYPASSRLS) and wraps queries in `withTenantContext(orgId, callback)`, which calls `set_config('app.current_org_id', orgId, true)` inside a Drizzle transaction. A global Fastify `preHandler` with session-level `SET LOCAL` was explicitly rejected as unsafe with PgBouncer transaction-mode pooling. See [03-data-model.md §4](./03-data-model.md) for the full 3-role pattern.
 - Team members must learn Drizzle's API (smaller community means fewer Stack Overflow answers, but official docs are comprehensive)
 
 ---
@@ -191,8 +193,8 @@ With the move to a TypeScript modular monolith using BullMQ for async processing
 
 Flow:
 ```
-DB transaction (mutation + domain_events row)
-  → Outbox poller (500ms)
+DB transaction (mutation + outbox_events row, status='pending')
+  → givernance-relay polls (500ms, SELECT ... FOR UPDATE SKIP LOCKED)
   → BullMQ enqueue (Redis)
   → givernance-worker (at-least-once, retries, dead-letter)
 ```
@@ -223,7 +225,7 @@ The transactional outbox pattern intentionally abstracts the publish backend. Sw
 - ✅ Phase 0 infrastructure: 8 services instead of 9 (simpler Docker Compose, faster local dev)
 - ✅ No NATS operational knowledge required until Phase 4
 - ✅ Webhook fan-out handled by BullMQ retry mechanism (sufficient for <1,000 webhooks/org at Phase 0-3 scale)
-- ⚠️ No event replay in Phase 0-3 — if needed, query `domain_events` table directly
+- ⚠️ No event replay in Phase 0-3 — if needed, query `outbox_events` table directly
 - ⚠️ Multi-subscriber fan-out not available until Phase 4 — enforce single-consumer contract in outbox design
 - Module event contracts should still be defined as TypeScript interfaces (in `packages/shared/events/`) to ease future NATS integration
 - BullMQ becomes the sole async backbone — its Redis dependency must be treated as critical infrastructure

--- a/docs/17-log-management.md
+++ b/docs/17-log-management.md
@@ -1,6 +1,6 @@
 # 17 — Log Management Strategy
 
-> **Status**: Spike / Analysis — Phase 1 implementation target
+> **Status**: Partially implemented (Phase 1 Sprint 1-2) — Pino + redaction live in API, Worker, and Relay
 > **Owner**: Log Analyst agent (`.claude/agents/log-analyst.md`)
 > **Related**: `02-reference-architecture.md`, `06-security-compliance.md`, `15-infra-adr.md`
 
@@ -30,10 +30,10 @@ The log management strategy must support investigation of:
 │              OTel Collector (optional gateway)                │
 └──────▲───────────────────▲──────────────────▲────────────────┘
        │                   │                  │
-┌──────┴──────┐     ┌──────┴──────┐    ┌──────┴──────┐
-│ Fastify API │     │BullMQ Worker│    │ Next.js SSR │
-│ pino + OTel │     │ pino + OTel │    │ pino + OTel │
-└──────┬──────┘     └──────┬──────┘    └─────────────┘
+┌──────┴──────┐  ┌──────┴──────┐  ┌──────┴──────┐  ┌─────────────┐
+│ Fastify API │  │Outbox Relay │  │BullMQ Worker│  │ Next.js SSR │
+│ pino + OTel │  │ pino + OTel │  │ pino + OTel │  │ pino + OTel │
+└──────┬──────┘  └──────┬──────┘  └──────┬──────┘  └─────────────┘
        │                   │
        ▼                   ▼
 ┌──────────────────────────────────────────────────────────────┐
@@ -137,8 +137,8 @@ Fastify API (onRequest hook)
   │     └─ Enqueue BullMQ job:
   │         job.data._meta = { correlationId, tenantId, userId }
   │
-  ├─► Transactional outbox (domain_events table):
-  │     domain_events.payload must include _meta.correlationId from
+  ├─► Transactional outbox (outbox_events table):
+  │     outbox_events.payload must include _meta.correlationId from
   │     the originating request. The outbox poller extracts this when
   │     enqueuing the BullMQ job — never generates a fresh one.
   │
@@ -174,7 +174,9 @@ export const requestContext = new AsyncLocalStorage<RequestContext>();
 
 Three layers of protection:
 
-1. **Pino `redact` option** — strips known PII paths from all log output (see agent for full path list)
+1. **Pino `redact` option** (**implemented**) — strips known PII paths from all log output. The following paths are redacted across API (`packages/api/src/server.ts`), Worker (`packages/worker/src/lib/logger.ts`), and Relay (`packages/relay/src/lib/logger.ts`):
+   - `req.headers.authorization`, `req.headers.cookie`
+   - `body.password`, `body.token`, `body.iban`, `body.cardNumber`, `body.cvv`, `body.pan`
 2. **Custom serializers** — domain objects are logged with safe projections only (`{ id, type }`, never `{ email, name }`)
 3. **Code review rule** — the Log Analyst agent flags any logged field that could contain PII
 4. **Custom Pino serializers for domain objects** — register serializers for `constituent`, `volunteer`, `donation` objects that return only safe projections (`{ id, type }`). This prevents PII leakage even if developers accidentally log full domain objects (e.g., in error handlers or catch blocks).
@@ -201,7 +203,7 @@ Three layers of protection:
 
 Several JSONB columns across the schema require special GDPR handling because their contents are dynamic or free-text:
 
-- **`domain_events.payload`** — may contain full entity snapshots including PII. Must be included in the PII redaction spec (apply `sanitizeAuditDiff` before logging payload contents) or excluded from Pino log output entirely.
+- **`outbox_events.payload`** — may contain full entity snapshots including PII. Must be included in the PII redaction spec (apply `sanitizeAuditDiff` before logging payload contents) or excluded from Pino log output entirely.
 - **`custom_fields` JSONB** on `constituents`, `donations`, `volunteer_profiles`, and other entities — contains arbitrary tenant-defined data whose schema is unknown at build time. Exclude from logging entirely (cannot redact unknown schemas). Add `body.customFields`, `body.customFields.*`, `body.custom_fields`, `body.custom_fields.*` to Pino redact paths.
 - **`constituent_relationships.notes`** — free-text field that may contain PII. Add `body.relationships[*].notes` to Pino redact paths.
 - **`body.notes`** — free-text notes fields on donations, grants, case notes, etc. Add to Pino redact paths.
@@ -394,7 +396,7 @@ The following rules should be added to existing agents to enforce logging standa
 
 | Phase | Scope | Priority |
 |-------|-------|----------|
-| **Phase 1 — Skeleton** | Pino setup in shared package, Fastify logger config, correlation ID plugin, PII redact paths, `testLogger` util | P0 |
+| **Phase 1 — Skeleton** | ~~Pino setup in shared package, Fastify logger config, correlation ID plugin, PII redact paths, `testLogger` util~~ **Done** — Pino with redaction implemented in API (`server.ts`), Worker (`lib/logger.ts`), and Relay (`lib/logger.ts`). TypeBox env validation in all three packages. | P0 ✅ |
 | **Phase 1 — Skeleton** | `audit_log` Drizzle schema + migration (canonical table name to be decided in Phase 1) | P0 |
 | **Phase 1 — Skeleton** | AsyncLocalStorage context propagation | P1 |
 | **Phase 2 — Core modules** | Audit log entries on all mutations (transactional outbox) | P0 |

--- a/docs/19-impersonation.md
+++ b/docs/19-impersonation.md
@@ -323,7 +323,7 @@ All mutating endpoints: audit logged (even if the action is the admin ending the
 - Every Drizzle audit write helper must accept optional `impersonatorId` (extracted from `act.sub`) and `impersonationSessionId` (from `imp_session_id`) parameters and pass them to the `audit_logs` insert
 - BullMQ `job.data._meta` must include `impersonatorId` and `impersonationSessionId` when jobs are enqueued during an impersonation session — workers must propagate these to their own audit writes
 - The impersonation token is delivered as `httpOnly` cookie — never exposed to JavaScript
-- Reason field minimum length: 20 characters — enforced with a Zod validator in `packages/shared/validators`
+- Reason field minimum length: 20 characters — enforced with a TypeBox validator in `packages/shared/validators`
 
 ### For QA Engineer
 


### PR DESCRIPTION
## Summary

Updates 7 documentation files to reflect the actual implemented architecture from PR #49 (Phase 0/1 integration):

- **Zod → TypeBox**: All references to Zod replaced with `@sinclair/typebox` across docs 02, 09, 15, 19. ADR-002 updated with implementation note explaining the switch.
- **PostgreSQL 3-Role Pattern**: Documented `givernance` (owner, BYPASSRLS) + `givernance_app` (NOBYPASSRLS) roles, `withTenantContext()` transaction wrapper, and `FORCE ROW LEVEL SECURITY` on all tenant tables (docs 02, 03, 06). Explicitly documents why a global Fastify `preHandler` was rejected.
- **Outbox Relay**: Renamed `domain_events` → `outbox_events` table (status enum instead of boolean). Added `packages/relay` as a standalone microservice with `SELECT ... FOR UPDATE SKIP LOCKED` pattern (docs 02, 03, 15, 17).
- **Worker Architecture**: Documented S3 streaming via `@aws-sdk/lib-storage`, atomic receipt numbering (`receipt_sequences` table with upsert pattern), Pino PII redaction paths, TypeBox env validation (docs 02, 03).
- **Security**: Added RFC 7807 error responses, Pino redaction defense-in-depth, and 3-role database security model (doc 06).

## Files Changed

| File | Key Changes |
|------|-------------|
| `docs/02-reference-architecture.md` | TypeBox, relay container, 3-role tenancy model, outbox_events flow, worker streaming |
| `docs/03-data-model.md` | outbox_events schema, receipt_sequences table, 3-role RLS §4 rewrite |
| `docs/06-security-compliance.md` | 3-role pattern, PII redaction layers, RFC 7807 |
| `docs/09-risk-register.md` | Zod → TypeBox |
| `docs/15-infra-adr.md` | ADR-002 TypeBox note, ADR-003 RLS pattern, ADR-005 outbox_events |
| `docs/17-log-management.md` | outbox_events refs, relay in architecture diagram, Phase 1 status |
| `docs/19-impersonation.md` | Zod → TypeBox |

## Test plan

- [ ] Review all changed docs for internal consistency (cross-references between docs)
- [ ] Verify code references match actual file paths in the integration branch
- [ ] Confirm no remaining stale `Zod` or `domain_events` references in `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)