### PR TITLE
refactor(web): extract shared error-page components

### DIFF
--- a/packages/web/src/app/error.tsx
+++ b/packages/web/src/app/error.tsx
@@ -2,6 +2,9 @@
 
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import { BrandLogo } from "@/components/brand-logo";
+import { ErrorPageShell } from "@/components/error-page-shell";
+import { PrimaryButton } from "@/components/primary-button";
 
 /**
  * 500 Error page — matches GLO-003 mockup (docs/design/global/500.html).
@@ -18,87 +21,75 @@ export default function ErrorPage({
   const tCommon = useTranslations("common");
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-6">
-      <div className="flex w-full max-w-[500px] flex-col items-center text-center">
-        {/* Logo */}
-        <div className="mb-10 flex items-center justify-center gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary text-xl font-bold text-on-primary">
-            G
-          </div>
-          <span className="font-heading text-2xl text-text">{tCommon("appName")}</span>
+    <ErrorPageShell>
+      <BrandLogo appName={tCommon("appName")} />
+
+      {/* Gear + wrench illustration */}
+      <div
+        className="relative mx-auto mb-8 h-[150px] w-[180px]"
+        role="img"
+        aria-label="Gears and wrench illustration indicating maintenance in progress"
+      >
+        {/* Accent dot */}
+        <div className="absolute right-10 top-0 h-3 w-3 rounded-full bg-primary-100" />
+        {/* Large gear */}
+        <div className="absolute left-6 top-2.5 h-[90px] w-[90px] animate-[spin_12s_linear_infinite] rounded-full border-8 border-neutral-200">
+          <div className="absolute left-1/2 top-1/2 h-[22px] w-[22px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-neutral-200" />
         </div>
-
-        {/* Gear + wrench illustration */}
-        <div
-          className="relative mb-8 h-[150px] w-[180px]"
-          role="img"
-          aria-label="Gears and wrench illustration indicating maintenance in progress"
-        >
-          {/* Accent dot */}
-          <div className="absolute right-10 top-0 h-3 w-3 rounded-full bg-primary-100" />
-          {/* Large gear */}
-          <div className="absolute left-6 top-2.5 h-[90px] w-[90px] animate-[spin_12s_linear_infinite] rounded-full border-8 border-neutral-200">
-            <div className="absolute left-1/2 top-1/2 h-[22px] w-[22px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-neutral-200" />
-          </div>
-          {/* Small gear */}
-          <div className="absolute right-6 top-[60px] h-[60px] w-[60px] animate-[spin_8s_linear_infinite_reverse] rounded-full border-6 border-neutral-300">
-            <div className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-neutral-300" />
-          </div>
-          {/* Wrench */}
-          <div className="absolute bottom-2 left-1/2 h-20 w-2 -translate-x-1/2 -rotate-[30deg] rounded bg-primary opacity-85">
-            <div className="absolute -top-1.5 left-1/2 h-[18px] w-6 -translate-x-1/2 rounded-t-xl border-5 border-b-0 border-primary bg-transparent" />
-            <div className="absolute -bottom-0.5 left-1/2 h-2 w-4 -translate-x-1/2 rounded-b bg-primary" />
-          </div>
+        {/* Small gear */}
+        <div className="absolute right-6 top-[60px] h-[60px] w-[60px] animate-[spin_8s_linear_infinite_reverse] rounded-full border-6 border-neutral-300">
+          <div className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-neutral-300" />
         </div>
-
-        {/* Title */}
-        <h1 className="mb-3 font-heading text-2xl font-normal leading-tight text-text">
-          {t("server.title")}
-        </h1>
-
-        {/* Message */}
-        <p className="mb-5 max-w-[420px] text-sm leading-relaxed text-text-secondary">
-          {t("server.description")}
-        </p>
-
-        {/* Error digest badge */}
-        {error.digest && (
-          <span className="mb-8 inline-block rounded-pill bg-neutral-100 px-4 py-1 font-mono text-xs tracking-wide text-text-secondary">
-            {t("server.errorId", { digest: error.digest })}
-          </span>
-        )}
-
-        {/* Actions */}
-        <div className="mb-6 flex items-center justify-center gap-3">
-          <button
-            type="button"
-            onClick={reset}
-            className="inline-flex h-[var(--btn-height-md)] items-center rounded-button bg-primary px-6 text-sm font-medium text-on-primary shadow-button transition-[background-color] hover:bg-primary-hover focus-visible:shadow-ring"
-          >
-            {tCommon("actions.tryAgain")}
-          </button>
-          <a
-            href="mailto:support@givernance.org"
-            className="inline-flex h-[var(--btn-height-md)] items-center rounded-button border border-border bg-white px-6 text-sm font-medium text-text shadow-sm transition-[background-color] hover:bg-surface-container-low focus-visible:shadow-ring"
-          >
-            {tCommon("actions.contactSupport")}
-          </a>
+        {/* Wrench */}
+        <div className="absolute bottom-2 left-1/2 h-20 w-2 -translate-x-1/2 -rotate-[30deg] rounded bg-primary opacity-85">
+          <div className="absolute -top-1.5 left-1/2 h-[18px] w-6 -translate-x-1/2 rounded-t-xl border-5 border-b-0 border-primary bg-transparent" />
+          <div className="absolute -bottom-0.5 left-1/2 h-2 w-4 -translate-x-1/2 rounded-b bg-primary" />
         </div>
