### PR TITLE
docs: Phase 1 - Multi-Tenant SSO Onboarding Architecture

### DIFF
--- a/docs/02-reference-architecture.md
+++ b/docs/02-reference-architecture.md
@@ -28,7 +28,7 @@ See: /diagrams/context.mmd
 ```
 
 Actors:
-- **NPO Staff** (fundraising manager, program manager, volunteer coordinator, data entry) — authenticate via SSO only; their `users` record is created Just-In-Time on first login (see doc 21 §2.4)
+- **NPO Staff** (fundraising manager, program manager, volunteer coordinator, data entry) — authenticate via SSO only after email validation; their `users` record is created Just-In-Time on first login (see doc 21 §2.4)
 - **NPO Administrator** (configures fund accounting, GL mapping, roles, GDPR actions) — authenticates via SSO; does **not** create the tenant (that is a Givernance Super Admin action)
 - **Beneficiaries** (optional self-service portal for case access)
 - **Volunteers** (self-service portal for shift booking and hour logging)
@@ -71,6 +71,7 @@ See: /diagrams/container.mmd
 - Client components for interactive forms and dashboards
 - Connects to `givernance-api` only (no direct DB)
 - Auth: OIDC flow through Keycloak; JWT stored in httpOnly cookie
+- Tenant routing: production uses tenant subdomains such as `https://redcross.givernance.app` or `https://redcross.givernance.org`; local development simulates the same routing context with `?namespace=redcross`
 - Static assets served from CDN (CloudFront / Cloudflare)
 
 #### `givernance-relay` (TypeScript, standalone)
@@ -122,10 +123,10 @@ See: /diagrams/container.mmd
 
 #### `keycloak` (Keycloak 24)
 - OIDC provider; issues JWTs consumed by `givernance-api`
