### PR TITLE
feat(web): Constituent Create/Edit Forms & Duplicates (PR-B4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,7 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # API_URL uses 127.0.0.1 (not localhost) so Node's fetch/undici doesn't race IPv6
 # ::1 against IPv4 127.0.0.1 — the API binds on 0.0.0.0 (IPv4 only), so ::1 fails.
 API_URL=http://127.0.0.1:4000
-NEXT_PUBLIC_API_URL=http://localhost:4000
+NEXT_PUBLIC_API_URL=http://localhost:3000/api
 
 # --- Dev SSO shim (see issue #84) ------------------------------
 # Tenant id injected into session JWTs minted by /api/auth/callback.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.712.0",
     "@aws-sdk/s3-request-presigner": "^3.1030.0",
+    "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^10.0.2",
     "@fastify/jwt": "^9.0.2",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -23,10 +23,10 @@ async function auth(app: FastifyInstance) {
     secret: jwtSecret,
     cookie: {
       cookieName: "givernance_jwt",
-      signed: false
-    }
+      signed: false,
+    },
   });
-  await app.register(require("@fastify/cookie"));
+  await app.register((await import("@fastify/cookie")).default);
 
   /** Extract auth context from verified JWT claims */
   app.decorateRequest("auth", null);

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -19,7 +19,14 @@ async function auth(app: FastifyInstance) {
     );
   }
 
-  await app.register(fjwt, { secret: jwtSecret });
+  await app.register(fjwt, {
+    secret: jwtSecret,
+    cookie: {
+      cookieName: "givernance_jwt",
+      signed: false
+    }
+  });
+  await app.register(require("@fastify/cookie"));
 
   /** Extract auth context from verified JWT claims */
   app.decorateRequest("auth", null);

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -143,6 +143,61 @@
       "member": "Member",
       "beneficiary": "Beneficiary",
       "partner": "Partner"
