### PR TITLE
feat(web): add campaign ROI visualization chart

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -420,7 +420,7 @@
       "roi": "ROI",
       "metric": "Metric",
       "amount": "Amount",
-      "unavailable": "N/A",
+      "unavailable": "Not available",
       "tableCaption": "Campaign ROI data",
       "chartSummary": "Raised {raised} against a cost of {cost}. ROI: {roi}.",
       "chartSummaryUnavailable": "Raised {raised} against a cost of {cost}. ROI unavailable."

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -402,20 +402,33 @@
       }
     },
     "detail": {
-      "stats": {
-        "title": "Campaign stats",
-        "raised": "Raised",
-        "donors": "Donors",
-        "created": "Created",
-        "noGoal": "No goal",
-        "goalHint": "Goal: {goal}",
-        "donationsHint": "{count, plural, =0 {No donations yet} one {# donation recorded} other {# donations recorded}}",
-        "updatedHint": "Updated {date}"
-      },
-      "actions": {
-        "title": "Status actions",
-        "description": "Move this campaign between draft, active, and closed states.",
-        "back": "Back to campaigns",
+    "stats": {
+      "title": "Campaign stats",
+      "raised": "Raised",
+      "donors": "Donors",
+      "created": "Created",
+      "noGoal": "No goal",
+      "goalHint": "Goal: {goal}",
+      "donationsHint": "{count, plural, =0 {No donations yet} one {# donation recorded} other {# donations recorded}}",
+      "updatedHint": "Updated {date}"
+    },
+    "roi": {
+      "title": "Campaign ROI",
+      "subtitle": "Compare campaign cost against funds raised.",
+      "cost": "Cost",
+      "raised": "Raised",
+      "roi": "ROI",
+      "metric": "Metric",
+      "amount": "Amount",
+      "unavailable": "N/A",
+      "tableCaption": "Campaign ROI data",
+      "chartSummary": "Raised {raised} against a cost of {cost}. ROI: {roi}.",
+      "chartSummaryUnavailable": "Raised {raised} against a cost of {cost}. ROI unavailable."
+    },
+    "actions": {
+      "title": "Status actions",
+      "description": "Move this campaign between draft, active, and closed states.",
+      "back": "Back to campaigns",
         "edit": "Edit",
         "activate": "Activate",
         "activating": "Activating…",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -402,20 +402,33 @@
       }
     },
     "detail": {
-      "stats": {
-        "title": "Statistiques de campagne",
-        "raised": "Collecté",
-        "donors": "Donateurs",
-        "created": "Créée",
-        "noGoal": "Aucun objectif",
-        "goalHint": "Objectif : {goal}",
-        "donationsHint": "{count, plural, =0 {Aucun don pour l'instant} one {# don enregistré} other {# dons enregistrés}}",
-        "updatedHint": "Mise à jour {date}"
-      },
-      "actions": {
-        "title": "Actions de statut",
-        "description": "Faites passer cette campagne entre les états brouillon, active et clôturée.",
-        "back": "Retour aux campagnes",
+    "stats": {
+      "title": "Statistiques de campagne",
+      "raised": "Collecté",
+      "donors": "Donateurs",
+      "created": "Créée",
+      "noGoal": "Aucun objectif",
+      "goalHint": "Objectif : {goal}",
+      "donationsHint": "{count, plural, =0 {Aucun don pour l'instant} one {# don enregistré} other {# dons enregistrés}}",
+      "updatedHint": "Mise à jour {date}"
+    },
+    "roi": {
+      "title": "ROI de la campagne",
+      "subtitle": "Comparez le coût de la campagne aux fonds collectés.",
+      "cost": "Coût",
+      "raised": "Collecté",
+      "roi": "ROI",
+      "metric": "Indicateur",
+      "amount": "Montant",
+      "unavailable": "N/A",
+      "tableCaption": "Données du ROI de la campagne",
+      "chartSummary": "Montant collecté : {raised}, pour un coût de {cost}. ROI : {roi}.",
+      "chartSummaryUnavailable": "Montant collecté : {raised}, pour un coût de {cost}. ROI indisponible."
+    },
+    "actions": {
+      "title": "Actions de statut",
+      "description": "Faites passer cette campagne entre les états brouillon, active et clôturée.",
+      "back": "Retour aux campagnes",
         "edit": "Modifier",
         "activate": "Activer",
         "activating": "Activation…",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -420,7 +420,7 @@
       "roi": "ROI",
       "metric": "Indicateur",
       "amount": "Montant",
-      "unavailable": "N/A",
+      "unavailable": "Indisponible",
       "tableCaption": "Données du ROI de la campagne",
       "chartSummary": "Montant collecté : {raised}, pour un coût de {cost}. ROI : {roi}.",
       "chartSummaryUnavailable": "Montant collecté : {raised}, pour un coût de {cost}. ROI indisponible."

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
+import { CampaignRoiChart } from "@/components/campaigns/campaign-roi-chart";
 import { CampaignStatusActions } from "@/components/campaigns/campaign-status-actions";
 import { PageHeader } from "@/components/shared/page-header";
 import { Badge } from "@/components/ui/badge";
@@ -132,11 +133,31 @@ export default async function CampaignDetailPage({
           <StatsCard campaign={campaign} stats={stats} locale={locale} />
           <StatusCard campaign={campaign} />
         </aside>
-        <DonationBreakdownCard
-          campaign={campaign}
-          donationsResult={donationsResult}
-          donationsLabel={tDonations("title")}
-        />
+        <div className="space-y-6">
+          <CampaignRoiChart
+            costCents={campaign.costCents}
+            totalRaisedCents={stats.totalRaisedCents}
+            locale={locale}
+            labels={{
+              title: t("roi.title"),
+              subtitle: t("roi.subtitle"),
+              cost: t("roi.cost"),
+              raised: t("roi.raised"),
+              roi: t("roi.roi"),
+              metric: t("roi.metric"),
+              amount: t("roi.amount"),
+              unavailable: t("roi.unavailable"),
+              tableCaption: t("roi.tableCaption"),
+              chartSummary: t("roi.chartSummary"),
+              chartSummaryUnavailable: t("roi.chartSummaryUnavailable"),
+            }}
+          />
+          <DonationBreakdownCard
+            campaign={campaign}
+            donationsResult={donationsResult}
+            donationsLabel={tDonations("title")}
+          />
+        </div>
       </div>
     </>
   );

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -94,6 +94,7 @@ export default async function CampaignDetailPage({
     getTranslations("donations"),
     getLocale(),
   ]);
+  const roi = CampaignService.calculateRoi(campaign.costCents, stats.totalRaisedCents);
 
   return (
     <>
@@ -137,6 +138,7 @@ export default async function CampaignDetailPage({
           <CampaignRoiChart
             costCents={campaign.costCents}
             totalRaisedCents={stats.totalRaisedCents}
+            roi={roi}
             locale={locale}
             labels={{
               title: t("roi.title"),

--- a/packages/web/src/components/campaigns/campaign-roi-chart.tsx
+++ b/packages/web/src/components/campaigns/campaign-roi-chart.tsx
@@ -1,0 +1,147 @@
+import { formatCurrency, formatPercent } from "@/lib/format";
+
+interface CampaignRoiChartLabels {
+  title: string;
+  subtitle: string;
+  cost: string;
+  raised: string;
+  roi: string;
+  metric: string;
+  amount: string;
+  unavailable: string;
+  tableCaption: string;
+  chartSummary: string;
+  chartSummaryUnavailable: string;
+}
+
+interface CampaignRoiChartProps {
+  costCents: number | null;
+  totalRaisedCents: number;
+  locale: string;
+  labels: CampaignRoiChartLabels;
+}
+
+interface SeriesItem {
+  key: "cost" | "raised";
+  label: string;
+  value: number;
+  displayValue: string;
+  barClassName: string;
+}
+
+export function CampaignRoiChart({
+  costCents,
+  totalRaisedCents,
+  locale,
+  labels,
+}: CampaignRoiChartProps) {
+  const roi =
+    costCents && costCents > 0 ? ((totalRaisedCents - costCents) / costCents) * 100 : null;
+  const chartMax = Math.max(costCents ?? 0, totalRaisedCents, 1);
+  const costDisplayValue =
+    costCents !== null ? formatCurrency(costCents, locale) : labels.unavailable;
+  const raisedDisplayValue = formatCurrency(totalRaisedCents, locale);
+  const roiDisplayValue = roi !== null ? formatPercent(roi, locale, 1) : labels.unavailable;
+  const summary =
+    roi !== null
+      ? labels.chartSummary
+          .replace("{raised}", raisedDisplayValue)
+          .replace("{cost}", costDisplayValue)
+          .replace("{roi}", roiDisplayValue)
+      : labels.chartSummaryUnavailable
+          .replace("{raised}", raisedDisplayValue)
+          .replace("{cost}", costDisplayValue);
+
+  const series: SeriesItem[] = [
+    {
+      key: "cost",
+      label: labels.cost,
+      value: costCents ?? 0,
+      displayValue: costDisplayValue,
+      barClassName: "bg-amber",
+    },
+    {
+      key: "raised",
+      label: labels.raised,
+      value: totalRaisedCents,
+      displayValue: raisedDisplayValue,
+      barClassName: "bg-primary",
+    },
+  ];
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="font-heading text-xl text-on-surface">{labels.title}</h2>
+          <p className="mt-1 text-sm text-on-surface-variant">{labels.subtitle}</p>
+        </div>
+        <div className="rounded-xl bg-surface-container px-4 py-3 sm:min-w-36">
+          <p className="text-xs font-medium uppercase tracking-wide text-on-surface-variant">
+            {labels.roi}
+          </p>
+          <p
+            className={`mt-1 font-mono text-2xl font-semibold tabular-nums ${
+              roi === null ? "text-on-surface" : roi >= 0 ? "text-success-text" : "text-error-text"
+            }`}
+          >
+            {roiDisplayValue}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 space-y-4" aria-describedby="campaign-roi-summary">
+        {series.map((item) => {
+          const width = Math.max((item.value / chartMax) * 100, item.value > 0 ? 6 : 0);
+          return (
+            <div key={item.key} className="space-y-2">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="text-sm font-medium text-on-surface">{item.label}</span>
+                <span className="font-mono text-sm tabular-nums text-on-surface-variant">
+                  {item.displayValue}
+                </span>
+              </div>
+              <div
+                className="h-4 overflow-hidden rounded-full bg-surface-container"
+                aria-hidden="true"
+              >
+                <div
+                  className={`h-full rounded-full ${item.barClassName}`}
+                  style={{ width: `${Math.min(width, 100)}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <p id="campaign-roi-summary" className="sr-only">
+        {summary}
+      </p>
+
+      <table className="sr-only">
+        <caption>{labels.tableCaption}</caption>
+        <thead>
+          <tr>
+            <th scope="col">{labels.metric}</th>
+            <th scope="col">{labels.amount}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">{labels.cost}</th>
+            <td>{costDisplayValue}</td>
+          </tr>
+          <tr>
+            <th scope="row">{labels.raised}</th>
+            <td>{raisedDisplayValue}</td>
+          </tr>
+          <tr>
+            <th scope="row">{labels.roi}</th>
+            <td>{roiDisplayValue}</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/packages/web/src/components/campaigns/campaign-roi-chart.tsx
+++ b/packages/web/src/components/campaigns/campaign-roi-chart.tsx
@@ -1,3 +1,5 @@
+import { useId } from "react";
+
 import { formatCurrency, formatPercent } from "@/lib/format";
 
 interface CampaignRoiChartLabels {
@@ -17,6 +19,7 @@ interface CampaignRoiChartLabels {
 interface CampaignRoiChartProps {
   costCents: number | null;
   totalRaisedCents: number;
+  roi: number | null;
   locale: string;
   labels: CampaignRoiChartLabels;
 }
@@ -32,11 +35,14 @@ interface SeriesItem {
 export function CampaignRoiChart({
   costCents,
   totalRaisedCents,
+  roi,
   locale,
   labels,
 }: CampaignRoiChartProps) {
-  const roi =
-    costCents && costCents > 0 ? ((totalRaisedCents - costCents) / costCents) * 100 : null;
+  const id = useId();
+  const figureCaptionId = `${id}-summary`;
+  const tableId = `${id}-table`;
+  const tableCaptionId = `${id}-table-caption`;
   const chartMax = Math.max(costCents ?? 0, totalRaisedCents, 1);
   const costDisplayValue =
     costCents !== null ? formatCurrency(costCents, locale) : labels.unavailable;
@@ -90,7 +96,7 @@ export function CampaignRoiChart({
         </div>
       </div>
 
-      <div className="mt-6 space-y-4" aria-describedby="campaign-roi-summary">
+      <figure className="mt-6 space-y-4" aria-describedby={figureCaptionId} aria-details={tableId}>
         {series.map((item) => {
           const width = Math.max((item.value / chartMax) * 100, item.value > 0 ? 6 : 0);
           return (
@@ -113,14 +119,17 @@ export function CampaignRoiChart({
             </div>
           );
         })}
-      </div>
+        <figcaption id={figureCaptionId} className="sr-only">
+          {summary}
+        </figcaption>
+      </figure>
 
-      <p id="campaign-roi-summary" className="sr-only">
-        {summary}
-      </p>
-
-      <table className="sr-only">
-        <caption>{labels.tableCaption}</caption>
+      <table
+        id={tableId}
+        aria-labelledby={`${figureCaptionId} ${tableCaptionId}`}
+        className="sr-only"
+      >
+        <caption id={tableCaptionId}>{labels.tableCaption}</caption>
         <thead>
           <tr>
             <th scope="col">{labels.metric}</th>

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -18,6 +18,14 @@ import type {
  * grows that filter.
  */
 export const CampaignService = {
+  calculateRoi(costCents: number | null, raisedCents: number): number | null {
+    if (costCents === null || costCents <= 0) {
+      return null;
+    }
+
+    return ((raisedCents - costCents) / costCents) * 100;
+  },
+
   async listCampaigns(
     client: ApiClient,
     query: CampaignListQuery = {},


### PR DESCRIPTION
Resolves #42 (PR-C4). Adds a Campaign ROI chart.