-- Realms: **one shared realm per deployment** (`givernance` for SaaS). Tenant isolation is carried in the JWT via `org_id` / `org_slug` / `role` claims and enforced at the application layer (PostgreSQL RLS — see §6)
+- Realms: **Option A / MVP choice is one shared realm per deployment** (`givernance` for SaaS, admin, tests, and the MVP). Tenant isolation is carried in the JWT via `org_id` / `org_slug` / `role` claims and enforced at the application layer (PostgreSQL RLS — see §6)
 - Multi-tenancy inside the shared realm: one Keycloak **group** per tenant (`/tenants/<slug>`) + per-tenant **Identity Provider federation** (Entra ID, Okta, Google Workspace, …). Domain routing uses `kc_idp_hint` or email-domain alias. See `21-authentication-sso.md` §2 for the full onboarding architecture (Spike [#80](https://github.com/purposestack/givernance/issues/80))
 - **No self-service signup**: tenant rows and Keycloak groups/IdPs are provisioned by a Givernance Super Admin via `POST /v1/admin/tenants`; NPO users are then created Just-In-Time on first SSO login from the JWT claims
-- Dedicated-realm-per-tenant mode is reserved as an enterprise escape hatch for self-hosted customers with hard IdP isolation requirements
+- **Option B / future evolution** is one dedicated Keycloak realm per tenant. It is reserved as an enterprise escape hatch for self-hosted customers with hard IdP isolation requirements, not the MVP SaaS path
 - Flows: standard OIDC (PKCE), SAML 2.0 bridge, magic link for volunteers
 - Brute-force protection, MFA enforcement by role
 - Retained in all deployment modes — no managed alternative covers the full feature set (SAML 2.0, magic-link, MFA by role). See [ADR-007](./15-infra-adr.md#adr-007-reject-convexdev-and-supabase-as-all-in-one-backend-replacements).

--- a/docs/02-reference-architecture.md
+++ b/docs/02-reference-architecture.md
@@ -28,12 +28,12 @@ See: /diagrams/context.mmd
 ```
 
 Actors:
-- **NPO Staff** (fundraising manager, program manager, volunteer coordinator, data entry)
-- **NPO Administrator** (configures org, manages users, runs GDPR actions)
+- **NPO Staff** (fundraising manager, program manager, volunteer coordinator, data entry) — authenticate via SSO only; their `users` record is created Just-In-Time on first login (see doc 21 §2.4)
+- **NPO Administrator** (configures fund accounting, GL mapping, roles, GDPR actions) — authenticates via SSO; does **not** create the tenant (that is a Givernance Super Admin action)
 - **Beneficiaries** (optional self-service portal for case access)
 - **Volunteers** (self-service portal for shift booking and hour logging)
 - **Finance/Auditors** (read-only access to reports and GL exports)
-- **Platform Operator** (Givernance operations team — super_admin)
+- **Platform Operator / Givernance Super Admin** (Givernance operations team — `super_admin`) — **provisions tenants and configures their Identity Providers** in the shared Keycloak realm before any NPO user can log in (doc 21 §2.3)
 
 External systems:
 - **Stripe / Mollie** — payment processing (recurring donations, SEPA)
@@ -122,8 +122,11 @@ See: /diagrams/container.mmd
 
 #### `keycloak` (Keycloak 24)
 - OIDC provider; issues JWTs consumed by `givernance-api`
-- Realms: one per deployment (not per tenant — tenant isolation is in the application layer)
-- Flows: standard, SAML 2.0 bridge, magic link for volunteers
+- Realms: **one shared realm per deployment** (`givernance` for SaaS). Tenant isolation is carried in the JWT via `org_id` / `org_slug` / `role` claims and enforced at the application layer (PostgreSQL RLS — see §6)
+- Multi-tenancy inside the shared realm: one Keycloak **group** per tenant (`/tenants/<slug>`) + per-tenant **Identity Provider federation** (Entra ID, Okta, Google Workspace, …). Domain routing uses `kc_idp_hint` or email-domain alias. See `21-authentication-sso.md` §2 for the full onboarding architecture (Spike [#80](https://github.com/purposestack/givernance/issues/80))
+- **No self-service signup**: tenant rows and Keycloak groups/IdPs are provisioned by a Givernance Super Admin via `POST /v1/admin/tenants`; NPO users are then created Just-In-Time on first SSO login from the JWT claims
+- Dedicated-realm-per-tenant mode is reserved as an enterprise escape hatch for self-hosted customers with hard IdP isolation requirements
+- Flows: standard OIDC (PKCE), SAML 2.0 bridge, magic link for volunteers
 - Brute-force protection, MFA enforcement by role
 - Retained in all deployment modes — no managed alternative covers the full feature set (SAML 2.0, magic-link, MFA by role). See [ADR-007](./15-infra-adr.md#adr-007-reject-convexdev-and-supabase-as-all-in-one-backend-replacements).
 
@@ -292,6 +295,10 @@ All tenant-scoped tables have `FORCE ROW LEVEL SECURITY` enabled (migration `001
 - PgBouncer works correctly in transaction mode
 
 **Security boundary**: RLS policies are the primary tenant boundary. All policies tested in integration test suite with cross-tenant access attempts. The `givernance_app` role does NOT have `BYPASSRLS` — this is the role used by the API server for all user-facing requests.
+
+### 6.5 Tenant binding at JIT provisioning
+
+The `org_id` used in `withTenantContext` is read from the Keycloak-signed JWT (`org_id` claim), which is mapped from the Keycloak group the user belongs to (`/tenants/<slug>`). On the very first request from a newly authenticated user, the API performs **Just-In-Time user provisioning** (`INSERT INTO users (id, org_id, email, role, keycloak_sub)`) using only the JWT claims; it never derives `org_id` from subdomain, email domain, or request body. If the JWT's `org_id` does not match an existing `tenants` row, the API returns `403 tenant_not_provisioned` — tenants are only created by a Givernance Super Admin (see `21-authentication-sso.md` §2.3, §2.4).
 
 ---
 

--- a/docs/02-reference-architecture.md
+++ b/docs/02-reference-architecture.md
@@ -28,7 +28,7 @@ See: /diagrams/context.mmd
 ```
 
 Actors:
-- **NPO Staff** (fundraising manager, program manager, volunteer coordinator, data entry) — authenticate via SSO only after email validation; their `users` record is created Just-In-Time on first login (see doc 21 §2.4)
+- **NPO Staff** (fundraising manager, program manager, volunteer coordinator, data entry) — authenticate via SSO only; their `users` record is created Just-In-Time on first login (email validation deferred to Phase 2) (see doc 21 §2.4)
 - **NPO Administrator** (configures fund accounting, GL mapping, roles, GDPR actions) — authenticates via SSO; does **not** create the tenant (that is a Givernance Super Admin action)
 - **Beneficiaries** (optional self-service portal for case access)
 - **Volunteers** (self-service portal for shift booking and hour logging)

--- a/docs/05-integration-migration.md
+++ b/docs/05-integration-migration.md
@@ -453,7 +453,7 @@ La migration depuis Salesforce NPSP est une fonctionnalité **différenciante ma
 
 ### 11.2 Migration Assistant — Interface produit (UX)
 
-Le **Migration Assistant** est un wizard step-by-step intégré dans l'onboarding Givernance. Il remplace le besoin de consulter un intégrateur externe pour 80% des migrations standards.
+Le **Migration Assistant** est un wizard step-by-step post-login, accessible depuis `Settings > Import > Depuis Salesforce`. Il peut être lancé à tout moment après que le Givernance Super Admin a provisionné le tenant et que l'admin NPO s'est connecté via SSO (voir Spike [#80](https://github.com/purposestack/givernance/issues/80) et `docs/21-authentication-sso.md` §2 — l'import n'est **plus** une étape du signup). Il remplace le besoin de consulter un intégrateur externe pour 80% des migrations standards.
 
 #### Étapes du wizard
 

--- a/docs/07-delivery-roadmap.md
+++ b/docs/07-delivery-roadmap.md
@@ -68,7 +68,7 @@ Frontend implementation of Sprints 1–3.
 - Constituents UI: list, detail, create, import CSV (issue #41)
 - Donations UI: list, new donation form, receipt preview (issue #41)
 - Dashboard UI: key widgets — total raised, active campaigns, grant deadlines (issue #42)
-- Auth UI: login, SSO, onboarding wizard 5 steps (issue #40)
+- Auth UI: SSO-only login page + back-office tenant provisioning (Spike [#80](https://github.com/purposestack/givernance/issues/80), issue #40). The former "5-step onboarding wizard" has been dropped — tenants are created by a Givernance Super Admin and user accounts are provisioned Just-In-Time on first SSO login (see `docs/21-authentication-sso.md` §2).
 
 **Done when**: A non-technical NPO staff member can log in, find a donor, record a gift, and see the receipt — without reading any documentation.
 

--- a/docs/10-open-questions.md
+++ b/docs/10-open-questions.md
@@ -70,7 +70,7 @@
 
 **Hypothesis**: A 5-person charity with no IT staff might want more automation (Autopilot default) while a 50-person NPO with dedicated data staff may prefer Manual or Assisted.
 
-**Decision needed**: Define default mode assignment logic in onboarding wizard.
+**Decision needed**: Define the default AI mode assignment logic. Since the self-service onboarding wizard is removed (Spike [#80](https://github.com/purposestack/givernance/issues/80)), the default must be set either (a) by the Givernance Super Admin at tenant provisioning time (`POST /v1/admin/tenants`) or (b) derived from tenant attributes (size tier, plan) on first login.
 
 ---
 

--- a/docs/12-user-journeys.md
+++ b/docs/12-user-journeys.md
@@ -433,24 +433,24 @@ Volunteers > Mon planning (vue mobile prioritaire)
 
 ---
 
-### 4.2 User Journey — Onboarding complet d'une nouvelle organisation + gestion quotidienne
+### 4.2 User Journey — Provisioning par Givernance puis configuration admin + gestion quotidienne
+
+> **Note d'architecture (Spike #80 — 2026-04)**: l'ancien "wizard d'onboarding" en 5 étapes auto-servi est **supprimé**. La création du tenant et la configuration OIDC (Entra ID, Okta, Google Workspace) sont désormais effectuées par un **Givernance Super Admin** dans le back-office *avant* que Marc ne reçoive son accès. Marc ne crée donc plus l'organisation ; il se connecte via SSO, son compte `users` est créé Just-In-Time (JIT) à partir des claims du JWT Keycloak (`sub`, `email`, `org_id`, `role`), puis il poursuit la configuration fonctionnelle (fonds, codes GL, rôles, invitations). La résidence des données n'est plus un choix utilisateur : elle est centralisée par ADR-009 (Scaleway Managed PostgreSQL EU, isolation RLS). Voir `21-authentication-sso.md` §2 pour les détails.
 
 ```mermaid
 flowchart TD
-    A([🆕 Jour 1 — Onboarding\nNouvelle organisation]) --> B[Settings > Organisation\nWizard de configuration]
-    B --> C[Import CSV\nconstituants depuis SF]
-    C --> D{Doublons détectés ?}
-    D -->|Oui| E[Interface de fusion\nsemi-automatique]
-    D -->|Non| F[Import validé\nX constituants migrés]
-    E --> F
-    F --> G[Configuration\nfunds & comptes GL]
-    G --> H[Configuration\nnominal codes → comptable]
-    H --> I[Gestion des rôles\net permissions]
+    A0([🏢 J-1 — Provisioning\nGivernance Super Admin\nconfigure le tenant + IdP Entra ID]) --> A
+    A([🆕 J1 9h00 — Marc se connecte\nvia SSO Entra ID]) --> A1[JIT provisioning\ncompte `users` créé\ndepuis le JWT]
+    A1 --> G[Settings > Finance > Fonds\n(configuration fonctionnelle)]
+    G --> H[Settings > Finance > Codes GL\nnominal codes → comptable]
+    H --> I[Settings > Utilisateurs > Rôles\n& permissions]
     I --> J{Sofia a besoin\nd'un accès Grants ?}
     J -->|Non| K[Rôle : Fundraising Manager\npas accès Programs]
     J -->|Oui| L[Rôle custom\nFundraising + Grants]
-    K --> M([📅 Semaine 1 — Quotidien])
-    L --> M
+    K --> K1[Confirmer la liste des utilisateurs\nauprès du Super Admin]
+    L --> K1
+    K1 --> K2[Les utilisateurs SSO\nsont ajoutés au groupe\nKeycloak du tenant]
+    K2 --> M([📅 Semaine 1 — Quotidien])
     M --> N{Demande RGPD\nreçue par email ?}
     N -->|Accès| O[RGPD > Accès >\nExporter dossier]
     N -->|Effacement| P[RGPD > Effacement >\nWizard anonymisation]
@@ -462,17 +462,18 @@ flowchart TD
     U --> V([✅ Organisation opérationnelle])
 ```
 
+> **Migration Salesforce / CSV**: l'import des constituants depuis Salesforce ou un CSV n'est **plus une étape d'onboarding**. Il est géré séparément dans l'epic Migration (voir `05-integration-migration.md`) et peut être déclenché à tout moment après la connexion SSO, via `Settings > Import > Depuis Salesforce`.
+
 #### Tableau du journey étape par étape — Onboarding J1 à J5
 
 | # | Moment | Écran Givernance | Action | Émotion | Friction potentielle | Moment de joie |
 |---|---|---|---|---|---|---|
-| 1 | **J1 9h00** — Démarrage de l'onboarding | `Settings > Organisation > Wizard` | Marc suit le wizard 5 étapes : infos org, RGPD, fonds, GL, utilisateurs | 😊 Confiant | Si le wizard est trop long ou demande des infos comptables qu'il n'a pas | ✨ Wizard resumable — il peut s'arrêter, revenir plus tard sans perdre sa progression |
-| 2 | **J1 10h00** — Import des constituants | `Settings > Import > Depuis Salesforce` | Upload du CSV exporté de Salesforce — Givernance mappe automatiquement les colonnes | 😐 Prudent | Colonnes SF non standard, mapping échoue | ✨ Mapping visuel avec aperçu ligne par ligne — il corrige 3 colonnes en 2 minutes |
-| 3 | **J1 11h00** — Résolution des doublons | `Settings > Import > Doublons (47 trouvés)` | Interface de fusion : côte à côte, 2 fiches, cases à cocher, ficher à conserver | 😐 Laborieux mais nécessaire | 47 doublons = 47 décisions manuelles ? | ✨ "Fusionner les 12 doublons évidents automatiquement" — les 35 ambigus sont présentés un par un |
+| 0 | **J-1 — Provisioning côté Givernance** | Back-office Givernance `POST /v1/admin/tenants` | Un Super Admin Givernance crée le tenant "Aide & Action Suisse" et configure la fédération OIDC vers Entra ID de Marc | 😌 Zéro friction côté Marc | Délai si le domaine email n'est pas bien routé (`kc_idp_hint`) | ✨ Marc reçoit simplement un email "Votre espace Givernance est prêt, connectez-vous avec votre compte Entra ID" |
+| 1 | **J1 9h00** — Première connexion SSO | `https://aide-action.givernance.app/login` → Keycloak → Entra ID | Marc clique "Se connecter avec SSO", s'authentifie via Entra ID, est redirigé vers `/dashboard`. Son compte `users` est créé automatiquement (JIT) à partir du JWT | 😊 Très confiant | Si le mapping du rôle `org_admin` n'a pas été poussé côté Keycloak, Marc atterrit avec un rôle réduit | ✨ Aucun mot de passe à créer, aucun formulaire de compte : Marc est opérationnel en un clic |
 | 4 | **J1 14h00** — Configuration des fonds | `Settings > Finance > Fonds` | Crée les fonds restreints et non restreints correspondant aux subventions actives | 😊 Organisé | Si la logique fonds / codes GL n'est pas expliquée | ✨ Tooltip contextuel : "Un fonds restreint est lié à une subvention spécifique — les dépenses sont suivies séparément." |
 | 5 | **J1 15h00** — Mapping codes GL | `Settings > Finance > Codes GL` | Mappe les fonds Givernance aux codes nominaux de la comptabilité (Sage 50, Swiss Chart of Accounts) | 😐 Technique | Si Givernance ne connaît pas le plan comptable suisse | ✨ Givernance propose un plan comptable suisse standard (PME/Asso) pré-chargé — Marc ajuste 3 lignes |
 | 6 | **J1 16h30** — Gestion des rôles | `Settings > Utilisateurs > Rôles` | Crée les rôles : Fundraising Manager, Program Coordinator, Volunteer Coordinator, Grants Officer, Admin | 😊 En contrôle | Si la granularité des permissions est insuffisante | ✨ Rôles pré-définis correspondant aux personas Givernance — Marc active/désactive des modules par rôle |
-| 7 | **J2 9h00** — Invitations utilisateurs | `Settings > Utilisateurs > Inviter` | Envoie les invitations par email aux 12 utilisateurs — ils configurent leur propre mot de passe | 😊 Délégué | Si les utilisateurs ont du mal à s'activer (lien expiré, etc.) | ✨ Lien d'invitation valable 7 jours, avec renouvellement facile depuis l'admin |
+| 7 | **J2 9h00** — Accès des coéquipiers | `Settings > Utilisateurs` | Marc vérifie la liste des utilisateurs : chaque nouveau collègue se connecte via Entra ID et son compte apparaît automatiquement (JIT) ; Marc lui attribue un rôle applicatif Givernance | 😊 Délégué | Si un collègue n'est pas encore dans le bon groupe Entra ID mappé vers le rôle `org_admin` / `fundraising_manager` | ✨ Aucun lien d'invitation à envoyer, aucun mot de passe à gérer — le SSO fait foi |
 | 8 | **Semaine 1 — Demande RGPD** | `RGPD > Demandes > Nouvelle demande` | Un donateur demande accès à ses données (article 15 RGPD) — Marc reçoit l'email | 😐 Attentif | Si le dossier complet doit être compilé manuellement | ✨ "Générer le dossier RGPD complet de M. Fernandez" → PDF en 3 minutes : dons, consentements, notes, communications |
 | 9 | **Semaine 1 — Demande effacement** | `RGPD > Effacement > Wizard` | Un ancien bénévole demande l'effacement de ses données — article 17 RGPD | 😐 Prudent | Si l'effacement casse des relations (dons liés, etc.) | ✨ Wizard d'anonymisation : "Ces données seront anonymisées. Les dons resteront pour la comptabilité mais sans lien nominatif." |
 | 10 | **Mensuel — Audit sécurité** | `Settings > Logs d'accès` | Marc consulte les logs d'accès du mois : qui a accédé à quoi, quand | 😊 Rassuré | Si les logs sont trop verbeux pour être exploitables | ✨ Logs filtrables : par utilisateur, par action, par type de données — export CSV pour le RSSI |
@@ -484,18 +485,25 @@ flowchart TD
 ### 4.3 Écrans traversés dans ce parcours
 
 ```
-Settings > Organisation > Wizard (onboarding 5 étapes)
-├── Settings > Import > Depuis CSV / Salesforce
-├── Settings > Import > Résolution doublons
+(Back-office Givernance — hors périmètre Marc)
+└── POST /v1/admin/tenants (Super Admin : tenant + IdP Entra ID)
+
+Auth (Keycloak, SSO only — pas d'écrans Givernance)
+├── /login → Keycloak → Entra ID → callback
+└── JIT provisioning du compte `users` au premier GET /v1/users/me
+
+Settings > Utilisateurs > Rôles & Permissions (Marc gère les rôles applicatifs)
 ├── Settings > Finance > Fonds & Codes GL
-├── Settings > Utilisateurs > Rôles & Permissions
-├── Settings > Utilisateurs > Invitations
+├── Settings > Import > Depuis Salesforce / CSV (post-login, epic Migration)
+├── Settings > Import > Résolution doublons
 ├── RGPD > Demandes (accès, effacement, portabilité)
 ├── RGPD > Registre des traitements (Art. 30)
 ├── Settings > Logs d'accès & Audit trail
 ├── Settings > Intégrations (Xero, Stripe, Mollie)
-└── Settings > Sécurité (2FA, SSO optionnel)
+└── Settings > Sécurité (MFA côté Keycloak, rôles / SoD côté Givernance)
 ```
+
+> Les anciens écrans AUTH-005 à AUTH-009 (`/auth/onboarding/1..5`) sont **dépréciés** ; voir `14-screen-inventory.md` §Module AUTH.
 
 ---
 
@@ -503,8 +511,10 @@ Settings > Organisation > Wizard (onboarding 5 étapes)
 
 | Friction | Probabilité | Impact | Mitigation recommandée |
 |---|---|---|---|
-| Import CSV Salesforce avec colonnes non standard | Haute | Haut | Mapper automatiquement les noms de colonnes SF connus + interface de correction visuelle |
-| 47 doublons = 47 décisions manuelles | Haute | Haut | Fusion automatique des doublons "évidents" (même email, même nom exact) ; humain seulement pour les ambigus |
+| IdP mal mappé : Marc se connecte mais arrive avec un rôle réduit | Moyenne | Haut | Le Super Admin valide un compte de test SSO avant de livrer le tenant ; Givernance affiche un bandeau explicite "Contactez votre administrateur Givernance" si le rôle `org_admin` est absent |
+| Domaine email non routé vers l'IdP du tenant | Moyenne | Haut | Ajouter `kc_idp_hint` / alias de domaine dans Keycloak au moment du provisioning (§2.3 doc 21) |
+| Import CSV Salesforce avec colonnes non standard (post-login, epic Migration) | Haute | Haut | Mapper automatiquement les noms de colonnes SF connus + interface de correction visuelle |
+| Doublons de constituants lors de la migration | Haute | Haut | Fusion automatique des doublons "évidents" (même email, même nom exact) ; humain seulement pour les ambigus |
 | Plan comptable suisse non disponible par défaut | Moyenne | Haut | Livrer plans comptables FR (PCG), CH (KMU), BE, NL pré-configurés |
 | Granularité permissions insuffisante | Moyenne | Moyen | Matrice de permissions par module (lecture/écriture/export/admin) |
 | Wizard d'effacement RGPD trop brutal | Faible | Critique | Différencier anonymisation (données conservées sans identité) vs. suppression totale — avec conséquences affichées |
@@ -514,9 +524,9 @@ Settings > Organisation > Wizard (onboarding 5 étapes)
 
 ### 4.5 Moments de joie
 
-1. **J1 10h30** : Le mapping automatique des colonnes Salesforce reconnaît 90 % des champs — Marc n'a que 3 corrections à faire.
-2. **J1 11h30** : La fusion automatique des 12 doublons évidents lui économise 30 minutes de clics.
-3. **J1 15h00** : Le plan comptable suisse est pré-chargé — Marc ajuste 3 lignes au lieu de saisir 80.
+1. **J1 9h00** : Marc se connecte au premier essai via son Entra ID existant — aucun mot de passe à créer, aucun formulaire de compte à remplir. JIT provisioning instantané.
+2. **J1 15h00** : Le plan comptable suisse est pré-chargé — Marc ajuste 3 lignes au lieu de saisir 80.
+3. **J2** : Ses 12 collègues se connectent chacun via Entra ID ; leur compte Givernance apparaît automatiquement dans `Settings > Utilisateurs` — Marc n'a envoyé aucun lien d'invitation.
 4. **Semaine 1** : Le dossier RGPD d'un donateur est généré en 3 minutes — Marc répond dans les 30 jours légaux sans effort.
 5. **Fin mois 1** : Marc n'a reçu que 2 demandes de support (contre 15/mois avec Salesforce). Les utilisateurs se débrouillent.
 
@@ -769,7 +779,7 @@ Sur la base des journeys documentés, voici l'ordre de priorité pour les sessio
 1. **Recruter 2-3 participants par persona** dans le réseau des ONG françaises et suisses pour des tests utilisateurs
 2. **Prototyper en priorité** : reçus fiscaux, vue mobile bénévoles, pipeline grants (Figma mid-fidelity)
 3. **Valider le format des reçus fiscaux** avec un expert-comptable spécialisé associations (France + Suisse)
-4. **Créer un prototype du wizard d'onboarding** Marc et le tester avec 2 admins IT d'ONG réelles
+4. **Prototyper le back-office Super Admin** (`POST /v1/admin/tenants` + configuration OIDC par tenant) et tester le parcours SSO / JIT avec 2 admins IT d'ONG réelles — voir Spike [#80](https://github.com/purposestack/givernance/issues/80)
 5. **Définir les templates de rapport** pour les 5 principaux bailleurs français et suisses (Fondation de France, FONJEP, Canton GE, Ville de Paris, Région IDF)
 
 ---

--- a/docs/14-screen-inventory.md
+++ b/docs/14-screen-inventory.md
@@ -1,8 +1,10 @@
 # 14 — Screen Inventory
 
 > **Givernance NPO Platform** — Inventaire complet de tous les écrans (v1)
-> Last updated: 2026-03-17
+> Last updated: 2026-04-17
 > Owner: Design Architect agent
+>
+> **2026-04-17 update (Spike [#80](https://github.com/purposestack/givernance/issues/80))**: AUTH-005 through AUTH-009 (self-service onboarding wizard) are deprecated. Tenant provisioning is now an admin-led back-office action and user accounts are created Just-In-Time on first SSO login. See `docs/21-authentication-sso.md` §2.
 
 ---
 
@@ -35,16 +37,11 @@ flowchart TD
     ROOT["/"] --> AUTH["/auth"]
     ROOT --> APP["/(app)"]
 
-    AUTH --> LOGIN["/auth/login"]
+    AUTH --> LOGIN["/auth/login (SSO only)"]
     AUTH --> SSO["/auth/sso"]
-    AUTH --> FORGOT["/auth/forgot-password"]
-    AUTH --> RESET["/auth/reset-password"]
-    AUTH --> ONBOARD["/auth/onboarding"]
-    ONBOARD --> OB1["/auth/onboarding/1 — Org"]
-    ONBOARD --> OB2["/auth/onboarding/2 — Équipe"]
-    ONBOARD --> OB3["/auth/onboarding/3 — Données"]
-    ONBOARD --> OB4["/auth/onboarding/4 — RGPD"]
-    ONBOARD --> OB5["/auth/onboarding/5 — Terminé"]
+    %% AUTH-005..AUTH-009 (/auth/onboarding/1..5) removed — tenants are now provisioned
+    %% by a Givernance Super Admin; user accounts are created Just-In-Time on first SSO login.
+    %% See docs/21-authentication-sso.md §2 and Spike #80.
 
     APP --> DASH["/dashboard"]
 
@@ -163,6 +160,13 @@ flowchart TD
 
 ## Module AUTH {#module-auth}
 
+> **Architecture note (Spike [#80](https://github.com/purposestack/givernance/issues/80), 2026-04)**: Givernance is now a **100% Keycloak OIDC** platform. Tenant creation and per-tenant Identity Provider configuration are performed by a **Givernance Super Admin** in the back-office, *before* any NPO user can log in. User accounts are provisioned Just-In-Time (JIT) on first SSO login from the Keycloak JWT claims (`sub`, `email`, `org_id`, `role`). Data residency is governed centrally by ADR-009 (Scaleway Managed PostgreSQL EU, RLS) and is no longer a per-tenant selection.
+>
+> Consequences for this inventory:
+> - **AUTH-005 through AUTH-009** (the 5-step self-service onboarding wizard at `/auth/onboarding/1..5`) are **DEPRECATED** and retained below for historical context only. They must not be implemented.
+> - The corresponding HTML mockups (`docs/design/auth/onboarding-1..5.html`) are orphaned and pending removal.
+> - AUTH-001/003/004 (email+password login, forgot-password, reset-password) describe a pre-Spike-#80 state; the `/login` page has been rewritten as SSO-only (see `docs/21-authentication-sso.md` §3 and `docs/design/auth/login.html`). Those entries are scheduled for revision in a follow-up doc pass.
+
 ### AUTH-001 — Page de connexion
 
 | Champ | Valeur |
@@ -239,7 +243,9 @@ flowchart TD
 
 ---
 
-### AUTH-005 — Onboarding Wizard — Étape 1 : Organisation
+### AUTH-005 — ~~Onboarding Wizard — Étape 1 : Organisation~~ (DEPRECATED — Spike #80)
+
+> **DEPRECATED** — replaced by back-office `POST /v1/admin/tenants` (Super Admin). See `docs/21-authentication-sso.md` §2.3. Retained for historical context only.
 
 | Champ | Valeur |
 |---|---|
@@ -258,7 +264,9 @@ flowchart TD
 
 ---
 
-### AUTH-006 — Onboarding Wizard — Étape 2 : Équipe
+### AUTH-006 — ~~Onboarding Wizard — Étape 2 : Équipe~~ (DEPRECATED — Spike #80)
+
+> **DEPRECATED** — team members are no longer invited via a signup wizard. NPO users sign in via SSO and their `users` row is created Just-In-Time from JWT claims; role mapping happens through Keycloak groups / IdP role mappers configured by the Super Admin at tenant provisioning time. See `docs/21-authentication-sso.md` §2.4.
 
 | Champ | Valeur |
 |---|---|
@@ -277,7 +285,9 @@ flowchart TD
 
 ---
 
-### AUTH-007 — Onboarding Wizard — Étape 3 : Données initiales
+### AUTH-007 — ~~Onboarding Wizard — Étape 3 : Données initiales~~ (DEPRECATED — Spike #80)
+
+> **DEPRECATED** — Salesforce / CSV import is no longer a signup step. It is handled post-login in the **Migration epic** (`docs/05-integration-migration.md`) and can be triggered at any time from `Settings > Import`.
 
 | Champ | Valeur |
 |---|---|
@@ -296,7 +306,9 @@ flowchart TD
 
 ---
 
-### AUTH-008 — Onboarding Wizard — Étape 4 : RGPD
+### AUTH-008 — ~~Onboarding Wizard — Étape 4 : RGPD~~ (DEPRECATED — Spike #80)
+
+> **DEPRECATED** — data residency is no longer a per-tenant selection. All SaaS tenants share Scaleway Managed PostgreSQL EU (ADR-009, which supersedes ADR-006). GDPR retention and consent parameters live in `Settings > RGPD` post-login, not at signup.
 
 | Champ | Valeur |
 |---|---|
@@ -315,7 +327,9 @@ flowchart TD
 
 ---
 
-### AUTH-009 — Onboarding Wizard — Étape 5 : Terminé
+### AUTH-009 — ~~Onboarding Wizard — Étape 5 : Terminé~~ (DEPRECATED — Spike #80)
+
+> **DEPRECATED** — there is no signup "completion" page. After SSO login and JIT provisioning, the user lands directly on `/dashboard`; the setup checklist formerly surfaced here now lives on the dashboard itself (see DASH-001).
 
 | Champ | Valeur |
 |---|---|
@@ -1611,11 +1625,11 @@ flowchart TD
 | AUTH-002 | Auth | Connexion SSO | `/auth/sso` | SHOULD |
 | AUTH-003 | Auth | Mot de passe oublié | `/auth/forgot-password` | MUST |
 | AUTH-004 | Auth | Réinitialisation mot de passe | `/auth/reset-password` | MUST |
-| AUTH-005 | Auth | Onboarding — Étape 1 : Organisation | `/auth/onboarding/1` | MUST |
-| AUTH-006 | Auth | Onboarding — Étape 2 : Équipe | `/auth/onboarding/2` | MUST |
-| AUTH-007 | Auth | Onboarding — Étape 3 : Données | `/auth/onboarding/3` | MUST |
-| AUTH-008 | Auth | Onboarding — Étape 4 : RGPD | `/auth/onboarding/4` | MUST |
-| AUTH-009 | Auth | Onboarding — Étape 5 : Terminé | `/auth/onboarding/5` | MUST |
+| ~~AUTH-005~~ | Auth | ~~Onboarding — Étape 1 : Organisation~~ | ~~`/auth/onboarding/1`~~ | **DEPRECATED** (Spike #80 — admin-led provisioning) |
+| ~~AUTH-006~~ | Auth | ~~Onboarding — Étape 2 : Équipe~~ | ~~`/auth/onboarding/2`~~ | **DEPRECATED** (Spike #80 — JIT user provisioning) |
+| ~~AUTH-007~~ | Auth | ~~Onboarding — Étape 3 : Données~~ | ~~`/auth/onboarding/3`~~ | **DEPRECATED** (Spike #80 — deferred to Migration epic) |
+| ~~AUTH-008~~ | Auth | ~~Onboarding — Étape 4 : RGPD~~ | ~~`/auth/onboarding/4`~~ | **DEPRECATED** (Spike #80 — residency centralised by ADR-009) |
+| ~~AUTH-009~~ | Auth | ~~Onboarding — Étape 5 : Terminé~~ | ~~`/auth/onboarding/5`~~ | **DEPRECATED** (Spike #80 — lands directly on `/dashboard`) |
 | DASH-001 | Dashboard | Tableau de bord principal | `/dashboard` | MUST |
 | DASH-002 | Dashboard | Configuration des widgets | `/dashboard/customize` | SHOULD |
 | CON-001 | Constituants | Liste individus | `/constituents` | MUST |

--- a/docs/21-authentication-sso.md
+++ b/docs/21-authentication-sso.md
@@ -13,13 +13,14 @@ Givernance uses **OpenID Connect (OIDC)** via **Keycloak** as the sole authentic
 |---|---|---|
 | Tenant creation | Anonymous visitor fills a 5-step signup wizard | **Givernance Super Admin** creates the tenant from the back-office |
 | Identity Provider configuration | Implicit (local password) | Super Admin configures the per-tenant OIDC/SAML connection (Entra ID, Okta, Google Workspace, …) in the shared Keycloak realm |
-| User account creation | Manual invite → user sets password | **Just-In-Time (JIT) provisioning** on first SSO login, driven by Keycloak JWT claims (`sub`, `email`, `org_id`, `role`) |
+| User account creation | Manual invite → user sets password | Email is validated by Keycloak or the external IdP, then **Just-In-Time (JIT) provisioning** runs on first SSO login from Keycloak JWT claims (`sub`, `email`, `org_id`, `role`) |
 | Data residency choice | Per-org selector in the wizard | **No longer a user choice** — governed centrally by ADR-009 (Scaleway Managed PostgreSQL EU, RLS-based isolation; supersedes ADR-006) |
 | Salesforce / CSV import at signup | Step 3 of the wizard | Deferred to the **Migration epic**, post-login |
+| Tenant URL routing | Generic app URL | Tenant is addressed by subdomain (`https://<tenant>.givernance.app`, or `.org` where appropriate); local development simulates this with `?namespace=<tenant>` |
 
 ## 2. Tenant Onboarding Architecture (Spike #80)
 
-### 2.1 Shared realm with per-tenant IdPs (baseline)
+### 2.1 Option A — shared realm with groups/attributes (MVP choice)
 
 Givernance operates **one shared Keycloak realm per deployment** (`givernance` for SaaS; see `02-reference-architecture.md` §3.2). Tenant membership is represented through:
 
@@ -29,7 +30,7 @@ Givernance operates **one shared Keycloak realm per deployment** (`givernance` f
 
 Because the realm is shared, thousands of small European NPOs can be onboarded without multiplying realms, clients, redirect URI configuration, or admin overhead. Tenant isolation is enforced at the application layer (`org_id` claim → PostgreSQL RLS, see `02-reference-architecture.md` §6).
 
-### 2.2 Dedicated-realm escape hatch (enterprise)
+### 2.2 Option B — dedicated realm per tenant (future evolution)
 
 For self-hosted enterprise tenants with strict IdP isolation requirements (dedicated realm-level policies, branding, MFA config), Givernance offers a **dedicated-realm deployment mode** as an opt-in escape hatch. This is operationally heavy and reserved for large NPOs or public-sector customers; it is not offered on the shared SaaS plane.
 
@@ -71,7 +72,7 @@ sequenceDiagram
 
 ### 2.4 User creation — Just-In-Time (JIT) on first SSO login
 
-Once the tenant is provisioned, NPO users never go through a signup form. Their PostgreSQL `users` row is created **Just-In-Time** on the first successful SSO login, using the trusted claims in the Keycloak-issued JWT:
+Once the tenant is provisioned, NPO users never go through a Givernance signup wizard. They must still pass an **email validation** gate before the account is usable: for enterprise SSO, the upstream IdP is authoritative for verified email; for Keycloak-local smoke tests or MVP-created users, Keycloak must require email verification before issuing a tenant-bearing token. Their PostgreSQL `users` row is then created **Just-In-Time** on the first successful SSO login, using the trusted claims in the Keycloak-issued JWT:
 
 ```mermaid
 sequenceDiagram
@@ -141,7 +142,7 @@ Data residency is **not a per-tenant choice** in the onboarding flow. All SaaS t
 
 ## 3. Authentication Flow (Next.js & Fastify)
 
-1. **Login Trigger**: The user visits `https://<tenant>.givernance.app/login` and clicks the "SSO Login" button.
+1. **Login Trigger**: The user visits `https://<tenant>.givernance.app/login` (or `https://<tenant>.givernance.org/login`) and clicks the "SSO Login" button. In local development, the same tenant context is simulated with `http://localhost:3000/login?namespace=<tenant>`.
 2. **Redirect to Keycloak**: The Next.js API route `GET /api/auth/login` generates:
    - `state` (Anti-CSRF)
    - `nonce` (OIDC replay protection)
@@ -150,10 +151,10 @@ Data residency is **not a per-tenant choice** in the onboarding flow. All SaaS t
 3. **Keycloak Auth**: The user authenticates (via Google Workspace, Microsoft Entra, or Keycloak local DB).
 4. **Callback**: Keycloak redirects to `GET /api/auth/callback` with an authorization `code`.
 5. **Token Exchange**: Next.js exchanges the `code` + `code_verifier` for an Access Token (JWT) via backend server-to-server call.
-6. **Session Establishment**: 
+6. **Session Establishment**:
    - The JWT is saved in the `givernance_jwt` cookie (`httpOnly`, `Secure`, `SameSite=Strict`).
    - A secondary `csrf-token` cookie (non-httpOnly) is set for the browser to read.
-   - The user is redirected to `/dashboard`.
+   - The web app resolves the tenant from the signed JWT claims and redirects the browser to `https://<org_slug>.givernance.app/dashboard` (or `.org` where appropriate). If the user started locally with `?namespace=<tenant>`, the local redirect remains on `localhost` and preserves the namespace for routing only.
 
 ## 4. Sign-Out Flow
 

--- a/docs/21-authentication-sso.md
+++ b/docs/21-authentication-sso.md
@@ -13,7 +13,7 @@ Givernance uses **OpenID Connect (OIDC)** via **Keycloak** as the sole authentic
 |---|---|---|
 | Tenant creation | Anonymous visitor fills a 5-step signup wizard | **Givernance Super Admin** creates the tenant from the back-office |
 | Identity Provider configuration | Implicit (local password) | Super Admin configures the per-tenant OIDC/SAML connection (Entra ID, Okta, Google Workspace, …) in the shared Keycloak realm |
-| User account creation | Manual invite → user sets password | Email is validated by Keycloak or the external IdP, then **Just-In-Time (JIT) provisioning** runs on first SSO login from Keycloak JWT claims (`sub`, `email`, `org_id`, `role`) |
+| User account creation | Manual invite → user sets password | **Just-In-Time (JIT) provisioning** runs on first SSO login from Keycloak JWT claims (`sub`, `email`, `org_id`, `role`). Email validation is deferred to Phase 2. |
 | Data residency choice | Per-org selector in the wizard | **No longer a user choice** — governed centrally by ADR-009 (Scaleway Managed PostgreSQL EU, RLS-based isolation; supersedes ADR-006) |
 | Salesforce / CSV import at signup | Step 3 of the wizard | Deferred to the **Migration epic**, post-login |
 | Tenant URL routing | Generic app URL | Tenant is addressed by subdomain (`https://<tenant>.givernance.app`, or `.org` where appropriate); local development simulates this with `?namespace=<tenant>` |
@@ -72,7 +72,7 @@ sequenceDiagram
 
 ### 2.4 User creation — Just-In-Time (JIT) on first SSO login
 
-Once the tenant is provisioned, NPO users never go through a Givernance signup wizard. They must still pass an **email validation** gate before the account is usable: for enterprise SSO, the upstream IdP is authoritative for verified email; for Keycloak-local smoke tests or MVP-created users, Keycloak must require email verification before issuing a tenant-bearing token. Their PostgreSQL `users` row is then created **Just-In-Time** on the first successful SSO login, using the trusted claims in the Keycloak-issued JWT:
+Once the tenant is provisioned, NPO users never go through a Givernance signup wizard. Their PostgreSQL `users` row is created **Just-In-Time** on the first successful SSO login, using the trusted claims in the Keycloak-issued JWT:
 
 ```mermaid
 sequenceDiagram

--- a/docs/21-authentication-sso.md
+++ b/docs/21-authentication-sso.md
@@ -1,15 +1,147 @@
 # 21 — Authentication & Single Sign-On (SSO)
 
 > **Status**: Approved (Phase 1)
-> **Related**: `06-security-compliance.md`, `15-infra-adr.md`, `19-impersonation.md`
-> **Context**: PR #73 (Sprint 4: Auth UI & App Shell)
+> **Related**: `02-reference-architecture.md` §3.2 & §6, `06-security-compliance.md`, `15-infra-adr.md` (ADR-009), `19-impersonation.md`
+> **Context**: PR #73 (Sprint 4: Auth UI & App Shell); Spike [#80](https://github.com/purposestack/givernance/issues/80) — Multi-Tenant SSO Onboarding Architecture
 
 ## 1. Overview
-Givernance uses **OpenID Connect (OIDC)** via **Keycloak** as the sole authentication mechanism. Local username/password forms have been intentionally discarded in favor of a 100% SSO-driven flow. This centralizes identity management, simplifies GDPR compliance (password handling), and enables enterprise-grade features (MFA, SAML federation) out of the box.
+Givernance uses **OpenID Connect (OIDC)** via **Keycloak** as the sole authentication mechanism. Local username/password forms and the former "self-service onboarding wizard" (organisation creation, team invite, data residency selection, GDPR parameters) have been intentionally discarded in favour of a 100% SSO-driven flow. This centralises identity management, simplifies GDPR compliance (no password storage), and enables enterprise-grade features (MFA, SAML federation) out of the box.
 
-## 2. Authentication Flow (Next.js & Fastify)
+### 1.1 Onboarding model at a glance
 
-1. **Login Trigger**: The user visits `https://givernance.app/login` and clicks the "SSO Login" button.
+| Concern | Previous model (deprecated) | Current model (Spike #80) |
+|---|---|---|
+| Tenant creation | Anonymous visitor fills a 5-step signup wizard | **Givernance Super Admin** creates the tenant from the back-office |
+| Identity Provider configuration | Implicit (local password) | Super Admin configures the per-tenant OIDC/SAML connection (Entra ID, Okta, Google Workspace, …) in the shared Keycloak realm |
+| User account creation | Manual invite → user sets password | **Just-In-Time (JIT) provisioning** on first SSO login, driven by Keycloak JWT claims (`sub`, `email`, `org_id`, `role`) |
+| Data residency choice | Per-org selector in the wizard | **No longer a user choice** — governed centrally by ADR-009 (Scaleway Managed PostgreSQL EU, RLS-based isolation; supersedes ADR-006) |
+| Salesforce / CSV import at signup | Step 3 of the wizard | Deferred to the **Migration epic**, post-login |
+
+## 2. Tenant Onboarding Architecture (Spike #80)
+
+### 2.1 Shared realm with per-tenant IdPs (baseline)
+
+Givernance operates **one shared Keycloak realm per deployment** (`givernance` for SaaS; see `02-reference-architecture.md` §3.2). Tenant membership is represented through:
+
+- A Keycloak **group** per tenant (e.g. `/tenants/red-cross`) holding all the tenant's users.
+- **Token mappers** that emit tenant claims on every access token: `org_id`, `org_slug`, and `role`.
+- **Per-tenant Identity Provider federation** (Entra ID, Okta, Google Workspace, or Keycloak local for smoke tests), routed via `kc_idp_hint` or email-domain alias on the login page.
+
+Because the realm is shared, thousands of small European NPOs can be onboarded without multiplying realms, clients, redirect URI configuration, or admin overhead. Tenant isolation is enforced at the application layer (`org_id` claim → PostgreSQL RLS, see `02-reference-architecture.md` §6).
+
+### 2.2 Dedicated-realm escape hatch (enterprise)
+
+For self-hosted enterprise tenants with strict IdP isolation requirements (dedicated realm-level policies, branding, MFA config), Givernance offers a **dedicated-realm deployment mode** as an opt-in escape hatch. This is operationally heavy and reserved for large NPOs or public-sector customers; it is not offered on the shared SaaS plane.
+
+### 2.3 Tenant provisioning — by Givernance Super Admin
+
+A new NPO (e.g. Red Cross) is provisioned **before** any of its users can log in. A Givernance platform operator (`super_admin`) performs the following flow from the back-office:
+
+```mermaid
+sequenceDiagram
+    actor SA as Givernance Super Admin
+    participant Web as Next.js Web (Back-office)
+    participant API as Givernance API
+    participant DB as PostgreSQL
+    participant KC as Keycloak (Admin API)
+
+    SA->>Web: Fill NPO details & OIDC config
+    Web->>API: POST /v1/admin/tenants (with IdP config)
+    API->>DB: INSERT INTO tenants (name, slug)
+
+    rect rgb(240, 248, 255)
+        Note right of API: Provision identity in Keycloak
+        API->>KC: Create Group (e.g. /tenants/red-cross)
+        API->>KC: Configure Identity Provider (e.g. Entra ID / Okta)
+        API->>KC: Map IdP roles to Keycloak groups/roles
+        API->>KC: Create domain routing rule (e.g. *@croix-rouge.fr → Entra ID)
+    end
+
+    API->>DB: Save Keycloak group-ID mapping
+    API-->>Web: 201 Created
+    Web-->>SA: Tenant successfully provisioned
+```
+
+**Scope of this step**:
+
+- Creates the `tenants` row (no user rows yet).
+- Wires the per-tenant OIDC/SAML Identity Provider in the shared `givernance` realm.
+- Publishes domain-routing rules so `*@<tenant-domain>` logins are hinted to the correct IdP.
+- **Does not** ask for data residency, GDPR retention, or CSV imports — those are centralised (ADR-009) or deferred to the Migration epic.
+
+### 2.4 User creation — Just-In-Time (JIT) on first SSO login
+
+Once the tenant is provisioned, NPO users never go through a signup form. Their PostgreSQL `users` row is created **Just-In-Time** on the first successful SSO login, using the trusted claims in the Keycloak-issued JWT:
+
+```mermaid
+sequenceDiagram
+    actor User as NPO User
+    participant Web as Next.js Web
+    participant API as Givernance API
+    participant KC as Keycloak
+    participant IdP as Enterprise IdP (Entra, Okta, Google)
+    participant DB as PostgreSQL
+
+    User->>Web: Navigate to redcross.givernance.app/login
+    Web->>KC: Redirect to /auth (with kc_idp_hint or email domain)
+
+    alt Enterprise SSO (dedicated IdP)
+        KC->>IdP: Redirect to tenant's IdP
+        IdP-->>User: Authenticate (Microsoft / Okta)
+        IdP-->>KC: SAML / OIDC callback
+    else Standard SSO (Google Workspace)
+        KC-->>User: Show Google login
+        User->>KC: Authenticate
+    end
+
+    KC-->>Web: Auth code + state
+    Web->>KC: Exchange code for access token (JWT)
+    KC-->>Web: JWT (sub, email, org_id, role)
+
+    Note right of Web: Store JWT in httpOnly cookie
+    Web->>API: GET /v1/users/me (first visit)
+
+    rect rgb(255, 245, 238)
+        Note right of API: Just-In-Time (JIT) provisioning
+        API->>DB: SELECT * FROM users WHERE keycloak_sub = :sub
+        alt User not in DB
+            API->>DB: INSERT INTO users (id, org_id, email, role, keycloak_sub)
+            API->>DB: INSERT INTO audit_logs (event='user.jit_provisioned')
+        end
+    end
+
+    API-->>Web: 200 OK (user profile)
+    Web-->>User: Render /dashboard
+```
+
+**JIT provisioning rules**:
+
+1. The API trusts **only the Keycloak-signed JWT claims** (`sub`, `email`, `org_id`, `role`) for the first INSERT. The `org_id` claim is the sole tenant-binding authority; the API MUST NOT derive `org_id` from the subdomain, email domain, or any client-provided hint.
+2. The user row is keyed by `keycloak_sub` (stable Keycloak UUID) — not by email — so IdP-side email changes do not create duplicates.
+3. The first provisioned user inherits the role claim from the IdP/Keycloak mapping. Tenants are expected to have at least one `org_admin` role mapping configured at provisioning time (§2.3), otherwise the first user will land with a reduced role and an explicit "Contact your Givernance administrator" banner.
+4. JIT provisioning is **audit-logged** (`audit_logs.event = 'user.jit_provisioned'`) with the Keycloak `sub`, `iss`, and the trusted `org_id` at insertion time.
+5. If the JWT `org_id` does not match any row in `tenants`, the API returns `403 tenant_not_provisioned` and does **not** auto-create a tenant — tenant creation is exclusively a super-admin back-office action (§2.3).
+
+### 2.5 API contracts
+
+| Endpoint | Caller | Purpose |
+|---|---|---|
+| `POST /v1/admin/tenants` | `super_admin` (requires step-up / admin secret) | Create tenant + Keycloak group + IdP federation |
+| `GET /v1/admin/tenants/:id/provisioning-status` | `super_admin` | Return `{tenant, keycloakGroupId, idpAlias, status}` |
+| `PATCH /v1/admin/tenants/:id/idp` | `super_admin` | Update the tenant's IdP config (rotate client secret, add domain alias) |
+| `GET /v1/users/me` | Any authenticated user | Returns the profile; triggers JIT INSERT on first call |
+
+All four endpoints live under `packages/api/src/modules/admin/` (super-admin) and `packages/api/src/modules/users/` (self); they are the integration surface for the follow-up implementation issues spawned from Spike #80.
+
+### 2.6 Data residency
+
+Data residency is **not a per-tenant choice** in the onboarding flow. All SaaS tenants share the Scaleway Managed PostgreSQL EU cluster, isolated by row-level security on `org_id` (see `02-reference-architecture.md` §6 and ADR-009, which supersedes ADR-006). Self-hosted deployments choose their own region at deploy time, independent of any user-facing onboarding UI.
+
+---
+
+## 3. Authentication Flow (Next.js & Fastify)
+
+1. **Login Trigger**: The user visits `https://<tenant>.givernance.app/login` and clicks the "SSO Login" button.
 2. **Redirect to Keycloak**: The Next.js API route `GET /api/auth/login` generates:
    - `state` (Anti-CSRF)
    - `nonce` (OIDC replay protection)
@@ -23,7 +155,7 @@ Givernance uses **OpenID Connect (OIDC)** via **Keycloak** as the sole authentic
    - A secondary `csrf-token` cookie (non-httpOnly) is set for the browser to read.
    - The user is redirected to `/dashboard`.
 
-## 3. Sign-Out Flow
+## 4. Sign-Out Flow
 
 The sidebar footer hosts a `LogOut` icon button that triggers the sign-out. It submits a form POST (not `fetch`) so the browser can natively follow the cross-origin redirect to Keycloak's end-session endpoint.
 
@@ -39,7 +171,7 @@ The sidebar footer hosts a `LogOut` icon button that triggers the sign-out. It s
 
 **Limitation — stateless session**: the JWT is self-contained and verified by signature, so revoking the Keycloak session does NOT invalidate an already-issued access token until its 8h TTL expires. Back-channel logout with a Redis `sid` blocklist is tracked in [#76](https://github.com/purposestack/givernance/issues/76).
 
-## 4. Cookies Set by the Flow
+## 5. Cookies Set by the Flow
 
 | Cookie | Purpose | httpOnly | SameSite | Lifetime |
 |--------|---------|:--------:|:--------:|----------|
@@ -48,7 +180,7 @@ The sidebar footer hosts a `LogOut` icon button that triggers the sign-out. It s
 | `csrf-token` | Double-submit CSRF token (readable by JS via `<meta>`) | No | Strict | session |
 | `oidc_state`, `oidc_code_verifier`, `oidc_nonce` | Short-lived OIDC flow state | Yes | Lax | 5 min |
 
-## 5. Local Development Setup
+## 6. Local Development Setup
 
 ### Required environment variables
 Copy `.env.example` to `.env` — the OIDC-relevant vars are:

--- a/docs/design-audit-report.md
+++ b/docs/design-audit-report.md
@@ -1,8 +1,10 @@
 # Design Audit Report — Givernance NPO Platform
 
-> **Audit date**: 2026-03-03
+> **Audit date**: 2026-03-03 (updated 2026-04-17 for Spike #80)
 > **Scope**: Cross-check of all HTML mockups against doc 14 (screen inventory), doc 11 (design identity), doc 13 (AI modes)
 > **Auditor**: Design Architect Agent (Agent 2)
+>
+> **2026-04-17 note (Spike [#80](https://github.com/purposestack/givernance/issues/80))**: AUTH-005..AUTH-009 mockups (`auth/onboarding-1..5.html`) are deprecated and retained only for historical reference. Tenant provisioning is now admin-led (back-office `POST /v1/admin/tenants`) and user accounts are created Just-In-Time on first SSO login. See `docs/21-authentication-sso.md` §2.
 
 ---
 
@@ -31,11 +33,11 @@
 | AUTH-002 | Connexion SSO | `auth/sso.html` | OK |
 | AUTH-003 | Mot de passe oublié | `auth/forgot-password.html` | OK |
 | AUTH-004 | Réinitialisation mdp | `auth/reset-password.html` | OK |
-| AUTH-005 | Onboarding — Étape 1 | `auth/onboarding-1.html` | OK |
-| AUTH-006 | Onboarding — Étape 2 | `auth/onboarding-2.html` | OK |
-| AUTH-007 | Onboarding — Étape 3 | `auth/onboarding-3.html` | OK |
-| AUTH-008 | Onboarding — Étape 4 | `auth/onboarding-4.html` | OK |
-| AUTH-009 | Onboarding — Étape 5 | `auth/onboarding-5.html` | OK |
+| ~~AUTH-005~~ | ~~Onboarding — Étape 1~~ | ~~`auth/onboarding-1.html`~~ | **DEPRECATED** — Spike #80 |
+| ~~AUTH-006~~ | ~~Onboarding — Étape 2~~ | ~~`auth/onboarding-2.html`~~ | **DEPRECATED** — Spike #80 |
+| ~~AUTH-007~~ | ~~Onboarding — Étape 3~~ | ~~`auth/onboarding-3.html`~~ | **DEPRECATED** — Spike #80 |
+| ~~AUTH-008~~ | ~~Onboarding — Étape 4~~ | ~~`auth/onboarding-4.html`~~ | **DEPRECATED** — Spike #80 |
+| ~~AUTH-009~~ | ~~Onboarding — Étape 5~~ | ~~`auth/onboarding-5.html`~~ | **DEPRECATED** — Spike #80 |
 | DASH-001 | Tableau de bord | `dashboard.html` | OK |
 | DASH-002 | Personnalisation dashboard | `dashboard-customize.html` | OK |
 | CON-001 | Liste constituants — Individus | `constituents/list.html` | OK |
@@ -148,7 +150,7 @@ The sitemap in doc 14 uses RESTful URL patterns that map cleanly to the HTML dir
 |---|---|---|
 | `/auth/login` | `auth/login.html` | OK |
 | `/auth/sso` | `auth/sso.html` | OK |
-| `/auth/onboarding/1–5` | `auth/onboarding-1..5.html` | OK |
+| ~~`/auth/onboarding/1–5`~~ | ~~`auth/onboarding-1..5.html`~~ | **DEPRECATED** — Spike #80 (admin-led provisioning + JIT user creation) |
 | `/constituents` | `constituents/list.html` | OK |
 | `/constituents/:id` | `constituents/detail.html` | OK |
 | `/constituents/organizations` | `constituents/organizations-list.html` | OK |


### PR DESCRIPTION
## Summary

Documents the new Keycloak-OIDC-only onboarding architecture defined in Spike **#80**. The former self-service onboarding wizard (organisation creation, team invite, data residency selection, GDPR parameters, CSV import) is **dead**.

- **Tenant provisioning** is now an admin-led back-office action: a Givernance Super Admin calls `POST /v1/admin/tenants` which creates the `tenants` row, a Keycloak group under `/tenants/<slug>`, and the per-tenant Identity Provider federation (Entra ID, Okta, Google Workspace, …) in the shared `givernance` realm.
- **User accounts** are created **Just-In-Time (JIT)** on first successful SSO login, driven exclusively by the trusted Keycloak JWT claims (`sub`, `email`, `org_id`, `role`). The API returns `403 tenant_not_provisioned` if the JWT `org_id` has no matching tenant — no auto-create.
- **Data residency** is no longer a per-tenant selection — governed centrally by **ADR-009** (Scaleway Managed PostgreSQL EU, RLS-based isolation; supersedes ADR-006).
- Salesforce / CSV import is deferred to the **Migration epic**, post-login (`Settings > Import`).

## Files touched

- `docs/21-authentication-sso.md` — new §2 with both Spike #80 sequence diagrams (tenant provisioning, JIT user login), API contracts, residency note, shared-realm baseline + dedicated-realm escape hatch.
- `docs/02-reference-architecture.md` — actors list, Keycloak container description, new §6.5 on tenant binding at JIT provisioning.
- `docs/12-user-journeys.md` — Marc's §4.2 journey rewritten: no more self-service wizard; SSO login → JIT provisioning → fund/GL/role configuration post-login.
- `docs/14-screen-inventory.md` — AUTH-005..AUTH-009 marked **DEPRECATED**, removed from Mermaid sitemap, summary table updated.
- `docs/design-audit-report.md` — `auth/onboarding-1..5.html` mockups flagged as orphaned/deprecated.
- `docs/05-integration-migration.md`, `docs/07-delivery-roadmap.md`, `docs/10-open-questions.md` — cascade edits so references stay consistent with Spike #80.

## Test plan

Docs-only change — no code or CI impact.

- [ ] Render `docs/21-authentication-sso.md` on GitHub and confirm both Mermaid sequence diagrams display correctly.
- [ ] Render `docs/12-user-journeys.md` and confirm Marc's updated flowchart renders.
- [ ] Verify `docs/14-screen-inventory.md` sitemap no longer mentions `/auth/onboarding/1..5`.
- [ ] Cross-read `docs/02-reference-architecture.md` §3.2 ↔ `docs/21-authentication-sso.md` §2 for narrative consistency.

Refs: #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)