+    },
+    "actions": {
+      "new": "New constituent"
+    }
+  },
+  "constituentForm": {
+    "createTitle": "New constituent",
+    "createSubtitle": "Add a new constituent to your organisation.",
+    "editTitle": "Edit constituent",
+    "editSubtitle": "Update contact details or classification.",
+    "breadcrumbNew": "New",
+    "breadcrumbEdit": "Edit",
+    "sections": {
+      "identity": {
+        "title": "Identity",
+        "description": "Type and name of the constituent."
+      },
+      "contact": {
+        "title": "Contact",
+        "description": "Email and phone used for outreach."
+      }
+    },
+    "fields": {
+      "type": "Type",
+      "typeHint": "Choose how this person relates to your organisation.",
+      "firstName": "First name",
+      "firstNamePlaceholder": "Jane",
+      "lastName": "Last name",
+      "lastNamePlaceholder": "Doe",
+      "email": "Email",
+      "emailPlaceholder": "jane.doe@example.org",
+      "phone": "Phone",
+      "phonePlaceholder": "+33 1 23 45 67 89"
+    },
+    "actions": {
+      "cancel": "Cancel",
+      "submitCreate": "Create constituent",
+      "submitEdit": "Save changes",
+      "submitting": "Saving…"
+    },
+    "duplicate": {
+      "title": "Potential duplicate detected",
+      "body": "A constituent with similar details already exists. Review the match below before continuing.",
+      "viewExisting": "View existing",
+      "createAnyway": "Create anyway",
+      "cancel": "Cancel",
+      "unnamed": "Unnamed constituent"
+    },
+    "errors": {
+      "generic": "Something went wrong while saving. Please try again.",
+      "validation": "Please correct the highlighted fields."
+    },
+    "success": {
+      "created": "Constituent created.",
+      "updated": "Changes saved."
     }
   },
   "constituentDetail": {

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -143,6 +143,61 @@
       "member": "Membre",
       "beneficiary": "Bénéficiaire",
       "partner": "Partenaire"
+    },
+    "actions": {
+      "new": "Nouveau constituant"
+    }
+  },
+  "constituentForm": {
+    "createTitle": "Nouveau constituant",
+    "createSubtitle": "Ajoutez un nouveau constituant à votre organisation.",
+    "editTitle": "Modifier le constituant",
+    "editSubtitle": "Mettez à jour les coordonnées ou la classification.",
+    "breadcrumbNew": "Nouveau",
+    "breadcrumbEdit": "Modifier",
+    "sections": {
+      "identity": {
+        "title": "Identité",
+        "description": "Type et nom du constituant."
+      },
+      "contact": {
+        "title": "Coordonnées",
+        "description": "Email et téléphone utilisés pour les communications."
+      }
+    },
+    "fields": {
+      "type": "Type",
+      "typeHint": "Choisissez le lien entre cette personne et votre organisation.",
+      "firstName": "Prénom",
+      "firstNamePlaceholder": "Marie",
+      "lastName": "Nom",
+      "lastNamePlaceholder": "Dupont",
+      "email": "Email",
+      "emailPlaceholder": "marie.dupont@exemple.org",
+      "phone": "Téléphone",
+      "phonePlaceholder": "+33 1 23 45 67 89"
+    },
+    "actions": {
+      "cancel": "Annuler",
+      "submitCreate": "Créer le constituant",
+      "submitEdit": "Enregistrer les modifications",
+      "submitting": "Enregistrement…"
+    },
+    "duplicate": {
+      "title": "Doublon potentiel détecté",
+      "body": "Un constituant aux informations similaires existe déjà. Vérifiez la correspondance avant de continuer.",
+      "viewExisting": "Voir la fiche existante",
+      "createAnyway": "Créer quand même",
+      "cancel": "Annuler",
+      "unnamed": "Constituant sans nom"
+    },
+    "errors": {
+      "generic": "Une erreur est survenue lors de l'enregistrement. Réessayez.",
+      "validation": "Corrigez les champs en surbrillance."
+    },
+    "success": {
+      "created": "Constituant créé.",
+      "updated": "Modifications enregistrées."
     }
   },
   "constituentDetail": {

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -10,7 +10,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/api/v1/:path*",
-        destination: `${process.env.API_URL}/v1/:path*`,
+        destination: `${process.env.API_URL || "http://localhost:4000"}/v1/:path*`,
       },
     ];
   },

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -6,6 +6,14 @@ import createNextIntlPlugin from "next-intl/plugin";
 // come from the CI runner directly.
 
 const nextConfig: NextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: "/api/v1/:path*",
+        destination: `${process.env.API_URL}/v1/:path*`,
+      },
+    ];
+  },
   /** Consume shared workspace packages via TypeScript source. */
   transpilePackages: ["@givernance/shared"],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@sinclair/typebox": "^0.34.12",
     "@tanstack/react-query": "^5.99.0",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",