-
-        {/* Footer */}
-        <p className="text-xs text-text-muted">
-          {t.rich("server.dashboardLink", {
-            link: (chunks) => (
-              <Link
-                href="/"
-                className="font-medium text-primary hover:text-primary-dark hover:underline"
-              >
-                {chunks}
-              </Link>
-            ),
-          })}
-        </p>
       </div>
-    </div>
+
+      {/* Title */}
+      <h1 className="mb-3 font-heading text-2xl font-normal leading-tight text-text">
+        {t("server.title")}
+      </h1>
+
+      {/* Message */}
+      <p className="mx-auto mb-5 max-w-[420px] text-sm leading-relaxed text-text-secondary">
+        {t("server.description")}
+      </p>
+
+      {/* Error digest badge */}
+      {error.digest && (
+        <span className="mb-8 inline-block rounded-pill bg-neutral-100 px-4 py-1 font-mono text-xs tracking-wide text-text-secondary">
+          {t("server.errorId", { digest: error.digest })}
+        </span>
+      )}
+
+      {/* Actions */}
+      <div className="mb-6 flex items-center justify-center gap-3">
+        <PrimaryButton type="button" onClick={reset}>
+          {tCommon("actions.tryAgain")}
+        </PrimaryButton>
+        <a
+          href="mailto:support@givernance.org"
+          className="inline-flex h-[var(--btn-height-md)] items-center rounded-button border border-border bg-white px-6 text-sm font-medium text-text shadow-sm transition-[background-color] hover:bg-surface-container-low focus-visible:shadow-ring"
+        >
+          {tCommon("actions.contactSupport")}
+        </a>
+      </div>
+
+      {/* Footer */}
+      <p className="text-xs text-text-muted">
+        {t.rich("server.dashboardLink", {
+          link: (chunks) => (
+            <Link
+              href="/"
+              className="font-medium text-primary hover:text-primary-dark hover:underline"
+            >
+              {chunks}
+            </Link>
+          ),
+        })}
+      </p>
+    </ErrorPageShell>
   );
 }

--- a/packages/web/src/app/not-found.tsx
+++ b/packages/web/src/app/not-found.tsx
@@ -1,5 +1,7 @@
-import Link from "next/link";
 import { getTranslations } from "next-intl/server";
+import { BrandLogo } from "@/components/brand-logo";
+import { ErrorPageShell } from "@/components/error-page-shell";
+import { PrimaryLink } from "@/components/primary-button";
 
 /**
  * 404 Not Found page — matches GLO-002 mockup (docs/design/global/404.html).
@@ -10,152 +12,141 @@ export default async function NotFound() {
   const tCommon = await getTranslations("common");
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-6">
-      <div className="w-full max-w-[500px] text-center">
-        {/* Logo */}
-        <div className="mb-10 flex items-center justify-center gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary text-xl font-bold text-on-primary">
-            G
-          </div>
-          <span className="font-heading text-2xl text-text">{tCommon("appName")}</span>
+    <ErrorPageShell>
+      <BrandLogo appName={tCommon("appName")} />
+
+      {/* Compass illustration with animations */}
+      <div className="relative mx-auto mb-8 h-[150px] w-[150px]">
+        {/* Outer ring */}
+        <div className="absolute inset-0 rounded-full border-3 border-neutral-200 bg-white shadow-card" />
+        {/* Inner dashed ring */}
+        <div className="absolute left-5 top-5 h-[110px] w-[110px] rounded-full border-2 border-dashed border-neutral-200" />
+        {/* Cardinal markers */}
+        <span className="absolute left-1/2 top-2 -translate-x-1/2 text-xs font-semibold text-primary">
+          N
+        </span>
+        <span className="absolute bottom-2 left-1/2 -translate-x-1/2 text-xs font-semibold text-neutral-400">
+          S
+        </span>
+        <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs font-semibold text-neutral-400">
+          E
+        </span>
+        <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-xs font-semibold text-neutral-400">
+          W
+        </span>
+
+        {/* Erratic needle — disturbed by magnetic fields */}
+        <div
+          className="absolute left-1/2 top-1/2 h-[52px] w-1 origin-center"
+          style={{ animation: "needle-lost 6s cubic-bezier(0.4, 0, 0.2, 1) infinite" }}
+        >
+          <div className="absolute left-1/2 top-0 -translate-x-1/2 border-x-[6px] border-b-[24px] border-x-transparent border-b-primary" />
+          <div className="absolute bottom-0 left-1/2 -translate-x-1/2 border-x-[5px] border-t-[22px] border-x-transparent border-t-neutral-300" />
         </div>
 
