### PR TITLE
feat(web): implement campaigns list view

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -325,6 +325,40 @@
       "new": "New constituent"
     }
   },
+  "campaigns": {
+    "title": "Campaigns",
+    "breadcrumbRoot": "Dashboard",
+    "subtitleWithCount": "{count, plural, =0 {No campaigns yet} one {# campaign} other {# campaigns}}",
+    "subtitleEmpty": "No campaigns yet.",
+    "empty": {
+      "title": "No campaigns to show",
+      "description": "Create a campaign to track outreach and donations.",
+      "seedHint": "Create a campaign to track outreach and donations."
+    },
+    "columns": {
+      "name": "Name",
+      "type": "Type",
+      "status": "Status",
+      "progress": "Progress",
+      "date": "Date"
+    },
+    "status": {
+      "draft": "Draft",
+      "active": "Active",
+      "paused": "Paused",
+      "closed": "Closed"
+    },
+    "types": {
+      "nominative_postal": "Nominative postal",
+      "door_drop": "Door drop",
+      "digital": "Digital"
+    },
+    "actions": {
+      "new": "New Campaign"
+    },
+    "noGoal": "No goal",
+    "progressAria": "{raised} raised of {goal}"
+  },
   "constituentForm": {
     "createTitle": "New constituent",
     "createSubtitle": "Add a new constituent to your organisation.",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -325,6 +325,40 @@
       "new": "Nouveau constituant"
     }
   },
