### PR TITLE
fix(api): define __dirname in ESM for i18n file loader

### DIFF
--- a/packages/api/src/lib/i18n.ts
+++ b/packages/api/src/lib/i18n.ts
@@ -1,3 +1,9 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 /**
  * Backend i18n helper — ADR-015.
  *


### PR DESCRIPTION
Fixes `__dirname is not defined` crash in ESM.