-        {/* Compass illustration with animations */}
-        <div className="relative mx-auto mb-8 h-[150px] w-[150px]">
-          {/* Outer ring */}
-          <div className="absolute inset-0 rounded-full border-3 border-neutral-200 bg-white shadow-card" />
-          {/* Inner dashed ring */}
-          <div className="absolute left-5 top-5 h-[110px] w-[110px] rounded-full border-2 border-dashed border-neutral-200" />
-          {/* Cardinal markers */}
-          <span className="absolute left-1/2 top-2 -translate-x-1/2 text-xs font-semibold text-primary">
-            N
-          </span>
-          <span className="absolute bottom-2 left-1/2 -translate-x-1/2 text-xs font-semibold text-neutral-400">
-            S
-          </span>
-          <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs font-semibold text-neutral-400">
-            E
-          </span>
-          <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-xs font-semibold text-neutral-400">
-            W
-          </span>
+        {/* Center pivot with pulse */}
+        <div
+          className="absolute left-1/2 top-1/2 z-[2] h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber"
+          style={{ animation: "pivot-pulse 2s ease-in-out infinite" }}
+        />
 
-          {/* Erratic needle — disturbed by magnetic fields */}
-          <div
-            className="absolute left-1/2 top-1/2 h-[52px] w-1 origin-center"
-            style={{ animation: "needle-lost 6s cubic-bezier(0.4, 0, 0.2, 1) infinite" }}
-          >
-            <div className="absolute left-1/2 top-0 -translate-x-1/2 border-x-[6px] border-b-[24px] border-x-transparent border-b-primary" />
-            <div className="absolute bottom-0 left-1/2 -translate-x-1/2 border-x-[5px] border-t-[22px] border-x-transparent border-t-neutral-300" />
-          </div>
+        {/* Floating question marks — curved paths from center outward */}
+        <span
+          className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-lg italic text-amber"
+          style={{ animation: "q-float-1 3.2s ease-out infinite", animationDelay: "0s" }}
+        >
+          ?
+        </span>
+        <span
+          className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-sm italic text-primary-light"
+          style={{ animation: "q-float-2 3.8s ease-out infinite", animationDelay: "0.6s" }}
+        >
+          ?
+        </span>
+        <span
+          className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-xl italic text-amber/60"
+          style={{ animation: "q-float-3 4.1s ease-out infinite", animationDelay: "1.2s" }}
+        >
+          ?
+        </span>
+        <span
+          className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-base italic text-primary/40"
+          style={{ animation: "q-float-4 3.5s ease-out infinite", animationDelay: "2.0s" }}
+        >
+          ?
+        </span>
+        <span
+          className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-lg italic text-amber/70"
+          style={{ animation: "q-float-5 4.4s ease-out infinite", animationDelay: "0.9s" }}
+        >
+          ?
+        </span>
+        <span
+          className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-xs italic text-primary-light/50"
+          style={{ animation: "q-float-6 3.0s ease-out infinite", animationDelay: "1.8s" }}
+        >
+          ?
+        </span>
 
