### PR TITLE
docs(adr): frontend architecture decisions ADR-011/012/013

### DIFF
--- a/.claude/agents/api-contract-designer.md
+++ b/.claude/agents/api-contract-designer.md
@@ -7,7 +7,7 @@ You are the API contract designer for Givernance. You own the shape, semantics, 
 - Design Fastify 5 route schemas using TypeBox (OpenAPI 3.1 compatible)
 - Define all request/response models with exact TypeScript types for `@givernance/shared`
 - Specify cursor-based pagination on every list endpoint
-- Define error responses using RFC 7807 Problem Details format
+- Define error responses using RFC 9457 Problem Details format
 - Ensure every endpoint declares: JWT Bearer auth, RLS context requirements, and audit log trigger
 - Verify consistency between API contracts and the Drizzle schema in `packages/shared/src/schema/`
 - Produce OpenAPI 3.1 snippets ready to paste into Fastify route definitions
@@ -22,7 +22,7 @@ You are the API contract designer for Givernance. You own the shape, semantics, 
 | Auth | JWT Bearer — validated by Keycloak 24 JWKS; `request.user` carries `{ sub, orgId, roles }` |
 | Multi-tenancy | PostgreSQL 16 RLS — every request sets `app.current_org_id` and `app.current_user_id` |
 | Pagination | Cursor-based only (`?cursor=<opaque base64>&limit=50`) |
-| Error format | RFC 7807 Problem Details (`application/problem+json`) |
+| Error format | RFC 9457 Problem Details (`application/problem+json`) |
 | Audit | Every write endpoint triggers an `audit_log` entry (DB trigger or service layer) |
 
 ## Contract structure
@@ -72,7 +72,7 @@ const ListResponseSchema = <T extends TSchema>(itemSchema: T) =>
 
 Cursor is always opaque base64 — encode `{ id, createdAt }` or similar; never expose raw DB offsets.
 
