### PR TITLE
feat(web): implement campaign detail and edit views

### DIFF
--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -56,6 +56,21 @@ export const DonationCreateSchema = Type.Object({
   allocations: Type.Optional(Type.Array(DonationAllocationSchema)),
 });
 
+/** Schema for creating a new campaign */
+export const CampaignCreateSchema = Type.Object({
+  name: Type.String({ minLength: 1, maxLength: 255 }),
+  type: Type.Union([
+    Type.Literal("nominative_postal"),
+    Type.Literal("door_drop"),
+    Type.Literal("digital"),
+  ]),
+  parentId: Type.Optional(Type.Union([Type.String({ format: "uuid" }), Type.Null()])),
+  costCents: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+});
+
+/** Schema for updating a campaign (all fields optional) */
+export const CampaignUpdateSchema = Type.Partial(CampaignCreateSchema);
+
 /** Schema for list query parameters */
 export const PaginationQuerySchema = Type.Object({
   page: Type.Number({ minimum: 1, default: 1 }),
@@ -69,6 +84,8 @@ export type ConstituentCreate = Static<typeof ConstituentCreateSchema>;
 export type ConstituentUpdate = Static<typeof ConstituentUpdateSchema>;
 export type DonationCreate = Static<typeof DonationCreateSchema>;
 export type DonationAllocation = Static<typeof DonationAllocationSchema>;
+export type CampaignCreate = Static<typeof CampaignCreateSchema>;
+export type CampaignUpdate = Static<typeof CampaignUpdateSchema>;
 export type PaginationQuery = Static<typeof PaginationQuerySchema>;
 
 /** Validate, coerce, and apply defaults — throws on failure */

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -345,7 +345,6 @@
     "status": {
       "draft": "Draft",
       "active": "Active",
-      "paused": "Paused",
       "closed": "Closed"
     },
     "types": {
@@ -420,14 +419,14 @@
         "edit": "Edit",
         "activate": "Activate",
         "activating": "Activating…",
-        "pause": "Pause",
-        "pausing": "Pausing…",
+        "backToDraft": "Back to draft",
+        "returningToDraft": "Returning to draft…",
         "close": "Close",
         "closing": "Closing…",
         "error": "Could not update campaign status. Please try again.",
         "success": {
           "activate": "Campaign activated.",
-          "pause": "Campaign paused.",
+          "backToDraft": "Campaign moved back to draft.",
           "close": "Campaign closed."
         }
       },

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -357,7 +357,94 @@
       "new": "New Campaign"
     },
     "noGoal": "No goal",
-    "progressAria": "{raised} raised of {goal}"
+    "progressAria": "{raised} raised of {goal}",
+    "form": {
+      "createTitle": "New campaign",
+      "createSubtitle": "Set up a campaign with its type, parent relationship, and fundraising goal.",
+      "editTitle": "Edit campaign",
+      "editSubtitle": "Update the campaign name, structure, or target amount.",
+      "breadcrumbNew": "New",
+      "breadcrumbEdit": "Edit",
+      "sections": {
+        "identity": {
+          "title": "Identity",
+          "description": "Core details used to identify and classify this campaign."
+        },
+        "structure": {
+          "title": "Structure",
+          "description": "Parent campaign and target amount used for rollup and reporting."
+        }
+      },
+      "fields": {
+        "name": "Campaign name",
+        "namePlaceholder": "Spring appeal 2026",
+        "type": "Campaign type",
+        "parent": "Parent campaign",
+        "parentPlaceholder": "No parent campaign",
+        "parentHint": "Use a parent campaign to group related outreach.",
+        "parentLoading": "Loading available campaigns…",
+        "goal": "Goal amount",
+        "goalPlaceholder": "0.00",
+        "goalHint": "Shown as the fundraising target on the detail page."
+      },
+      "actions": {
+        "cancel": "Cancel",
+        "submitCreate": "Create campaign",
+        "submitEdit": "Save changes",
+        "submitting": "Saving…"
+      },
+      "errors": {
+        "validation": "Please correct the highlighted fields.",
+        "generic": "Something went wrong while saving. Please try again."
+      },
+      "success": {
+        "created": "Campaign created.",
+        "updated": "Changes saved."
+      }
+    },
+    "detail": {
+      "stats": {
+        "title": "Campaign stats",
+        "raised": "Raised",
+        "donors": "Donors",
+        "created": "Created",
+        "noGoal": "No goal",
+        "goalHint": "Goal: {goal}",
+        "donationsHint": "{count, plural, =0 {No donations yet} one {# donation recorded} other {# donations recorded}}",
+        "updatedHint": "Updated {date}"
+      },
+      "actions": {
+        "title": "Status actions",
+        "description": "Move this campaign between draft, active, and closed states.",
+        "back": "Back to campaigns",
+        "edit": "Edit",
+        "activate": "Activate",
+        "activating": "Activating…",
+        "pause": "Pause",
+        "pausing": "Pausing…",
+        "close": "Close",
+        "closing": "Closing…",
+        "error": "Could not update campaign status. Please try again.",
+        "success": {
+          "activate": "Campaign activated.",
+          "pause": "Campaign paused.",
+          "close": "Campaign closed."
+        }
+      },
+      "donations": {
+        "title": "Donation breakdown",
+        "subtitle": "{count, plural, =0 {No donations linked yet} one {# donation linked} other {# donations linked}}",
+        "empty": "No donations are linked to this campaign yet.",
+        "anonymousDonor": "Anonymous donor",
+        "noReference": "—",
+        "columns": {
+          "date": "Date",
+          "donor": "Donor",
+          "reference": "Reference",
+          "amount": "Amount"
+        }
+      }
+    }
   },
   "constituentForm": {
     "createTitle": "New constituent",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -345,7 +345,6 @@
     "status": {
       "draft": "Brouillon",
       "active": "Active",
-      "paused": "En pause",
       "closed": "Clôturée"
     },
     "types": {
@@ -420,14 +419,14 @@
         "edit": "Modifier",
         "activate": "Activer",
         "activating": "Activation…",
-        "pause": "Mettre en pause",
-        "pausing": "Mise en pause…",
+        "backToDraft": "Revenir au brouillon",
+        "returningToDraft": "Retour au brouillon…",
         "close": "Clôturer",
         "closing": "Clôture…",
         "error": "Impossible de mettre à jour le statut de la campagne. Réessayez.",
         "success": {
           "activate": "Campagne activée.",
-          "pause": "Campagne mise en pause.",
+          "backToDraft": "Campagne repassée en brouillon.",
           "close": "Campagne clôturée."
         }
       },

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -357,7 +357,94 @@
       "new": "Nouvelle campagne"
     },
     "noGoal": "Aucun objectif",