-          {/* Center pivot with pulse */}
-          <div
-            className="absolute left-1/2 top-1/2 z-[2] h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber"
-            style={{ animation: "pivot-pulse 2s ease-in-out infinite" }}
-          />
-
-          {/* Floating question marks — curved paths from center outward */}
-          <span
-            className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-lg italic text-amber"
-            style={{ animation: "q-float-1 3.2s ease-out infinite", animationDelay: "0s" }}
-          >
-            ?
-          </span>
-          <span
-            className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-sm italic text-primary-light"
-            style={{ animation: "q-float-2 3.8s ease-out infinite", animationDelay: "0.6s" }}
-          >
-            ?
-          </span>
-          <span
-            className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-xl italic text-amber/60"
-            style={{ animation: "q-float-3 4.1s ease-out infinite", animationDelay: "1.2s" }}
-          >
-            ?
-          </span>
-          <span
-            className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-base italic text-primary/40"
-            style={{ animation: "q-float-4 3.5s ease-out infinite", animationDelay: "2.0s" }}
-          >
-            ?
-          </span>
-          <span
-            className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-lg italic text-amber/70"
-            style={{ animation: "q-float-5 4.4s ease-out infinite", animationDelay: "0.9s" }}
-          >
-            ?
-          </span>
-          <span
-            className="pointer-events-none absolute left-1/2 top-1/2 font-heading text-xs italic text-primary-light/50"
-            style={{ animation: "q-float-6 3.0s ease-out infinite", animationDelay: "1.8s" }}
-          >
-            ?
-          </span>
-
-          {/* Wandering path */}
-          <div className="absolute -bottom-2 -right-5 h-10 w-[60px] rounded-br-[30px] border-2 border-l-0 border-t-0 border-dashed border-primary-light opacity-70">
-            <div className="absolute -bottom-[3px] -right-[3px] h-2.5 w-2.5 rounded-full bg-primary shadow-[0_0_0_3px_var(--color-primary-50)]" />
-          </div>
+        {/* Wandering path */}
+        <div className="absolute -bottom-2 -right-5 h-10 w-[60px] rounded-br-[30px] border-2 border-l-0 border-t-0 border-dashed border-primary-light opacity-70">
+          <div className="absolute -bottom-[3px] -right-[3px] h-2.5 w-2.5 rounded-full bg-primary shadow-[0_0_0_3px_var(--color-primary-50)]" />
         </div>
-
-        {/* Error label */}
-        <div className="mb-3 font-mono text-sm font-semibold uppercase tracking-wider text-primary">
-          {t("notFound.label")}
-        </div>
-
-        {/* Title */}
-        <h1 className="mb-4 font-heading text-3xl font-normal leading-tight text-text">
-          {t("notFound.title")}
-        </h1>
-
-        {/* Message */}
-        <p className="mx-auto mb-8 max-w-[380px] text-sm leading-relaxed text-text-secondary">
-          {t("notFound.description")}
-        </p>
-
-        {/* Primary CTA */}
-        <div className="mb-6 flex items-center justify-center gap-3">
-          <Link
-            href="/"
-            className="inline-flex h-[var(--btn-height-lg)] items-center rounded-button bg-primary px-6 text-sm font-medium text-on-primary shadow-button transition-[background-color] hover:bg-primary-hover focus-visible:shadow-ring"
-          >
-            {tCommon("actions.backToDashboard")}
-          </Link>
-        </div>
-
-        {/* Divider */}
-        <div className="mb-5 flex items-center gap-3 text-xs text-text-muted">
-          <span className="h-px flex-1 bg-neutral-200" />
-          {tCommon("actions.or")}
-          <span className="h-px flex-1 bg-neutral-200" />
-        </div>
-
-        {/* Search placeholder */}
-        <div className="mx-auto mb-8 max-w-[320px]">
-          <input
-            type="search"
-            placeholder={t("notFound.searchPlaceholder")}
-            aria-label={t("notFound.searchLabel")}
-            readOnly
-            className="h-[var(--input-height)] w-full rounded-input border border-border bg-white px-4 text-center text-sm text-text placeholder:text-text-muted focus-visible:shadow-ring"
-          />
-        </div>
-
-        {/* Footer */}
-        <footer className="text-xs text-text-muted">
-          {t.rich("notFound.persistsMessage", {
-            link: (chunks) => (
-              <a
-                href="mailto:support@givernance.org"
-                className="font-medium text-primary hover:text-primary-dark hover:underline"
-              >
-                {chunks}
-              </a>
-            ),
-          })}
-        </footer>
       </div>