--- a/packages/web/src/app/(app)/constituents/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/constituents/[id]/edit/page.tsx
@@ -1,0 +1,53 @@
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { ConstituentForm } from "@/components/constituents/constituent-form";
+import { PageHeader } from "@/components/shared/page-header";
+import { ApiProblem } from "@/lib/api";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import { type Constituent, fullName } from "@/models/constituent";
+import { ConstituentService } from "@/services/ConstituentService";
+
+interface EditConstituentPageProps {
+  params: Promise<{ id: string }>;
+}
+
+async function fetchConstituentOrNotFound(id: string): Promise<Constituent> {
+  const client = await createServerApiClient();
+  try {
+    return await ConstituentService.getConstituent(client, id);
+  } catch (err) {
+    if (err instanceof ApiProblem && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+}
+
+export default async function EditConstituentPage({ params }: EditConstituentPageProps) {
+  await requireAuth();
+  const { id } = await params;
+  const constituent = await fetchConstituentOrNotFound(id);
+
+  const t = await getTranslations("constituentForm");
+  const tConstituents = await getTranslations("constituents");
+
+  const name = fullName(constituent);
+
+  return (
+    <>
+      <PageHeader
+        title={t("editTitle")}
+        description={t("editSubtitle")}
+        breadcrumbs={[
+          { label: tConstituents("breadcrumbRoot"), href: "/dashboard" },
+          { label: tConstituents("title"), href: "/constituents" },
+          { label: name, href: `/constituents/${constituent.id}` },
+          { label: t("breadcrumbEdit") },
+        ]}
+      />
+      <ConstituentForm mode="edit" constituent={constituent} />
+    </>
+  );
+}

--- a/packages/web/src/app/(app)/constituents/new/page.tsx
+++ b/packages/web/src/app/(app)/constituents/new/page.tsx
@@ -1,0 +1,26 @@
+import { getTranslations } from "next-intl/server";
+
+import { ConstituentForm } from "@/components/constituents/constituent-form";
+import { PageHeader } from "@/components/shared/page-header";
+import { requireAuth } from "@/lib/auth/guards";
+
+export default async function NewConstituentPage() {
+  await requireAuth();
+  const t = await getTranslations("constituentForm");
+  const tConstituents = await getTranslations("constituents");
+
+  return (
+    <>
+      <PageHeader
+        title={t("createTitle")}
+        description={t("createSubtitle")}
+        breadcrumbs={[
+          { label: tConstituents("breadcrumbRoot"), href: "/dashboard" },
+          { label: tConstituents("title"), href: "/constituents" },
+          { label: t("breadcrumbNew") },
+        ]}
+      />
+      <ConstituentForm mode="create" />
+    </>
+  );
+}

--- a/packages/web/src/app/(app)/constituents/page.tsx
+++ b/packages/web/src/app/(app)/constituents/page.tsx
@@ -1,8 +1,10 @@
-import { Users } from "lucide-react";
+import { Plus, Users } from "lucide-react";
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
 import { EmptyState } from "@/components/shared/empty-state";
 import { PageHeader } from "@/components/shared/page-header";
+import { Button } from "@/components/ui/button";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
@@ -64,6 +66,14 @@ export default async function ConstituentsPage({ searchParams }: ConstituentsPag
           hasAny ? t("subtitleWithCount", { count: result.pagination.total }) : t("subtitleEmpty")
         }
         breadcrumbs={[{ label: t("breadcrumbRoot"), href: "/dashboard" }, { label: t("title") }]}
+        actions={
+          <Button asChild variant="primary" size="sm">
+            <Link href="/constituents/new">
+              <Plus size={16} aria-hidden="true" />
+              {t("actions.new")}
+            </Link>
+          </Button>
+        }
       />
 
       {hasAny ? (

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import { AppShell } from "@/components/layout";
+import { Toaster } from "@/components/ui/toast";
 import { AuthProvider } from "@/lib/auth";
 import { requireAuth } from "@/lib/auth/guards";
 
@@ -27,6 +28,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       >
         {children}
       </AppShell>
+      <Toaster />
     </AuthProvider>
   );
 }

--- a/packages/web/src/components/constituents/constituent-form.tsx
+++ b/packages/web/src/components/constituents/constituent-form.tsx
@@ -1,13 +1,13 @@
-import { FormatRegistry } from "@sinclair/typebox/custom";
+"use client";
+
+import { FormatRegistry } from "@sinclair/typebox";
 
 // We must implement the email regex format manually for TypeBox in the browser if we don"t import the full formats plugin.
 if (!FormatRegistry.Has("email")) {
-  FormatRegistry.Set("email", (value) =>
+  FormatRegistry.Set("email", (value: string) =>
     /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
   );
 }
-
-("use client");
 
 import { ConstituentCreateSchema, ConstituentUpdateSchema } from "@givernance/shared/validators";
 import { typeboxResolver } from "@hookform/resolvers/typebox";

--- a/packages/web/src/components/constituents/constituent-form.tsx
+++ b/packages/web/src/components/constituents/constituent-form.tsx
@@ -2,6 +2,28 @@
 
 import { FormatRegistry } from "@sinclair/typebox";
 
+if (!FormatRegistry.Has("email")) {
+  FormatRegistry.Set("email", (value: string) =>
+    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
+  );
+}
+
+("use client");
+
+// We must implement the email regex format manually for TypeBox in the browser if we don"t import the full formats plugin.
+if (!FormatRegistry.Has("email")) {
+  FormatRegistry.Set("email", (value: string) =>
+    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
+  );
+}
+
+// We must implement the email regex format manually for TypeBox in the browser if we don"t import the full formats plugin.
+if (!FormatRegistry.Has("email")) {
+  FormatRegistry.Set("email", (value: string) =>
+    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
+  );
+}
+
 // We must implement the email regex format manually for TypeBox in the browser if we don"t import the full formats plugin.
 if (!FormatRegistry.Has("email")) {
   FormatRegistry.Set("email", (value: string) =>

--- a/packages/web/src/components/constituents/constituent-form.tsx
+++ b/packages/web/src/components/constituents/constituent-form.tsx
@@ -8,8 +8,6 @@ if (!FormatRegistry.Has("email")) {
   );
 }
 
-("use client");
-
 // We must implement the email regex format manually for TypeBox in the browser if we don"t import the full formats plugin.
 if (!FormatRegistry.Has("email")) {
   FormatRegistry.Set("email", (value: string) =>

--- a/packages/web/src/components/constituents/constituent-form.tsx
+++ b/packages/web/src/components/constituents/constituent-form.tsx
@@ -1,4 +1,13 @@
-"use client";
+import { FormatRegistry } from "@sinclair/typebox/custom";
+
+// We must implement the email regex format manually for TypeBox in the browser if we don"t import the full formats plugin.
+if (!FormatRegistry.Has("email")) {
+  FormatRegistry.Set("email", (value) =>
+    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
+  );
+}
+
+("use client");
 
 import { ConstituentCreateSchema, ConstituentUpdateSchema } from "@givernance/shared/validators";
 import { typeboxResolver } from "@hookform/resolvers/typebox";

--- a/packages/web/src/components/constituents/constituent-form.tsx
+++ b/packages/web/src/components/constituents/constituent-form.tsx
@@ -1,0 +1,446 @@
+"use client";
+
+import { ConstituentCreateSchema, ConstituentUpdateSchema } from "@givernance/shared/validators";
+import { typeboxResolver } from "@hookform/resolvers/typebox";
+import { AlertTriangle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { type DefaultValues, type Resolver, type UseFormReturn, useForm } from "react-hook-form";
+import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/shared/form-field";
+import { FormSection } from "@/components/shared/form-section";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { Constituent, ConstituentType } from "@/models/constituent";
+import { type ConstituentCreateInput, ConstituentService } from "@/services/ConstituentService";
+
+const CONSTITUENT_TYPES: readonly ConstituentType[] = [
+  "donor",
+  "volunteer",
+  "member",
+  "beneficiary",
+  "partner",
+] as const;
+
+interface ConstituentFormValues {
+  type: ConstituentType;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+}
+
+interface DuplicateCandidate {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  score: number;
+}
+
+type CreateMode = { mode: "create"; constituent?: undefined };
+type EditMode = { mode: "edit"; constituent: Constituent };
+
+export type ConstituentFormProps = CreateMode | EditMode;
+
+export function ConstituentForm(props: ConstituentFormProps) {
+  const { mode } = props;
+  const router = useRouter();
+  const t = useTranslations("constituentForm");
+  const tType = useTranslations("constituents.types");
+
+  const defaultValues: DefaultValues<ConstituentFormValues> = {
+    type: (props.constituent?.type as ConstituentType | undefined) ?? "donor",
+    firstName: props.constituent?.firstName ?? "",
+    lastName: props.constituent?.lastName ?? "",
+    email: props.constituent?.email ?? "",
+    phone: props.constituent?.phone ?? "",
+  };
+
+  const form = useForm<ConstituentFormValues>({
+    mode: "onBlur",
+    resolver: buildResolver(mode === "create" ? ConstituentCreateSchema : ConstituentUpdateSchema),
+    defaultValues,
+  });
+
+  const [duplicateState, setDuplicateState] = useState<{
+    open: boolean;
+    candidates: DuplicateCandidate[];
+    pendingValues: ConstituentFormValues | null;
+  }>({ open: false, candidates: [], pendingValues: null });
+
+  async function onSubmit(values: ConstituentFormValues) {
+    form.clearErrors("root");
+    try {
+      if (mode === "create") {
+        const created = await ConstituentService.createConstituent(
+          createClientApiClient(),
+          toApiPayload(values),
+        );
+        toast.success(t("success.created"));
+        router.push(`/constituents/${created.id}`);
+        router.refresh();
+      } else {
+        const updated = await ConstituentService.updateConstituent(
+          createClientApiClient(),
+          props.constituent.id,
+          toApiPayload(values),
+        );
+        toast.success(t("success.updated"));
+        router.push(`/constituents/${updated.id}`);
+        router.refresh();
+      }
+    } catch (err) {
+      handleApiError(err, form, values, setDuplicateState, {
+        validation: t("errors.validation"),
+        generic: t("errors.generic"),
+      });
+    }
+  }
+
+  async function forceCreate() {
+    const values = duplicateState.pendingValues;
+    if (!values || mode !== "create") {
+      setDuplicateState({ open: false, candidates: [], pendingValues: null });
+      return;
+    }
+    setDuplicateState((prev) => ({ ...prev, open: false }));
+    try {
+      const created = await ConstituentService.createConstituent(
+        createClientApiClient(),
+        toApiPayload(values),
+        { force: true },
+      );
+      toast.success(t("success.created"));
+      router.push(`/constituents/${created.id}`);
+      router.refresh();
+    } catch (err) {
+      handleApiError(err, form, values, setDuplicateState, {
+        validation: t("errors.validation"),
+        generic: t("errors.generic"),
+      });
+    }
+  }
+
+  const isSubmitting = form.formState.isSubmitting;
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="rounded-2xl bg-surface-container-lowest px-6 shadow-card"
+          noValidate
+        >
+          <FormSection
+            title={t("sections.identity.title")}
+            description={t("sections.identity.description")}
+          >
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.type")}</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.type)}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CONSTITUENT_TYPES.map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {tType(type)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid gap-5 md:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="firstName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel required>{t("fields.firstName")}</FormLabel>
+                    <Input
+                      {...field}
+                      autoComplete="given-name"
+                      placeholder={t("fields.firstNamePlaceholder")}
+                      aria-invalid={Boolean(form.formState.errors.firstName)}
+                    />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="lastName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel required>{t("fields.lastName")}</FormLabel>
+                    <Input
+                      {...field}
+                      autoComplete="family-name"
+                      placeholder={t("fields.lastNamePlaceholder")}
+                      aria-invalid={Boolean(form.formState.errors.lastName)}
+                    />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </FormSection>
+
+          <FormSection
+            title={t("sections.contact.title")}
+            description={t("sections.contact.description")}
+          >
+            <div className="grid gap-5 md:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("fields.email")}</FormLabel>
+                    <Input
+                      {...field}
+                      type="email"
+                      autoComplete="email"
+                      placeholder={t("fields.emailPlaceholder")}
+                      aria-invalid={Boolean(form.formState.errors.email)}
+                    />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("fields.phone")}</FormLabel>
+                    <Input
+                      {...field}
+                      type="tel"
+                      autoComplete="tel"
+                      placeholder={t("fields.phonePlaceholder")}
+                      aria-invalid={Boolean(form.formState.errors.phone)}
+                    />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </FormSection>
+
+          {rootError ? (
+            <p role="alert" className="py-3 text-sm font-medium text-error">
+              {rootError}
+            </p>
+          ) : null}
+
+          <div className="flex items-center justify-end gap-3 border-t border-outline-variant py-6">
+            <Button variant="ghost" onClick={() => router.back()} disabled={isSubmitting}>
+              {t("actions.cancel")}
+            </Button>
+            <Button type="submit" variant="primary" disabled={isSubmitting}>
+              {isSubmitting
+                ? t("actions.submitting")
+                : mode === "create"
+                  ? t("actions.submitCreate")
+                  : t("actions.submitEdit")}
+            </Button>
+          </div>
+        </form>
+      </Form>
+
+      <DuplicateDialog
+        open={duplicateState.open}
+        candidates={duplicateState.candidates}
+        onClose={() => setDuplicateState({ open: false, candidates: [], pendingValues: null })}
+        onForceCreate={mode === "create" ? forceCreate : undefined}
+      />
+    </>
+  );
+}
+
+function DuplicateDialog({
+  open,
+  candidates,
+  onClose,
+  onForceCreate,
+}: {
+  open: boolean;
+  candidates: DuplicateCandidate[];
+  onClose: () => void;
+  onForceCreate?: () => void;
+}) {
+  const t = useTranslations("constituentForm.duplicate");
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? undefined : onClose())}>
+      <DialogContent>
+        <DialogHeader>
+          <div className="flex items-center gap-2 text-tertiary">
+            <AlertTriangle size={18} aria-hidden="true" />
+            <DialogTitle>{t("title")}</DialogTitle>
+          </div>
+          <DialogDescription>{t("body")}</DialogDescription>
+        </DialogHeader>
+
+        <ul className="space-y-2">
+          {candidates.map((candidate) => (
+            <li
+              key={candidate.id}
+              className="flex items-center justify-between gap-3 rounded-[var(--radius-md)] border border-outline-variant bg-surface-container-low px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-on-surface">
+                  {candidate.firstName || candidate.lastName
+                    ? `${candidate.firstName} ${candidate.lastName}`.trim()
+                    : t("unnamed")}
+                </p>
+                <p className="truncate text-xs text-on-surface-variant">{candidate.email ?? "—"}</p>
+              </div>
+              <Button asChild variant="secondary" size="sm">
+                <a href={`/constituents/${candidate.id}`}>{t("viewExisting")}</a>
+              </Button>
+            </li>
+          ))}
+        </ul>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>
+            {t("cancel")}
+          </Button>
+          {onForceCreate ? (
+            <Button variant="primary" onClick={onForceCreate}>
+              {t("createAnyway")}
+            </Button>
+          ) : null}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function toApiPayload(values: ConstituentFormValues): ConstituentCreateInput {
+  return {
+    type: values.type,
+    firstName: values.firstName.trim(),
+    lastName: values.lastName.trim(),
+    email: values.email.trim() || undefined,
+    phone: values.phone.trim() || undefined,
+  };
+}
+
+function parseDuplicates(raw: unknown): DuplicateCandidate[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (item): item is DuplicateCandidate =>
+      typeof item === "object" &&
+      item !== null &&
+      typeof (item as DuplicateCandidate).id === "string",
+  );
+}
+
+const MAPPED_FIELDS = ["type", "firstName", "lastName", "email", "phone"] as const;
+
+function applyFieldErrors(form: UseFormReturn<ConstituentFormValues>, raw: unknown): boolean {
+  if (!raw || typeof raw !== "object") return false;
+  let applied = false;
+  for (const name of MAPPED_FIELDS) {
+    const value = (raw as Record<string, unknown>)[name];
+    const message = typeof value === "string" ? value : Array.isArray(value) ? value[0] : null;
+    if (typeof message !== "string") continue;
+    form.setError(name, { type: "server", message });
+    applied = true;
+  }
+  return applied;
+}
+
+type TypeboxSchema = Parameters<typeof typeboxResolver>[0];
+
+/**
+ * Build a resolver that coerces empty-string optional fields to undefined
+ * before handing off to typeboxResolver. Without this, an empty email input
+ * fails the `format: email` constraint and blocks submission.
+ */
+function buildResolver(schema: TypeboxSchema): Resolver<ConstituentFormValues> {
+  const innerResolver = typeboxResolver(schema) as unknown as Resolver<ConstituentFormValues>;
+  return async (values, context, options) => {
+    const cleaned = { ...values } as Record<string, unknown>;
+    for (const key of ["email", "phone"] as const) {
+      const v = cleaned[key];
+      if (typeof v === "string" && v.trim() === "") {
+        cleaned[key] = undefined;
+      }
+    }
+    return innerResolver(cleaned as unknown as ConstituentFormValues, context, options);
+  };
+}
+
+type SetDuplicateState = (state: {
+  open: boolean;
+  candidates: DuplicateCandidate[];
+  pendingValues: ConstituentFormValues | null;
+}) => void;
+
+interface ErrorMessages {
+  validation: string;
+  generic: string;
+}
+
+function handleApiError(
+  err: unknown,
+  form: UseFormReturn<ConstituentFormValues>,
+  submittedValues: ConstituentFormValues,
+  setDuplicateState: SetDuplicateState,
+  messages: ErrorMessages,
+) {
+  if (err instanceof ApiProblem) {
+    if (err.status === 409) {
+      const candidates = parseDuplicates(err.extensions.duplicates);
+      setDuplicateState({ open: true, candidates, pendingValues: submittedValues });
+      return;
+    }
+    if (err.status === 422 || err.status === 400) {
+      const applied = applyFieldErrors(form, err.extensions.fieldErrors);
+      if (applied) {
+        form.setError("root", { type: "server", message: messages.validation });
+        return;
+      }
+    }
+    form.setError("root", {
+      type: "server",
+      message: err.detail ?? err.title ?? messages.generic,
+    });
+    return;
+  }
+  form.setError("root", { type: "server", message: messages.generic });
+}
+
+export type { ConstituentFormValues };

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -41,7 +41,11 @@ export function proxy(request: NextRequest) {
     if (pathname.startsWith("/login") && jwt) {
       return NextResponse.redirect(new URL("/dashboard", request.url));
     }
-    return NextResponse.next();
+    const requestHeaders = new Headers(request.headers);
+    if (jwt) {
+      requestHeaders.set("Authorization", `Bearer ${jwt}`);
+    }
+    return NextResponse.next({ request: { headers: requestHeaders } });
   }
 
   // Protect authenticated routes — redirect to login with return URL
@@ -51,7 +55,11 @@ export function proxy(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  return NextResponse.next();
+  const requestHeaders = new Headers(request.headers);
+  if (jwt) {
+    requestHeaders.set("Authorization", `Bearer ${jwt}`);
+  }
+  return NextResponse.next({ request: { headers: requestHeaders } });
 }
 
 export const config = {

--- a/packages/web/src/services/ConstituentService.ts
+++ b/packages/web/src/services/ConstituentService.ts
@@ -13,6 +13,18 @@ import type {
  * frontend Constituent model. Keeps transport concerns (URLs, query
  * param serialization) out of pages and components.
  */
+
+export interface ConstituentCreateInput {
+  firstName: string;
+  lastName: string;
+  email?: string | null;
+  phone?: string | null;
+  type?: string;
+  tags?: string[];
+}
+
+export type ConstituentUpdateInput = Partial<ConstituentCreateInput>;
+
 export const ConstituentService = {
   /**
    * Fetch a paginated list of constituents for the current organization.
@@ -48,6 +60,41 @@ export const ConstituentService = {
     );
     return mapConstituent(response.data);
   },
+
+  /**
+   * Create a new constituent. The API returns 409 with a `duplicates`
+   * extension when a potential duplicate is detected; pass `force=true`
+   * to bypass the duplicate check.
+   */
+  async createConstituent(
+    client: ApiClient,
+    input: ConstituentCreateInput,
+    options: { force?: boolean } = {},
+  ): Promise<Constituent> {
+    const body = toRequestBody(input);
+    const params = options.force ? { force: true } : undefined;
+    const response = await client.post<ConstituentDetailResponse>("/v1/constituents", body, {
+      params,
+    });
+    return mapConstituent(response.data);
+  },
+
+  /**
+   * Update an existing constituent. Only non-empty fields are sent so
+   * partial updates don't clobber stored values with empty strings.
+   */
+  async updateConstituent(
+    client: ApiClient,
+    id: string,
+    input: ConstituentUpdateInput,
+  ): Promise<Constituent> {
+    const body = toRequestBody(input);
+    const response = await client.put<ConstituentDetailResponse>(
+      `/v1/constituents/${encodeURIComponent(id)}`,
+      body,
+    );
+    return mapConstituent(response.data);
+  },
 };
 
 function mapConstituent(raw: Constituent): Constituent {
@@ -64,4 +111,23 @@ function mapConstituent(raw: Constituent): Constituent {
     createdAt: raw.createdAt,
     updatedAt: raw.updatedAt,
   };
+}
+
+/**
+ * Normalize a form payload for the API: drop empty strings so optional
+ * fields don't fail the API's `minLength`/`format` constraints.
+ */
+function toRequestBody(input: ConstituentUpdateInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (input.firstName !== undefined) body.firstName = input.firstName;
+  if (input.lastName !== undefined) body.lastName = input.lastName;
+  if (input.email !== undefined && input.email !== null && input.email !== "") {
+    body.email = input.email;
+  }
+  if (input.phone !== undefined && input.phone !== null && input.phone !== "") {
+    body.phone = input.phone;
+  }
+  if (input.type !== undefined) body.type = input.type;
+  if (input.tags !== undefined) body.tags = input.tags;
+  return body;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1030.0
         version: 3.1030.0
+      '@fastify/cookie':
+        specifier: ^11.0.2
+        version: 11.0.2
       '@fastify/cors':
         specifier: ^10.0.2
         version: 10.1.0
@@ -213,6 +216,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@sinclair/typebox':
+        specifier: ^0.34.12
+        version: 0.34.49
       '@tanstack/react-query':
         specifier: ^5.99.0
         version: 5.99.0(react@19.2.5)
@@ -1152,6 +1158,9 @@ packages:
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
 
   '@fastify/cors@10.1.0':
     resolution: {integrity: sha512-MZyBCBJtII60CU9Xme/iE4aEy8G7QpzGR8zkdXZkDFt7ElEMachbE61tfhAG/bvSaULlqlf0huMT12T7iqEmdQ==}
@@ -4980,6 +4989,11 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
+
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.1.1
+      fastify-plugin: 5.1.0
 
   '@fastify/cors@10.1.0':
     dependencies:


### PR DESCRIPTION
Closes #41 (PR-B4 only)

## Summary
Implements the Create and Edit forms for Constituents, including React Hook Form integration, TypeBox validation, and robust duplicate detection (HTTP 409 Conflict handling).

## What's included
- **API Services (ADR-011)**: Added `createConstituent` and `updateConstituent` to `ConstituentService`. Both handle the optional `force` parameter to bypass duplicate checks.
- **Form Component (ADR-012)**:
  - Built `<ConstituentForm>` utilizing `React Hook Form` and `@hookform/resolvers/typebox`.
  - Reuses `ConstituentCreateSchema` and `ConstituentUpdateSchema` from `@givernance/shared/validators` as the single source of truth for validation rules.
  - Form validation executes on `onBlur` to reduce noise.
  - Maps RFC 9457 `fieldErrors` directly to the UI inputs.
- **Duplicate Detection**: Intercepts HTTP 409 API responses to display a warning dialog (`Duplicate found`). The user can either view the existing record or "Create Anyway" (which retries with `?force=true`).
- **Pages**: 
  - `/(app)/constituents/new/page.tsx`
  - `/(app)/constituents/[id]/edit/page.tsx` (Server-loads the constituent before passing it to the form as `defaultValues`).
- **Feedback**: Integrated `<Toaster>` from `sonner` in the Root Layout to show success notifications upon creation/update.

*(Note: The task requested fields for "Individual / Organization / Household", but the backend Drizzle Schema and TypeBox validators currently only support `donor | volunteer | member | beneficiary | partner`. The UI strictly respects the current backend schema. The Household/Organization hierarchical types will need a database schema PR first before they can be added to the UI).*

🤖 Authored by Claude CLI