### PR TITLE
feat(web): implement main dashboard with KPI widgets

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -118,9 +118,51 @@
     }
   },
   "dashboard": {
-    "greeting": "Hello{name, select, empty {} other {, {name}}}",
+    "greeting": "Good Morning{name, select, empty {} other {, {name}}}",
     "subtitle": "Here is your organisation's activity today.",
-    "placeholder": "Dashboard content under construction (Sprint 4, PR-C1)."
+    "viewAll": "View all",
+    "stats": {
+      "ariaLabel": "Organisation key performance indicators",
+      "totalRaised": "Total raised",
+      "totalRaisedHint": "Based on the latest recorded donations.",
+      "activeCampaigns": "Active campaigns",
+      "activeCampaignsHint": "Campaigns currently marked active.",
+      "donors": "Donors",
+      "newDonorsThisMonth": "{count, plural, =0 {No new donors this month} one {# new donor this month} other {# new donors this month}}",
+      "grantDeadlines": "Grant deadlines",
+      "noGrantDeadlinesValue": "0",
+      "noGrantDeadlinesHint": "Grant tracking is coming in a later sprint."
+    },
+    "recentDonations": {
+      "title": "Recent donations",
+      "empty": "No donations recorded yet.",
+      "anonymous": "Anonymous donor"
+    },
+    "campaigns": {
+      "title": "Active campaigns",
+      "empty": "No active campaigns yet.",
+      "activeSince": "Active since {date}",
+      "progressWithGoal": "{progress}% of {goal}",
+      "progressWithoutGoal": "{donations, plural, =0 {No donations yet} one {# donation recorded} other {# donations recorded}}"
+    },
+    "quickActions": {
+      "title": "Quick actions",
+      "description": "Create the next record without leaving the dashboard.",
+      "newDonation": "New Donation",
+      "newConstituent": "New Constituent",
+      "newCampaign": "New Campaign"
+    },
+    "aiSuggestion": {
+      "title": "AI suggestion",
+      "body": "Review donors who gave last spring but have not contributed this year. A short personal note could recover momentum before the next campaign."
+    },
+    "onboarding": {
+      "title": "Onboarding checklist",
+      "description": "Set up the basics for a working fundraising workspace.",
+      "addConstituents": "Add your first constituents",
+      "recordDonation": "Record your first donation",
+      "launchCampaign": "Launch an active campaign"
+    }
   },
   "donations": {
     "title": "Donations",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -120,7 +120,49 @@
   "dashboard": {
     "greeting": "Bonjour{name, select, empty {} other {, {name}}}",
     "subtitle": "Voici l'activité de votre organisation aujourd'hui.",
-    "placeholder": "Contenu du tableau de bord en construction (Sprint 4, PR-C1)."
+    "viewAll": "Tout voir",
+    "stats": {
+      "ariaLabel": "Indicateurs clés de l'organisation",
+      "totalRaised": "Total collecté",
+      "totalRaisedHint": "Basé sur les derniers dons enregistrés.",
+      "activeCampaigns": "Campagnes actives",
+      "activeCampaignsHint": "Campagnes actuellement marquées comme actives.",
+      "donors": "Donateurs",
+      "newDonorsThisMonth": "{count, plural, =0 {Aucun nouveau donateur ce mois-ci} one {# nouveau donateur ce mois-ci} other {# nouveaux donateurs ce mois-ci}}",
+      "grantDeadlines": "Échéances de subventions",
+      "noGrantDeadlinesValue": "0",
+      "noGrantDeadlinesHint": "Le suivi des subventions arrivera dans un sprint ultérieur."
+    },
+    "recentDonations": {
+      "title": "Dons récents",
+      "empty": "Aucun don enregistré pour l'instant.",
+      "anonymous": "Donateur anonyme"
+    },
+    "campaigns": {
+      "title": "Campagnes actives",
+      "empty": "Aucune campagne active pour l'instant.",
+      "activeSince": "Active depuis le {date}",
+      "progressWithGoal": "{progress}% de {goal}",
+      "progressWithoutGoal": "{donations, plural, =0 {Aucun don pour l'instant} one {# don enregistré} other {# dons enregistrés}}"
+    },
+    "quickActions": {
+      "title": "Actions rapides",
+      "description": "Créez le prochain enregistrement sans quitter le tableau de bord.",
+      "newDonation": "Nouveau don",
+      "newConstituent": "Nouveau constituant",
+      "newCampaign": "Nouvelle campagne"
+    },
+    "aiSuggestion": {
+      "title": "Suggestion IA",
+      "body": "Passez en revue les donateurs qui ont donné au printemps dernier mais pas cette année. Un court message personnel peut relancer l'élan avant la prochaine campagne."
+    },
+    "onboarding": {
+      "title": "Checklist d'intégration",
+      "description": "Configurez les bases d'un espace de collecte opérationnel.",
+      "addConstituents": "Ajouter vos premiers constituants",
+      "recordDonation": "Enregistrer votre premier don",
+      "launchCampaign": "Lancer une campagne active"
+    }
   },
   "donations": {
     "title": "Dons",

--- a/packages/web/src/app/(app)/dashboard/page.tsx
+++ b/packages/web/src/app/(app)/dashboard/page.tsx
@@ -1,28 +1,354 @@
-import { getTranslations } from "next-intl/server";
+import { CalendarClock, CheckCircle2, Circle, Lightbulb, Plus } from "lucide-react";
+import Link from "next/link";
+import { getLocale, getTranslations } from "next-intl/server";
 
+import { Button } from "@/components/ui/button";
+import { ApiProblem } from "@/lib/api";
+import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
+import { formatCurrency, formatDate, formatNumber } from "@/lib/format";
+import type { Campaign, CampaignStats } from "@/models/campaign";
+import type { ConstituentListResponse } from "@/models/constituent";
+import type { DonationListRow } from "@/models/donation";
+import { donationDonorName } from "@/models/donation";
+import { CampaignService } from "@/services/CampaignService";
+import { ConstituentService } from "@/services/ConstituentService";
+import { DonationService } from "@/services/DonationService";
+
+const RECENT_DONATIONS_LIMIT = 5;
+const KPI_SAMPLE_LIMIT = 100;
+
+type DashboardT = Awaited<ReturnType<typeof getTranslations>>;
+
+interface CampaignWithStats {
+  campaign: Campaign;
+  stats: CampaignStats | null;
+}
 
 /**
  * Dashboard page — protected, requires authentication.
  * The app shell (sidebar, topbar) is provided by the (app) layout.
- * Placeholder for Sprint 4 PR-C1 implementation.
  */
 export default async function DashboardPage() {
   const auth = await requireAuth();
   const t = await getTranslations("dashboard");
+  const locale = await getLocale();
+  const client = await createServerApiClient();
+
+  const [recentDonations, kpiDonations, donorResult, activeCampaigns] = await Promise.all([
+    getSafeData(() =>
+      DonationService.listDonations(client, { page: 1, perPage: RECENT_DONATIONS_LIMIT }),
+    ),
+    getSafeData(() => DonationService.listDonations(client, { page: 1, perPage: KPI_SAMPLE_LIMIT })),
+    getSafeData(() =>
+      ConstituentService.listConstituents(client, {
+        page: 1,
+        perPage: KPI_SAMPLE_LIMIT,
+        type: "donor",
+      }),
+    ),
+    getSafeData(() =>
+      CampaignService.listCampaigns(client, { page: 1, perPage: 5, status: "active" }),
+    ),
+  ]);
+
+  const activeCampaignStats = await getActiveCampaignStats(activeCampaigns?.data ?? []);
+  const totalRaisedCents = (kpiDonations?.data ?? []).reduce(
+    (sum, donation) => sum + donation.amountCents,
+    0,
+  );
+  const primaryCurrency = kpiDonations?.data[0]?.currency ?? "EUR";
+  const newDonorsThisMonth = countCreatedThisMonth(donorResult?.data ?? []);
+  const activeCampaignCount = activeCampaigns?.pagination.total ?? 0;
 
   return (
-    <>
-      <div className="mb-8">
-        <h1 className="font-heading text-5xl font-normal leading-tight tracking-tight text-on-surface">
-          {t("greeting", { name: auth.firstName ?? "empty" })}
+    <div className="space-y-8">
+      <div>
+        <h1 className="font-heading text-5xl font-normal leading-tight text-on-surface">
+          {t("greeting", { name: auth.firstName ?? "" })}
         </h1>
         <p className="mt-2 text-lg text-on-surface-variant">{t("subtitle")}</p>
       </div>
 
-      <div className="rounded-2xl bg-surface-container-lowest p-8 shadow-card">
-        <p className="text-sm text-text-secondary">{t("placeholder")}</p>
+      <section
+        aria-label={t("stats.ariaLabel")}
+        className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"
+      >
+        <StatCard
+          label={t("stats.totalRaised")}
+          value={formatCurrency(totalRaisedCents, locale, primaryCurrency)}
+          description={t("stats.totalRaisedHint")}
+          valueClassName="font-mono"
+        />
+        <StatCard
+          label={t("stats.activeCampaigns")}
+          value={formatNumber(activeCampaignCount, locale)}
+          description={t("stats.activeCampaignsHint")}
+        />
+        <StatCard
+          label={t("stats.donors")}
+          value={formatNumber(donorResult?.pagination.total ?? 0, locale)}
+          description={t("stats.newDonorsThisMonth", { count: newDonorsThisMonth })}
+        />
+        <StatCard
+          label={t("stats.grantDeadlines")}
+          value={t("stats.noGrantDeadlinesValue")}
+          description={t("stats.noGrantDeadlinesHint")}
+        />
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.65fr)]">
+        <section className="rounded-md bg-surface-container-lowest p-6 shadow-card">
+          <SectionHeader
+            title={t("recentDonations.title")}
+            actionHref="/donations"
+            actionLabel={t("viewAll")}
+          />
+          <div className="mt-4 divide-y divide-outline-variant/50">
+            {(recentDonations?.data ?? []).length > 0 ? (
+              recentDonations?.data.map((donation) => (
+                <DonationFeedItem key={donation.id} donation={donation} t={t} locale={locale} />
+              ))
+            ) : (
+              <p className="py-6 text-sm text-on-surface-variant">{t("recentDonations.empty")}</p>
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-md bg-surface-container-lowest p-6 shadow-card">
+          <SectionHeader
+            title={t("quickActions.title")}
+            description={t("quickActions.description")}
+          />
+          <div className="mt-4 grid gap-3">
+            <QuickAction href="/donations/new" label={t("quickActions.newDonation")} />
+            <QuickAction href="/constituents/new" label={t("quickActions.newConstituent")} />
+            <QuickAction href="/campaigns/new" label={t("quickActions.newCampaign")} />
+          </div>
+        </section>
       </div>
-    </>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.65fr)]">
+        <section className="rounded-md bg-surface-container-lowest p-6 shadow-card">
+          <SectionHeader
+            title={t("campaigns.title")}
+            actionHref="/campaigns"
+            actionLabel={t("viewAll")}
+          />
+          <div className="mt-5 space-y-4">
+            {activeCampaignStats.length > 0 ? (
+              activeCampaignStats.map((item) => (
+                <CampaignProgressItem key={item.campaign.id} item={item} t={t} locale={locale} />
+              ))
+            ) : (
+              <p className="text-sm text-on-surface-variant">{t("campaigns.empty")}</p>
+            )}
+          </div>
+        </section>
+
+        <div className="space-y-6">
+          <section className="rounded-md border border-primary/20 bg-ai-bg p-6 shadow-card">
+            <div className="flex items-center gap-2 text-ai-text">
+              <Lightbulb size={18} aria-hidden="true" />
+              <h2 className="font-heading text-xl leading-tight">{t("aiSuggestion.title")}</h2>
+            </div>
+            <p className="mt-3 text-sm leading-relaxed text-on-surface">{t("aiSuggestion.body")}</p>
+          </section>
+
+          <section className="rounded-md bg-surface-container-lowest p-6 shadow-card">
+            <SectionHeader title={t("onboarding.title")} description={t("onboarding.description")} />
+            <ul className="mt-4 space-y-3">
+              <ChecklistItem
+                complete={Boolean(donorResult?.pagination.total)}
+                label={t("onboarding.addConstituents")}
+              />
+              <ChecklistItem
+                complete={Boolean(recentDonations?.pagination.total)}
+                label={t("onboarding.recordDonation")}
+              />
+              <ChecklistItem complete={Boolean(activeCampaignCount)} label={t("onboarding.launchCampaign")} />
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+
+  async function getActiveCampaignStats(campaigns: Campaign[]): Promise<CampaignWithStats[]> {
+    return Promise.all(
+      campaigns.map(async (campaign) => ({
+        campaign,
+        stats: await getSafeData(() => CampaignService.getCampaignStats(client, campaign.id)),
+      })),
+    );
+  }
+}
+
+async function getSafeData<T>(loader: () => Promise<T>): Promise<T | null> {
+  try {
+    return await loader();
+  } catch (err) {
+    if (err instanceof ApiProblem && (err.status === 401 || err.status === 403)) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+function countCreatedThisMonth(constituents: ConstituentListResponse["data"]) {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), 1);
+  return constituents.filter((constituent) => new Date(constituent.createdAt) >= start).length;
+}
+
+function SectionHeader({
+  title,
+  description,
+  actionHref,
+  actionLabel,
+}: {
+  title: string;
+  description?: string;
+  actionHref?: string;
+  actionLabel?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h2 className="font-heading text-xl leading-tight text-on-surface">{title}</h2>
+        {description ? (
+          <p className="mt-1 text-sm text-on-surface-variant">{description}</p>
+        ) : null}
+      </div>
+      {actionHref && actionLabel ? (
+        <Button asChild variant="ghost" size="sm">
+          <Link href={actionHref}>{actionLabel}</Link>
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  description,
+  valueClassName,
+}: {
+  label: string;
+  value: string;
+  description: string;
+  valueClassName?: string;
+}) {
+  return (
+    <article className="min-h-36 rounded-md bg-surface-container-lowest p-5 shadow-card">
+      <p className="text-sm font-medium text-on-surface-variant">{label}</p>
+      <p
+        className={`mt-3 font-heading text-4xl font-normal leading-tight text-on-surface ${valueClassName ?? ""}`.trim()}
+      >
+        {value}
+      </p>
+      <p className="mt-2 text-sm text-on-surface-variant">{description}</p>
+    </article>
+  );
+}
+
+function DonationFeedItem({
+  donation,
+  t,
+  locale,
+}: {
+  donation: DonationListRow;
+  t: DashboardT;
+  locale: string;
+}) {
+  const donorName = donationDonorName(donation) ?? t("recentDonations.anonymous");
+
+  return (
+    <Link
+      href={`/donations/${donation.id}`}
+      className="grid gap-2 py-3 transition-colors hover:text-primary sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+    >
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-on-surface">{donorName}</p>
+        <p className="text-xs text-on-surface-variant">
+          {formatDate(donation.donatedAt, locale, "medium")}
+        </p>
+      </div>
+      <span className="font-mono text-sm font-semibold tabular-nums text-on-surface">
+        {formatCurrency(donation.amountCents, locale, donation.currency)}
+      </span>
+    </Link>
+  );
+}
+
+function QuickAction({ href, label }: { href: string; label: string }) {
+  return (
+    <Button asChild variant="secondary" className="justify-start">
+      <Link href={href}>
+        <Plus size={16} aria-hidden="true" />
+        {label}
+      </Link>
+    </Button>
+  );
+}
+
+function CampaignProgressItem({
+  item,
+  t,
+  locale,
+}: {
+  item: CampaignWithStats;
+  t: DashboardT;
+  locale: string;
+}) {
+  const { campaign, stats } = item;
+  const raisedCents = stats?.totalRaisedCents ?? 0;
+  const goalCents = campaign.costCents ?? 0;
+  const progress = goalCents > 0 ? Math.min(Math.round((raisedCents / goalCents) * 100), 100) : 0;
+
+  return (
+    <article className="rounded-md border border-outline-variant/60 p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-on-surface">{campaign.name}</h3>
+          <p className="mt-1 flex items-center gap-1 text-xs text-on-surface-variant">
+            <CalendarClock size={14} aria-hidden="true" />
+            {t("campaigns.activeSince", { date: formatDate(campaign.createdAt, locale, "medium") })}
+          </p>
+        </div>
+        <span className="font-mono text-sm font-semibold text-on-surface">
+          {formatCurrency(raisedCents, locale)}
+        </span>
+      </div>
+      <div className="mt-4 h-2 overflow-hidden rounded-md bg-surface-container">
+        <div className="h-full rounded-md bg-primary" style={{ width: `${progress}%` }} />
+      </div>
+      <p className="mt-2 text-xs text-on-surface-variant">
+        {goalCents > 0
+          ? t("campaigns.progressWithGoal", {
+              progress,
+              goal: formatCurrency(goalCents, locale),
+            })
+          : t("campaigns.progressWithoutGoal", {
+              donations: stats?.donationCount ?? 0,
+            })}
+      </p>
+    </article>
+  );
+}
+
+function ChecklistItem({ complete, label }: { complete: boolean; label: string }) {
+  const Icon = complete ? CheckCircle2 : Circle;
+
+  return (
+    <li className="flex items-start gap-3 text-sm text-on-surface">
+      <Icon
+        size={18}
+        aria-hidden="true"
+        className={complete ? "mt-0.5 shrink-0 text-primary" : "mt-0.5 shrink-0 text-outline"}
+      />
+      <span>{label}</span>
+    </li>
   );
 }

--- a/packages/web/src/app/(app)/dashboard/page.tsx
+++ b/packages/web/src/app/(app)/dashboard/page.tsx
@@ -39,7 +39,9 @@ export default async function DashboardPage() {
     getSafeData(() =>
       DonationService.listDonations(client, { page: 1, perPage: RECENT_DONATIONS_LIMIT }),
     ),
-    getSafeData(() => DonationService.listDonations(client, { page: 1, perPage: KPI_SAMPLE_LIMIT })),
+    getSafeData(() =>
+      DonationService.listDonations(client, { page: 1, perPage: KPI_SAMPLE_LIMIT }),
+    ),
     getSafeData(() =>
       ConstituentService.listConstituents(client, {
         page: 1,
@@ -156,7 +158,10 @@ export default async function DashboardPage() {
           </section>
 
           <section className="rounded-md bg-surface-container-lowest p-6 shadow-card">
-            <SectionHeader title={t("onboarding.title")} description={t("onboarding.description")} />
+            <SectionHeader
+              title={t("onboarding.title")}
+              description={t("onboarding.description")}
+            />
             <ul className="mt-4 space-y-3">
               <ChecklistItem
                 complete={Boolean(donorResult?.pagination.total)}
@@ -166,7 +171,10 @@ export default async function DashboardPage() {
                 complete={Boolean(recentDonations?.pagination.total)}
                 label={t("onboarding.recordDonation")}
               />
-              <ChecklistItem complete={Boolean(activeCampaignCount)} label={t("onboarding.launchCampaign")} />
+              <ChecklistItem
+                complete={Boolean(activeCampaignCount)}
+                label={t("onboarding.launchCampaign")}
+              />
             </ul>
           </section>
         </div>
@@ -216,9 +224,7 @@ function SectionHeader({
     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div>
         <h2 className="font-heading text-xl leading-tight text-on-surface">{title}</h2>
-        {description ? (
-          <p className="mt-1 text-sm text-on-surface-variant">{description}</p>
-        ) : null}
+        {description ? <p className="mt-1 text-sm text-on-surface-variant">{description}</p> : null}
       </div>
       {actionHref && actionLabel ? (
         <Button asChild variant="ghost" size="sm">

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -590,6 +590,7 @@ function parseDateString(val: string): string | undefined {
   if (parts.length === 3) {
     // assume DD/MM/YYYY
     const [d, m, y] = parts;
+    if (!d || !m || !y) return undefined;
     const yStr = y.length === 2 ? `20${y}` : y;
     const iso = `${yStr}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T00:00:00Z`;
     const dt = new Date(iso);

--- a/packages/web/src/models/campaign.ts
+++ b/packages/web/src/models/campaign.ts
@@ -1,0 +1,38 @@
+import type { Pagination } from "@/models/constituent";
+
+export type CampaignType = "nominative_postal" | "door_drop" | "digital";
+export type CampaignStatus = "draft" | "active" | "closed";
+
+export interface Campaign {
+  id: string;
+  orgId: string;
+  name: string;
+  type: CampaignType;
+  status: CampaignStatus;
+  parentId: string | null;
+  costCents: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CampaignListQuery {
+  page?: number;
+  perPage?: number;
+  status?: CampaignStatus;
+}
+
+export interface CampaignListResponse {
+  data: Campaign[];
+  pagination: Pagination;
+}
+
+export interface CampaignStats {
+  campaignId: string;
+  totalRaisedCents: number;
+  donationCount: number;
+  uniqueDonors: number;
+}
+
+export interface CampaignStatsResponse {
+  data: CampaignStats;
+}

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -1,0 +1,69 @@
+import type { ApiClient } from "@/lib/api";
+import type {
+  Campaign,
+  CampaignListQuery,
+  CampaignListResponse,
+  CampaignStats,
+  CampaignStatsResponse,
+} from "@/models/campaign";
+
+/**
+ * CampaignService — ADR-011 Layer 2 (services).
+ *
+ * The API list endpoint does not expose a status query yet. Keep status
+ * filtering in this web adapter for dashboard reads until the API contract
+ * grows that filter.
+ */
+export const CampaignService = {
+  async listCampaigns(
+    client: ApiClient,
+    query: CampaignListQuery = {},
+  ): Promise<CampaignListResponse> {
+    const page = query.page ?? 1;
+    const perPage = query.perPage ?? 20;
+    const requestPerPage = query.status ? Math.max(perPage, 100) : perPage;
+
+    const response = await client.get<CampaignListResponse>("/v1/campaigns", {
+      params: { page, perPage: requestPerPage },
+    });
+
+    const data = response.data.map(mapCampaign);
+
+    if (!query.status) {
+      return { data, pagination: response.pagination };
+    }
+
+    const filtered = data.filter((campaign) => campaign.status === query.status);
+
+    return {
+      data: filtered.slice(0, perPage),
+      pagination: {
+        page,
+        perPage,
+        total: filtered.length,
+        totalPages: Math.ceil(filtered.length / perPage),
+      },
+    };
+  },
+
+  async getCampaignStats(client: ApiClient, id: string): Promise<CampaignStats> {
+    const response = await client.get<CampaignStatsResponse>(
+      `/v1/campaigns/${encodeURIComponent(id)}/stats`,
+    );
+    return response.data;
+  },
+};
+
+function mapCampaign(raw: Campaign): Campaign {
+  return {
+    id: raw.id,
+    orgId: raw.orgId,
+    name: raw.name,
+    type: raw.type,
+    status: raw.status,
+    parentId: raw.parentId,
+    costCents: raw.costCents,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}


### PR DESCRIPTION
Resolves #42 (PR-C1).

## Changes
- Implemented the main dashboard (`page.tsx`) using React Server Components.
- Added KPI widgets (Total raised, Active campaigns, Donors count).
- Added Recent Donations feed via `DonationService`.
- Added Active Campaigns progress tracker via `CampaignService`.
- Added i18n support for Dashboard UI (English and French).

## Architecture Notes
- Uses bounded server-side aggregation for KPIs directly in the web layer adapter, compensating for the current lack of a dedicated API summary endpoint.