-    </div>
+
+      {/* Error label */}
+      <div className="mb-3 font-mono text-sm font-semibold uppercase tracking-wider text-primary">
+        {t("notFound.label")}
+      </div>
+
+      {/* Title */}
+      <h1 className="mb-4 font-heading text-3xl font-normal leading-tight text-text">
+        {t("notFound.title")}
+      </h1>
+
+      {/* Message */}
+      <p className="mx-auto mb-8 max-w-[380px] text-sm leading-relaxed text-text-secondary">
+        {t("notFound.description")}
+      </p>
+
+      {/* Primary CTA */}
+      <div className="mb-6 flex items-center justify-center gap-3">
+        <PrimaryLink href="/" size="lg">
+          {tCommon("actions.backToDashboard")}
+        </PrimaryLink>
+      </div>
+
+      {/* Divider */}
+      <div className="mb-5 flex items-center gap-3 text-xs text-text-muted">
+        <span className="h-px flex-1 bg-neutral-200" />
+        {tCommon("actions.or")}
+        <span className="h-px flex-1 bg-neutral-200" />
+      </div>
+
+      {/* Search placeholder */}
+      <div className="mx-auto mb-8 max-w-[320px]">
+        <input
+          type="search"
+          placeholder={t("notFound.searchPlaceholder")}
+          aria-label={t("notFound.searchLabel")}
+          readOnly
+          className="h-[var(--input-height)] w-full rounded-input border border-border bg-white px-4 text-center text-sm text-text placeholder:text-text-muted focus-visible:shadow-ring"
+        />
+      </div>
+
+      {/* Footer */}
+      <footer className="text-xs text-text-muted">
+        {t.rich("notFound.persistsMessage", {
+          link: (chunks) => (
+            <a
+              href="mailto:support@givernance.org"
+              className="font-medium text-primary hover:text-primary-dark hover:underline"
+            >
+              {chunks}
+            </a>
+          ),
+        })}
+      </footer>
+    </ErrorPageShell>
   );
 }

--- a/packages/web/src/components/brand-logo.tsx
+++ b/packages/web/src/components/brand-logo.tsx
@@ -1,0 +1,14 @@
+/**
+ * Givernance brand mark — the "G" badge + wordmark used on standalone pages
+ * (error, 404, auth, etc.) that render outside the main app shell.
+ */
+export function BrandLogo({ appName }: { appName: string }) {
+  return (
+    <div className="mb-10 flex items-center justify-center gap-3">
+      <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary text-xl font-bold text-on-primary">
+        G
+      </div>
+      <span className="font-heading text-2xl text-text">{appName}</span>
+    </div>
+  );
+}

--- a/packages/web/src/components/error-page-shell.tsx
+++ b/packages/web/src/components/error-page-shell.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+/**
+ * Full-screen centred shell used by standalone error pages (404, 500, etc.).
+ * Renders a vertically/horizontally centred column of up to 500 px wide.
+ */
+export function ErrorPageShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-6">
+      <div className="w-full max-w-[500px] text-center">{children}</div>
+    </div>
+  );
+}

--- a/packages/web/src/components/primary-button.tsx
+++ b/packages/web/src/components/primary-button.tsx
@@ -1,0 +1,41 @@
+import Link, { type LinkProps } from "next/link";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type Size = "md" | "lg";
+
+const sizeClass: Record<Size, string> = {
+  md: "h-[var(--btn-height-md)]",
+  lg: "h-[var(--btn-height-lg)]",
+};
+
+const baseClass =
+  "inline-flex items-center rounded-button bg-primary px-6 text-sm font-medium text-on-primary shadow-button transition-[background-color] hover:bg-primary-hover focus-visible:shadow-ring";
+
+/**
+ * Primary action button (renders a <button>).
+ */
+export function PrimaryButton({
+  size = "md",
+  className,
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & { size?: Size }) {
+  const cls = `${sizeClass[size]} ${baseClass}${className ? ` ${className}` : ""}`;
+  return <button {...props} className={cls} />;
+}
+
+/**
+ * Primary action link (renders a Next.js <Link>).
+ */
+export function PrimaryLink({
+  size = "md",
+  className,
+  children,
+  ...props
+}: LinkProps & { size?: Size; className?: string; children?: ReactNode }) {
+  const cls = `${sizeClass[size]} ${baseClass}${className ? ` ${className}` : ""}`;
+  return (
+    <Link {...props} className={cls}>
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicated brand logo block from `error.tsx` and `not-found.tsx` into a `BrandLogo` component
- Extracts the identical full-screen centred wrapper into an `ErrorPageShell` component
- Extracts the primary CTA styles into `PrimaryButton` (renders `<button>`) and `PrimaryLink` (renders Next.js `<Link>`), with a `size` prop for `md`/`lg` variants

All three live under the new `packages/web/src/components/` directory and are imported via the `@/` alias. No behaviour changes.

## Test plan

- [ ] Visit `/` then navigate to a non-existent path — 404 page renders correctly with brand logo, compass animation, and "Back to dashboard" CTA
- [ ] Trigger a runtime error to verify the 500 page renders correctly with brand logo, gear animation, digest badge (if present), and "Try again" / "Contact support" buttons
- [ ] Check visual parity with the GLO-002 and GLO-003 mockups

🤖 Generated with [Claude Code](https://claude.com/claude-code)