### PR TITLE
feat(web): Donation Entry Form & Receipt Preview (PR-B7)

### DIFF
--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -25,6 +25,12 @@ export const ConstituentCreateSchema = Type.Object({
 /** Schema for updating a constituent (all fields optional) */
 export const ConstituentUpdateSchema = Type.Partial(ConstituentCreateSchema);
 
+/** Schema for a fund allocation within a donation */
+export const DonationAllocationSchema = Type.Object({
+  fundId: Type.String({ format: "uuid" }),
+  amountCents: Type.Integer({ exclusiveMinimum: 0 }),
+});
+
 /** Schema for creating a new donation */
 export const DonationCreateSchema = Type.Object({
   constituentId: Type.String({ format: "uuid" }),
@@ -47,6 +53,7 @@ export const DonationCreateSchema = Type.Object({
   paymentRef: Type.Optional(Type.String({ maxLength: 255 })),
   donatedAt: Type.Optional(Type.String({ format: "date-time" })),
   fiscalYear: Type.Optional(Type.Integer()),
+  allocations: Type.Optional(Type.Array(DonationAllocationSchema)),
 });
 
 /** Schema for list query parameters */
@@ -61,6 +68,7 @@ export const PaginationQuerySchema = Type.Object({
 export type ConstituentCreate = Static<typeof ConstituentCreateSchema>;
 export type ConstituentUpdate = Static<typeof ConstituentUpdateSchema>;
 export type DonationCreate = Static<typeof DonationCreateSchema>;
+export type DonationAllocation = Static<typeof DonationAllocationSchema>;
 export type PaginationQuery = Static<typeof PaginationQuerySchema>;
 
 /** Validate, coerce, and apply defaults — throws on failure */

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -152,6 +152,108 @@
     },
     "actions": {
       "new": "New donation"
+    },
+    "form": {
+      "createTitle": "Record a donation",
+      "createSubtitle": "Log a new donation manually — by cheque, wire, cash, or card.",
+      "breadcrumbNew": "New donation",
+      "sections": {
+        "donor": {
+          "title": "Donor",
+          "description": "Who made this donation?"
+        },
+        "donation": {
+          "title": "Donation details",
+          "description": "Amount, payment method, and reference."
+        },
+        "attribution": {
+          "title": "Attribution",
+          "description": "Campaign and fund allocation (optional)."
+        }
+      },
+      "fields": {
+        "constituent": "Constituent",
+        "constituentPlaceholder": "Search for a donor…",
+        "constituentEmpty": "No constituents match your search.",
+        "constituentLoading": "Loading…",
+        "amount": "Amount",
+        "amountPlaceholder": "0.00",
+        "currency": "Currency",
+        "donatedAt": "Donation date",
+        "paymentMethod": "Payment method",
+        "paymentMethodPlaceholder": "Select a payment method",
+        "paymentRef": "External reference",
+        "paymentRefPlaceholder": "e.g. WIRE-2026-0342",
+        "paymentRefHint": "Bank transfer reference, cheque number, etc.",
+        "campaignId": "Campaign",
+        "campaignIdPlaceholder": "No campaign",
+        "allocations": "Fund allocations",
+        "allocationFund": "Fund ID (UUID)",
+        "allocationFundPlaceholder": "Fund UUID",
+        "allocationAmount": "Amount",
+        "allocationRemove": "Remove allocation",
+        "allocationAdd": "Add allocation",
+        "allocationsHint": "Allocations must sum to the total amount. Leave empty for unallocated."
+      },
+      "paymentMethods": {
+        "wire": "Bank transfer",
+        "cheque": "Cheque",
+        "card": "Card",
+        "sepa": "SEPA direct debit",
+        "cash": "Cash",
+        "other": "Other"
+      },
+      "actions": {
+        "cancel": "Cancel",
+        "submitCreate": "Save donation",
+        "submitting": "Saving…"
+      },
+      "errors": {
+        "validation": "Please correct the highlighted fields.",
+        "generic": "Something went wrong while saving. Please try again.",
+        "allocationSumMismatch": "Allocation amounts must sum to the donation total.",
+        "constituentRequired": "Choose a constituent for this donation.",
+        "amountInvalid": "Amount must be greater than zero."
+      },
+      "success": {
+        "created": "Donation recorded."
+      }
+    },
+    "detail": {
+      "breadcrumbRoot": "Dashboard",
+      "breadcrumbDonations": "Donations",
+      "title": "Donation",
+      "anonymousDonor": "Anonymous donor",
+      "notRecorded": "—",
+      "infoSection": "Donation information",
+      "allocationsSection": "Fund allocations",
+      "fields": {
+        "donor": "Donor",
+        "date": "Date",
+        "amount": "Amount",
+        "paymentMethod": "Payment method",
+        "paymentRef": "Reference",
+        "campaign": "Campaign",
+        "fiscalYear": "Fiscal year",
+        "recordedAt": "Recorded"
+      },
+      "allocations": {
+        "columnFund": "Fund",
+        "columnAmount": "Amount",
+        "columnPercent": "%",
+        "total": "Total",
+        "empty": "No allocations recorded for this donation."
+      },
+      "actions": {
+        "back": "Back to donations",
+        "previewReceipt": "Receipt preview",
+        "generatingReceipt": "Generating receipt…"
+      },
+      "receipt": {
+        "pending": "Receipt is still being generated.",
+        "error": "Could not open the receipt. Please try again.",
+        "missing": "No receipt available yet."
+      }
     }
   },
   "constituents": {

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -152,6 +152,108 @@
     },
     "actions": {
       "new": "Nouveau don"
+    },
+    "form": {
+      "createTitle": "Enregistrer un don",
+      "createSubtitle": "Ajoutez manuellement un don — chèque, virement, espèces ou carte.",
+      "breadcrumbNew": "Nouveau don",
+      "sections": {
+        "donor": {
+          "title": "Donateur",
+          "description": "Qui a effectué ce don ?"
+        },
+        "donation": {
+          "title": "Informations du don",
+          "description": "Montant, moyen de paiement et référence."
+        },
+        "attribution": {
+          "title": "Attribution",
+          "description": "Campagne et répartition des fonds (optionnel)."
+        }
+      },
+      "fields": {
+        "constituent": "Constituant",
+        "constituentPlaceholder": "Rechercher un donateur…",
+        "constituentEmpty": "Aucun constituant ne correspond à votre recherche.",
+        "constituentLoading": "Chargement…",
+        "amount": "Montant",
+        "amountPlaceholder": "0,00",
+        "currency": "Devise",
+        "donatedAt": "Date du don",
+        "paymentMethod": "Moyen de paiement",
+        "paymentMethodPlaceholder": "Choisissez un moyen de paiement",
+        "paymentRef": "Référence externe",
+        "paymentRefPlaceholder": "Ex. : VIR-2026-0342",
+        "paymentRefHint": "Référence bancaire, numéro de chèque, etc.",
+        "campaignId": "Campagne",
+        "campaignIdPlaceholder": "Aucune campagne",
+        "allocations": "Répartition des fonds",
+        "allocationFund": "Fonds (UUID)",
+        "allocationFundPlaceholder": "UUID du fonds",
+        "allocationAmount": "Montant",
+        "allocationRemove": "Supprimer la ligne",
+        "allocationAdd": "Ajouter une ligne",
+        "allocationsHint": "Les répartitions doivent totaliser le montant du don. Laissez vide pour un don non-alloué."
+      },
+      "paymentMethods": {
+        "wire": "Virement bancaire",
+        "cheque": "Chèque",
+        "card": "Carte bancaire",
+        "sepa": "Prélèvement SEPA",
+        "cash": "Espèces",
+        "other": "Autre"
+      },
+      "actions": {
+        "cancel": "Annuler",
+        "submitCreate": "Enregistrer le don",
+        "submitting": "Enregistrement…"
+      },
+      "errors": {
+        "validation": "Corrigez les champs en surbrillance.",
+        "generic": "Une erreur est survenue lors de l'enregistrement. Réessayez.",
+        "allocationSumMismatch": "La somme des répartitions doit égaler le montant total.",
+        "constituentRequired": "Sélectionnez un constituant pour ce don.",
+        "amountInvalid": "Le montant doit être supérieur à zéro."
+      },
+      "success": {
+        "created": "Don enregistré."
+      }
+    },
+    "detail": {
+      "breadcrumbRoot": "Tableau de bord",
+      "breadcrumbDonations": "Dons",
+      "title": "Don",
+      "anonymousDonor": "Donateur anonyme",
+      "notRecorded": "—",
+      "infoSection": "Informations du don",
+      "allocationsSection": "Allocation aux fonds",
+      "fields": {
+        "donor": "Donateur",
+        "date": "Date",
+        "amount": "Montant",
+        "paymentMethod": "Moyen de paiement",
+        "paymentRef": "Référence",
+        "campaign": "Campagne",
+        "fiscalYear": "Année fiscale",
+        "recordedAt": "Enregistré"
+      },
+      "allocations": {
+        "columnFund": "Fonds",
+        "columnAmount": "Montant",
+        "columnPercent": "%",
+        "total": "Total",
+        "empty": "Aucune répartition enregistrée pour ce don."
+      },
+      "actions": {
+        "back": "Retour aux dons",
+        "previewReceipt": "Aperçu du reçu",
+        "generatingReceipt": "Génération du reçu…"
+      },
+      "receipt": {
+        "pending": "Le reçu est encore en cours de génération.",
+        "error": "Impossible d'ouvrir le reçu. Réessayez.",
+        "missing": "Aucun reçu disponible pour l'instant."
+      }
     }
   },
   "constituents": {

--- a/packages/web/src/app/(app)/donations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/donations/[id]/page.tsx
@@ -1,0 +1,221 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+
+import { ReceiptPreviewButton } from "@/components/donations/receipt-preview-button";
+import { PageHeader } from "@/components/shared/page-header";
+import { Button } from "@/components/ui/button";
+import { ApiProblem } from "@/lib/api";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import { formatCurrency, formatDate } from "@/lib/format";
+import type { DonationAllocation, DonationDetail } from "@/models/donation";
+import { donationDetailDonorName } from "@/models/donation";
+import { DonationService } from "@/services/DonationService";
+
+interface DonationDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+async function fetchDonationOrNotFound(id: string): Promise<DonationDetail> {
+  const client = await createServerApiClient();
+  try {
+    return await DonationService.getDonation(client, id);
+  } catch (err) {
+    if (err instanceof ApiProblem && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+}
+
+export default async function DonationDetailPage({ params }: DonationDetailPageProps) {
+  await requireAuth();
+  const { id } = await params;
+  const donation = await fetchDonationOrNotFound(id);
+
+  const [t, tDonations, locale] = await Promise.all([
+    getTranslations("donations.detail"),
+    getTranslations("donations"),
+    getLocale(),
+  ]);
+
+  const donorName = donationDetailDonorName(donation) || t("anonymousDonor");
+  const amountLabel = formatCurrency(donation.amountCents, locale, donation.currency);
+
+  return (
+    <>
+      <PageHeader
+        title={`${t("title")} — ${amountLabel}`}
+        description={donorName}
+        breadcrumbs={[
+          { label: t("breadcrumbRoot"), href: "/dashboard" },
+          { label: tDonations("title"), href: "/donations" },
+          { label: amountLabel },
+        ]}
+        actions={
+          <>
+            <Button asChild variant="ghost" size="sm">
+              <Link href="/donations">
+                <ArrowLeft size={16} aria-hidden="true" />
+                {t("actions.back")}
+              </Link>
+            </Button>
+            <ReceiptPreviewButton donationId={donation.id} />
+          </>
+        }
+      />
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <InfoCard
+          donation={donation}
+          donorName={donorName}
+          amountLabel={amountLabel}
+          locale={locale}
+        />
+        <AllocationsCard donation={donation} allocations={donation.allocations} locale={locale} />
+      </div>
+    </>
+  );
+}
+
+async function InfoCard({
+  donation,
+  donorName,
+  amountLabel,
+  locale,
+}: {
+  donation: DonationDetail;
+  donorName: string;
+  amountLabel: string;
+  locale: string;
+}) {
+  const t = await getTranslations("donations.detail");
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+      <h2 className="mb-4 font-heading text-xl text-on-surface">{t("infoSection")}</h2>
+      <dl className="space-y-3">
+        <DetailRow label={t("fields.donor")}>
+          <Link
+            href={`/constituents/${donation.constituentId}`}
+            className="text-sky-text hover:underline"
+          >
+            {donorName}
+          </Link>
+        </DetailRow>
+        <DetailRow label={t("fields.date")}>
+          {formatDate(donation.donatedAt, locale, "long")}
+        </DetailRow>
+        <DetailRow label={t("fields.amount")}>
+          <span className="font-mono font-semibold tabular-nums">{amountLabel}</span>
+        </DetailRow>
+        <DetailRow label={t("fields.paymentMethod")}>
+          {donation.paymentMethod ?? t("notRecorded")}
+        </DetailRow>
+        <DetailRow label={t("fields.paymentRef")}>
+          {donation.paymentRef ? (
+            <span className="font-mono text-sm">{donation.paymentRef}</span>
+          ) : (
+            t("notRecorded")
+          )}
+        </DetailRow>
+        <DetailRow label={t("fields.campaign")}>
+          {donation.campaignId ? (
+            <Link
+              href={`/campaigns/${donation.campaignId}`}
+              className="text-sky-text hover:underline"
+            >
+              {donation.campaignId}
+            </Link>
+          ) : (
+            t("notRecorded")
+          )}
+        </DetailRow>
+        <DetailRow label={t("fields.fiscalYear")}>{String(donation.fiscalYear)}</DetailRow>
+        <DetailRow label={t("fields.recordedAt")}>
+          {formatDate(donation.createdAt, locale, "long")}
+        </DetailRow>
+      </dl>
+    </section>
+  );
+}
+
+async function AllocationsCard({
+  donation,
+  allocations,
+  locale,
+}: {
+  donation: DonationDetail;
+  allocations: DonationAllocation[];
+  locale: string;
+}) {
+  const t = await getTranslations("donations.detail");
+
+  if (allocations.length === 0) {
+    return (
+      <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+        <h2 className="mb-4 font-heading text-xl text-on-surface">{t("allocationsSection")}</h2>
+        <p className="text-sm text-on-surface-variant">{t("allocations.empty")}</p>
+      </section>
+    );
+  }
+
+  const total = allocations.reduce((sum, a) => sum + a.amountCents, 0) || 1;
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+      <h2 className="mb-4 font-heading text-xl text-on-surface">{t("allocationsSection")}</h2>
+      <table className="w-full border-separate border-spacing-0 text-sm">
+        <thead>
+          <tr className="text-xs uppercase tracking-wide text-on-surface-variant">
+            <th className="border-b border-outline-variant py-2 text-left font-medium">
+              {t("allocations.columnFund")}
+            </th>
+            <th className="border-b border-outline-variant py-2 text-right font-medium">
+              {t("allocations.columnAmount")}
+            </th>
+            <th className="border-b border-outline-variant py-2 text-right font-medium">
+              {t("allocations.columnPercent")}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {allocations.map((allocation) => {
+            const percent = Math.round((allocation.amountCents / total) * 100);
+            return (
+              <tr key={allocation.id}>
+                <td className="border-b border-outline-variant/50 py-2 font-mono text-xs">
+                  {allocation.fundId}
+                </td>
+                <td className="border-b border-outline-variant/50 py-2 text-right font-mono tabular-nums">
+                  {formatCurrency(allocation.amountCents, locale, donation.currency)}
+                </td>
+                <td className="border-b border-outline-variant/50 py-2 text-right text-on-surface-variant">
+                  {percent}%
+                </td>
+              </tr>
+            );
+          })}
+          <tr className="font-semibold">
+            <td className="py-2">{t("allocations.total")}</td>
+            <td className="py-2 text-right font-mono tabular-nums">
+              {formatCurrency(donation.amountCents, locale, donation.currency)}
+            </td>
+            <td className="py-2 text-right">100%</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline gap-3 border-b border-outline-variant/50 pb-2 last:border-b-0">
+      <dt className="w-40 shrink-0 text-sm font-medium text-on-surface-variant">{label}</dt>
+      <dd className="min-w-0 flex-1 text-sm text-on-surface">{children}</dd>
+    </div>
+  );
+}

--- a/packages/web/src/app/(app)/donations/new/page.tsx
+++ b/packages/web/src/app/(app)/donations/new/page.tsx
@@ -1,0 +1,26 @@
+import { getTranslations } from "next-intl/server";
+
+import { DonationForm } from "@/components/donations/donation-form";
+import { PageHeader } from "@/components/shared/page-header";
+import { requireAuth } from "@/lib/auth/guards";
+
+export default async function NewDonationPage() {
+  await requireAuth();
+  const t = await getTranslations("donations.form");
+  const tDonations = await getTranslations("donations");
+
+  return (
+    <>
+      <PageHeader
+        title={t("createTitle")}
+        description={t("createSubtitle")}
+        breadcrumbs={[
+          { label: tDonations("breadcrumbRoot"), href: "/dashboard" },
+          { label: tDonations("title"), href: "/donations" },
+          { label: t("breadcrumbNew") },
+        ]}
+      />
+      <DonationForm />
+    </>
+  );
+}

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -605,7 +605,7 @@ function parseDateString(val: string): string | undefined {
 
 function toApiPayload(values: DonationFormValues): DonationCreateInput {
   const donatedAt = parseDateString(values.donatedAt);
-  const allocations = values.allocations
+  const allocations = (values.allocations || [])
     .map((a) => ({ fundId: a.fundId.trim(), amountCents: a.amountCents ?? 0 }))
     .filter((a) => a.fundId !== "" && a.amountCents > 0);
 
@@ -652,7 +652,7 @@ function buildResolver(): Resolver<DonationFormValues> {
       const parsed = parseDateString(values.donatedAt);
       if (parsed) cleaned.donatedAt = parsed;
     }
-    const allocations = values.allocations
+    const allocations = (values.allocations || [])
       .filter((a) => a.fundId.trim() !== "" && a.amountCents !== null && a.amountCents > 0)
       .map((a) => ({ fundId: a.fundId.trim(), amountCents: a.amountCents as number }));
     if (allocations.length > 0) {

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -1,5 +1,16 @@
 "use client";
 
+import { FormatRegistry } from "@sinclair/typebox";
+
+if (!FormatRegistry.Has("uuid")) {
+  FormatRegistry.Set("uuid", (value: string) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value),
+  );
+}
+if (!FormatRegistry.Has("date-time")) {
+  FormatRegistry.Set("date-time", (value: string) => !Number.isNaN(Date.parse(value)));
+}
+
 import { DonationCreateSchema } from "@givernance/shared/validators";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { Check, ChevronsUpDown, Plus, Trash2 } from "lucide-react";

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -613,9 +613,9 @@ function toApiPayload(values: DonationFormValues): DonationCreateInput {
     constituentId: values.constituentId,
     amountCents: values.amountCents ?? 0,
     currency: values.currency,
-    campaignId: values.campaignId.trim() || undefined,
+    campaignId: (values.campaignId || "").trim() || undefined,
     paymentMethod: values.paymentMethod || undefined,
-    paymentRef: values.paymentRef.trim() || undefined,
+    paymentRef: (values.paymentRef || "").trim() || undefined,
     donatedAt,
     allocations: allocations.length > 0 ? allocations : undefined,
   };
@@ -639,14 +639,14 @@ function buildResolver(): Resolver<DonationFormValues> {
       amountCents: values.amountCents ?? 0,
       currency: values.currency,
     };
-    if (values.campaignId && values.campaignId.trim() !== "") {
-      cleaned.campaignId = values.campaignId.trim();
+    if (values.campaignId && (values.campaignId || "").trim() !== "") {
+      cleaned.campaignId = (values.campaignId || "").trim();
     }
     if (values.paymentMethod) {
       cleaned.paymentMethod = values.paymentMethod;
     }
-    if (values.paymentRef && values.paymentRef.trim() !== "") {
-      cleaned.paymentRef = values.paymentRef.trim();
+    if (values.paymentRef && (values.paymentRef || "").trim() !== "") {
+      cleaned.paymentRef = (values.paymentRef || "").trim();
     }
     if (values.donatedAt) {
       const parsed = parseDateString(values.donatedAt);

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -1,0 +1,667 @@
+"use client";
+
+import { DonationCreateSchema } from "@givernance/shared/validators";
+import { typeboxResolver } from "@hookform/resolvers/typebox";
+import { Check, ChevronsUpDown, Plus, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type DefaultValues,
+  type Resolver,
+  type UseFormReturn,
+  useFieldArray,
+  useForm,
+} from "react-hook-form";
+
+import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/shared/form-field";
+import { FormSection } from "@/components/shared/form-section";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { cn } from "@/lib/utils";
+import { type Constituent, fullName } from "@/models/constituent";
+import type { DonationCreateInput } from "@/models/donation";
+import { ConstituentService } from "@/services/ConstituentService";
+import { DonationService } from "@/services/DonationService";
+
+const CURRENCIES = ["EUR", "GBP", "CHF", "SEK", "NOK", "DKK", "PLN", "CZK"] as const;
+const PAYMENT_METHODS = ["wire", "cheque", "card", "sepa", "cash", "other"] as const;
+
+interface AllocationFormValue {
+  fundId: string;
+  amountCents: number | null;
+}
+
+interface DonationFormValues {
+  constituentId: string;
+  amountCents: number | null;
+  currency: (typeof CURRENCIES)[number];
+  campaignId: string;
+  paymentMethod: (typeof PAYMENT_METHODS)[number] | "";
+  paymentRef: string;
+  donatedAt: string;
+  allocations: AllocationFormValue[];
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+const DEFAULT_VALUES: DefaultValues<DonationFormValues> = {
+  constituentId: "",
+  amountCents: null,
+  currency: "EUR",
+  campaignId: "",
+  paymentMethod: "",
+  paymentRef: "",
+  donatedAt: todayIso(),
+  allocations: [],
+};
+
+export function DonationForm() {
+  const router = useRouter();
+  const t = useTranslations("donations.form");
+
+  const form = useForm<DonationFormValues>({
+    mode: "onBlur",
+    resolver: buildResolver(),
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  const {
+    fields: allocationFields,
+    append: appendAllocation,
+    remove: removeAllocation,
+  } = useFieldArray({
+    control: form.control,
+    name: "allocations",
+  });
+
+  const [selectedConstituent, setSelectedConstituent] = useState<Constituent | null>(null);
+
+  async function onSubmit(values: DonationFormValues) {
+    form.clearErrors("root");
+
+    if (!values.constituentId) {
+      form.setError("constituentId", { type: "manual", message: t("errors.constituentRequired") });
+      return;
+    }
+    if (!values.amountCents || values.amountCents <= 0) {
+      form.setError("amountCents", { type: "manual", message: t("errors.amountInvalid") });
+      return;
+    }
+
+    const payload = toApiPayload(values);
+
+    try {
+      const created = await DonationService.createDonation(createClientApiClient(), payload);
+      toast.success(t("success.created"));
+      router.push(`/donations/${created.id}`);
+      router.refresh();
+    } catch (err) {
+      handleApiError(err, form, {
+        allocationSumMismatch: t("errors.allocationSumMismatch"),
+        validation: t("errors.validation"),
+        generic: t("errors.generic"),
+      });
+    }
+  }
+
+  const isSubmitting = form.formState.isSubmitting;
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="rounded-2xl bg-surface-container-lowest px-6 shadow-card"
+        noValidate
+      >
+        <FormSection
+          title={t("sections.donor.title")}
+          description={t("sections.donor.description")}
+        >
+          <FormField
+            control={form.control}
+            name="constituentId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel required>{t("fields.constituent")}</FormLabel>
+                <ConstituentPicker
+                  value={field.value}
+                  selected={selectedConstituent}
+                  onSelect={(constituent) => {
+                    setSelectedConstituent(constituent);
+                    field.onChange(constituent?.id ?? "");
+                    if (constituent?.id) form.clearErrors("constituentId");
+                  }}
+                  invalid={Boolean(form.formState.errors.constituentId)}
+                />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection
+          title={t("sections.donation.title")}
+          description={t("sections.donation.description")}
+        >
+          <div className="grid gap-5 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="amountCents"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.amount")}</FormLabel>
+                  <AmountInput
+                    value={field.value}
+                    onChange={(v) => {
+                      field.onChange(v);
+                      if (v && v > 0) form.clearErrors("amountCents");
+                    }}
+                    invalid={Boolean(form.formState.errors.amountCents)}
+                    placeholder={t("fields.amountPlaceholder")}
+                  />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="currency"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("fields.currency")}</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.currency)}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CURRENCIES.map((c) => (
+                        <SelectItem key={c} value={c}>
+                          {c}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="donatedAt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("fields.donatedAt")}</FormLabel>
+                  <Input
+                    type="date"
+                    value={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    aria-invalid={Boolean(form.formState.errors.donatedAt)}
+                  />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="paymentMethod"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("fields.paymentMethod")}</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={(value) => field.onChange(value === "" ? "" : value)}
+                  >
+                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.paymentMethod)}>
+                      <SelectValue placeholder={t("fields.paymentMethodPlaceholder")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PAYMENT_METHODS.map((method) => (
+                        <SelectItem key={method} value={method}>
+                          {t(`paymentMethods.${method}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <FormField
+            control={form.control}
+            name="paymentRef"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("fields.paymentRef")}</FormLabel>
+                <Input
+                  {...field}
+                  placeholder={t("fields.paymentRefPlaceholder")}
+                  aria-invalid={Boolean(form.formState.errors.paymentRef)}
+                />
+                <p className="text-xs text-on-surface-variant">{t("fields.paymentRefHint")}</p>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <FormSection
+          title={t("sections.attribution.title")}
+          description={t("sections.attribution.description")}
+        >
+          <FormField
+            control={form.control}
+            name="campaignId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("fields.campaignId")}</FormLabel>
+                <Input
+                  {...field}
+                  placeholder={t("fields.campaignIdPlaceholder")}
+                  aria-invalid={Boolean(form.formState.errors.campaignId)}
+                />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="space-y-3">
+            <FormLabelPlain>{t("fields.allocations")}</FormLabelPlain>
+            <p className="text-xs text-on-surface-variant">{t("fields.allocationsHint")}</p>
+
+            {allocationFields.length > 0 ? (
+              <ul className="space-y-3">
+                {allocationFields.map((fieldItem, index) => (
+                  <li key={fieldItem.id} className="grid gap-3 md:grid-cols-[1fr_200px_auto]">
+                    <FormField
+                      control={form.control}
+                      name={`allocations.${index}.fundId`}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>{t("fields.allocationFund")}</FormLabel>
+                          <Input
+                            {...field}
+                            placeholder={t("fields.allocationFundPlaceholder")}
+                            aria-invalid={Boolean(
+                              form.formState.errors.allocations?.[index]?.fundId,
+                            )}
+                          />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`allocations.${index}.amountCents`}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>{t("fields.allocationAmount")}</FormLabel>
+                          <AmountInput
+                            value={field.value}
+                            onChange={field.onChange}
+                            invalid={Boolean(
+                              form.formState.errors.allocations?.[index]?.amountCents,
+                            )}
+                            placeholder={t("fields.amountPlaceholder")}
+                          />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <div className="flex items-end">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => removeAllocation(index)}
+                        aria-label={t("fields.allocationRemove")}
+                      >
+                        <Trash2 size={16} aria-hidden="true" />
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => appendAllocation({ fundId: "", amountCents: null })}
+            >
+              <Plus size={16} aria-hidden="true" />
+              {t("fields.allocationAdd")}
+            </Button>
+          </div>
+        </FormSection>
+
+        {rootError ? (
+          <p role="alert" className="py-3 text-sm font-medium text-error">
+            {rootError}
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-3 border-t border-outline-variant py-6">
+          <Button variant="ghost" onClick={() => router.back()} disabled={isSubmitting}>
+            {t("actions.cancel")}
+          </Button>
+          <Button type="submit" variant="primary" disabled={isSubmitting}>
+            {isSubmitting ? t("actions.submitting") : t("actions.submitCreate")}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+/** Plain label outside the FormField context (not tied to a specific input). */
+function FormLabelPlain({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-sm font-medium text-on-surface">
+      <span>{children}</span>
+    </p>
+  );
+}
+
+interface ConstituentPickerProps {
+  value: string;
+  selected: Constituent | null;
+  onSelect: (constituent: Constituent | null) => void;
+  invalid: boolean;
+}
+
+function ConstituentPicker({ value, selected, onSelect, invalid }: ConstituentPickerProps) {
+  const t = useTranslations("donations.form");
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [candidates, setCandidates] = useState<Constituent[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadConstituents = useCallback(async (query: string) => {
+    setLoading(true);
+    try {
+      const client = createClientApiClient();
+      const result = await ConstituentService.listConstituents(client, {
+        page: 1,
+        perPage: 50,
+        search: query || undefined,
+      });
+      setCandidates(result.data);
+    } catch {
+      setCandidates([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = setTimeout(() => {
+      loadConstituents(search.trim());
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [open, search, loadConstituents]);
+
+  const triggerLabel = selected ? fullName(selected) : t("fields.constituentPlaceholder");
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-invalid={invalid}
+          aria-expanded={open}
+          className={cn(
+            "flex w-full items-center justify-between gap-2",
+            "h-[var(--input-height)] px-3",
+            "bg-surface-container-lowest text-on-surface",
+            "border border-outline-variant rounded-[var(--radius-input)]",
+            "font-body text-base",
+            "transition-[border-color,box-shadow] duration-normal ease-out",
+            "focus-visible:outline-none focus-visible:border-primary focus-visible:shadow-ring",
+            "aria-invalid:border-error aria-invalid:focus-visible:shadow-ring-error",
+            !selected && "text-text-muted",
+          )}
+        >
+          <span className="truncate">{triggerLabel}</span>
+          <ChevronsUpDown size={16} className="shrink-0 opacity-60" aria-hidden="true" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder={t("fields.constituentPlaceholder")}
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            {loading ? (
+              <div className="py-4 text-center text-sm text-on-surface-variant">
+                {t("fields.constituentLoading")}
+              </div>
+            ) : candidates.length === 0 ? (
+              <CommandEmpty>{t("fields.constituentEmpty")}</CommandEmpty>
+            ) : (
+              <CommandGroup>
+                {candidates.map((constituent) => {
+                  const name = fullName(constituent);
+                  return (
+                    <CommandItem
+                      key={constituent.id}
+                      value={constituent.id}
+                      onSelect={() => {
+                        onSelect(constituent);
+                        setOpen(false);
+                      }}
+                    >
+                      <Check
+                        size={14}
+                        aria-hidden="true"
+                        className={cn(
+                          "mr-2",
+                          value === constituent.id ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate font-medium text-on-surface">{name}</span>
+                        {constituent.email ? (
+                          <span className="truncate text-xs text-on-surface-variant">
+                            {constituent.email}
+                          </span>
+                        ) : null}
+                      </div>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface AmountInputProps {
+  value: number | null | undefined;
+  onChange: (value: number | null) => void;
+  invalid: boolean;
+  placeholder?: string;
+}
+
+function AmountInput({ value, onChange, invalid, placeholder }: AmountInputProps) {
+  const [raw, setRaw] = useState<string>(() => centsToDisplay(value));
+  const lastValueRef = useRef<number | null | undefined>(value);
+
+  useEffect(() => {
+    if (value !== lastValueRef.current) {
+      lastValueRef.current = value;
+      setRaw(centsToDisplay(value));
+    }
+  }, [value]);
+
+  return (
+    <div className="relative">
+      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-on-surface-variant">
+        €
+      </span>
+      <Input
+        type="text"
+        inputMode="decimal"
+        value={raw}
+        placeholder={placeholder}
+        aria-invalid={invalid}
+        className="pl-7 font-mono tabular-nums"
+        onChange={(e) => {
+          const next = e.target.value;
+          setRaw(next);
+          const parsed = parseAmount(next);
+          lastValueRef.current = parsed;
+          onChange(parsed);
+        }}
+        onBlur={() => {
+          const parsed = parseAmount(raw);
+          lastValueRef.current = parsed;
+          setRaw(centsToDisplay(parsed));
+        }}
+      />
+    </div>
+  );
+}
+
+function centsToDisplay(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "";
+  return (value / 100).toFixed(2);
+}
+
+function parseAmount(raw: string): number | null {
+  const trimmed = raw.trim().replace(/\s/g, "").replace(",", ".");
+  if (trimmed === "") return null;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.round(parsed * 100);
+}
+
+function toApiPayload(values: DonationFormValues): DonationCreateInput {
+  const donatedAt = values.donatedAt
+    ? new Date(`${values.donatedAt}T00:00:00Z`).toISOString()
+    : undefined;
+  const allocations = values.allocations
+    .map((a) => ({ fundId: a.fundId.trim(), amountCents: a.amountCents ?? 0 }))
+    .filter((a) => a.fundId !== "" && a.amountCents > 0);
+
+  return {
+    constituentId: values.constituentId,
+    amountCents: values.amountCents ?? 0,
+    currency: values.currency,
+    campaignId: values.campaignId.trim() || undefined,
+    paymentMethod: values.paymentMethod || undefined,
+    paymentRef: values.paymentRef.trim() || undefined,
+    donatedAt,
+    allocations: allocations.length > 0 ? allocations : undefined,
+  };
+}
+
+type TypeboxSchema = Parameters<typeof typeboxResolver>[0];
+
+/**
+ * Resolver adapter — converts the form's friendly shape (date-only string,
+ * empty optional strings) into the payload expected by DonationCreateSchema
+ * before handing off to typeboxResolver.
+ */
+function buildResolver(): Resolver<DonationFormValues> {
+  const innerResolver = typeboxResolver(
+    DonationCreateSchema as TypeboxSchema,
+  ) as unknown as Resolver<Record<string, unknown>>;
+
+  const adapted: Resolver<DonationFormValues> = async (values, context, options) => {
+    const cleaned: Record<string, unknown> = {
+      constituentId: values.constituentId,
+      amountCents: values.amountCents ?? 0,
+      currency: values.currency,
+    };
+    if (values.campaignId && values.campaignId.trim() !== "") {
+      cleaned.campaignId = values.campaignId.trim();
+    }
+    if (values.paymentMethod) {
+      cleaned.paymentMethod = values.paymentMethod;
+    }
+    if (values.paymentRef && values.paymentRef.trim() !== "") {
+      cleaned.paymentRef = values.paymentRef.trim();
+    }
+    if (values.donatedAt) {
+      cleaned.donatedAt = new Date(`${values.donatedAt}T00:00:00Z`).toISOString();
+    }
+    const allocations = values.allocations
+      .filter((a) => a.fundId.trim() !== "" && a.amountCents !== null && a.amountCents > 0)
+      .map((a) => ({ fundId: a.fundId.trim(), amountCents: a.amountCents as number }));
+    if (allocations.length > 0) {
+      cleaned.allocations = allocations;
+    }
+    const result = await innerResolver(
+      cleaned,
+      context,
+      options as unknown as Parameters<typeof innerResolver>[2],
+    );
+    return result as unknown as Awaited<ReturnType<Resolver<DonationFormValues>>>;
+  };
+
+  return adapted;
+}
+
+interface ErrorMessages {
+  allocationSumMismatch: string;
+  validation: string;
+  generic: string;
+}
+
+function handleApiError(
+  err: unknown,
+  form: UseFormReturn<DonationFormValues>,
+  messages: ErrorMessages,
+) {
+  if (err instanceof ApiProblem) {
+    if (err.status === 422 && err.detail?.toLowerCase().includes("alloc")) {
+      form.setError("root", { type: "server", message: messages.allocationSumMismatch });
+      return;
+    }
+    if (err.status === 422 || err.status === 400) {
+      form.setError("root", { type: "server", message: err.detail ?? messages.validation });
+      return;
+    }
+    form.setError("root", {
+      type: "server",
+      message: err.detail ?? err.title ?? messages.generic,
+    });
+    return;
+  }
+  form.setError("root", { type: "server", message: messages.generic });
+}

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -581,10 +581,30 @@ function parseAmount(raw: string): number | null {
   return Math.round(parsed * 100);
 }
 
+function parseDateString(val: string): string | undefined {
+  if (!val) return undefined;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(val)) return new Date(`${val}T00:00:00Z`).toISOString();
+
+  // Try parsing DD/MM/YYYY
+  const parts = val.split("/");
+  if (parts.length === 3) {
+    // assume DD/MM/YYYY
+    const [d, m, y] = parts;
+    const yStr = y.length === 2 ? `20${y}` : y;
+    const iso = `${yStr}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T00:00:00Z`;
+    const dt = new Date(iso);
+    if (!Number.isNaN(dt.getTime())) return dt.toISOString();
+  }
+
+  // Fallback to normal Date parsing
+  const dt = new Date(val);
+  if (!Number.isNaN(dt.getTime())) return dt.toISOString();
+
+  return undefined;
+}
+
 function toApiPayload(values: DonationFormValues): DonationCreateInput {
-  const donatedAt = values.donatedAt
-    ? new Date(`${values.donatedAt}T00:00:00Z`).toISOString()
-    : undefined;
+  const donatedAt = parseDateString(values.donatedAt);
   const allocations = values.allocations
     .map((a) => ({ fundId: a.fundId.trim(), amountCents: a.amountCents ?? 0 }))
     .filter((a) => a.fundId !== "" && a.amountCents > 0);
@@ -629,7 +649,8 @@ function buildResolver(): Resolver<DonationFormValues> {
       cleaned.paymentRef = values.paymentRef.trim();
     }
     if (values.donatedAt) {
-      cleaned.donatedAt = new Date(`${values.donatedAt}T00:00:00Z`).toISOString();
+      const parsed = parseDateString(values.donatedAt);
+      if (parsed) cleaned.donatedAt = parsed;
     }
     const allocations = values.allocations
       .filter((a) => a.fundId.trim() !== "" && a.amountCents !== null && a.amountCents > 0)

--- a/packages/web/src/components/donations/receipt-preview-button.tsx
+++ b/packages/web/src/components/donations/receipt-preview-button.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Receipt } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { DonationService } from "@/services/DonationService";
+
+interface ReceiptPreviewButtonProps {
+  donationId: string;
+}
+
+export function ReceiptPreviewButton({ donationId }: ReceiptPreviewButtonProps) {
+  const t = useTranslations("donations.detail");
+  const [loading, setLoading] = useState(false);
+
+  async function handlePreview() {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const url = await DonationService.getDonationReceiptUrl(createClientApiClient(), donationId);
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      if (err instanceof ApiProblem && err.status === 404) {
+        toast.warning(t("receipt.pending"));
+      } else {
+        toast.error(t("receipt.error"));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Button type="button" variant="secondary" size="sm" onClick={handlePreview} disabled={loading}>
+      <Receipt size={16} aria-hidden="true" />
+      {loading ? t("actions.generatingReceipt") : t("actions.previewReceipt")}
+    </Button>
+  );
+}

--- a/packages/web/src/models/donation.ts
+++ b/packages/web/src/models/donation.ts
@@ -46,8 +46,53 @@ export interface DonationListQuery {
   amountMax?: number;
 }
 
+export interface DonationAllocation {
+  id: string;
+  fundId: string;
+  amountCents: number;
+}
+
+export interface DonationAllocationInput {
+  fundId: string;
+  amountCents: number;
+}
+
+export interface DonationDetail extends Donation {
+  constituent: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+  };
+  allocations: DonationAllocation[];
+}
+
+export interface DonationDetailResponse {
+  data: DonationDetail;
+}
+
+export interface DonationCreateInput {
+  constituentId: string;
+  amountCents: number;
+  currency?: string;
+  campaignId?: string;
+  paymentMethod?: string;
+  paymentRef?: string;
+  donatedAt?: string;
+  fiscalYear?: number;
+  allocations?: DonationAllocationInput[];
+}
+
+export interface DonationReceiptUrl {
+  url: string;
+}
+
 export function donationDonorName(row: DonationListRow): string | null {
   if (!row.constituent) return null;
   const name = `${row.constituent.firstName} ${row.constituent.lastName}`.trim();
   return name.length > 0 ? name : null;
+}
+
+export function donationDetailDonorName(detail: DonationDetail): string {
+  return `${detail.constituent.firstName} ${detail.constituent.lastName}`.trim();
 }

--- a/packages/web/src/services/DonationService.ts
+++ b/packages/web/src/services/DonationService.ts
@@ -1,5 +1,14 @@
 import type { ApiClient } from "@/lib/api";
-import type { DonationListQuery, DonationListResponse, DonationListRow } from "@/models/donation";
+import type {
+  Donation,
+  DonationCreateInput,
+  DonationDetail,
+  DonationDetailResponse,
+  DonationListQuery,
+  DonationListResponse,
+  DonationListRow,
+  DonationReceiptUrl,
+} from "@/models/donation";
 
 /**
  * DonationService — ADR-011 Layer 2 (services).
@@ -31,6 +40,25 @@ export const DonationService = {
       pagination: response.pagination,
     };
   },
+
+  async getDonation(client: ApiClient, id: string): Promise<DonationDetail> {
+    const response = await client.get<DonationDetailResponse>(
+      `/v1/donations/${encodeURIComponent(id)}`,
+    );
+    return response.data;
+  },
+
+  async createDonation(client: ApiClient, input: DonationCreateInput): Promise<Donation> {
+    const response = await client.post<{ data: Donation }>("/v1/donations", toRequestBody(input));
+    return response.data;
+  },
+
+  async getDonationReceiptUrl(client: ApiClient, id: string): Promise<string> {
+    const response = await client.get<{ data: DonationReceiptUrl }>(
+      `/v1/donations/${encodeURIComponent(id)}/receipt`,
+    );
+    return response.data.url;
+  },
 };
 
 function mapDonationRow(raw: DonationListRow): DonationListRow {
@@ -52,4 +80,28 @@ function mapDonationRow(raw: DonationListRow): DonationListRow {
       : null,
     receiptStatus: raw.receiptStatus,
   };
+}
+
+/**
+ * Normalize the form payload for the API: drop empty-string optionals so
+ * they don't fail the API's `minLength`/`format` constraints, and omit an
+ * empty allocations list so the server treats the donation as unallocated.
+ */
+function toRequestBody(input: DonationCreateInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    constituentId: input.constituentId,
+    amountCents: input.amountCents,
+  };
+  if (input.currency) body.currency = input.currency;
+  if (input.campaignId) body.campaignId = input.campaignId;
+  if (input.paymentMethod) body.paymentMethod = input.paymentMethod;
+  if (input.paymentRef) body.paymentRef = input.paymentRef;
+  if (input.donatedAt) body.donatedAt = input.donatedAt;
+  if (input.fiscalYear !== undefined && input.fiscalYear !== null) {
+    body.fiscalYear = input.fiscalYear;
+  }
+  if (input.allocations && input.allocations.length > 0) {
+    body.allocations = input.allocations;
+  }
+  return body;
 }


### PR DESCRIPTION
Closes #41 (PR-B7 only)

## Summary
Implements the manual entry form for incoming donations and the detailed transaction view with direct access to auto-generated Tax Receipts (PDFs).

## What's included
- **API Services (ADR-011)**: Added `getDonation`, `createDonation`, and `getDonationReceiptUrl` to the Frontend `DonationService.ts`.
- **New Donation Form (`/(app)/donations/new`)**:
  - Validated by TypeBox (`DonationCreateSchema`) on blur.
  - **Constituent Picker**: Built an intelligent Autocomplete combobox using `Command` (`cmdk`). It lazily fetches search results via `ConstituentService.listConstituents({ search })` so users can easily attach a donation to a donor name.
  - **Fund Allocations**: Implemented a dynamic `useFieldArray` letting the user split a single 100€ donation into multiple internal accounting funds (e.g. 50€ to Operations, 50€ to Emergency).
  - Amount coercion correctly scales Euros inputs to `amountCents` for the backend.
- **Donation Detail View (`/(app)/donations/[id]`)**:
  - Server-rendered summary cards showing the Donor Name, Amount, Campaign, Date, and Payment Method.
  - Lists the internal fund allocations below.
- **Receipt Preview Button**: 
  - Placed on the detail view. 
  - Clicking calls `GET /v1/donations/:id/receipt`.
  - If the Outbox/Worker hasn't finished rendering the PDF yet (404), displays a Toast `Receipt is still being generated`.
  - If generated, opens the presigned S3/MinIO secure URL in a new browser tab for immediate download!

Tests, linter, and typecheck are 100% green. 🚀

🤖 Authored by Claude CLI