-## RFC 7807 Problem Details (mandatory for all error responses)
+## RFC 9457 Problem Details (mandatory for all error responses)
 
 ```typescript
 const ProblemDetailsSchema = Type.Object({
@@ -227,7 +227,7 @@ Before finalising a contract:
 | Anti-pattern | Correct approach |
 |---|---|
 | Offset pagination (`?page=2`) | Cursor-based only (`?cursor=<opaque>`) |
-| Plain error strings (`{ error: "not found" }`) | RFC 7807 Problem Details always |
+| Plain error strings (`{ error: "not found" }`) | RFC 9457 Problem Details always |
 | `Type.Optional()` for nullable DB columns | `Type.Union([Type.String(), Type.Null()])` |
 | Returning `deletedAt` records by default | Filter `WHERE deleted_at IS NULL` unless admin override |
 | Skipping auth declaration | Every endpoint must declare `security` or explicitly justify public access |

--- a/.claude/agents/mvp-engineer.md
+++ b/.claude/agents/mvp-engineer.md
@@ -75,7 +75,7 @@ packages/shared/src/
 | RLS context | `SET LOCAL app.current_org_id = $1` before every query in a request handler |
 | RLS context | `SET LOCAL app.current_user_id = $1` alongside org |
 | Outbox pattern | Every mutation that needs async processing inserts a row in `domain_events` within the same DB transaction — BullMQ worker picks it up |
-| Error codes | RFC 7807 Problem Details — return `{ type, title, status, detail, instance }` |
+| Error codes | RFC 9457 Problem Details — return `{ type, title, status, detail, instance }` |
 | Pagination | Cursor-based only: `?cursor=<opaque base64>&limit=50` — no offset pagination |
 | Audit logs | Every write operation triggers `audit_log` insert (via DB trigger or service layer) |
 
@@ -169,7 +169,7 @@ export function createDonationReceiptWorker(connection: Redis) {
 - **New module**: produce `routes.ts`, `service.ts`, and the integration test file together
 - **New job**: produce the processor file + the job type definition in `@givernance/shared/jobs/`
 - **Schema change**: produce the Drizzle migration file + updated type exports in `@givernance/shared`
-- **Always include**: TypeScript types, Zod validators for external inputs, error handling with RFC 7807
+- **Always include**: TypeScript types, Zod validators for external inputs, error handling with RFC 9457
 - **Code style**: functional, no classes except where Fastify plugin patterns require it
 - **Comments**: explain _why_, not _what_ — the code explains what
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Use these agents for domain-specific tasks via Claude Code:
 | UX Researcher | `.claude/agents/ux-researcher.md` | User research, personas, usability |
 | Design Architect | `.claude/agents/design-architect.md` | Visual identity, design system |
 | MVP Engineer | `.claude/agents/mvp-engineer.md` | Full-stack implementation, Fastify routes, Drizzle ORM, BullMQ jobs |
-| API Contract Designer | `.claude/agents/api-contract-designer.md` | REST API contracts, TypeBox schemas, OpenAPI 3.1, RFC 7807 errors |
+| API Contract Designer | `.claude/agents/api-contract-designer.md` | REST API contracts, TypeBox schemas, OpenAPI 3.1, RFC 9457 errors |
 | QA Engineer | `.claude/agents/qa-engineer.md` | Integration tests, RLS isolation, GDPR compliance, Stripe webhooks |
 | Log Analyst | `.claude/agents/log-analyst.md` | Structured logging, distributed tracing, audit trail, GDPR log compliance, performance diagnostics |
 | Feature Flag Engineer | `.claude/agents/feature-flag-engineer.md` | Feature flags: schema, evaluation, backend/frontend enforcement, lifecycle, plan-gating |

--- a/docs/02-reference-architecture.md
+++ b/docs/02-reference-architecture.md
@@ -60,7 +60,7 @@ See: /diagrams/container.mmd
 - Fastify 5 router + plugin stack (auth, audit, rate limit, tracing); `@sinclair/typebox` for OpenAPI schema validation, JSON serialization, and type-safe routes (Zod was abandoned — see ADR-002 note)
 - Drizzle ORM for type-safe PostgreSQL queries; connects via PgBouncer (transaction mode) or directly to Scaleway Managed PostgreSQL in SaaS deployment
 - **TypeBox** for runtime input validation with inferred TypeScript types (replaces Zod for better Fastify JSON serialization performance and native Swagger/OpenAPI integration)
-- All API error responses conform to **RFC 7807** (`application/problem+json`) with strict `schema.response` on all routes to prevent PII leakage
+- All API error responses conform to **RFC 9457** (`application/problem+json`) with strict `schema.response` on all routes to prevent PII leakage
 - Connects to PostgreSQL via `DATABASE_URL_APP` using the `givernance_app` role (NOBYPASSRLS) — see §6 Tenancy model
 - Publishes domain events via transactional outbox (`outbox_events` table) → `packages/relay` poller → BullMQ job queue (NATS JetStream deferred to Phase 4+)
 - Serves REST API on `:8080`; admin API on `:8081` (internal only)
@@ -218,7 +218,7 @@ packages/
 - **Auth**: Bearer token (JWT issued by Keycloak); token introspection cached in Redis
 - **Format**: JSON everywhere; `Content-Type: application/json`
 - **Pagination**: Cursor-based (`?cursor=<opaque>&limit=50`); never offset-based
-- **Errors**: RFC 7807 Problem Details (`type`, `title`, `status`, `detail`, `instance`)
+- **Errors**: RFC 9457 Problem Details (`type`, `title`, `status`, `detail`, `instance`)
 - **Timestamps**: ISO 8601 with timezone (`2024-03-15T14:30:00Z`)
 - **IDs**: UUID v7 (string format in JSON)
 - **Envelopes**: Collections return `{data: [...], meta: {total, cursor_next, cursor_prev}}`

--- a/docs/06-security-compliance.md
+++ b/docs/06-security-compliance.md
@@ -9,7 +9,7 @@
 - RBAC + permission scopes by capability
 - Immutable audit log for privileged actions
 - Secrets in vault; no plaintext secrets in DB
-- All API error responses use **RFC 7807** (`application/problem+json`) with strict `schema.response` on all routes to prevent PII leakage
+- All API error responses use **RFC 9457** (`application/problem+json`) with strict `schema.response` on all routes to prevent PII leakage
 - Structured logging via **Pino** with built-in PII redaction (defense in depth)
 
 ## Database role model (3-role pattern)
@@ -32,7 +32,7 @@ Three layers prevent PII from appearing in logs or error responses:
 
 1. **Pino `redact` option**: All service loggers (API, relay, worker) strip known PII paths: `authorization`, `cookie`, `password`, `token`, `iban`, `cardNumber`, `cvv`, `pan`
 2. **Custom serializers**: Domain objects are logged with safe projections only (`{ id, type }`, never `{ email, name }`)
-3. **RFC 7807 strict response schemas**: All routes define explicit `schema.response` — only declared fields are serialized. Undeclared PII fields on internal objects are never exposed to clients.
+3. **RFC 9457 strict response schemas**: All routes define explicit `schema.response` — only declared fields are serialized. Undeclared PII fields on internal objects are never exposed to clients.
 
 ## GDPR-by-design
 - Lawful basis per contact/communication

--- a/docs/15-infra-adr.md
+++ b/docs/15-infra-adr.md
@@ -400,4 +400,377 @@ Evaluated Convex.dev and Supabase as potential all-in-one backend platforms. Sup
 
 ---
 
+## ADR-011: Layered Service Architecture over MVC for Frontend
+
+- **Status**: Accepted
+- **Date**: 2026-04-16
+- **Deciders**: Magino (founder/architect)
+
+### Context
+
+Givernance's frontend is a Next.js 15 App Router application (React 19, TypeScript) consuming a Fastify 5 REST API (ADR-002). The backend already enforces a clear modular monolith structure (ADR-001) with TypeBox schemas, Drizzle ORM, and PostgreSQL RLS. The frontend needs an equivalent architectural pattern that:
+
+1. Provides clean separation of concerns between API communication, data shaping, domain logic orchestration, and rendering
+2. Works naturally with React Server Components (RSC) and the App Router's file-based routing
+3. Supports two distinct execution contexts — server-side (RSC, route handlers) and client-side (interactive components) — each with different auth token forwarding mechanisms
+4. Avoids redundant abstraction layers that duplicate what the framework already provides
+
+The classical MVC pattern was evaluated and found to be a poor fit for a React/Next.js App Router frontend.
+
+### Decision
+
+Use a **4-layer service architecture** for the Next.js frontend:
+
+```
+┌─────────────────────────────────────────────────┐
+│  UI Layer                                       │
+│  src/app/ (pages, layouts, route segments)       │
+│  src/components/ (reusable React components)     │
+│  ── renders data, delegates all API calls ──     │
+├─────────────────────────────────────────────────┤
+│  Services Layer                                  │
+│  src/services/ (domain-specific orchestration)   │
+│  ── class-based, ApiClient injected via ctor ──  │
+│  ── e.g. DonationService, ContactService ──      │
+├─────────────────────────────────────────────────┤
+│  Domain Models Layer                             │
+│  src/models/ (TypeScript interfaces)             │
+│  ── frontend-specific shapes ──                  │
+│  ── dates as ISO strings, not Date objects ──    │
+├─────────────────────────────────────────────────┤
+│  API Client Layer                                │
+│  src/lib/api/ (typed fetch wrapper)              │
+│  ── JWT from httpOnly cookies (server) ──        │
+│  ── credentials: 'include' (client) ──           │
+│  ── RFC 7807 error parsing ──                    │
+└─────────────────────────────────────────────────┘
+```
+
+**State management** (part of this decision):
+
+- **TanStack Query v5** for server data caching, deduplication, background refetching, and optimistic updates in Client Components
+- **React Context** for cross-cutting concerns only: auth state, feature flags (`18-feature-flags.md`), AI mode (`13-ai-modes.md`)
+- **No global state library** (Redux, Zustand, Jotai) — Server Components eliminate most client-side state; remaining interactive state is local to component trees
+
+### Layer Responsibilities
+
+**1. API Client (`src/lib/api/`)**
+
+Two factory functions produce a typed fetch wrapper:
+
+- `createServerApiClient()` — used in Server Components and route handlers; reads JWT from `cookies()` (Next.js `next/headers`)
+- `createClientApiClient()` — used in Client Components; sends `credentials: 'include'` for browser-managed httpOnly cookies
+
+Both factories share the same interface: typed `get<T>()`, `post<T>()`, `put<T>()`, `patch<T>()`, `delete<T>()` methods with automatic RFC 7807 error parsing into a structured `ApiError` type. Base URL is configured via `NEXT_PUBLIC_API_URL` (client, must point to public gateway/reverse proxy — never an internal service address) and `API_URL` (server, internal network — e.g., `http://api:8080`).
+
+**Security requirements for the API Client layer:**
+
+- **JWT cookie attributes**: Authentication tokens are stored in `httpOnly` + `Secure` + `SameSite=Strict` cookies. `SameSite=Strict` (not `Lax`) is required because `GET`-based state reads could leak data via cross-origin navigation.
+- **CSRF protection**: The client API client attaches a CSRF token (double-submit cookie pattern) as an `X-CSRF-Token` header on all state-changing requests (`POST`, `PUT`, `PATCH`, `DELETE`). The server validates the token matches the value in the CSRF cookie.
+- **PII in error responses**: RFC 7807 error details parsed by the API Client must not be logged to browser console or forwarded to error tracking services if they contain PII. Error display uses only the `title` and `detail` fields through sanitized UI components.
+- **TanStack Query cache hygiene**: The in-memory query cache may hold PII (donor names, emails, financial data). `gcTime` must be configured to minimize PII retention, and the cache must be explicitly cleared on logout via `queryClient.clear()`.
+
+**2. Domain Models (`src/models/`)**
+
+Frontend-specific TypeScript interfaces that represent API response shapes. These are **not** copies of the Drizzle schema from `@givernance/shared` — they reflect the serialized JSON contract:
+
+- Dates are `string` (ISO 8601), not `Date`
+- Monetary amounts are `number` (cents) or `string` (formatted), depending on the endpoint
+- Nested relations are flattened or omitted per the API's response envelope
+
+Models are pure types with no runtime code — they exist solely for type safety across services and components. See ADR-013 for the import boundary enforcement that ensures `packages/web` never imports Drizzle ORM types from `@givernance/shared/schema`.
+
+**3. Services (`src/services/`)**
+
+Class-based services with `ApiClient` injected via the constructor:
+
+```typescript
+class DonationService {
+  constructor(private api: ApiClient) {}
+  async list(orgId: string, filters: DonationFilters): Promise<PaginatedResponse<Donation>> { ... }
+  async getById(orgId: string, id: string): Promise<Donation> { ... }
+  async create(orgId: string, data: CreateDonationInput): Promise<Donation> { ... }
+}
+```
+
+Constructor injection enables the same service class to work in both execution contexts — the caller provides the appropriate `ApiClient` factory. Services handle domain-specific orchestration: composing multiple API calls, transforming responses, and encapsulating business rules that are purely presentational (e.g., computing a donor's lifetime value from paginated donation history for a dashboard widget).
+
+**4. UI (`src/app/` + `src/components/`)**
+
+- `src/app/` — Next.js App Router route segments (`page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`). Server Components by default; fetch data via services with `createServerApiClient()`
+- `src/components/` — reusable React components. Client Components that need data use TanStack Query hooks wrapping service calls with `createClientApiClient()`
+
+### Why MVC Was Rejected
+
+| MVC Layer | Next.js App Router Equivalent | Problem |
+|---|---|---|
+| **Controller** | Route segments (`page.tsx`, `layout.tsx`, `route.ts`) already dispatch requests based on URL — the App Router **is** the controller | Adding a controller layer creates a redundant dispatch abstraction over file-based routing |
+| **View** | React components **are** the view — JSX is the template language | No template engine to abstract; a "View" layer separate from components is meaningless in React |
+| **Model** | No ORM on the frontend — there is no local database to model | "Model" degenerates into API call wrappers, which is exactly what the Services + API Client layers provide with clearer naming |
+
+MVC was designed for server-rendered applications where the controller receives HTTP requests, the model manages persistent state, and the view renders templates. In a React SPA/RSC hybrid, all three responsibilities are already handled by the framework — layering MVC on top adds indirection without adding separation.
+
+### Rejected Alternatives
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **MVC (Model-View-Controller)** | Familiar pattern, well-documented | Controller redundant with App Router routing, View redundant with React components, Model has no ORM to wrap — all three layers collapse into what the framework already provides | Rejected |
+| **MVVM (Model-View-ViewModel)** | Clean data binding, good for complex forms | ViewModel pattern assumes two-way binding (Knockout, Angular) — React's unidirectional data flow makes ViewModels unnecessary; TanStack Query already manages the "ViewModel" concern (cached server state + loading/error states) | Rejected |
+| **Feature-sliced architecture** (co-located per feature) | Strong co-location, scales to large teams | Premature for a 1–3 person team; fragments shared services and models across feature directories; harder to enforce consistent API client usage; revisit at Phase 4 if team exceeds 5 engineers | Rejected — revisit at scale |
+| **No layering** (pages call `fetch()` directly) | Minimal abstraction, fast to start | JWT forwarding logic duplicated in every page/component, no RFC 7807 error handling consistency, no type safety on API responses, impossible to test business logic without rendering components | Rejected |
+| **Layered service architecture** | Clean separation matching actual concerns (transport, shape, orchestration, rendering); works with both RSC and Client Components; testable services via DI; no redundant layers | Requires discipline to avoid services becoming "god classes"; slightly more boilerplate than direct fetch | **Selected** |
+
+### Consequences
+
+- ✅ API Client layer centralizes JWT forwarding, base URL configuration, and error parsing — no `fetch()` calls scattered across components
+- ✅ Services are testable in isolation by injecting a mock `ApiClient` — no need to render React components to test API orchestration logic
+- ✅ Domain Models provide a single source of truth for API response types on the frontend — TypeScript catches shape mismatches at compile time
+- ✅ TanStack Query eliminates the need for Redux/Zustand — server state is cached, deduplicated, and background-refreshed without a global store
+- ✅ React Context remains minimal (auth, feature flags, AI mode) — avoids the "everything in global state" anti-pattern
+- ✅ Constructor injection of `ApiClient` into services makes the server/client boundary explicit — no accidental `cookies()` calls in Client Components
+- ⚠️ Services must not grow into god classes — enforce one service per domain aggregate (e.g., `DonationService`, `ContactService`, `CampaignService`), matching the backend module boundaries from ADR-001
+- ⚠️ Domain Models in `src/models/` will drift from `@givernance/shared` TypeBox schemas if the API contract changes — mitigate by generating frontend types from OpenAPI spec in Phase 2+
+- ⚠️ Feature-sliced architecture should be re-evaluated if the team exceeds 5 engineers or the frontend exceeds ~40 routes (Phase 4+)
+
+---
+
+## ADR-012: shadcn/ui + TanStack Ecosystem for UI Components
+
+- **Status**: Accepted
+- **Date**: 2026-04-16
+- **Deciders**: Magino (founder/architect) + Claude agents (architecture review)
+
+### Context
+
+Givernance's frontend (Next.js 15, React 19, Tailwind CSS v4) must render 84+ screens across 17 domain modules — from dense financial data tables and multi-step grant wizards to inline AI suggestion cards. The existing design system is mature: 366-line `tokens.css` (CSS custom properties for colors, typography, spacing, shadows, motion), 2,000+ line `base.css` component styles, and 97 interactive HTML mockups defining the Material You Warm visual language.
+
+Key constraints driving this decision:
+
+1. **White-label readiness**: Every color must resolve through CSS custom properties in `@theme` — no default Tailwind palette colors permitted anywhere in the codebase
+2. **WCAG 2.1 AA accessibility**: Non-negotiable for NPO staff who are not power users — keyboard navigation, screen reader support, focus management, and ARIA compliance on every interactive element
+3. **Colorblind-safe semantics**: Indigo for destructive/error states (not red/green pairs); color is never the sole signal — always paired with icon + text label
+4. **Density modes**: All data-heavy components must support `comfortable` (48px rows) and `compact` (36px rows) density
+5. **Financial data integrity**: Pagination required on all financial tables — infinite scroll explicitly prohibited (see `11-design-identity.md` section 7 anti-patterns)
+6. **TypeBox schema reuse**: Form validation schemas defined once in `@givernance/shared/validators` must flow through to frontend form validation without duplication
+
+### Decision
+
+Adopt a **four-library frontend component stack** (note: TanStack Query v5 for server data caching is decided in ADR-011 as part of state management, not repeated here):
+
+1. **shadcn/ui** — UI primitive layer (code-ownership model)
+2. **@tanstack/react-table v8** — headless data table engine
+3. **React Hook Form + @hookform/resolvers/typebox** — form state management with shared schema validation
+4. **lucide-react** — icon library
+
+#### 1. shadcn/ui (UI Primitives)
+
+Copy shadcn/ui components into the repository (`components/ui/`) and own every line. Components are built on **Radix UI** accessibility primitives and restyled to match Givernance's Material You Warm design tokens exactly.
+
+**Component hierarchy**:
+
+```
+components/
+├── ui/                  ← shadcn/ui primitives (Button, Dialog, Select, Tabs, Tooltip, etc.)
+├── data/                ← Data composites (DataTable, StatWidget, DonorTimeline, etc.)
+├── forms/               ← Form composites (FormSection, ConstituentForm, DonationWizard, etc.)
+└── layout/              ← Layout composites (Sidebar, Topbar, CommandPalette, PageShell, etc.)
+```
+
+- **Tier 1 — UI Primitives** (`components/ui/`): Direct shadcn/ui components restyled with Givernance tokens. These are generic, reusable, and have no domain knowledge.
+- **Tier 2 — Composites** (`components/data/`, `forms/`, `layout/`): Domain-specific components that compose Tier 1 primitives. Examples: `ConstituentCard` composes `Card` + `Avatar` + `Badge`; `CampaignProgress` composes `Progress` + `StatWidget`.
+
+**Token integration**: shadcn/ui's default CSS variables are replaced entirely with Givernance's `tokens.css` custom properties. The `components.json` configuration points Tailwind to the project's custom theme — no `slate`, `zinc`, or `neutral` from the default palette.
+
+#### 2. @tanstack/react-table v8 (Data Tables)
+
+Headless table engine providing sort, filter, pagination, row selection, and column visibility — with zero rendering opinions. The visual layer is implemented using Givernance's `DataTable` composite component, which applies:
+
+- Sticky headers with `backdrop-filter: blur(12px)` glass effect
+- Zebra striping using `--color-neutral-50` alternation
+- Density toggle (`comfortable` / `compact` via `--table-row-height` token)
+- Server-side pagination with configurable page sizes (25 / 50 / 100)
+- Monospace font (`--font-mono`, JetBrains Mono) for financial columns
+- Sort indicators with Lucide `arrow-up` / `arrow-down` icons
+
+**Pagination is mandatory on all financial data tables.** Infinite scroll is explicitly prohibited — auditability requires deterministic page boundaries (see `11-design-identity.md` section 7 anti-patterns).
+
+#### 3. React Hook Form + @hookform/resolvers/typebox (Forms)
+
+Form state management using React Hook Form with TypeBox schema validation, enabling a **single source of truth** for data contracts:
+
+```
+@givernance/shared/validators/donation.ts (TypeBox schema)
+  → API route: Fastify request validation + OpenAPI 3.1 generation
+  → Frontend form: React Hook Form validation via @hookform/resolvers/typebox
+```
+
+Configuration:
+- Validation mode: `onBlur` — validates each field when the user leaves it, never on keystroke (reduces noise) and never only on submit (too late)
+- Server error mapping: RFC 7807 `fieldErrors` from API responses are mapped to form fields via `setError()`, providing inline server-side validation feedback
+- Multi-step forms (grant wizard, constituent create): each step validates its own TypeBox sub-schema independently before allowing progression
+
+#### 4. lucide-react (Icons)
+
+Tree-shakeable icon library providing named SVG imports. Only icons actually used are included in the bundle — no variable font download.
+
+- Grid: 24px
+- Stroke weight: 1.5px (matches design spec in `11-design-identity.md` section 2.4)
+- Native shadcn/ui integration (icons used directly in Button, Alert, Badge, etc.)
+- Consistent with the 97 existing HTML mockups which already use Lucide CDN
+
+### Rationale
+
+#### Why shadcn/ui over alternatives
+
+| Criterion | shadcn/ui + Radix | Headless UI (Tailwind Labs) | Ant Design | Material UI | Build from scratch |
+|---|---|---|---|---|---|
+| **Code ownership** | Full — components copied into repo, every line editable | Full — headless primitives | None — import from `antd`, override via `ConfigProvider` | None — import from `@mui`, override via `createTheme` | Full |
+| **Accessibility** | Radix UI primitives — WAI-ARIA compliant, focus trap, keyboard nav, screen reader tested | Good — built by Tailwind Labs | Mixed — some components lack ARIA compliance | Good — follows Material spec | Must build from scratch |
+| **Tailwind v4 compatibility** | Native — designed for Tailwind | Native | Poor — CSS-in-JS (Emotion) conflicts with Tailwind utility model | Poor — Emotion/styled-components, theme provider conflicts | N/A |
+| **White-label theming** | CSS custom properties — drop-in token replacement | CSS custom properties | `ConfigProvider` + `antd-style` — complex, leaks default styles | `createTheme` — deep but opinionated | Full control |
+| **Bundle size** | Tree-shakeable, only imported components included | Minimal | ~1.2 MB minified (full import), heavy even with tree-shaking | ~300 KB+ for core, Emotion runtime overhead | Minimal |
+| **Design language** | Neutral — adapts to any design system | Neutral | Opinionated Ant style — fighting it is constant work | Opinionated Material — requires heavy override for non-Material designs | Any |
+| **React 19 / RSC support** | Yes — `"use client"` only where needed | Yes | Partial — many components require client-side rendering | Partial — Emotion SSR complexity | Must implement |
+| **Community + ecosystem** | 75k+ GitHub stars, 100+ components, active maintenance | Smaller component set (~15 primitives) | Massive (Chinese enterprise ecosystem) | Massive (Google-backed) | None |
+| **Verdict** | **Selected** | Good primitives but fewer components; would need to build more composites | Rejected — CSS-in-JS conflicts, opinionated style, heavy bundle | Rejected — CSS-in-JS conflicts, Material design language fights Givernance identity | Rejected — 6+ months to reach shadcn/ui parity on accessibility alone |
+
+#### Why @tanstack/react-table over alternatives
+
+| Criterion | @tanstack/react-table v8 | AG Grid | Mantine DataTable |
+|---|---|---|---|
+| **Rendering model** | Headless — full visual control | Opinionated grid with theme API | Mantine-styled — tied to Mantine theme |
+| **Givernance token integration** | Direct — render layer uses Tailwind + design tokens | Theme override required, AG Grid CSS fights custom styles | Requires Mantine `MantineProvider`, separate from Tailwind |
+| **Server-side pagination** | Native — `manualPagination`, `pageCount`, `onPaginationChange` | Native | Native |
+| **Bundle size** | ~15 KB (headless core) | ~200 KB+ (community), ~1 MB+ (enterprise) | ~50 KB + Mantine core dependency |
+| **License** | MIT | Community: MIT, Enterprise: paid (features like row grouping, pivoting) | MIT |
+| **Financial table fit** | Excellent — monospace columns, custom cell renderers, controlled pagination | Excellent — but visual override cost is high | Good — but Mantine style dependency |
+| **Verdict** | **Selected** | Rejected — too heavy, visual lock-in, enterprise features not needed at Phase 1 | Rejected — introduces Mantine as a parallel design system |
+
+#### Why React Hook Form + TypeBox over alternatives
+
+| Criterion | React Hook Form + TypeBox | Formik | Native React forms |
+|---|---|---|---|
+| **Performance** | Uncontrolled inputs — minimal re-renders | Controlled inputs — re-renders entire form on every change | Depends on implementation |
+| **Schema reuse** | `@hookform/resolvers/typebox` — validates with the same TypeBox schemas used by Fastify routes | Yup/Zod schemas — separate from TypeBox API schemas, duplication risk | Manual validation — full duplication |
+| **Bundle size** | ~9 KB (RHF) + ~2 KB (resolver) | ~13 KB | 0 KB |
+| **Server error integration** | `setError()` API maps RFC 7807 `fieldErrors` directly to fields | `setFieldError()` — similar capability | Manual state management |
+| **Multi-step forms** | Built-in — each step is a separate `useForm()` or sub-schema validation | Possible but verbose | Manual orchestration |
+| **TypeScript DX** | Excellent — form values inferred from TypeBox schema type | Good with Yup, weaker with plain objects | Manual typing |
+| **Verdict** | **Selected** | Rejected — heavier, controlled re-renders, separate schema system | Rejected — no schema reuse, no built-in validation lifecycle |
+
+#### Why lucide-react over alternatives
+
+| Criterion | lucide-react | Material Symbols | Heroicons | Phosphor Icons |
+|---|---|---|---|---|
+| **Bundle strategy** | Named imports — tree-shakeable, only used icons in bundle | Variable font — ~300 KB download regardless of usage | Named imports — tree-shakeable | Named imports — tree-shakeable |
+| **Icon count** | 1,500+ | 3,000+ | ~300 | 1,200+ |
+| **Grid / stroke** | 24px / 1.5px — matches design spec | 24px / variable weight — configurable but heavier | 24px / 1.5px or 2px | 24px / variable weight |
+| **shadcn/ui integration** | Native — shadcn/ui uses Lucide by default | None — must configure separately | Partial — some shadcn forks use Heroicons | None — must configure separately |
+| **Consistency with mockups** | Direct match — 97 HTML mockups already use Lucide CDN | Would require icon remapping across all mockups | Different icon set — visual inconsistency | Different icon set — visual inconsistency |
+| **Verdict** | **Selected** | Rejected — 300 KB font download, no tree-shaking, mockup inconsistency | Rejected — too small a set (300 icons), partial shadcn compatibility | Rejected — good alternative but no native shadcn integration, mockup inconsistency |
+
+### Consequences
+
+- ✅ **Code ownership**: Every UI component lives in the repository — no upstream dependency can break the design or introduce breaking changes
+- ✅ **Single validation source of truth**: TypeBox schemas in `@givernance/shared/validators` are used by Fastify routes (API validation + OpenAPI generation) and React Hook Form (frontend validation) — zero schema duplication
+- ✅ **Full visual control**: Headless primitives (Radix UI, TanStack Table) render through Givernance's token system — white-label theming requires only `tokens.css` override, no library-specific theme configuration
+- ✅ **Accessibility baseline**: Radix UI provides WAI-ARIA compliant focus management, keyboard navigation, and screen reader support out of the box — the team builds on top of tested primitives rather than implementing ARIA from scratch
+- ✅ **Mockup continuity**: The 97 existing HTML mockups already use Lucide icons and the same visual patterns — migration to React components is a 1:1 translation, not a redesign
+- ✅ **Bundle efficiency**: Tree-shakeable icons (Lucide) + headless table (~15 KB) + uncontrolled forms (RHF ~9 KB) — no large framework runtime overhead
+- ⚠️ **shadcn/ui update friction**: Because components are copied (not imported), upstream improvements require manual cherry-picking — the team must periodically review shadcn/ui releases for accessibility fixes and new primitives
+- ⚠️ **Radix UI version coupling**: shadcn/ui components depend on specific Radix UI primitive versions — major Radix updates may require coordinated component updates
+- ⚠️ **TypeBox resolver maturity**: `@hookform/resolvers/typebox` is less widely used than the Zod resolver — edge cases in complex nested schemas may require custom resolver patches
+- ⚠️ **Component build-out effort**: shadcn/ui provides ~40 primitives; Givernance needs ~25 domain composites (DataTable, ConstituentCard, DonorTimeline, CampaignProgress, etc.) — these must be designed and built by the team
+- ⚠️ **AI suggestion card XSS risk**: AI-generated content rendered in suggestion cards must never use `dangerouslySetInnerHTML`. All AI output must be rendered as plain text or through a sanitization layer (e.g., DOMPurify) to prevent stored XSS from model outputs. See `13-ai-modes.md` for AI output policy.
+- ⚠️ **CSP compatibility**: Radix UI primitives use inline styles for positioning (popovers, tooltips, dropdown menus). A Content Security Policy with `style-src 'unsafe-inline'` may be required, or a nonce-based CSP strategy must be adopted. Evaluate CSP impact during Phase 1 deployment.
+- ⚠️ **Dependency scanning**: shadcn/ui components are copied into the repository but still depend on Radix UI npm packages as runtime dependencies. These must be included in the SBOM and scanned for CVEs in CI, consistent with `06-security-compliance.md` requirements.
+
+### Revisit Criteria
+
+- shadcn/ui abandons Radix UI as its accessibility foundation — re-evaluate primitive layer
+- React 20+ introduces built-in form primitives that obsolete React Hook Form
+- A headless component library emerges with significantly better RSC support or accessibility coverage
+- TanStack Table v9 introduces breaking API changes — evaluate migration cost vs alternatives
+- Bundle size analysis at Phase 2 reveals unexpected bloat from the component stack
+
+---
+
+## ADR-013: Frontend Type Boundary — No Drizzle Imports in Web Package
+
+- **Status**: Accepted
+- **Date**: 2026-04-16
+- **Deciders**: Magino (founder/architect)
+
+### Context
+
+Givernance is a full-stack TypeScript monorepo (ADR-002) where `@givernance/shared` exports five subpath modules:
+
+| Subpath | Contents | Runtime dependency |
+|---|---|---|
+| `@givernance/shared/schema` | Drizzle ORM table definitions (`pgTable`, columns, relations) | `drizzle-orm`, `drizzle-orm/pg-core` |
+| `@givernance/shared/types` | Pure TypeScript interfaces and enums (`AuthContext`, `Currency`, `ConstituentType`) | None |
+| `@givernance/shared/validators` | TypeBox schemas for request/response validation | `@sinclair/typebox` |
+| `@givernance/shared/events` | Domain event type definitions (CloudEvents envelope, outbox types) | Type-only (no runtime import), but exposes internal system topology |
+| `@givernance/shared/jobs` | Background job payload definitions | Type-only (no runtime import), but exposes worker capabilities and queue structure |
+
+The frontend (`packages/web`, Next.js 15) communicates with the backend exclusively through REST API calls — it never connects to PostgreSQL directly. However, without explicit import restrictions, a developer could import Drizzle schema types into frontend code, creating type-safety illusions and security surface expansion.
+
+Drizzle's `InferSelectModel<typeof constituents>` produces TypeScript types where:
+- Date columns are typed as `Date` objects — but JSON serialization returns ISO 8601 strings
+- Nullable columns include `null` — but API responses may use default values or omit fields
+- `bigint` columns are typed as `bigint` — but `JSON.parse` returns `number`
+
+These mismatches are invisible at compile time but cause runtime errors: `.toISOString()` called on a string, strict equality checks failing between `bigint` and `number`, and `null` propagating through UI components that expected `undefined`.
+
+### Decision
+
+Enforce a strict import boundary: **`packages/web` MUST NOT import from `@givernance/shared/schema`, `@givernance/shared/events`, or `@givernance/shared/jobs`.**
+
+`packages/web` MAY import from:
+- `@givernance/shared/types` — pure TypeScript interfaces with no runtime dependencies (enums, auth context, currency codes)
+- `@givernance/shared/validators` — TypeBox schemas reused for client-side form validation (same validation rules on API and frontend, single source of truth per ADR-002)
+
+Frontend-specific API response models live in `packages/web/src/models/` as plain TypeScript interfaces where dates are `string` (ISO 8601), matching JSON serialization reality (see ADR-011 Domain Models layer).
+
+### Enforcement
+
+| Mechanism | Layer | Description |
+|---|---|---|
+| Subpath exports | Package level | `@givernance/shared/package.json` declares explicit `"exports"` — only listed subpaths are resolvable |
+| Lint rule | CI/IDE | Biome `noRestrictedImports` rule in `packages/web/biome.json` bans `@givernance/shared/schema`, `@givernance/shared/events`, `@givernance/shared/jobs` with actionable error messages |
+| Code review | Process | PR reviews verify no new Drizzle imports in `packages/web/` |
+| Source maps | Build config | Production builds (`next.config.ts`) MUST disable source maps (`productionBrowserSourceMaps: false`) to prevent exposing internal architecture via client-side JavaScript |
+
+### Rationale
+
+- **Type/runtime mismatch prevention**: Drizzle `InferSelectModel` types describe database row shapes, not JSON API response shapes. Using them in frontend code creates a false sense of type safety — the types compile but lie about runtime values. Frontend models must reflect what `JSON.parse` actually produces.
+- **Server-only dependency containment**: Importing `@givernance/shared/schema` pulls `drizzle-orm` and `drizzle-orm/pg-core` into the Next.js bundle. These are server-only packages with Node.js dependencies (`pg`, `crypto`) that fail in browser environments and inflate bundle size.
+- **Least privilege / attack surface reduction**: Domain events expose internal system topology (queue names, retry policies, outbox structure). Job definitions expose worker capabilities and processing semantics. Neither is needed by the frontend — exposing them violates the principle of least privilege and leaks architectural details that could inform targeted attacks.
+- **GDPR defense in depth**: The API layer is the GDPR enforcement boundary — it applies RLS tenant isolation (`06-security-compliance.md`, 3-role pattern), RBAC permission checks, PII redaction, and audit logging before returning data. Frontend code that appears to "know" database column structure may encourage developers to bypass the API contract or assume field-level access that RBAC actually restricts. Maintaining a clean API boundary reinforces the single enforcement point for data protection.
+- **Module boundary discipline**: Consistent with ADR-001 (modular monolith) — boundaries between modules are enforced via linting rules, not just convention. The frontend/backend boundary is the most critical module boundary in the system.
+
+### Rejected Alternatives
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| Import Drizzle types directly (`InferSelectModel`) | Zero duplication, single type source | `Date` vs `string` mismatch causes runtime bugs; pulls `drizzle-orm` into browser bundle; false type safety | Rejected |
+| Single barrel export from `@givernance/shared` | Simple imports (`from '@givernance/shared'`) | No boundary enforcement; any consumer gets everything; impossible to lint restricted imports | Rejected |
+| Generate OpenAPI types from Fastify schemas | True contract-first; auto-generated frontend types | Requires `openapi-typescript` toolchain + CI codegen step; heavy for current team size (1-2 engineers); revisit at Phase 3 | Rejected — revisit at Phase 3 |
+| Use Zod instead of TypeBox for shareable schemas | Zod is popular, good DX | Rejected per ADR-002 implementation note; TypeBox provides native Fastify integration and OpenAPI 3.1 compatibility without conversion | Rejected |
+| **Subpath restriction + lint enforcement + frontend models** | Clean boundary, enforced at multiple layers, frontend types match JSON reality | Small duplication between DB types and API response types | **Selected** |
+
+### Consequences
+
+- ✅ **Runtime correctness**: Frontend types match actual JSON wire format — dates are `string`, numbers are `number`, no `bigint` surprises
+- ✅ **Bundle safety**: `drizzle-orm` and `drizzle-orm/pg-core` never enter the Next.js client bundle — no Node.js polyfill failures, smaller bundle
+- ✅ **GDPR enforcement boundary preserved**: The REST API remains the single point of GDPR control — RLS tenant isolation via `withTenantContext()`, RBAC permission matrix (`06-security-compliance.md`), PII redaction (Pino `redact` + RFC 7807 strict response schemas), and immutable audit logging. Frontend developers cannot accidentally circumvent data protection by importing database-level types that suggest direct field access
+- ✅ **Security posture**: Internal system architecture (event topology, job queue structure, outbox design) is not exposed to frontend code — reduces information available to an attacker who gains access to client-side source maps or bundled JavaScript
+- ✅ **Lint-enforced in CI**: Violations are caught by Biome before merge — not dependent on code review alone
+- ✅ **Consistent with ADR-011**: The Domain Models layer in `packages/web/src/models/` is the designated home for frontend-specific API response types, reinforcing the layered service architecture
+- ⚠️ **Type duplication**: API response interfaces in `packages/web/src/models/` partially duplicate fields from Drizzle schema types. This is intentional — the duplication reflects a real semantic difference (DB row shape vs. JSON response shape) and prevents a class of runtime bugs
+- ⚠️ **Developer onboarding**: New developers must understand why `import { constituents } from '@givernance/shared/schema'` is banned in `packages/web/`. Lint error messages must include actionable guidance (e.g., "Import from `@/models/constituent` for API response types — see ADR-013")
+- ⚠️ **OpenAPI codegen re-evaluation at Phase 3**: When the team grows beyond 2 engineers, auto-generating frontend types from Fastify route schemas (via `openapi-typescript`) should be re-evaluated to eliminate manual model maintenance while preserving the type boundary
+
+---
+
 *This document is curated to show only active architectural decisions. Superseded decisions are removed for clarity.*

--- a/docs/15-infra-adr.md
+++ b/docs/15-infra-adr.md
@@ -408,7 +408,7 @@ Evaluated Convex.dev and Supabase as potential all-in-one backend platforms. Sup
 
 ### Context
 
-Givernance's frontend is a Next.js 15 App Router application (React 19, TypeScript) consuming a Fastify 5 REST API (ADR-002). The backend already enforces a clear modular monolith structure (ADR-001) with TypeBox schemas, Drizzle ORM, and PostgreSQL RLS. The frontend needs an equivalent architectural pattern that:
+Givernance's frontend is a Next.js 16 App Router application (React 19, TypeScript) consuming a Fastify 5 REST API (ADR-002). The backend already enforces a clear modular monolith structure (ADR-001) with TypeBox schemas, Drizzle ORM, and PostgreSQL RLS. The frontend needs an equivalent architectural pattern that:
 
 1. Provides clean separation of concerns between API communication, data shaping, domain logic orchestration, and rendering
 2. Works naturally with React Server Components (RSC) and the App Router's file-based routing
@@ -542,7 +542,7 @@ MVC was designed for server-rendered applications where the controller receives 
 
 ### Context
 
-Givernance's frontend (Next.js 15, React 19, Tailwind CSS v4) must render 84+ screens across 17 domain modules — from dense financial data tables and multi-step grant wizards to inline AI suggestion cards. The existing design system is mature: 366-line `tokens.css` (CSS custom properties for colors, typography, spacing, shadows, motion), 2,000+ line `base.css` component styles, and 97 interactive HTML mockups defining the Material You Warm visual language.
+Givernance's frontend (Next.js 16, React 19, Tailwind CSS v4) must render 84+ screens across 17 domain modules — from dense financial data tables and multi-step grant wizards to inline AI suggestion cards. The existing design system is mature: 366-line `tokens.css` (CSS custom properties for colors, typography, spacing, shadows, motion), 2,000+ line `base.css` component styles, and 97 interactive HTML mockups defining the Material You Warm visual language.
 
 Key constraints driving this decision:
 
@@ -713,7 +713,7 @@ Givernance is a full-stack TypeScript monorepo (ADR-002) where `@givernance/shar
 | `@givernance/shared/events` | Domain event type definitions (CloudEvents envelope, outbox types) | Type-only (no runtime import), but exposes internal system topology |
 | `@givernance/shared/jobs` | Background job payload definitions | Type-only (no runtime import), but exposes worker capabilities and queue structure |
 
-The frontend (`packages/web`, Next.js 15) communicates with the backend exclusively through REST API calls — it never connects to PostgreSQL directly. However, without explicit import restrictions, a developer could import Drizzle schema types into frontend code, creating type-safety illusions and security surface expansion.
+The frontend (`packages/web`, Next.js 16) communicates with the backend exclusively through REST API calls — it never connects to PostgreSQL directly. However, without explicit import restrictions, a developer could import Drizzle schema types into frontend code, creating type-safety illusions and security surface expansion.
 
 Drizzle's `InferSelectModel<typeof constituents>` produces TypeScript types where:
 - Date columns are typed as `Date` objects — but JSON serialization returns ISO 8601 strings

--- a/docs/15-infra-adr.md
+++ b/docs/15-infra-adr.md
@@ -442,7 +442,7 @@ Use a **4-layer service architecture** for the Next.js frontend:
 │  src/lib/api/ (typed fetch wrapper)              │
 │  ── JWT from httpOnly cookies (server) ──        │
 │  ── credentials: 'include' (client) ──           │
-│  ── RFC 7807 error parsing ──                    │
+│  ── RFC 9457 error parsing ──                    │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -461,13 +461,13 @@ Two factory functions produce a typed fetch wrapper:
 - `createServerApiClient()` — used in Server Components and route handlers; reads JWT from `cookies()` (Next.js `next/headers`)
 - `createClientApiClient()` — used in Client Components; sends `credentials: 'include'` for browser-managed httpOnly cookies
 
-Both factories share the same interface: typed `get<T>()`, `post<T>()`, `put<T>()`, `patch<T>()`, `delete<T>()` methods with automatic RFC 7807 error parsing into a structured `ApiError` type. Base URL is configured via `NEXT_PUBLIC_API_URL` (client, must point to public gateway/reverse proxy — never an internal service address) and `API_URL` (server, internal network — e.g., `http://api:8080`).
+Both factories share the same interface: typed `get<T>()`, `post<T>()`, `put<T>()`, `patch<T>()`, `delete<T>()` methods with automatic RFC 9457 error parsing into a structured `ApiError` type. Base URL is configured via `NEXT_PUBLIC_API_URL` (client, must point to public gateway/reverse proxy — never an internal service address) and `API_URL` (server, internal network — e.g., `http://api:8080`).
 
 **Security requirements for the API Client layer:**
 
 - **JWT cookie attributes**: Authentication tokens are stored in `httpOnly` + `Secure` + `SameSite=Strict` cookies. `SameSite=Strict` (not `Lax`) is required because `GET`-based state reads could leak data via cross-origin navigation.
 - **CSRF protection**: The client API client attaches a CSRF token (double-submit cookie pattern) as an `X-CSRF-Token` header on all state-changing requests (`POST`, `PUT`, `PATCH`, `DELETE`). The server validates the token matches the value in the CSRF cookie.
-- **PII in error responses**: RFC 7807 error details parsed by the API Client must not be logged to browser console or forwarded to error tracking services if they contain PII. Error display uses only the `title` and `detail` fields through sanitized UI components.
+- **PII in error responses**: RFC 9457 error details parsed by the API Client must not be logged to browser console or forwarded to error tracking services if they contain PII. Error display uses only the `title` and `detail` fields through sanitized UI components.
 - **TanStack Query cache hygiene**: The in-memory query cache may hold PII (donor names, emails, financial data). `gcTime` must be configured to minimize PII retention, and the cache must be explicitly cleared on logout via `queryClient.clear()`.
 
 **2. Domain Models (`src/models/`)**
@@ -517,7 +517,7 @@ MVC was designed for server-rendered applications where the controller receives 
 | **MVC (Model-View-Controller)** | Familiar pattern, well-documented | Controller redundant with App Router routing, View redundant with React components, Model has no ORM to wrap — all three layers collapse into what the framework already provides | Rejected |
 | **MVVM (Model-View-ViewModel)** | Clean data binding, good for complex forms | ViewModel pattern assumes two-way binding (Knockout, Angular) — React's unidirectional data flow makes ViewModels unnecessary; TanStack Query already manages the "ViewModel" concern (cached server state + loading/error states) | Rejected |
 | **Feature-sliced architecture** (co-located per feature) | Strong co-location, scales to large teams | Premature for a 1–3 person team; fragments shared services and models across feature directories; harder to enforce consistent API client usage; revisit at Phase 4 if team exceeds 5 engineers | Rejected — revisit at scale |
-| **No layering** (pages call `fetch()` directly) | Minimal abstraction, fast to start | JWT forwarding logic duplicated in every page/component, no RFC 7807 error handling consistency, no type safety on API responses, impossible to test business logic without rendering components | Rejected |
+| **No layering** (pages call `fetch()` directly) | Minimal abstraction, fast to start | JWT forwarding logic duplicated in every page/component, no RFC 9457 error handling consistency, no type safety on API responses, impossible to test business logic without rendering components | Rejected |
 | **Layered service architecture** | Clean separation matching actual concerns (transport, shape, orchestration, rendering); works with both RSC and Client Components; testable services via DI; no redundant layers | Requires discipline to avoid services becoming "god classes"; slightly more boilerplate than direct fetch | **Selected** |
 
 ### Consequences
@@ -606,7 +606,7 @@ Form state management using React Hook Form with TypeBox schema validation, enab
 
 Configuration:
 - Validation mode: `onBlur` — validates each field when the user leaves it, never on keystroke (reduces noise) and never only on submit (too late)
-- Server error mapping: RFC 7807 `fieldErrors` from API responses are mapped to form fields via `setError()`, providing inline server-side validation feedback
+- Server error mapping: RFC 9457 `fieldErrors` from API responses are mapped to form fields via `setError()`, providing inline server-side validation feedback
 - Multi-step forms (grant wizard, constituent create): each step validates its own TypeBox sub-schema independently before allowing progression
 
 #### 4. lucide-react (Icons)
@@ -653,7 +653,7 @@ Tree-shakeable icon library providing named SVG imports. Only icons actually use
 | **Performance** | Uncontrolled inputs — minimal re-renders | Controlled inputs — re-renders entire form on every change | Depends on implementation |
 | **Schema reuse** | `@hookform/resolvers/typebox` — validates with the same TypeBox schemas used by Fastify routes | Yup/Zod schemas — separate from TypeBox API schemas, duplication risk | Manual validation — full duplication |
 | **Bundle size** | ~9 KB (RHF) + ~2 KB (resolver) | ~13 KB | 0 KB |
-| **Server error integration** | `setError()` API maps RFC 7807 `fieldErrors` directly to fields | `setFieldError()` — similar capability | Manual state management |
+| **Server error integration** | `setError()` API maps RFC 9457 `fieldErrors` directly to fields | `setFieldError()` — similar capability | Manual state management |
 | **Multi-step forms** | Built-in — each step is a separate `useForm()` or sub-schema validation | Possible but verbose | Manual orchestration |
 | **TypeScript DX** | Excellent — form values inferred from TypeBox schema type | Good with Yup, weaker with plain objects | Manual typing |
 | **Verdict** | **Selected** | Rejected — heavier, controlled re-renders, separate schema system | Rejected — no schema reuse, no built-in validation lifecycle |
@@ -763,7 +763,7 @@ Frontend-specific API response models live in `packages/web/src/models/` as plai
 
 - ✅ **Runtime correctness**: Frontend types match actual JSON wire format — dates are `string`, numbers are `number`, no `bigint` surprises
 - ✅ **Bundle safety**: `drizzle-orm` and `drizzle-orm/pg-core` never enter the Next.js client bundle — no Node.js polyfill failures, smaller bundle
-- ✅ **GDPR enforcement boundary preserved**: The REST API remains the single point of GDPR control — RLS tenant isolation via `withTenantContext()`, RBAC permission matrix (`06-security-compliance.md`), PII redaction (Pino `redact` + RFC 7807 strict response schemas), and immutable audit logging. Frontend developers cannot accidentally circumvent data protection by importing database-level types that suggest direct field access
+- ✅ **GDPR enforcement boundary preserved**: The REST API remains the single point of GDPR control — RLS tenant isolation via `withTenantContext()`, RBAC permission matrix (`06-security-compliance.md`), PII redaction (Pino `redact` + RFC 9457 strict response schemas), and immutable audit logging. Frontend developers cannot accidentally circumvent data protection by importing database-level types that suggest direct field access
 - ✅ **Security posture**: Internal system architecture (event topology, job queue structure, outbox design) is not exposed to frontend code — reduces information available to an attacker who gains access to client-side source maps or bundled JavaScript
 - ✅ **Lint-enforced in CI**: Violations are caught by Biome before merge — not dependent on code review alone
 - ✅ **Consistent with ADR-011**: The Domain Models layer in `packages/web/src/models/` is the designated home for frontend-specific API response types, reinforcing the layered service architecture

--- a/docs/17-log-management.md
+++ b/docs/17-log-management.md
@@ -381,7 +381,7 @@ The following rules should be added to existing agents to enforce logging standa
 | Rule | Description |
 |------|-------------|
 | `X-Request-Id` header in all API responses | Document in OpenAPI spec |
-| Error responses include `correlationId` | RFC 7807 `instance` field = correlation ID |
+| Error responses include `correlationId` | RFC 9457 `instance` field = correlation ID |
 | No PII in error detail messages | Error messages are logged — PII would leak |
 
 ### Data Architect

--- a/packages/api/src/lib/schemas.ts
+++ b/packages/api/src/lib/schemas.ts
@@ -17,7 +17,7 @@ export const PaginationQuery = Type.Object({
   perPage: Type.Optional(Type.Integer({ minimum: 1, maximum: 100, default: 20 })),
 });
 
-/** RFC 7807 Problem Details response schema (all members optional per spec) */
+/** RFC 9457 Problem Details response schema (all members optional per spec) */
 export const ProblemDetailSchema = Type.Object(
   {
     type: Type.Optional(Type.String()),
@@ -74,7 +74,7 @@ export const ErrorResponses = {
   404: ProblemDetailSchema,
 };
 
-/** Helper to create an RFC 7807 problem detail object */
+/** Helper to create an RFC 9457 problem detail object */
 export function problemDetail(status: number, title: string, detail: string) {
   return {
     type: `https://httpproblems.com/http-status/${status}`,
@@ -84,5 +84,5 @@ export function problemDetail(status: number, title: string, detail: string) {
   };
 }
 
-/** Content-Type for RFC 7807 responses */
+/** Content-Type for RFC 9457 responses */
 export const PROBLEM_JSON = "application/problem+json";

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -72,7 +72,7 @@ export async function createServer() {
     routePrefix: "/docs",
   });
 
-  // --- Global error handler (RFC 7807 application/problem+json) ---
+  // --- Global error handler (RFC 9457 application/problem+json) ---
   app.setErrorHandler((error: FastifyError, _request, reply) => {
     const status = error.statusCode ?? 500;
     const body = problemDetail(

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -15,7 +15,7 @@ export interface ApiResponse<T> {
   meta?: Record<string, unknown>;
 }
 
-/** Standard API error response (RFC 7807 Problem Details) */
+/** Standard API error response (RFC 9457 Problem Details) */
 export interface ApiError {
   type: string;
   title: string;


### PR DESCRIPTION
## Summary

Adds three Architecture Decision Records for the Sprint 4 frontend implementation:

- **ADR-011 — Layered Service Architecture over MVC**: Defines the 4-layer pattern (API Client → Domain Models → Services → UI) for `packages/web/`, including state management with TanStack Query v5 and security requirements (CSRF, JWT cookie attributes, cache hygiene)
- **ADR-012 — shadcn/ui + TanStack Ecosystem**: Selects the component library (shadcn/ui + Radix), data tables (@tanstack/react-table), forms (React Hook Form + TypeBox), and icons (lucide-react) with detailed rejected alternatives comparison
- **ADR-013 — Frontend Type Boundary**: Bans Drizzle ORM imports in `packages/web` to prevent type/runtime mismatches (Date vs string), enforced via subpath exports, Biome lint rules, and source map policy

## Process

These decisions were produced through a multi-agent architecture review:
1. **Platform Architect** drafted ADR-011 (architecture layers)
2. **Design Architect** drafted ADR-012 (component ecosystem)
3. **Security Architect** drafted ADR-013 (type boundary + security implications)
4. **Security Architect** reviewed all three ADRs → identified 3 blockers + 7 suggestions
5. **Platform Architect** cross-reviewed for consistency → identified 1 blocker + 4 suggestions
6. All BLOCKER and key SUGGESTION findings were addressed before PR creation

## Security Review Findings Addressed

- ✅ CSRF protection documented (double-submit cookie pattern)
- ✅ JWT cookie attributes specified (httpOnly + Secure + SameSite=Strict)
- ✅ Source maps disabled in production builds
- ✅ AI suggestion card XSS prevention (no dangerouslySetInnerHTML)
- ✅ CSP compatibility notes for Radix inline styles
- ✅ TanStack Query cache PII hygiene (gcTime + clear on logout)
- ✅ NEXT_PUBLIC_API_URL topology leak prevention

## Related Issues

- Closes #65
- Supports #40, #41, #42 (Sprint 4 frontend implementation)

## Test plan

- [ ] Verify ADR numbering follows ADR-010 (in `20-payment-strategy.md`)
- [ ] Verify no contradictions with ADR-001 (modular monolith), ADR-002 (TypeScript), ADR-003 (Drizzle)
- [ ] Verify consistent format with existing ADRs (Status/Date/Deciders/Context/Decision/Rationale/Alternatives/Consequences)
- [ ] Verify all doc references use full filenames (e.g., `06-security-compliance.md`, not `doc 06`)
- [ ] Verify cross-references between ADR-011 ↔ ADR-013 are bidirectional

🤖 Generated with [Claude Code](https://claude.com/claude-code)