+  "campaigns": {
+    "title": "Campagnes",
+    "breadcrumbRoot": "Tableau de bord",
+    "subtitleWithCount": "{count, plural, =0 {Aucune campagne} one {# campagne} other {# campagnes}}",
+    "subtitleEmpty": "Aucune campagne pour l'instant.",
+    "empty": {
+      "title": "Aucune campagne à afficher",
+      "description": "Créez une campagne pour suivre les communications et les dons.",
+      "seedHint": "Créez une campagne pour suivre les communications et les dons."
+    },
+    "columns": {
+      "name": "Nom",
+      "type": "Type",
+      "status": "Statut",
+      "progress": "Progression",
+      "date": "Date"
+    },
+    "status": {
+      "draft": "Brouillon",
+      "active": "Active",
+      "paused": "En pause",
+      "closed": "Clôturée"
+    },
+    "types": {
+      "nominative_postal": "Postal nominatif",
+      "door_drop": "Boîtage",
+      "digital": "Digital"
+    },
+    "actions": {
+      "new": "Nouvelle campagne"
+    },
+    "noGoal": "Aucun objectif",
+    "progressAria": "{raised} collectés sur {goal}"
+  },
   "constituentForm": {
     "createTitle": "Nouveau constituant",
     "createSubtitle": "Ajoutez un nouveau constituant à votre organisation.",

--- a/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
+++ b/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { Megaphone } from "lucide-react";
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { useCallback, useMemo } from "react";
+
+import { EmptyState } from "@/components/shared/empty-state";
+import { Badge } from "@/components/ui/badge";
+import { DataTable, type DataTablePagination } from "@/components/ui/data-table";
+import { formatCurrency, formatDate } from "@/lib/format";
+import type { Campaign, CampaignStats, CampaignStatus, CampaignType } from "@/models/campaign";
+
+type BadgeVariant = "success" | "warning" | "error" | "info" | "neutral";
+type CampaignListStatus = CampaignStatus | "paused";
+
+interface CampaignWithStats {
+  campaign: Campaign;
+  stats: CampaignStats | null;
+}
+
+const STATUS_VARIANTS: Record<CampaignListStatus, BadgeVariant> = {
+  draft: "neutral",
+  active: "success",
+  paused: "warning",
+  closed: "info",
+};
+
+const TYPE_VARIANTS: Record<CampaignType, BadgeVariant> = {
+  nominative_postal: "info",
+  door_drop: "warning",
+  digital: "success",
+};
+
+const CAMPAIGN_TYPES = new Set<CampaignType>(["nominative_postal", "door_drop", "digital"]);
+const CAMPAIGN_STATUSES = new Set<CampaignListStatus>(["draft", "active", "paused", "closed"]);
+
+interface CampaignsTableProps {
+  campaigns: CampaignWithStats[];
+  pagination: DataTablePagination;
+}
+
+function isCampaignType(value: string): value is CampaignType {
+  return CAMPAIGN_TYPES.has(value as CampaignType);
+}
+
+function isCampaignStatus(value: string): value is CampaignListStatus {
+  return CAMPAIGN_STATUSES.has(value as CampaignListStatus);
+}
+
+export function CampaignsTable({ campaigns, pagination }: CampaignsTableProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const locale = useLocale();
+  const t = useTranslations("campaigns");
+
+  const navigateToPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (page <= 1) {
+        params.delete("page");
+      } else {
+        params.set("page", String(page));
+      }
+      const query = params.toString();
+      router.push(query ? `${pathname}?${query}` : pathname);
+    },
+    [pathname, router, searchParams],
+  );
+
+  const columns = useMemo<ColumnDef<CampaignWithStats>[]>(
+    () => [
+      {
+        id: "name",
+        accessorFn: (row) => row.campaign.name,
+        header: () => t("columns.name"),
+        enableSorting: true,
+        cell: ({ row }) => {
+          const campaign = row.original.campaign;
+          return (
+            <Link
+              href={`/campaigns/${campaign.id}`}
+              onClick={(event) => event.stopPropagation()}
+              className="font-medium text-on-surface hover:text-primary hover:underline"
+            >
+              {campaign.name}
+            </Link>
+          );
+        },
+      },
+      {
+        id: "type",
+        accessorFn: (row) => row.campaign.type,
+        header: () => t("columns.type"),
+        enableSorting: true,
+        cell: ({ row }) => {
+          const type = String(row.original.campaign.type);
+          if (!isCampaignType(type)) {
+            return <Badge variant="neutral">{type}</Badge>;
+          }
+          return <Badge variant={TYPE_VARIANTS[type]}>{t(`types.${type}`)}</Badge>;
+        },
+      },
+      {
+        id: "status",
+        accessorFn: (row) => row.campaign.status,
+        header: () => t("columns.status"),
+        enableSorting: true,
+        cell: ({ row }) => {
+          const status = String(row.original.campaign.status);
+          if (!isCampaignStatus(status)) {
+            return <Badge variant="neutral">{status}</Badge>;
+          }
+          return <Badge variant={STATUS_VARIANTS[status]}>{t(`status.${status}`)}</Badge>;
+        },
+      },
+      {
+        id: "progress",
+        header: () => t("columns.progress"),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const { campaign, stats } = row.original;
+          const raisedCents = stats?.totalRaisedCents ?? 0;
+          const goalCents = campaign.costCents ?? 0;
+          const progress = goalCents > 0 ? Math.min((raisedCents / goalCents) * 100, 100) : 0;
+
+          return (
+            <div className="min-w-44">
+              <div className="flex items-baseline justify-between gap-3 text-sm">
+                <span className="font-mono font-semibold tabular-nums text-on-surface">
+                  {formatCurrency(raisedCents, locale)}
+                </span>
+                <span className="font-mono text-xs tabular-nums text-on-surface-variant">
+                  {goalCents > 0 ? formatCurrency(goalCents, locale) : "—"}
+                </span>
+              </div>
+              <div
+                className="mt-2 h-1.5 overflow-hidden rounded-md bg-surface-container"
+                aria-label={t("progressAria", {
+                  raised: formatCurrency(raisedCents, locale),
+                  goal: goalCents > 0 ? formatCurrency(goalCents, locale) : t("noGoal"),
+                })}
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={Math.round(progress)}
+              >
+                <div className="h-full rounded-md bg-primary" style={{ width: `${progress}%` }} />
+              </div>
+            </div>
+          );
+        },
+      },
+      {
+        id: "createdAt",
+        accessorFn: (row) => row.campaign.createdAt,
+        header: () => t("columns.date"),
+        enableSorting: true,
+        cell: ({ row }) => (
+          <span className="whitespace-nowrap text-on-surface-variant">
+            {formatDate(row.original.campaign.createdAt, locale, "short")}
+          </span>
+        ),
+      },
+    ],
+    [t, locale],
+  );
+
+  return (
+    <div className="transition-opacity duration-normal">
+      <DataTable
+        columns={columns}
+        data={campaigns}
+        pagination={pagination}
+        onPageChange={navigateToPage}
+        onRowClick={(row) => router.push(`/campaigns/${row.original.campaign.id}`)}
+        emptyState={
+          <EmptyState
+            icon={Megaphone}
+            title={t("empty.title")}
+            description={t("empty.description")}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/(app)/campaigns/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/page.tsx
@@ -1,0 +1,100 @@
+import { Megaphone, Plus } from "lucide-react";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+
+import { EmptyState } from "@/components/shared/empty-state";
+import { PageHeader } from "@/components/shared/page-header";
+import { Button } from "@/components/ui/button";
+import { ApiProblem } from "@/lib/api";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import type { CampaignListResponse } from "@/models/campaign";
+import { CampaignService } from "@/services/CampaignService";
+
+import { CampaignsTable } from "./campaigns-table";
+
+const DEFAULT_PER_PAGE = 20;
+const MAX_PER_PAGE = 100;
+
+interface CampaignsPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function parsePositiveInt(value: string | string[] | undefined, fallback: number, max?: number) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return max ? Math.min(parsed, max) : parsed;
+}
+
+export default async function CampaignsPage({ searchParams }: CampaignsPageProps) {
+  await requireAuth();
+  const params = await searchParams;
+  const t = await getTranslations("campaigns");
+
+  const page = parsePositiveInt(params.page, 1);
+  const perPage = parsePositiveInt(params.perPage, DEFAULT_PER_PAGE, MAX_PER_PAGE);
+
+  const client = await createServerApiClient();
+
+  let result: CampaignListResponse;
+  try {
+    result = await CampaignService.listCampaigns(client, { page, perPage });
+  } catch (err) {
+    if (err instanceof ApiProblem && (err.status === 401 || err.status === 403)) {
+      result = {
+        data: [],
+        pagination: { page, perPage, total: 0, totalPages: 0 },
+      };
+    } else {
+      throw err;
+    }
+  }
+
+  const campaignsWithStats = await Promise.all(
+    result.data.map(async (campaign) => ({
+      campaign,
+      stats: await getSafeData(() => CampaignService.getCampaignStats(client, campaign.id)),
+    })),
+  );
+  const hasAny = result.pagination.total > 0;
+
+  return (
+    <>
+      <PageHeader
+        title={t("title")}
+        description={
+          hasAny ? t("subtitleWithCount", { count: result.pagination.total }) : t("subtitleEmpty")
+        }
+        breadcrumbs={[{ label: t("breadcrumbRoot"), href: "/dashboard" }, { label: t("title") }]}
+        actions={
+          <Button asChild variant="primary" size="sm">
+            <Link href="/campaigns/new">
+              <Plus size={16} aria-hidden="true" />
+              {t("actions.new")}
+            </Link>
+          </Button>
+        }
+      />
+
+      {hasAny ? (
+        <CampaignsTable campaigns={campaignsWithStats} pagination={result.pagination} />
+      ) : (
+        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+          <EmptyState icon={Megaphone} title={t("empty.title")} description={t("empty.seedHint")} />
+        </div>
+      )}
+    </>
+  );
+}
+
+async function getSafeData<T>(loader: () => Promise<T>): Promise<T | null> {
+  try {
+    return await loader();
+  } catch (err) {
+    if (err instanceof ApiProblem && (err.status === 401 || err.status === 403)) {
+      return null;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
Resolves #42 (PR-C2).

## Changes
- Implemented the campaigns list view (`/(app)/campaigns/page.tsx`).
- Fetched and displayed campaigns using `CampaignService.listCampaigns`.
- Fetched individual campaign stats for progress bars.
- Displayed Name, Type, Status, Progress, and Date with corresponding formatting and accessible UI elements.
- Added English and French translations.

## Notes
- Progress bar computes current raised vs goal amounts.
- Badges indicate the status and type of the campaigns.