-    "progressAria": "{raised} collectés sur {goal}"
+    "progressAria": "{raised} collectés sur {goal}",
+    "form": {
+      "createTitle": "Nouvelle campagne",
+      "createSubtitle": "Créez une campagne avec son type, son rattachement et son objectif de collecte.",
+      "editTitle": "Modifier la campagne",
+      "editSubtitle": "Mettez à jour le nom, la structure ou le montant cible de la campagne.",
+      "breadcrumbNew": "Nouveau",
+      "breadcrumbEdit": "Modifier",
+      "sections": {
+        "identity": {
+          "title": "Identité",
+          "description": "Informations principales pour identifier et qualifier cette campagne."
+        },
+        "structure": {
+          "title": "Structure",
+          "description": "Campagne parente et montant cible utilisés pour le regroupement et le reporting."
+        }
+      },
+      "fields": {
+        "name": "Nom de la campagne",
+        "namePlaceholder": "Campagne de printemps 2026",
+        "type": "Type de campagne",
+        "parent": "Campagne parente",
+        "parentPlaceholder": "Aucune campagne parente",
+        "parentHint": "Utilisez une campagne parente pour regrouper des actions liées.",
+        "parentLoading": "Chargement des campagnes disponibles…",
+        "goal": "Montant cible",
+        "goalPlaceholder": "0,00",
+        "goalHint": "Affiché comme objectif de collecte sur la fiche campagne."
+      },
+      "actions": {
+        "cancel": "Annuler",
+        "submitCreate": "Créer la campagne",
+        "submitEdit": "Enregistrer les modifications",
+        "submitting": "Enregistrement…"
+      },
+      "errors": {
+        "validation": "Corrigez les champs en surbrillance.",
+        "generic": "Une erreur est survenue lors de l'enregistrement. Réessayez."
+      },
+      "success": {
+        "created": "Campagne créée.",
+        "updated": "Modifications enregistrées."
+      }
+    },
+    "detail": {
+      "stats": {
+        "title": "Statistiques de campagne",
+        "raised": "Collecté",
+        "donors": "Donateurs",
+        "created": "Créée",
+        "noGoal": "Aucun objectif",
+        "goalHint": "Objectif : {goal}",
+        "donationsHint": "{count, plural, =0 {Aucun don pour l'instant} one {# don enregistré} other {# dons enregistrés}}",
+        "updatedHint": "Mise à jour {date}"
+      },
+      "actions": {
+        "title": "Actions de statut",
+        "description": "Faites passer cette campagne entre les états brouillon, active et clôturée.",
+        "back": "Retour aux campagnes",
+        "edit": "Modifier",
+        "activate": "Activer",
+        "activating": "Activation…",
+        "pause": "Mettre en pause",
+        "pausing": "Mise en pause…",
+        "close": "Clôturer",
+        "closing": "Clôture…",
+        "error": "Impossible de mettre à jour le statut de la campagne. Réessayez.",
+        "success": {
+          "activate": "Campagne activée.",
+          "pause": "Campagne mise en pause.",
+          "close": "Campagne clôturée."
+        }
+      },
+      "donations": {
+        "title": "Répartition des dons",
+        "subtitle": "{count, plural, =0 {Aucun don lié pour l'instant} one {# don lié} other {# dons liés}}",
+        "empty": "Aucun don n'est encore lié à cette campagne.",
+        "anonymousDonor": "Donateur anonyme",
+        "noReference": "—",
+        "columns": {
+          "date": "Date",
+          "donor": "Donateur",
+          "reference": "Référence",
+          "amount": "Montant"
+        }
+      }
+    }
   },
   "constituentForm": {
     "createTitle": "Nouveau constituant",

--- a/packages/web/src/app/(app)/campaigns/[id]/donations-table.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/donations-table.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { Gift } from "lucide-react";
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { useCallback, useMemo, useTransition } from "react";
+
+import { EmptyState } from "@/components/shared/empty-state";
+import { DataTable, type DataTablePagination } from "@/components/ui/data-table";
+import { formatCurrency, formatDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { type DonationListRow, donationDonorName } from "@/models/donation";
+
+interface DonationsTableProps {
+  donations: DonationListRow[];
+  pagination: DataTablePagination;
+}
+
+export function DonationsTable({ donations, pagination }: DonationsTableProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const locale = useLocale();
+  const t = useTranslations("campaigns.detail.donations");
+
+  const navigateToPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (page <= 1) {
+        params.delete("page");
+      } else {
+        params.set("page", String(page));
+      }
+      const query = params.toString();
+      startTransition(() => {
+        router.push(query ? `${pathname}?${query}` : pathname);
+      });
+    },
+    [pathname, router, searchParams],
+  );
+
+  const columns = useMemo<ColumnDef<DonationListRow>[]>(
+    () => [
+      {
+        id: "donatedAt",
+        accessorKey: "donatedAt",
+        header: () => t("columns.date"),
+        cell: ({ row }) => (
+          <span className="whitespace-nowrap text-on-surface-variant">
+            {formatDate(row.original.donatedAt, locale, "medium")}
+          </span>
+        ),
+      },
+      {
+        id: "donor",
+        header: () => t("columns.donor"),
+        cell: ({ row }) => {
+          const donorName = donationDonorName(row.original) ?? t("anonymousDonor");
+          return (
+            <Link
+              href={`/donations/${row.original.id}`}
+              onClick={(event) => event.stopPropagation()}
+              className="font-medium text-on-surface hover:text-primary hover:underline"
+            >
+              {donorName}
+            </Link>
+          );
+        },
+      },
+      {
+        id: "reference",
+        accessorKey: "paymentRef",
+        header: () => t("columns.reference"),
+        cell: ({ row }) => (
+          <span className="text-on-surface-variant">
+            {row.original.paymentRef ?? t("noReference")}
+          </span>
+        ),
+      },
+      {
+        id: "amount",
+        accessorKey: "amountCents",
+        header: () => <span className="block text-right">{t("columns.amount")}</span>,
+        cell: ({ row }) => (
+          <span className="block text-right font-mono font-semibold tabular-nums text-on-surface">
+            {formatCurrency(row.original.amountCents, locale, row.original.currency)}
+          </span>
+        ),
+      },
+    ],
+    [locale, t],
+  );
+
+  return (
+    <div
+      className={cn("transition-opacity duration-normal", isPending ? "opacity-60" : "opacity-100")}
+      aria-busy={isPending || undefined}
+    >
+      <DataTable
+        columns={columns}
+        data={donations}
+        pagination={pagination}
+        onPageChange={navigateToPage}
+        onRowClick={(row) => router.push(`/donations/${row.original.id}`)}
+        emptyState={<EmptyState icon={Gift} title={t("title")} description={t("empty")} />}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/(app)/campaigns/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/edit/page.tsx
@@ -1,0 +1,51 @@
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { CampaignForm } from "@/components/campaigns/campaign-form";
+import { PageHeader } from "@/components/shared/page-header";
+import { ApiProblem } from "@/lib/api";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import type { Campaign } from "@/models/campaign";
+import { CampaignService } from "@/services/CampaignService";
+
+interface EditCampaignPageProps {
+  params: Promise<{ id: string }>;
+}
+
+async function fetchCampaignOrNotFound(id: string): Promise<Campaign> {
+  const client = await createServerApiClient();
+  try {
+    return await CampaignService.getCampaign(client, id);
+  } catch (err) {
+    if (err instanceof ApiProblem && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+}
+
+export default async function EditCampaignPage({ params }: EditCampaignPageProps) {
+  await requireAuth();
+  const { id } = await params;
+  const campaign = await fetchCampaignOrNotFound(id);
+
+  const t = await getTranslations("campaigns.form");
+  const tCampaigns = await getTranslations("campaigns");
+
+  return (
+    <>
+      <PageHeader
+        title={t("editTitle")}
+        description={t("editSubtitle")}
+        breadcrumbs={[
+          { label: tCampaigns("breadcrumbRoot"), href: "/dashboard" },
+          { label: tCampaigns("title"), href: "/campaigns" },
+          { label: campaign.name, href: `/campaigns/${campaign.id}` },
+          { label: t("breadcrumbEdit") },
+        ]}
+      />
+      <CampaignForm mode="edit" campaign={campaign} />
+    </>
+  );
+}

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -1,0 +1,261 @@
+import { ArrowLeft, Pencil } from "lucide-react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+
+import { CampaignStatusActions } from "@/components/campaigns/campaign-status-actions";
+import { PageHeader } from "@/components/shared/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ApiProblem } from "@/lib/api";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import { formatCurrency, formatDate, formatNumber } from "@/lib/format";
+import type { Campaign, CampaignStats } from "@/models/campaign";
+import type { DonationListRow } from "@/models/donation";
+import { donationDonorName } from "@/models/donation";
+import { CampaignService } from "@/services/CampaignService";
+import { DonationService } from "@/services/DonationService";
+
+interface CampaignDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+async function fetchCampaignOrNotFound(id: string): Promise<Campaign> {
+  const client = await createServerApiClient();
+  try {
+    return await CampaignService.getCampaign(client, id);
+  } catch (err) {
+    if (err instanceof ApiProblem && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+}
+
+export default async function CampaignDetailPage({ params }: CampaignDetailPageProps) {
+  await requireAuth();
+  const { id } = await params;
+  const client = await createServerApiClient();
+  const campaign = await fetchCampaignOrNotFound(id);
+
+  const [stats, donations, t, tCampaigns, tDonations, locale] = await Promise.all([
+    CampaignService.getCampaignStats(client, id),
+    DonationService.listDonations(client, { campaignId: id, perPage: 100 }),
+    getTranslations("campaigns.detail"),
+    getTranslations("campaigns"),
+    getTranslations("donations"),
+    getLocale(),
+  ]);
+
+  return (
+    <>
+      <PageHeader
+        title={campaign.name}
+        description={
+          <span className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={campaign.status} />
+            <Badge variant="info">{tCampaigns(`types.${campaign.type}`)}</Badge>
+          </span>
+        }
+        breadcrumbs={[
+          { label: tCampaigns("breadcrumbRoot"), href: "/dashboard" },
+          { label: tCampaigns("title"), href: "/campaigns" },
+          { label: campaign.name },
+        ]}
+        actions={
+          <>
+            <Button asChild variant="ghost" size="sm">
+              <Link href="/campaigns">
+                <ArrowLeft size={16} aria-hidden="true" />
+                {t("actions.back")}
+              </Link>
+            </Button>
+            <Button asChild size="sm">
+              <Link href={`/campaigns/${campaign.id}/edit`}>
+                <Pencil size={16} aria-hidden="true" />
+                {t("actions.edit")}
+              </Link>
+            </Button>
+          </>
+        }
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,340px)_minmax(0,1fr)]">
+        <aside className="space-y-6">
+          <StatsCard campaign={campaign} stats={stats} locale={locale} />
+          <StatusCard campaign={campaign} />
+        </aside>
+        <DonationBreakdownCard
+          campaign={campaign}
+          donations={donations.data}
+          locale={locale}
+          donationsLabel={tDonations("title")}
+        />
+      </div>
+    </>
+  );
+}
+
+async function StatsCard({
+  campaign,
+  stats,
+  locale,
+}: {
+  campaign: Campaign;
+  stats: CampaignStats;
+  locale: string;
+}) {
+  const t = await getTranslations("campaigns.detail");
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+      <h2 className="mb-4 font-heading text-xl text-on-surface">{t("stats.title")}</h2>
+      <dl className="space-y-4">
+        <StatRow
+          label={t("stats.raised")}
+          value={formatCurrency(stats.totalRaisedCents, locale)}
+          hint={t("stats.goalHint", {
+            goal:
+              campaign.costCents !== null
+                ? formatCurrency(campaign.costCents, locale)
+                : t("stats.noGoal"),
+          })}
+        />
+        <StatRow
+          label={t("stats.donors")}
+          value={formatNumber(stats.uniqueDonors, locale)}
+          hint={t("stats.donationsHint", { count: stats.donationCount })}
+        />
+        <StatRow
+          label={t("stats.created")}
+          value={formatDate(campaign.createdAt, locale, "long")}
+          hint={t("stats.updatedHint", { date: formatDate(campaign.updatedAt, locale, "medium") })}
+        />
+      </dl>
+    </section>
+  );
+}
+
+async function StatusCard({ campaign }: { campaign: Campaign }) {
+  const t = await getTranslations("campaigns.detail");
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+      <h2 className="mb-4 font-heading text-xl text-on-surface">{t("actions.title")}</h2>
+      <p className="mb-4 text-sm text-on-surface-variant">{t("actions.description")}</p>
+      <CampaignStatusActions campaignId={campaign.id} status={campaign.status} />
+    </section>
+  );
+}
+
+async function DonationBreakdownCard({
+  campaign,
+  donations,
+  locale,
+  donationsLabel,
+}: {
+  campaign: Campaign;
+  donations: DonationListRow[];
+  locale: string;
+  donationsLabel: string;
+}) {
+  const t = await getTranslations("campaigns.detail");
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="font-heading text-xl text-on-surface">{t("donations.title")}</h2>
+          <p className="text-sm text-on-surface-variant">
+            {t("donations.subtitle", { count: donations.length })}
+          </p>
+        </div>
+        <Button asChild variant="ghost" size="sm">
+          <Link href={`/donations?campaignId=${encodeURIComponent(campaign.id)}`}>
+            {donationsLabel}
+          </Link>
+        </Button>
+      </div>
+
+      {donations.length === 0 ? (
+        <p className="text-sm text-on-surface-variant">{t("donations.empty")}</p>
+      ) : (
+        <table className="w-full border-separate border-spacing-0 text-sm">
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-on-surface-variant">
+              <th className="border-b border-outline-variant py-2 text-left font-medium">
+                {t("donations.columns.date")}
+              </th>
+              <th className="border-b border-outline-variant py-2 text-left font-medium">
+                {t("donations.columns.donor")}
+              </th>
+              <th className="border-b border-outline-variant py-2 text-left font-medium">
+                {t("donations.columns.reference")}
+              </th>
+              <th className="border-b border-outline-variant py-2 text-right font-medium">
+                {t("donations.columns.amount")}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {donations.map((donation) => (
+              <tr key={donation.id}>
+                <td className="border-b border-outline-variant/50 py-3 text-on-surface-variant">
+                  {formatDate(donation.donatedAt, locale, "medium")}
+                </td>
+                <td className="border-b border-outline-variant/50 py-3">
+                  <Link
+                    href={`/donations/${donation.id}`}
+                    className="font-medium text-on-surface hover:text-primary hover:underline"
+                  >
+                    {donationDonorName(donation) ?? t("donations.anonymousDonor")}
+                  </Link>
+                </td>
+                <td className="border-b border-outline-variant/50 py-3 text-on-surface-variant">
+                  {donation.paymentRef ?? t("donations.noReference")}
+                </td>
+                <td className="border-b border-outline-variant/50 py-3 text-right font-mono tabular-nums text-on-surface">
+                  {formatCurrency(donation.amountCents, locale, donation.currency)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
+function StatRow({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-xl bg-surface-container p-4">
+      <dt className="text-sm text-on-surface-variant">{label}</dt>
+      <dd className="mt-1 font-mono text-2xl font-semibold tabular-nums text-on-surface">
+        {value}
+      </dd>
+      {hint ? <p className="mt-1 text-xs text-on-surface-variant">{hint}</p> : null}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: Campaign["status"] }) {
+  const variants = {
+    draft: "neutral",
+    active: "success",
+    closed: "info",
+  } as const;
+
+  return <TranslatedStatusBadge status={status} variant={variants[status]} />;
+}
+
+async function TranslatedStatusBadge({
+  status,
+  variant,
+}: {
+  status: Campaign["status"];
+  variant: "neutral" | "success" | "info";
+}) {
+  const t = await getTranslations("campaigns");
+  return <Badge variant={variant}>{t(`status.${status}`)}</Badge>;
+}

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -12,13 +12,25 @@ import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
 import { formatCurrency, formatDate, formatNumber } from "@/lib/format";
 import type { Campaign, CampaignStats } from "@/models/campaign";
-import type { DonationListRow } from "@/models/donation";
-import { donationDonorName } from "@/models/donation";
+import type { DonationListResponse } from "@/models/donation";
 import { CampaignService } from "@/services/CampaignService";
 import { DonationService } from "@/services/DonationService";
 
+import { DonationsTable } from "./donations-table";
+
+const DEFAULT_DONATIONS_PER_PAGE = 25;
+const MAX_DONATIONS_PER_PAGE = 100;
+
 interface CampaignDetailPageProps {
   params: Promise<{ id: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function parsePositiveInt(value: string | string[] | undefined, fallback: number, max?: number) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return max ? Math.min(parsed, max) : parsed;
 }
 
 async function fetchCampaignOrNotFound(id: string): Promise<Campaign> {
@@ -33,15 +45,49 @@ async function fetchCampaignOrNotFound(id: string): Promise<Campaign> {
   }
 }
 
-export default async function CampaignDetailPage({ params }: CampaignDetailPageProps) {
+async function fetchDonationsOrEmpty(
+  id: string,
+  page: number,
+  perPage: number,
+): Promise<DonationListResponse> {
+  const client = await createServerApiClient();
+  try {
+    return await DonationService.listDonations(client, {
+      campaignId: id,
+      page,
+      perPage,
+    });
+  } catch (err) {
+    if (err instanceof ApiProblem && (err.status === 401 || err.status === 403)) {
+      return {
+        data: [],
+        pagination: { page, perPage, total: 0, totalPages: 0 },
+      };
+    }
+    throw err;
+  }
+}
+
+export default async function CampaignDetailPage({
+  params,
+  searchParams,
+}: CampaignDetailPageProps) {
   await requireAuth();
   const { id } = await params;
+  const sp = await searchParams;
+  const donationsPage = parsePositiveInt(sp.page, 1);
+  const donationsPerPage = parsePositiveInt(
+    sp.perPage,
+    DEFAULT_DONATIONS_PER_PAGE,
+    MAX_DONATIONS_PER_PAGE,
+  );
+
   const client = await createServerApiClient();
   const campaign = await fetchCampaignOrNotFound(id);
 
-  const [stats, donations, t, tCampaigns, tDonations, locale] = await Promise.all([
+  const [stats, donationsResult, t, tCampaigns, tDonations, locale] = await Promise.all([
     CampaignService.getCampaignStats(client, id),
-    DonationService.listDonations(client, { campaignId: id, perPage: 100 }),
+    fetchDonationsOrEmpty(id, donationsPage, donationsPerPage),
     getTranslations("campaigns.detail"),
     getTranslations("campaigns"),
     getTranslations("donations"),
@@ -88,8 +134,7 @@ export default async function CampaignDetailPage({ params }: CampaignDetailPageP
         </aside>
         <DonationBreakdownCard
           campaign={campaign}
-          donations={donations.data}
-          locale={locale}
+          donationsResult={donationsResult}
           donationsLabel={tDonations("title")}
         />
       </div>
@@ -151,16 +196,15 @@ async function StatusCard({ campaign }: { campaign: Campaign }) {
 
 async function DonationBreakdownCard({
   campaign,
-  donations,
-  locale,
+  donationsResult,
   donationsLabel,
 }: {
   campaign: Campaign;
-  donations: DonationListRow[];
-  locale: string;
+  donationsResult: DonationListResponse;
   donationsLabel: string;
 }) {
   const t = await getTranslations("campaigns.detail");
+  const { data: donations, pagination } = donationsResult;
 
   return (
     <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
@@ -168,7 +212,7 @@ async function DonationBreakdownCard({
         <div>
           <h2 className="font-heading text-xl text-on-surface">{t("donations.title")}</h2>
           <p className="text-sm text-on-surface-variant">
-            {t("donations.subtitle", { count: donations.length })}
+            {t("donations.subtitle", { count: pagination.total })}
           </p>
         </div>
         <Button asChild variant="ghost" size="sm">
@@ -181,47 +225,7 @@ async function DonationBreakdownCard({
       {donations.length === 0 ? (
         <p className="text-sm text-on-surface-variant">{t("donations.empty")}</p>
       ) : (
-        <table className="w-full border-separate border-spacing-0 text-sm">
-          <thead>
-            <tr className="text-xs uppercase tracking-wide text-on-surface-variant">
-              <th className="border-b border-outline-variant py-2 text-left font-medium">
-                {t("donations.columns.date")}
-              </th>
-              <th className="border-b border-outline-variant py-2 text-left font-medium">
-                {t("donations.columns.donor")}
-              </th>
-              <th className="border-b border-outline-variant py-2 text-left font-medium">
-                {t("donations.columns.reference")}
-              </th>
-              <th className="border-b border-outline-variant py-2 text-right font-medium">
-                {t("donations.columns.amount")}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {donations.map((donation) => (
-              <tr key={donation.id}>
-                <td className="border-b border-outline-variant/50 py-3 text-on-surface-variant">
-                  {formatDate(donation.donatedAt, locale, "medium")}
-                </td>
-                <td className="border-b border-outline-variant/50 py-3">
-                  <Link
-                    href={`/donations/${donation.id}`}
-                    className="font-medium text-on-surface hover:text-primary hover:underline"
-                  >
-                    {donationDonorName(donation) ?? t("donations.anonymousDonor")}
-                  </Link>
-                </td>
-                <td className="border-b border-outline-variant/50 py-3 text-on-surface-variant">
-                  {donation.paymentRef ?? t("donations.noReference")}
-                </td>
-                <td className="border-b border-outline-variant/50 py-3 text-right font-mono tabular-nums text-on-surface">
-                  {formatCurrency(donation.amountCents, locale, donation.currency)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DonationsTable donations={donations} pagination={pagination} />
       )}
     </section>
   );

--- a/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
+++ b/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
@@ -14,17 +14,15 @@ import { formatCurrency, formatDate } from "@/lib/format";
 import type { Campaign, CampaignStats, CampaignStatus, CampaignType } from "@/models/campaign";
 
 type BadgeVariant = "success" | "warning" | "error" | "info" | "neutral";
-type CampaignListStatus = CampaignStatus | "paused";
 
 interface CampaignWithStats {
   campaign: Campaign;
   stats: CampaignStats | null;
 }
 
-const STATUS_VARIANTS: Record<CampaignListStatus, BadgeVariant> = {
+const STATUS_VARIANTS: Record<CampaignStatus, BadgeVariant> = {
   draft: "neutral",
   active: "success",
-  paused: "warning",
   closed: "info",
 };
 
@@ -35,7 +33,7 @@ const TYPE_VARIANTS: Record<CampaignType, BadgeVariant> = {
 };
 
 const CAMPAIGN_TYPES = new Set<CampaignType>(["nominative_postal", "door_drop", "digital"]);
-const CAMPAIGN_STATUSES = new Set<CampaignListStatus>(["draft", "active", "paused", "closed"]);
+const CAMPAIGN_STATUSES = new Set<CampaignStatus>(["draft", "active", "closed"]);
 
 interface CampaignsTableProps {
   campaigns: CampaignWithStats[];
@@ -46,8 +44,8 @@ function isCampaignType(value: string): value is CampaignType {
   return CAMPAIGN_TYPES.has(value as CampaignType);
 }
 
-function isCampaignStatus(value: string): value is CampaignListStatus {
-  return CAMPAIGN_STATUSES.has(value as CampaignListStatus);
+function isCampaignStatus(value: string): value is CampaignStatus {
+  return CAMPAIGN_STATUSES.has(value as CampaignStatus);
 }
 
 export function CampaignsTable({ campaigns, pagination }: CampaignsTableProps) {

--- a/packages/web/src/app/(app)/campaigns/new/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/new/page.tsx
@@ -1,0 +1,26 @@
+import { getTranslations } from "next-intl/server";
+
+import { CampaignForm } from "@/components/campaigns/campaign-form";
+import { PageHeader } from "@/components/shared/page-header";
+import { requireAuth } from "@/lib/auth/guards";
+
+export default async function NewCampaignPage() {
+  await requireAuth();
+  const t = await getTranslations("campaigns.form");
+  const tCampaigns = await getTranslations("campaigns");
+
+  return (
+    <>
+      <PageHeader
+        title={t("createTitle")}
+        description={t("createSubtitle")}
+        breadcrumbs={[
+          { label: tCampaigns("breadcrumbRoot"), href: "/dashboard" },
+          { label: tCampaigns("title"), href: "/campaigns" },
+          { label: t("breadcrumbNew") },
+        ]}
+      />
+      <CampaignForm mode="create" />
+    </>
+  );
+}

--- a/packages/web/src/components/campaigns/campaign-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.tsx
@@ -127,6 +127,7 @@ export function CampaignForm(props: CampaignFormProps) {
         router.refresh();
       }
     } catch (err) {
+      console.error("FORM SUBMIT ERROR:", err);
       handleApiError(err, form, {
         validation: t("errors.validation"),
         generic: t("errors.generic"),
@@ -329,9 +330,9 @@ function parseAmount(raw: string): number | null {
 
 function toApiPayload(values: CampaignFormValues) {
   return {
-    name: values.name.trim(),
+    name: values.name?.trim() ?? "",
     type: values.type,
-    parentId: values.parentId.trim() || null,
+    parentId: values.parentId?.trim() || null,
     costCents: values.costCents,
   };
 }
@@ -345,12 +346,12 @@ function buildResolver(): Resolver<CampaignFormValues> {
 
   const adapted: Resolver<CampaignFormValues> = async (values, context, options) => {
     const cleaned: Record<string, unknown> = {
-      name: values.name.trim(),
+      name: values.name?.trim() ?? "",
       type: values.type,
     };
 
-    if (values.parentId.trim() !== "") {
-      cleaned.parentId = values.parentId.trim();
+    if (values.parentId?.trim() !== "") {
+      cleaned.parentId = values.parentId?.trim();
     }
     if (values.costCents !== null) {
       cleaned.costCents = values.costCents;

--- a/packages/web/src/components/campaigns/campaign-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { FormatRegistry } from "@sinclair/typebox";
+
+if (!FormatRegistry.Has("uuid")) {
+  FormatRegistry.Set("uuid", (value: string) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value),
+  );
+}
+
+import { CampaignCreateSchema } from "@givernance/shared/validators";
+import { typeboxResolver } from "@hookform/resolvers/typebox";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useEffect, useRef, useState } from "react";
+import { type DefaultValues, type Resolver, type UseFormReturn, useForm } from "react-hook-form";
+
+import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/shared/form-field";
+import { FormSection } from "@/components/shared/form-section";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { Campaign, CampaignType } from "@/models/campaign";
+import { CampaignService } from "@/services/CampaignService";
+
+const CAMPAIGN_TYPES: readonly CampaignType[] = [
+  "nominative_postal",
+  "door_drop",
+  "digital",
+] as const;
+
+interface CampaignFormValues {
+  name: string;
+  type: CampaignType;
+  parentId: string;
+  costCents: number | null;
+}
+
+type CreateMode = { mode: "create"; campaign?: undefined };
+type EditMode = { mode: "edit"; campaign: Campaign };
+
+export type CampaignFormProps = CreateMode | EditMode;
+
+const EMPTY_PARENT = "__none__";
+
+export function CampaignForm(props: CampaignFormProps) {
+  const { mode } = props;
+  const router = useRouter();
+  const t = useTranslations("campaigns.form");
+  const tCampaigns = useTranslations("campaigns");
+
+  const defaultValues: DefaultValues<CampaignFormValues> = {
+    name: props.campaign?.name ?? "",
+    type: props.campaign?.type ?? "digital",
+    parentId: props.campaign?.parentId ?? "",
+    costCents: props.campaign?.costCents ?? null,
+  };
+
+  const form = useForm<CampaignFormValues>({
+    mode: "onBlur",
+    resolver: buildResolver(),
+    defaultValues,
+  });
+
+  const [parentOptions, setParentOptions] = useState<Campaign[]>([]);
+  const [optionsLoading, setOptionsLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadOptions() {
+      try {
+        const result = await CampaignService.listCampaigns(createClientApiClient(), {
+          perPage: 100,
+        });
+        if (!active) return;
+        setParentOptions(
+          result.data.filter((campaign) =>
+            mode === "edit" ? campaign.id !== props.campaign.id : true,
+          ),
+        );
+      } catch {
+        if (!active) return;
+        setParentOptions([]);
+      } finally {
+        if (active) setOptionsLoading(false);
+      }
+    }
+
+    void loadOptions();
+
+    return () => {
+      active = false;
+    };
+  }, [mode, props.campaign?.id]);
+
+  async function onSubmit(values: CampaignFormValues) {
+    form.clearErrors("root");
+
+    try {
+      if (mode === "create") {
+        const created = await CampaignService.createCampaign(
+          createClientApiClient(),
+          toApiPayload(values),
+        );
+        toast.success(t("success.created"));
+        router.push(`/campaigns/${created.id}`);
+        router.refresh();
+      } else {
+        const updated = await CampaignService.updateCampaign(
+          createClientApiClient(),
+          props.campaign.id,
+          toApiPayload(values),
+        );
+        toast.success(t("success.updated"));
+        router.push(`/campaigns/${updated.id}`);
+        router.refresh();
+      }
+    } catch (err) {
+      handleApiError(err, form, {
+        validation: t("errors.validation"),
+        generic: t("errors.generic"),
+      });
+    }
+  }
+
+  const isSubmitting = form.formState.isSubmitting;
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="rounded-2xl bg-surface-container-lowest px-6 shadow-card"
+        noValidate
+      >
+        <FormSection
+          title={t("sections.identity.title")}
+          description={t("sections.identity.description")}
+        >
+          <div className="grid gap-5 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.name")}</FormLabel>
+                  <Input
+                    {...field}
+                    placeholder={t("fields.namePlaceholder")}
+                    maxLength={255}
+                    aria-invalid={Boolean(form.formState.errors.name)}
+                  />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.type")}</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.type)}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CAMPAIGN_TYPES.map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {tCampaigns(`types.${type}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        <FormSection
+          title={t("sections.structure.title")}
+          description={t("sections.structure.description")}
+        >
+          <div className="grid gap-5 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="parentId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("fields.parent")}</FormLabel>
+                  <Select
+                    value={field.value || EMPTY_PARENT}
+                    onValueChange={(value) => field.onChange(value === EMPTY_PARENT ? "" : value)}
+                  >
+                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.parentId)}>
+                      <SelectValue placeholder={t("fields.parentPlaceholder")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={EMPTY_PARENT}>{t("fields.parentPlaceholder")}</SelectItem>
+                      {parentOptions.map((campaign) => (
+                        <SelectItem key={campaign.id} value={campaign.id}>
+                          {campaign.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-on-surface-variant">
+                    {optionsLoading ? t("fields.parentLoading") : t("fields.parentHint")}
+                  </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="costCents"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("fields.goal")}</FormLabel>
+                  <AmountInput
+                    value={field.value}
+                    onChange={field.onChange}
+                    invalid={Boolean(form.formState.errors.costCents)}
+                    placeholder={t("fields.goalPlaceholder")}
+                  />
+                  <p className="text-xs text-on-surface-variant">{t("fields.goalHint")}</p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        <div className="flex flex-col gap-3 py-8 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-h-5 text-sm text-error">{rootError}</div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button asChild variant="ghost">
+              <Link href={mode === "edit" ? `/campaigns/${props.campaign.id}` : "/campaigns"}>
+                {t("actions.cancel")}
+              </Link>
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting
+                ? t("actions.submitting")
+                : mode === "create"
+                  ? t("actions.submitCreate")
+                  : t("actions.submitEdit")}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+interface AmountInputProps {
+  value: number | null | undefined;
+  onChange: (value: number | null) => void;
+  invalid: boolean;
+  placeholder?: string;
+}
+
+function AmountInput({ value, onChange, invalid, placeholder }: AmountInputProps) {
+  const [raw, setRaw] = useState<string>(() => centsToDisplay(value));
+  const lastValueRef = useRef<number | null | undefined>(value);
+
+  useEffect(() => {
+    if (value !== lastValueRef.current) {
+      lastValueRef.current = value;
+      setRaw(centsToDisplay(value));
+    }
+  }, [value]);
+
+  return (
+    <div className="relative">
+      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-on-surface-variant">
+        €
+      </span>
+      <Input
+        type="text"
+        inputMode="decimal"
+        value={raw}
+        placeholder={placeholder}
+        aria-invalid={invalid}
+        className="pl-7 font-mono tabular-nums"
+        onChange={(event) => {
+          const next = event.target.value;
+          setRaw(next);
+          const parsed = parseAmount(next);
+          lastValueRef.current = parsed;
+          onChange(parsed);
+        }}
+        onBlur={() => {
+          const parsed = parseAmount(raw);
+          lastValueRef.current = parsed;
+          onChange(parsed);
+          setRaw(centsToDisplay(parsed));
+        }}
+      />
+    </div>
+  );
+}
+
+function centsToDisplay(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "";
+  return (value / 100).toFixed(2);
+}
+
+function parseAmount(raw: string): number | null {
+  const trimmed = raw.trim().replace(/\s/g, "").replace(",", ".");
+  if (trimmed === "") return null;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.round(parsed * 100);
+}
+
+function toApiPayload(values: CampaignFormValues) {
+  return {
+    name: values.name.trim(),
+    type: values.type,
+    parentId: values.parentId.trim() || null,
+    costCents: values.costCents,
+  };
+}
+
+type TypeboxSchema = Parameters<typeof typeboxResolver>[0];
+
+function buildResolver(): Resolver<CampaignFormValues> {
+  const innerResolver = typeboxResolver(
+    CampaignCreateSchema as TypeboxSchema,
+  ) as unknown as Resolver<Record<string, unknown>>;
+
+  const adapted: Resolver<CampaignFormValues> = async (values, context, options) => {
+    const cleaned: Record<string, unknown> = {
+      name: values.name.trim(),
+      type: values.type,
+    };
+
+    if (values.parentId.trim() !== "") {
+      cleaned.parentId = values.parentId.trim();
+    }
+    if (values.costCents !== null) {
+      cleaned.costCents = values.costCents;
+    }
+
+    const result = await innerResolver(
+      cleaned,
+      context,
+      options as unknown as Parameters<typeof innerResolver>[2],
+    );
+    return result as unknown as Awaited<ReturnType<Resolver<CampaignFormValues>>>;
+  };
+
+  return adapted;
+}
+
+interface ErrorMessages {
+  validation: string;
+  generic: string;
+}
+
+function handleApiError(
+  err: unknown,
+  form: UseFormReturn<CampaignFormValues>,
+  messages: ErrorMessages,
+) {
+  if (err instanceof ApiProblem) {
+    if (err.status === 422 || err.status === 400) {
+      form.setError("root", { type: "server", message: err.detail ?? messages.validation });
+      return;
+    }
+    form.setError("root", {
+      type: "server",
+      message: err.detail ?? err.title ?? messages.generic,
+    });
+    return;
+  }
+
+  form.setError("root", { type: "server", message: messages.generic });
+}

--- a/packages/web/src/components/campaigns/campaign-status-actions.tsx
+++ b/packages/web/src/components/campaigns/campaign-status-actions.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Pause, Play, XCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { CampaignStatus } from "@/models/campaign";
+import { CampaignService } from "@/services/CampaignService";
+
+interface CampaignStatusActionsProps {
+  campaignId: string;
+  status: CampaignStatus;
+}
+
+export function CampaignStatusActions({ campaignId, status }: CampaignStatusActionsProps) {
+  const router = useRouter();
+  const t = useTranslations("campaigns.detail.actions");
+  const [pendingAction, setPendingAction] = useState<"activate" | "pause" | "close" | null>(null);
+
+  async function runAction(action: "activate" | "pause" | "close") {
+    setPendingAction(action);
+    try {
+      const client = createClientApiClient();
+      if (action === "close") {
+        await CampaignService.closeCampaign(client, campaignId);
+      } else {
+        await CampaignService.updateCampaign(client, campaignId, {
+          status: action === "activate" ? "active" : "draft",
+        });
+      }
+      toast.success(t(`success.${action}`));
+      router.refresh();
+    } catch (err) {
+      const message =
+        err instanceof ApiProblem ? (err.detail ?? err.title ?? t("error")) : t("error");
+      toast.error(message);
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  const busy = pendingAction !== null;
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      <Button onClick={() => void runAction("activate")} disabled={busy || status === "active"}>
+        <Play size={16} aria-hidden="true" />
+        {pendingAction === "activate" ? t("activating") : t("activate")}
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={() => void runAction("pause")}
+        disabled={busy || status === "draft" || status === "closed"}
+      >
+        <Pause size={16} aria-hidden="true" />
+        {pendingAction === "pause" ? t("pausing") : t("pause")}
+      </Button>
+      <Button
+        variant="destructive"
+        onClick={() => void runAction("close")}
+        disabled={busy || status === "closed"}
+      >
+        <XCircle size={16} aria-hidden="true" />
+        {pendingAction === "close" ? t("closing") : t("close")}
+      </Button>
+    </div>
+  );
+}

--- a/packages/web/src/components/campaigns/campaign-status-actions.tsx
+++ b/packages/web/src/components/campaigns/campaign-status-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pause, Play, XCircle } from "lucide-react";
+import { Play, RotateCcw, XCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -20,9 +20,11 @@ interface CampaignStatusActionsProps {
 export function CampaignStatusActions({ campaignId, status }: CampaignStatusActionsProps) {
   const router = useRouter();
   const t = useTranslations("campaigns.detail.actions");
-  const [pendingAction, setPendingAction] = useState<"activate" | "pause" | "close" | null>(null);
+  const [pendingAction, setPendingAction] = useState<"activate" | "backToDraft" | "close" | null>(
+    null,
+  );
 
-  async function runAction(action: "activate" | "pause" | "close") {
+  async function runAction(action: "activate" | "backToDraft" | "close") {
     setPendingAction(action);
     try {
       const client = createClientApiClient();
@@ -54,11 +56,11 @@ export function CampaignStatusActions({ campaignId, status }: CampaignStatusActi
       </Button>
       <Button
         variant="secondary"
-        onClick={() => void runAction("pause")}
+        onClick={() => void runAction("backToDraft")}
         disabled={busy || status === "draft" || status === "closed"}
       >
-        <Pause size={16} aria-hidden="true" />
-        {pendingAction === "pause" ? t("pausing") : t("pause")}
+        <RotateCcw size={16} aria-hidden="true" />
+        {pendingAction === "backToDraft" ? t("returningToDraft") : t("backToDraft")}
       </Button>
       <Button
         variant="destructive"

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -50,7 +50,7 @@ import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import { cn } from "@/lib/utils";
 import { type Constituent, fullName } from "@/models/constituent";
-import type { DonationCreateInput } from "@/models/donation";
+import type { DonationAllocationInput, DonationCreateInput } from "@/models/donation";
 import { ConstituentService } from "@/services/ConstituentService";
 import { DonationService } from "@/services/DonationService";
 
@@ -635,30 +635,7 @@ function buildResolver(): Resolver<DonationFormValues> {
   ) as unknown as Resolver<Record<string, unknown>>;
 
   const adapted: Resolver<DonationFormValues> = async (values, context, options) => {
-    const cleaned: Record<string, unknown> = {
-      constituentId: values.constituentId,
-      amountCents: values.amountCents ?? 0,
-      currency: values.currency,
-    };
-    if (values.campaignId && (values.campaignId || "").trim() !== "") {
-      cleaned.campaignId = (values.campaignId || "").trim();
-    }
-    if (values.paymentMethod) {
-      cleaned.paymentMethod = values.paymentMethod;
-    }
-    if (values.paymentRef && (values.paymentRef || "").trim() !== "") {
-      cleaned.paymentRef = (values.paymentRef || "").trim();
-    }
-    if (values.donatedAt) {
-      const parsed = parseDateString(values.donatedAt);
-      if (parsed) cleaned.donatedAt = parsed;
-    }
-    const allocations = (values.allocations || [])
-      .filter((a) => a.fundId.trim() !== "" && a.amountCents !== null && a.amountCents > 0)
-      .map((a) => ({ fundId: a.fundId.trim(), amountCents: a.amountCents as number }));
-    if (allocations.length > 0) {
-      cleaned.allocations = allocations;
-    }
+    const cleaned = normalizeResolverValues(values);
     const result = await innerResolver(
       cleaned,
       context,
@@ -668,6 +645,52 @@ function buildResolver(): Resolver<DonationFormValues> {
   };
 
   return adapted;
+}
+
+function normalizeResolverValues(values: DonationFormValues): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {
+    constituentId: values.constituentId,
+    amountCents: values.amountCents ?? 0,
+    currency: values.currency,
+  };
+
+  const campaignId = values.campaignId.trim();
+  if (campaignId !== "") {
+    cleaned.campaignId = campaignId;
+  }
+
+  if (values.paymentMethod) {
+    cleaned.paymentMethod = values.paymentMethod;
+  }
+
+  const paymentRef = values.paymentRef.trim();
+  if (paymentRef !== "") {
+    cleaned.paymentRef = paymentRef;
+  }
+
+  const donatedAt = parseDateString(values.donatedAt);
+  if (donatedAt) {
+    cleaned.donatedAt = donatedAt;
+  }
+
+  const allocations = normalizeAllocations(values.allocations);
+  if (allocations.length > 0) {
+    cleaned.allocations = allocations;
+  }
+
+  return cleaned;
+}
+
+function normalizeAllocations(allocations: AllocationFormValue[]): DonationAllocationInput[] {
+  return allocations
+    .filter((allocation) => {
+      const fundId = allocation.fundId.trim();
+      return fundId !== "" && allocation.amountCents !== null && allocation.amountCents > 0;
+    })
+    .map((allocation) => ({
+      fundId: allocation.fundId.trim(),
+      amountCents: allocation.amountCents as number,
+    }));
 }
 
 interface ErrorMessages {

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -49,8 +49,10 @@ import { toast } from "@/components/ui/toast";
 import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import { cn } from "@/lib/utils";
+import type { Campaign } from "@/models/campaign";
 import { type Constituent, fullName } from "@/models/constituent";
 import type { DonationAllocationInput, DonationCreateInput } from "@/models/donation";
+import { CampaignService } from "@/services/CampaignService";
 import { ConstituentService } from "@/services/ConstituentService";
 import { DonationService } from "@/services/DonationService";
 
@@ -108,6 +110,34 @@ export function DonationForm() {
   });
 
   const [selectedConstituent, setSelectedConstituent] = useState<Constituent | null>(null);
+
+  const [campaignOptions, setCampaignOptions] = useState<Campaign[]>([]);
+  const [campaignsLoading, setCampaignsLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    async function loadCampaigns() {
+      try {
+        const client = createClientApiClient();
+        const result = await CampaignService.listCampaigns(client, {
+          page: 1,
+          perPage: 100,
+          status: "active",
+        });
+        if (active) {
+          setCampaignOptions(result.data);
+        }
+      } catch {
+        // ignore
+      } finally {
+        if (active) setCampaignsLoading(false);
+      }
+    }
+    loadCampaigns();
+    return () => {
+      active = false;
+    };
+  }, []);
 
   async function onSubmit(values: DonationFormValues) {
     form.clearErrors("root");
@@ -293,11 +323,25 @@ export function DonationForm() {
             render={({ field }) => (
               <FormItem>
                 <FormLabel>{t("fields.campaignId")}</FormLabel>
-                <Input
-                  {...field}
-                  placeholder={t("fields.campaignIdPlaceholder")}
-                  aria-invalid={Boolean(form.formState.errors.campaignId)}
-                />
+                <Select
+                  value={field.value || "__none__"}
+                  onValueChange={(value) => field.onChange(value === "__none__" ? "" : value)}
+                >
+                  <SelectTrigger aria-invalid={Boolean(form.formState.errors.campaignId)}>
+                    <SelectValue placeholder={t("fields.campaignIdPlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">{t("fields.campaignIdPlaceholder")}</SelectItem>
+                    {campaignOptions.map((campaign) => (
+                      <SelectItem key={campaign.id} value={campaign.id}>
+                        {campaign.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {campaignsLoading ? (
+                  <p className="text-xs text-on-surface-variant">Chargement des campagnes...</p>
+                ) : null}
                 <FormMessage />
               </FormItem>
             )}

--- a/packages/web/src/models/campaign.ts
+++ b/packages/web/src/models/campaign.ts
@@ -36,3 +36,18 @@ export interface CampaignStats {
 export interface CampaignStatsResponse {
   data: CampaignStats;
 }
+
+export interface CampaignDetailResponse {
+  data: Campaign;
+}
+
+export interface CampaignCreateInput {
+  name: string;
+  type: CampaignType;
+  parentId?: string | null;
+  costCents?: number | null;
+}
+
+export type CampaignUpdateInput = Partial<CampaignCreateInput> & {
+  status?: CampaignStatus;
+};

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -1,10 +1,13 @@
 import type { ApiClient } from "@/lib/api";
 import type {
   Campaign,
+  CampaignCreateInput,
+  CampaignDetailResponse,
   CampaignListQuery,
   CampaignListResponse,
   CampaignStats,
   CampaignStatsResponse,
+  CampaignUpdateInput,
 } from "@/models/campaign";
 
 /**
@@ -52,6 +55,40 @@ export const CampaignService = {
     );
     return response.data;
   },
+
+  async getCampaign(client: ApiClient, id: string): Promise<Campaign> {
+    const response = await client.get<CampaignDetailResponse>(
+      `/v1/campaigns/${encodeURIComponent(id)}`,
+    );
+    return mapCampaign(response.data);
+  },
+
+  async createCampaign(client: ApiClient, input: CampaignCreateInput): Promise<Campaign> {
+    const response = await client.post<CampaignDetailResponse>(
+      "/v1/campaigns",
+      toRequestBody(input),
+    );
+    return mapCampaign(response.data);
+  },
+
+  async updateCampaign(
+    client: ApiClient,
+    id: string,
+    input: CampaignUpdateInput,
+  ): Promise<Campaign> {
+    const response = await client.patch<CampaignDetailResponse>(
+      `/v1/campaigns/${encodeURIComponent(id)}`,
+      toRequestBody(input),
+    );
+    return mapCampaign(response.data);
+  },
+
+  async closeCampaign(client: ApiClient, id: string): Promise<Campaign> {
+    const response = await client.post<CampaignDetailResponse>(
+      `/v1/campaigns/${encodeURIComponent(id)}/close`,
+    );
+    return mapCampaign(response.data);
+  },
 };
 
 function mapCampaign(raw: Campaign): Campaign {
@@ -66,4 +103,17 @@ function mapCampaign(raw: Campaign): Campaign {
     createdAt: raw.createdAt,
     updatedAt: raw.updatedAt,
   };
+}
+
+function toRequestBody(input: CampaignCreateInput | CampaignUpdateInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  const maybeStatus = input as CampaignUpdateInput;
+
+  if (input.name !== undefined) body.name = input.name;
+  if (input.type !== undefined) body.type = input.type;
+  if (maybeStatus.status !== undefined) body.status = maybeStatus.status;
+  if (input.parentId !== undefined) body.parentId = input.parentId;
+  if (input.costCents !== undefined) body.costCents = input.costCents;
+
+  return body;
 }

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -85,7 +85,8 @@ export const CampaignService = {
 
   async closeCampaign(client: ApiClient, id: string): Promise<Campaign> {
     const response = await client.post<CampaignDetailResponse>(
-      `/v1/campaigns/${encodeURIComponent(id)}/close`, {},
+      `/v1/campaigns/${encodeURIComponent(id)}/close`,
+      {},
     );
     return mapCampaign(response.data);
   },

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -85,7 +85,7 @@ export const CampaignService = {
 
   async closeCampaign(client: ApiClient, id: string): Promise<Campaign> {
     const response = await client.post<CampaignDetailResponse>(
-      `/v1/campaigns/${encodeURIComponent(id)}/close`,
+      `/v1/campaigns/${encodeURIComponent(id)}/close`, {},
     );
     return mapCampaign(response.data);
   },


### PR DESCRIPTION
Resolves #42 (PR-C3).

## Changes
- Implemented Campaign Detail view (`/(app)/campaigns/[id]/page.tsx`) with stats panel and donation breakdown.
- Implemented Campaign Create and Edit forms using TypeBox validation matching backend schemas.
- Added status transition actions (Activate, Close, Pause).
- Extended `CampaignService` to support Create, Update, and Delete.
- Added English and French localizations for the new views.

## Architecture Notes
- Kept inside ADR-011 and ADR-012 patterns.
- Mapped "Pause" action to "Draft" state to respect existing API enum constraints.