### PR TITLE
[codex] Close issue #95 phase 1 QA testing and UX consistency

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,6 +7,7 @@
     "dev": "dotenv -e ../../.env -- next dev --turbopack -p 3000",
     "build": "next build",
     "start": "next start",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -39,9 +40,14 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@tailwindcss/postcss": "^4.1.4",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "jsdom": "^25.0.1",
     "tailwindcss": "^4.1.4",
     "typescript": "^5.7.2"
   }

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -1,10 +1,11 @@
-import { ArrowLeft, Globe, Pencil } from "lucide-react";
+import { ArrowLeft, Gift, Globe, Pencil } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { CampaignRoiChart } from "@/components/campaigns/campaign-roi-chart";
 import { CampaignStatusActions } from "@/components/campaigns/campaign-status-actions";
+import { EmptyState } from "@/components/shared/empty-state";
 import { PageHeader } from "@/components/shared/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -141,7 +142,7 @@ export default async function CampaignDetailPage({
         }
       />
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,340px)_minmax(0,1fr)]">
+      <div className="grid gap-6 lg:grid-cols-[minmax(280px,340px)_minmax(0,1fr)]">
         <aside className="space-y-6">
           <StatsCard campaign={campaign} stats={stats} locale={locale} />
           <StatusCard campaign={campaign} />
@@ -196,7 +197,7 @@ async function StatsCard({
   const t = await getTranslations("campaigns.detail");
 
   return (
-    <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
       <h2 className="mb-4 font-heading text-xl text-on-surface">{t("stats.title")}</h2>
       <dl className="space-y-4">
         <StatRow
@@ -228,7 +229,7 @@ async function StatusCard({ campaign }: { campaign: Campaign }) {
   const t = await getTranslations("campaigns.detail");
 
   return (
-    <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
       <h2 className="mb-4 font-heading text-xl text-on-surface">{t("actions.title")}</h2>
       <p className="mb-4 text-sm text-on-surface-variant">{t("actions.description")}</p>
       <CampaignStatusActions campaignId={campaign.id} status={campaign.status} />
@@ -249,7 +250,7 @@ async function DonationBreakdownCard({
   const { data: donations, pagination } = donationsResult;
 
   return (
-    <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
       <div className="mb-4 flex items-center justify-between gap-3">
         <div>
           <h2 className="font-heading text-xl text-on-surface">{t("donations.title")}</h2>
@@ -265,7 +266,12 @@ async function DonationBreakdownCard({
       </div>
 
       {donations.length === 0 ? (
-        <p className="text-sm text-on-surface-variant">{t("donations.empty")}</p>
+        <EmptyState
+          icon={Gift}
+          title={t("donations.title")}
+          description={t("donations.empty")}
+          className="px-0 py-8"
+        />
       ) : (
         <DonationsTable donations={donations} pagination={pagination} />
       )}

--- a/packages/web/src/app/(app)/dashboard/page.tsx
+++ b/packages/web/src/app/(app)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { CalendarClock, CheckCircle2, Circle, Lightbulb, Plus } from "lucide-rea
 import Link from "next/link";
 import { getLocale, getTranslations } from "next-intl/server";
 
+import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
@@ -18,7 +19,8 @@ import { DonationService } from "@/services/DonationService";
 const RECENT_DONATIONS_LIMIT = 5;
 const KPI_SAMPLE_LIMIT = 100;
 
-type DashboardT = Awaited<ReturnType<typeof getTranslations>>;
+type DashboardT = (key: string, values?: Record<string, unknown>) => string;
+type DashboardTranslate = (key: string, values?: Record<string, string | number>) => string;
 
 interface CampaignWithStats {
   campaign: Campaign;
@@ -31,7 +33,7 @@ interface CampaignWithStats {
  */
 export default async function DashboardPage() {
   const auth = await requireAuth();
-  const t = await getTranslations("dashboard");
+  const t = (await getTranslations("dashboard")) as unknown as DashboardT;
   const locale = await getLocale();
   const client = await createServerApiClient();
 
@@ -64,12 +66,14 @@ export default async function DashboardPage() {
   const activeCampaignCount = activeCampaigns?.pagination.total ?? 0;
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6 sm:space-y-8">
       <div>
-        <h1 className="font-heading text-5xl font-normal leading-tight text-on-surface">
+        <h1 className="font-heading text-4xl font-normal leading-tight text-on-surface sm:text-5xl">
           {t("greeting", { name: auth.firstName ?? "" })}
         </h1>
-        <p className="mt-2 text-lg text-on-surface-variant">{t("subtitle")}</p>
+        <p className="mt-2 max-w-3xl text-base text-on-surface-variant sm:text-lg">
+          {t("subtitle")}
+        </p>
       </div>
 
       <section
@@ -100,7 +104,7 @@ export default async function DashboardPage() {
       </section>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.65fr)]">
-        <section className="rounded-md bg-surface-container-lowest p-6 shadow-card">
+        <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
           <SectionHeader
             title={t("recentDonations.title")}
             actionHref="/donations"
@@ -112,17 +116,22 @@ export default async function DashboardPage() {
                 <DonationFeedItem key={donation.id} donation={donation} t={t} locale={locale} />
               ))
             ) : (
-              <p className="py-6 text-sm text-on-surface-variant">{t("recentDonations.empty")}</p>
+              <EmptyState
+                icon={CalendarClock}
+                title={t("recentDonations.title")}
+                description={t("recentDonations.empty")}
+                className="px-0 py-8"
+              />
             )}
           </div>
         </section>
 
-        <section className="rounded-md bg-surface-container-lowest p-6 shadow-card">
+        <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
           <SectionHeader
             title={t("quickActions.title")}
             description={t("quickActions.description")}
           />
-          <div className="mt-4 grid gap-3">
+          <div className="mt-4 grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
             <QuickAction href="/donations/new" label={t("quickActions.newDonation")} />
             <QuickAction href="/constituents/new" label={t("quickActions.newConstituent")} />
             <QuickAction href="/campaigns/new" label={t("quickActions.newCampaign")} />
@@ -131,7 +140,7 @@ export default async function DashboardPage() {
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.65fr)]">
-        <section className="rounded-md bg-surface-container-lowest p-6 shadow-card">
+        <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
           <SectionHeader
             title={t("campaigns.title")}
             actionHref="/campaigns"
@@ -143,13 +152,18 @@ export default async function DashboardPage() {
                 <CampaignProgressItem key={item.campaign.id} item={item} t={t} locale={locale} />
               ))
             ) : (
-              <p className="text-sm text-on-surface-variant">{t("campaigns.empty")}</p>
+              <EmptyState
+                icon={Circle}
+                title={t("campaigns.title")}
+                description={t("campaigns.empty")}
+                className="px-0 py-8"
+              />
             )}
           </div>
         </section>
 
         <div className="space-y-6">
-          <section className="rounded-md border border-primary/20 bg-ai-bg p-6 shadow-card">
+          <section className="rounded-2xl border border-primary/20 bg-ai-bg p-5 shadow-card sm:p-6">
             <div className="flex items-center gap-2 text-ai-text">
               <Lightbulb size={18} aria-hidden="true" />
               <h2 className="font-heading text-xl leading-tight">{t("aiSuggestion.title")}</h2>
@@ -157,7 +171,7 @@ export default async function DashboardPage() {
             <p className="mt-3 text-sm leading-relaxed text-on-surface">{t("aiSuggestion.body")}</p>
           </section>
 
-          <section className="rounded-md bg-surface-container-lowest p-6 shadow-card">
+          <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
             <SectionHeader
               title={t("onboarding.title")}
               description={t("onboarding.description")}
@@ -247,7 +261,7 @@ function StatCard({
   valueClassName?: string;
 }) {
   return (
-    <article className="min-h-36 rounded-md bg-surface-container-lowest p-5 shadow-card">
+    <article className="min-h-36 rounded-2xl bg-surface-container-lowest p-5 shadow-card">
       <p className="text-sm font-medium text-on-surface-variant">{label}</p>
       <p
         className={`mt-3 font-heading text-4xl font-normal leading-tight text-on-surface ${valueClassName ?? ""}`.trim()}
@@ -312,9 +326,10 @@ function CampaignProgressItem({
   const raisedCents = stats?.totalRaisedCents ?? 0;
   const goalCents = campaign.costCents ?? 0;
   const progress = goalCents > 0 ? Math.min(Math.round((raisedCents / goalCents) * 100), 100) : 0;
+  const translate = t as unknown as DashboardTranslate;
 
   return (
-    <article className="rounded-md border border-outline-variant/60 p-4">
+    <article className="rounded-2xl border border-outline-variant/60 p-4 sm:p-5">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <h3 className="truncate text-sm font-semibold text-on-surface">{campaign.name}</h3>
@@ -332,11 +347,11 @@ function CampaignProgressItem({
       </div>
       <p className="mt-2 text-xs text-on-surface-variant">
         {goalCents > 0
-          ? t("campaigns.progressWithGoal", {
+          ? translate("campaigns.progressWithGoal", {
               progress,
               goal: formatCurrency(goalCents, locale),
             })
-          : t("campaigns.progressWithoutGoal", {
+          : translate("campaigns.progressWithoutGoal", {
               donations: stats?.donationCount ?? 0,
             })}
       </p>

--- a/packages/web/src/app/(public)/p/[id]/page.tsx
+++ b/packages/web/src/app/(public)/p/[id]/page.tsx
@@ -35,8 +35,8 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
 
     return (
       <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(9,100,71,0.14),_transparent_42%),linear-gradient(180deg,_var(--color-surface-container-lowest)_0%,_var(--color-surface)_100%)]">
-        <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-6 sm:px-8 lg:px-10 lg:py-10">
-          <div className="flex items-center justify-between gap-4">
+        <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-4 sm:px-8 sm:py-6 lg:px-10 lg:py-10">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <Button asChild variant="ghost" size="sm">
               <Link href="/">
                 <ArrowLeft size={16} aria-hidden="true" />
@@ -49,10 +49,10 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
             </Badge>
           </div>
 
-          <div className="mt-8 grid flex-1 gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(340px,420px)] lg:items-start">
+          <div className="mt-6 grid flex-1 gap-6 lg:mt-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(320px,420px)] lg:items-start">
             <section className="overflow-hidden rounded-[32px] border border-outline-variant bg-surface-container-lowest shadow-card">
               <div
-                className="px-6 py-10 sm:px-10 sm:py-12"
+                className="px-5 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12"
                 style={{
                   background: `linear-gradient(135deg, ${colorPrimary}, color-mix(in srgb, ${colorPrimary} 60%, #0B1220))`,
                   color: onPrimary,
@@ -69,7 +69,7 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
                 </p>
               </div>
 
-              <div className="grid gap-4 border-t border-outline-variant px-6 py-6 sm:grid-cols-2 sm:px-10 sm:py-8">
+              <div className="grid gap-4 border-t border-outline-variant px-5 py-5 sm:grid-cols-2 sm:px-8 sm:py-6 lg:px-10 lg:py-8">
                 <Metric
                   label={t("metrics.goal")}
                   value={
@@ -106,7 +106,7 @@ function Metric({ label, value }: { label: string; value: string }) {
       <p className="text-xs font-medium uppercase tracking-[0.14em] text-on-surface-variant">
         {label}
       </p>
-      <p className="mt-2 text-lg font-semibold text-on-surface">{value}</p>
+      <p className="mt-2 text-base font-semibold text-on-surface sm:text-lg">{value}</p>
     </div>
   );
 }

--- a/packages/web/src/components/campaigns/campaign-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.test.tsx
@@ -1,0 +1,83 @@
+import { CampaignForm } from "@/components/campaigns/campaign-form";
+import { ApiProblem } from "@/lib/api";
+import type { Campaign } from "@/models/campaign";
+import { CampaignService } from "@/services/CampaignService";
+import { mockRouter, mockToast, render, screen, userEvent, waitFor } from "../../tests/test-utils";
+
+const parentCampaign: Campaign = {
+  id: "11111111-1111-4111-8111-111111111111",
+  orgId: "00000000-0000-0000-0000-0000000000a1",
+  name: "Regional Appeal",
+  type: "digital",
+  status: "active",
+  parentId: null,
+  costCents: 35000,
+  createdAt: "2026-04-21T10:00:00.000Z",
+  updatedAt: "2026-04-21T10:00:00.000Z",
+};
+
+describe("CampaignForm", () => {
+  beforeEach(() => {
+    vi.spyOn(CampaignService, "listCampaigns").mockResolvedValue({
+      data: [parentCampaign],
+      pagination: { page: 1, perPage: 100, total: 1, totalPages: 1 },
+    });
+  });
+
+  it("submits trimmed values in create mode", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignService, "createCampaign").mockResolvedValue({
+      ...parentCampaign,
+      id: "22222222-2222-4222-8222-222222222222",
+      name: "Spring Appeal 2026",
+      costCents: 1250,
+    });
+
+    render(<CampaignForm mode="create" />);
+
+    await waitFor(() => expect(CampaignService.listCampaigns).toHaveBeenCalled());
+
+    await user.type(screen.getByPlaceholderText("Spring appeal 2026"), "  Spring Appeal 2026  ");
+    await user.type(screen.getByPlaceholderText("0.00"), "12.50");
+    await user.click(screen.getByRole("button", { name: "Create campaign" }));
+
+    await waitFor(() =>
+      expect(CampaignService.createCampaign).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          name: "Spring Appeal 2026",
+          type: "digital",
+          parentId: null,
+          costCents: 1250,
+        }),
+      ),
+    );
+
+    expect(mockToast.success).toHaveBeenCalledWith("Campaign created.");
+    expect(mockRouter.push).toHaveBeenCalledWith("/campaigns/22222222-2222-4222-8222-222222222222");
+    expect(mockRouter.refresh).toHaveBeenCalled();
+  });
+
+  it("surfaces API validation errors at the form level", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignService, "createCampaign").mockRejectedValue(
+      new ApiProblem({
+        type: "https://givernance.test/problems/validation",
+        title: "Validation failed",
+        status: 422,
+        detail: "Campaign name is already used.",
+      }),
+    );
+
+    render(<CampaignForm mode="create" />);
+
+    await waitFor(() => expect(CampaignService.listCampaigns).toHaveBeenCalled());
+
+    await user.type(screen.getByPlaceholderText("Spring appeal 2026"), "Existing campaign");
+    await user.click(screen.getByRole("button", { name: "Create campaign" }));
+
+    expect(await screen.findByText("Campaign name is already used.")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/campaigns/campaign-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.tsx
@@ -13,10 +13,18 @@ import { typeboxResolver } from "@hookform/resolvers/typebox";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { type DefaultValues, type Resolver, type UseFormReturn, useForm } from "react-hook-form";
 
-import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/shared/form-field";
+import { AmountInput } from "@/components/shared/amount-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/shared/form-field";
 import { FormSection } from "@/components/shared/form-section";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -142,7 +150,7 @@ export function CampaignForm(props: CampaignFormProps) {
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="rounded-2xl bg-surface-container-lowest px-6 shadow-card"
+        className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
         noValidate
       >
         <FormSection
@@ -156,12 +164,14 @@ export function CampaignForm(props: CampaignFormProps) {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel required>{t("fields.name")}</FormLabel>
-                  <Input
-                    {...field}
-                    placeholder={t("fields.namePlaceholder")}
-                    maxLength={255}
-                    aria-invalid={Boolean(form.formState.errors.name)}
-                  />
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder={t("fields.namePlaceholder")}
+                      maxLength={255}
+                      aria-invalid={Boolean(form.formState.errors.name)}
+                    />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
@@ -173,9 +183,11 @@ export function CampaignForm(props: CampaignFormProps) {
                 <FormItem>
                   <FormLabel required>{t("fields.type")}</FormLabel>
                   <Select value={field.value} onValueChange={field.onChange}>
-                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.type)}>
-                      <SelectValue />
-                    </SelectTrigger>
+                    <FormControl>
+                      <SelectTrigger aria-invalid={Boolean(form.formState.errors.type)}>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
                     <SelectContent>
                       {CAMPAIGN_TYPES.map((type) => (
                         <SelectItem key={type} value={type}>
@@ -206,9 +218,11 @@ export function CampaignForm(props: CampaignFormProps) {
                     value={field.value || EMPTY_PARENT}
                     onValueChange={(value) => field.onChange(value === EMPTY_PARENT ? "" : value)}
                   >
-                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.parentId)}>
-                      <SelectValue placeholder={t("fields.parentPlaceholder")} />
-                    </SelectTrigger>
+                    <FormControl>
+                      <SelectTrigger aria-invalid={Boolean(form.formState.errors.parentId)}>
+                        <SelectValue placeholder={t("fields.parentPlaceholder")} />
+                      </SelectTrigger>
+                    </FormControl>
                     <SelectContent>
                       <SelectItem value={EMPTY_PARENT}>{t("fields.parentPlaceholder")}</SelectItem>
                       {parentOptions.map((campaign) => (
@@ -231,12 +245,13 @@ export function CampaignForm(props: CampaignFormProps) {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>{t("fields.goal")}</FormLabel>
-                  <AmountInput
-                    value={field.value}
-                    onChange={field.onChange}
-                    invalid={Boolean(form.formState.errors.costCents)}
-                    placeholder={t("fields.goalPlaceholder")}
-                  />
+                  <FormControl>
+                    <AmountInput
+                      value={field.value}
+                      onChange={(nextValue) => field.onChange(nextValue)}
+                      placeholder={t("fields.goalPlaceholder")}
+                    />
+                  </FormControl>
                   <p className="text-xs text-on-surface-variant">{t("fields.goalHint")}</p>
                   <FormMessage />
                 </FormItem>
@@ -265,67 +280,6 @@ export function CampaignForm(props: CampaignFormProps) {
       </form>
     </Form>
   );
-}
-
-interface AmountInputProps {
-  value: number | null | undefined;
-  onChange: (value: number | null) => void;
-  invalid: boolean;
-  placeholder?: string;
-}
-
-function AmountInput({ value, onChange, invalid, placeholder }: AmountInputProps) {
-  const [raw, setRaw] = useState<string>(() => centsToDisplay(value));
-  const lastValueRef = useRef<number | null | undefined>(value);
-
-  useEffect(() => {
-    if (value !== lastValueRef.current) {
-      lastValueRef.current = value;
-      setRaw(centsToDisplay(value));
-    }
-  }, [value]);
-
-  return (
-    <div className="relative">
-      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-on-surface-variant">
-        €
-      </span>
-      <Input
-        type="text"
-        inputMode="decimal"
-        value={raw}
-        placeholder={placeholder}
-        aria-invalid={invalid}
-        className="pl-7 font-mono tabular-nums"
-        onChange={(event) => {
-          const next = event.target.value;
-          setRaw(next);
-          const parsed = parseAmount(next);
-          lastValueRef.current = parsed;
-          onChange(parsed);
-        }}
-        onBlur={() => {
-          const parsed = parseAmount(raw);
-          lastValueRef.current = parsed;
-          onChange(parsed);
-          setRaw(centsToDisplay(parsed));
-        }}
-      />
-    </div>
-  );
-}
-
-function centsToDisplay(value: number | null | undefined): string {
-  if (value === null || value === undefined || Number.isNaN(value)) return "";
-  return (value / 100).toFixed(2);
-}
-
-function parseAmount(raw: string): number | null {
-  const trimmed = raw.trim().replace(/\s/g, "").replace(",", ".");
-  if (trimmed === "") return null;
-  const parsed = Number(trimmed);
-  if (!Number.isFinite(parsed) || parsed < 0) return null;
-  return Math.round(parsed * 100);
 }
 
 function toApiPayload(values: CampaignFormValues) {

--- a/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
@@ -1,0 +1,54 @@
+import { CampaignPublicPageForm } from "@/components/campaigns/campaign-public-page-form";
+import { CampaignPublicPageService } from "@/services/CampaignPublicPageService";
+import { mockRouter, render, screen, userEvent, waitFor } from "@/tests/test-utils";
+
+describe("CampaignPublicPageForm", () => {
+  it("blocks submission when the goal amount input stays invalid", async () => {
+    const user = userEvent.setup();
+
+    const upsertCampaignPublicPage = vi
+      .spyOn(CampaignPublicPageService, "upsertCampaignPublicPage")
+      .mockResolvedValue({
+        id: "44444444-4444-4444-8444-444444444444",
+        orgId: "org-1",
+        campaignId: "11111111-1111-4111-8111-111111111111",
+        title: "Spring Appeal",
+        description: null,
+        colorPrimary: "#096447",
+        goalAmountCents: null,
+        status: "draft",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+    render(
+      <CampaignPublicPageForm
+        campaign={{
+          id: "11111111-1111-4111-8111-111111111111",
+          orgId: "org-1",
+          name: "Spring Appeal",
+          type: "digital",
+          status: "active",
+          parentId: null,
+          costCents: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        }}
+        initialPage={null}
+      />,
+    );
+
+    const amountInput = screen.getByLabelText("Displayed goal amount");
+    await user.type(amountInput, "12.345");
+    await user.tab();
+    await user.click(screen.getByRole("button", { name: "Save public page" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Enter a valid amount with no more than two decimal places."),
+      ).toBeInTheDocument(),
+    );
+    expect(upsertCampaignPublicPage).not.toHaveBeenCalled();
+    expect(mockRouter.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/campaigns/campaign-public-page-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-public-page-form.tsx
@@ -9,7 +9,7 @@ import { Copy, ExternalLink, Eye, Globe, Palette, Save } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import {
   type DefaultValues,
   type Resolver,
@@ -18,6 +18,7 @@ import {
   useWatch,
 } from "react-hook-form";
 
+import { AmountInput } from "@/components/shared/amount-input";
 import {
   Form,
   FormControl,
@@ -130,7 +131,7 @@ export function CampaignPublicPageForm({ campaign, initialPage }: CampaignPublic
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
-          className="rounded-2xl bg-surface-container-lowest px-6 shadow-card"
+          className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
           noValidate
         >
           <FormSection
@@ -193,7 +194,9 @@ export function CampaignPublicPageForm({ campaign, initialPage }: CampaignPublic
                     <FormControl>
                       <AmountInput
                         value={field.value}
-                        onChange={field.onChange}
+                        onChange={(nextValue, meta) =>
+                          field.onChange(meta.isValid ? nextValue : (Number.NaN as number))
+                        }
                         placeholder={t("fields.goalPlaceholder")}
                       />
                     </FormControl>
@@ -328,7 +331,7 @@ function CampaignPublicPagePreview({
 
   return (
     <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
-      <section className="rounded-2xl bg-surface-container-lowest p-6 shadow-card">
+      <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
         <div className="mb-4 flex items-center justify-between gap-3">
           <div>
             <h2 className="font-heading text-xl text-on-surface">{t("title")}</h2>
@@ -341,7 +344,7 @@ function CampaignPublicPagePreview({
 
         <div className="overflow-hidden rounded-[28px] border border-outline-variant bg-surface shadow-card">
           <div
-            className="px-6 py-5"
+            className="px-5 py-5 sm:px-6"
             style={{
               background: `linear-gradient(135deg, ${safeColor}, color-mix(in srgb, ${safeColor} 55%, #0B1220))`,
               color: onColor,
@@ -365,7 +368,7 @@ function CampaignPublicPagePreview({
             </p>
           </div>
 
-          <div className="space-y-5 p-6">
+          <div className="space-y-5 p-5 sm:p-6">
             <div className="grid gap-3 sm:grid-cols-2">
               <PreviewMetric
                 label={t("campaign")}
@@ -462,93 +465,6 @@ function PublicPageShareActions({
       </Button>
     </>
   );
-}
-
-interface AmountInputProps {
-  value: number | null | undefined;
-  onChange: (value: number | null) => void;
-  placeholder?: string;
-  id?: string;
-  "aria-describedby"?: string;
-  "aria-invalid"?: boolean;
-}
-
-function AmountInput({
-  value,
-  onChange,
-  placeholder,
-  id,
-  "aria-describedby": ariaDescribedBy,
-  "aria-invalid": ariaInvalid,
-}: AmountInputProps) {
-  const [raw, setRaw] = useState<string>(() => centsToDisplay(value));
-  const lastValueRef = useRef<number | null | undefined>(value);
-
-  useEffect(() => {
-    if (!Object.is(value, lastValueRef.current)) {
-      lastValueRef.current = value;
-      setRaw(centsToDisplay(value));
-    }
-  }, [value]);
-
-  return (
-    <div className="relative">
-      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-on-surface-variant">
-        €
-      </span>
-      <Input
-        id={id}
-        type="text"
-        inputMode="decimal"
-        value={raw}
-        placeholder={placeholder}
-        aria-describedby={ariaDescribedBy}
-        aria-invalid={ariaInvalid}
-        className="pl-7 font-mono tabular-nums"
-        onChange={(event) => {
-          const next = event.target.value;
-          setRaw(next);
-          const parsed = parseAmount(next);
-          const nextValue = parsed.isValid ? sanitizeGoalAmount(parsed.value) : Number.NaN;
-          lastValueRef.current = nextValue;
-          onChange(nextValue);
-        }}
-        onBlur={() => {
-          const parsed = parseAmount(raw);
-          if (!parsed.isValid) {
-            lastValueRef.current = Number.NaN;
-            onChange(Number.NaN);
-            return;
-          }
-
-          const nextValue = sanitizeGoalAmount(parsed.value);
-          lastValueRef.current = nextValue;
-          onChange(nextValue);
-          setRaw(centsToDisplay(nextValue));
-        }}
-      />
-    </div>
-  );
-}
-
-function centsToDisplay(value: number | null | undefined): string {
-  if (value === null || value === undefined || Number.isNaN(value)) return "";
-  return (value / 100).toFixed(2);
-}
-
-function parseAmount(raw: string): { value: number | null; isValid: boolean } {
-  const trimmed = raw.trim().replace(/\s/g, "").replace(",", ".");
-  if (trimmed === "") return { value: null, isValid: true };
-  if (!/^\d+(\.\d{0,2})?$/.test(trimmed)) {
-    return { value: null, isValid: false };
-  }
-
-  const parsed = Number(trimmed);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return { value: null, isValid: false };
-  }
-
-  return { value: Math.round(parsed * 100), isValid: true };
 }
 
 function getReadableTextColor(hex: string): "#FFFFFF" | "#111827" {

--- a/packages/web/src/components/campaigns/public-donation-form.test.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.test.tsx
@@ -1,0 +1,99 @@
+import { PublicDonationForm } from "@/components/campaigns/public-donation-form";
+import { ApiProblem } from "@/lib/api";
+import { CampaignPublicPageService } from "@/services/CampaignPublicPageService";
+import { mockToast, render, screen, userEvent, waitFor } from "../../tests/test-utils";
+
+describe("PublicDonationForm", () => {
+  it("shows inline validation errors before submission", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={50000}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Continue to payment" }));
+
+    expect(await screen.findByText("Enter your first name.")).toBeInTheDocument();
+    expect(screen.getByText("Enter your last name.")).toBeInTheDocument();
+    expect(screen.getByText("Enter your email address.")).toBeInTheDocument();
+    expect(screen.getByText("Enter a donation amount.")).toBeInTheDocument();
+  });
+
+  it("creates a donation intent with trimmed values and cents", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      clientSecret: "pi_secret_123",
+    });
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={50000}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^First name/), "  Jane ");
+    await user.type(screen.getByLabelText(/^Last name/), " Doe  ");
+    await user.type(screen.getByLabelText(/^Email/), " jane@example.org ");
+    await user.click(screen.getByRole("button", { name: "€100" }));
+    await user.click(screen.getByRole("button", { name: "Continue to payment" }));
+
+    await waitFor(() =>
+      expect(CampaignPublicPageService.createPublicDonationIntent).toHaveBeenCalledWith(
+        expect.anything(),
+        "11111111-1111-4111-8111-111111111111",
+        {
+          amountCents: 10000,
+          currency: "EUR",
+          email: "jane@example.org",
+          firstName: "Jane",
+          lastName: "Doe",
+        },
+        expect.any(String),
+      ),
+    );
+
+    expect(mockToast.success).toHaveBeenCalledWith(
+      "Your donation is ready. The Stripe payment step is the next integration.",
+    );
+    expect(await screen.findByText("Next step")).toBeInTheDocument();
+  });
+
+  it("shows an API error toast when payment preparation fails", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockRejectedValue(
+      new ApiProblem({
+        type: "https://givernance.test/problems/payment",
+        title: "Payment failure",
+        status: 500,
+        detail: "Stripe is unavailable.",
+      }),
+    );
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={null}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^First name/), "Jane");
+    await user.type(screen.getByLabelText(/^Last name/), "Doe");
+    await user.type(screen.getByLabelText(/^Email/), "jane@example.org");
+    await user.type(screen.getByLabelText(/^Amount/), "50");
+    await user.click(screen.getByRole("button", { name: "Continue to payment" }));
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalledWith("Stripe is unavailable."));
+  });
+});

--- a/packages/web/src/components/campaigns/public-donation-form.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.tsx
@@ -109,12 +109,12 @@ export function PublicDonationForm({
 
       <p className="mt-3 text-sm leading-6 text-on-surface-variant">{t("description")}</p>
 
-      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+      <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
         {SUGGESTED_AMOUNTS.map((amount) => (
           <button
             key={amount}
             type="button"
-            className="rounded-2xl border border-outline-variant bg-surface px-4 py-5 text-center transition-colors hover:border-primary"
+            className="rounded-2xl border border-outline-variant bg-surface px-4 py-4 text-center transition-colors hover:border-primary sm:py-5"
             style={{
               backgroundColor: values.amount === String(amount) ? colorPrimary : undefined,
               color:
@@ -125,7 +125,7 @@ export function PublicDonationForm({
               setErrors((current) => ({ ...current, amount: undefined }));
             }}
           >
-            <span className="block text-center text-xl font-semibold">
+            <span className="block text-center text-lg font-semibold sm:text-xl">
               {new Intl.NumberFormat(locale, {
                 style: "currency",
                 currency: "EUR",
@@ -145,11 +145,13 @@ export function PublicDonationForm({
       <form className="mt-6 space-y-4" onSubmit={handleSubmit} noValidate>
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
+            inputId="public-donation-first-name"
             label={t("fields.firstName")}
             error={errors.firstName}
             required
             input={
               <Input
+                id="public-donation-first-name"
                 value={values.firstName}
                 onChange={(event) => {
                   setValues((current) => ({ ...current, firstName: event.target.value }));
@@ -162,11 +164,13 @@ export function PublicDonationForm({
             }
           />
           <Field
+            inputId="public-donation-last-name"
             label={t("fields.lastName")}
             error={errors.lastName}
             required
             input={
               <Input
+                id="public-donation-last-name"
                 value={values.lastName}
                 onChange={(event) => {
                   setValues((current) => ({ ...current, lastName: event.target.value }));
@@ -181,11 +185,13 @@ export function PublicDonationForm({
         </div>
 
         <Field
+          inputId="public-donation-email"
           label={t("fields.email")}
           error={errors.email}
           required
           input={
             <Input
+              id="public-donation-email"
               type="email"
               value={values.email}
               onChange={(event) => {
@@ -200,6 +206,7 @@ export function PublicDonationForm({
         />
 
         <Field
+          inputId="public-donation-amount"
           label={t("fields.amount")}
           error={errors.amount}
           required
@@ -209,6 +216,7 @@ export function PublicDonationForm({
                 €
               </span>
               <Input
+                id="public-donation-amount"
                 type="number"
                 min="1"
                 step="1"
@@ -249,18 +257,22 @@ export function PublicDonationForm({
           )}
         </Button>
 
-        <p className="text-xs leading-5 text-on-surface-variant">{t("footnote")}</p>
+        <p className="text-center text-xs leading-5 text-on-surface-variant sm:text-left">
+          {t("footnote")}
+        </p>
       </form>
     </section>
   );
 }
 
 function Field({
+  inputId,
   label,
   error,
   required,
   input,
 }: {
+  inputId?: string;
   label: string;
   error?: string;
   required?: boolean;
@@ -268,10 +280,10 @@ function Field({
 }) {
   return (
     <div className="block space-y-2">
-      <span className="text-sm font-medium text-on-surface">
+      <label htmlFor={inputId} className="text-sm font-medium text-on-surface">
         {label}
         {required ? <span className="ml-1 text-error">*</span> : null}
-      </span>
+      </label>
       {input}
       {error ? <span className="block text-sm text-error">{error}</span> : null}
     </div>

--- a/packages/web/src/components/campaigns/public-donation-form.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.tsx
@@ -267,14 +267,14 @@ function Field({
   input: ReactNode;
 }) {
   return (
-    <label className="block space-y-2">
+    <div className="block space-y-2">
       <span className="text-sm font-medium text-on-surface">
         {label}
         {required ? <span className="ml-1 text-error">*</span> : null}
       </span>
       {input}
       {error ? <span className="block text-sm text-error">{error}</span> : null}
-    </label>
+    </div>
   );
 }
 

--- a/packages/web/src/components/constituents/constituent-form.tsx
+++ b/packages/web/src/components/constituents/constituent-form.tsx
@@ -8,27 +8,6 @@ if (!FormatRegistry.Has("email")) {
   );
 }
 
-// We must implement the email regex format manually for TypeBox in the browser if we don"t import the full formats plugin.
-if (!FormatRegistry.Has("email")) {
-  FormatRegistry.Set("email", (value: string) =>
-    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
-  );
-}
-
-// We must implement the email regex format manually for TypeBox in the browser if we don"t import the full formats plugin.
-if (!FormatRegistry.Has("email")) {
-  FormatRegistry.Set("email", (value: string) =>
-    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
-  );
-}
-
-// We must implement the email regex format manually for TypeBox in the browser if we don"t import the full formats plugin.
-if (!FormatRegistry.Has("email")) {
-  FormatRegistry.Set("email", (value: string) =>
-    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
-  );
-}
-
 import { ConstituentCreateSchema, ConstituentUpdateSchema } from "@givernance/shared/validators";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { AlertTriangle } from "lucide-react";
@@ -36,7 +15,14 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { type DefaultValues, type Resolver, type UseFormReturn, useForm } from "react-hook-form";
-import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/shared/form-field";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/shared/form-field";
 import { FormSection } from "@/components/shared/form-section";
 import { Button } from "@/components/ui/button";
 import {
@@ -191,9 +177,11 @@ export function ConstituentForm(props: ConstituentFormProps) {
                 <FormItem>
                   <FormLabel required>{t("fields.type")}</FormLabel>
                   <Select value={field.value} onValueChange={field.onChange}>
-                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.type)}>
-                      <SelectValue />
-                    </SelectTrigger>
+                    <FormControl>
+                      <SelectTrigger aria-invalid={Boolean(form.formState.errors.type)}>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
                     <SelectContent>
                       {CONSTITUENT_TYPES.map((type) => (
                         <SelectItem key={type} value={type}>
@@ -214,12 +202,14 @@ export function ConstituentForm(props: ConstituentFormProps) {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel required>{t("fields.firstName")}</FormLabel>
-                    <Input
-                      {...field}
-                      autoComplete="given-name"
-                      placeholder={t("fields.firstNamePlaceholder")}
-                      aria-invalid={Boolean(form.formState.errors.firstName)}
-                    />
+                    <FormControl>
+                      <Input
+                        {...field}
+                        autoComplete="given-name"
+                        placeholder={t("fields.firstNamePlaceholder")}
+                        aria-invalid={Boolean(form.formState.errors.firstName)}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -230,12 +220,14 @@ export function ConstituentForm(props: ConstituentFormProps) {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel required>{t("fields.lastName")}</FormLabel>
-                    <Input
-                      {...field}
-                      autoComplete="family-name"
-                      placeholder={t("fields.lastNamePlaceholder")}
-                      aria-invalid={Boolean(form.formState.errors.lastName)}
-                    />
+                    <FormControl>
+                      <Input
+                        {...field}
+                        autoComplete="family-name"
+                        placeholder={t("fields.lastNamePlaceholder")}
+                        aria-invalid={Boolean(form.formState.errors.lastName)}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -254,13 +246,15 @@ export function ConstituentForm(props: ConstituentFormProps) {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>{t("fields.email")}</FormLabel>
-                    <Input
-                      {...field}
-                      type="email"
-                      autoComplete="email"
-                      placeholder={t("fields.emailPlaceholder")}
-                      aria-invalid={Boolean(form.formState.errors.email)}
-                    />
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={t("fields.emailPlaceholder")}
+                        aria-invalid={Boolean(form.formState.errors.email)}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -271,13 +265,15 @@ export function ConstituentForm(props: ConstituentFormProps) {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>{t("fields.phone")}</FormLabel>
-                    <Input
-                      {...field}
-                      type="tel"
-                      autoComplete="tel"
-                      placeholder={t("fields.phonePlaceholder")}
-                      aria-invalid={Boolean(form.formState.errors.phone)}
-                    />
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="tel"
+                        autoComplete="tel"
+                        placeholder={t("fields.phonePlaceholder")}
+                        aria-invalid={Boolean(form.formState.errors.phone)}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -422,11 +418,17 @@ function buildResolver(schema: TypeboxSchema): Resolver<ConstituentFormValues> {
   const innerResolver = typeboxResolver(schema) as unknown as Resolver<ConstituentFormValues>;
   return async (values, context, options) => {
     const cleaned = { ...values } as Record<string, unknown>;
-    for (const key of ["email", "phone"] as const) {
+    for (const key of ["firstName", "lastName", "email", "phone"] as const) {
       const v = cleaned[key];
-      if (typeof v === "string" && v.trim() === "") {
-        cleaned[key] = undefined;
+      if (typeof v !== "string") continue;
+
+      const trimmed = v.trim();
+      if (trimmed === "") {
+        cleaned[key] = key === "firstName" || key === "lastName" ? "" : undefined;
+        continue;
       }
+
+      cleaned[key] = trimmed;
     }
     return innerResolver(cleaned as unknown as ConstituentFormValues, context, options);
   };

--- a/packages/web/src/components/donations/donation-form.test.tsx
+++ b/packages/web/src/components/donations/donation-form.test.tsx
@@ -1,0 +1,74 @@
+import { DonationForm } from "@/components/donations/donation-form";
+import { CampaignService } from "@/services/CampaignService";
+import { ConstituentService } from "@/services/ConstituentService";
+import { DonationService } from "@/services/DonationService";
+import { mockRouter, mockToast, render, screen, userEvent, waitFor } from "@/tests/test-utils";
+
+describe("DonationForm", () => {
+  it("creates a donation after selecting a constituent and entering a valid amount", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignService, "listCampaigns").mockResolvedValue({
+      data: [],
+      pagination: { page: 1, perPage: 100, total: 0, totalPages: 0 },
+    });
+    vi.spyOn(ConstituentService, "listConstituents").mockResolvedValue({
+      data: [
+        {
+          id: "22222222-2222-4222-8222-222222222222",
+          orgId: "org-1",
+          firstName: "Ada",
+          lastName: "Lovelace",
+          email: "ada@example.com",
+          phone: null,
+          type: "donor",
+          tags: null,
+          deletedAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      pagination: { page: 1, perPage: 50, total: 1, totalPages: 1 },
+    });
+    const createDonation = vi.spyOn(DonationService, "createDonation").mockResolvedValue({
+      id: "33333333-3333-4333-8333-333333333333",
+      orgId: "org-1",
+      constituentId: "22222222-2222-4222-8222-222222222222",
+      amountCents: 2550,
+      currency: "EUR",
+      campaignId: null,
+      paymentMethod: null,
+      paymentRef: null,
+      donatedAt: "2026-04-22T00:00:00.000Z",
+      fiscalYear: 2026,
+      createdAt: "2026-04-22T00:00:00.000Z",
+      updatedAt: "2026-04-22T00:00:00.000Z",
+    });
+
+    render(<DonationForm />);
+
+    await waitFor(() => expect(CampaignService.listCampaigns).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: "Search for a donor…" }));
+    await waitFor(() => expect(ConstituentService.listConstituents).toHaveBeenCalled());
+    await user.click(await screen.findByText("Ada Lovelace"));
+
+    const amountInput = screen.getByPlaceholderText("0.00");
+    await user.type(amountInput, "25,50");
+    await user.tab();
+    await user.click(screen.getByRole("button", { name: "Save donation" }));
+
+    await waitFor(() => expect(createDonation).toHaveBeenCalled());
+    expect(createDonation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        constituentId: "22222222-2222-4222-8222-222222222222",
+        amountCents: 2550,
+        currency: "EUR",
+      }),
+    );
+    expect(mockToast.success).toHaveBeenCalledWith("Donation recorded.");
+    expect(mockRouter.push).toHaveBeenCalledWith("/donations/33333333-3333-4333-8333-333333333333");
+    expect(mockRouter.refresh).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -16,7 +16,7 @@ import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { Check, ChevronsUpDown, Plus, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   type DefaultValues,
   type Resolver,
@@ -25,7 +25,15 @@ import {
   useForm,
 } from "react-hook-form";
 
-import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/shared/form-field";
+import { AmountInput } from "@/components/shared/amount-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/shared/form-field";
 import { FormSection } from "@/components/shared/form-section";
 import { Button } from "@/components/ui/button";
 import {
@@ -174,7 +182,7 @@ export function DonationForm() {
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="rounded-2xl bg-surface-container-lowest px-6 shadow-card"
+        className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
         noValidate
       >
         <FormSection
@@ -187,16 +195,18 @@ export function DonationForm() {
             render={({ field }) => (
               <FormItem>
                 <FormLabel required>{t("fields.constituent")}</FormLabel>
-                <ConstituentPicker
-                  value={field.value}
-                  selected={selectedConstituent}
-                  onSelect={(constituent) => {
-                    setSelectedConstituent(constituent);
-                    field.onChange(constituent?.id ?? "");
-                    if (constituent?.id) form.clearErrors("constituentId");
-                  }}
-                  invalid={Boolean(form.formState.errors.constituentId)}
-                />
+                <FormControl>
+                  <ConstituentPicker
+                    value={field.value}
+                    selected={selectedConstituent}
+                    onSelect={(constituent) => {
+                      setSelectedConstituent(constituent);
+                      field.onChange(constituent?.id ?? "");
+                      if (constituent?.id) form.clearErrors("constituentId");
+                    }}
+                    invalid={Boolean(form.formState.errors.constituentId)}
+                  />
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}
@@ -214,15 +224,18 @@ export function DonationForm() {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel required>{t("fields.amount")}</FormLabel>
-                  <AmountInput
-                    value={field.value}
-                    onChange={(v) => {
-                      field.onChange(v);
-                      if (v && v > 0) form.clearErrors("amountCents");
-                    }}
-                    invalid={Boolean(form.formState.errors.amountCents)}
-                    placeholder={t("fields.amountPlaceholder")}
-                  />
+                  <FormControl>
+                    <AmountInput
+                      value={field.value}
+                      onChange={(nextValue, meta) => {
+                        field.onChange(nextValue);
+                        if (meta.isValid && nextValue && nextValue > 0) {
+                          form.clearErrors("amountCents");
+                        }
+                      }}
+                      placeholder={t("fields.amountPlaceholder")}
+                    />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
@@ -234,9 +247,11 @@ export function DonationForm() {
                 <FormItem>
                   <FormLabel>{t("fields.currency")}</FormLabel>
                   <Select value={field.value} onValueChange={field.onChange}>
-                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.currency)}>
-                      <SelectValue />
-                    </SelectTrigger>
+                    <FormControl>
+                      <SelectTrigger aria-invalid={Boolean(form.formState.errors.currency)}>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
                     <SelectContent>
                       {CURRENCIES.map((c) => (
                         <SelectItem key={c} value={c}>
@@ -258,12 +273,14 @@ export function DonationForm() {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>{t("fields.donatedAt")}</FormLabel>
-                  <Input
-                    type="date"
-                    value={field.value}
-                    onChange={(e) => field.onChange(e.target.value)}
-                    aria-invalid={Boolean(form.formState.errors.donatedAt)}
-                  />
+                  <FormControl>
+                    <Input
+                      type="date"
+                      value={field.value}
+                      onChange={(e) => field.onChange(e.target.value)}
+                      aria-invalid={Boolean(form.formState.errors.donatedAt)}
+                    />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
@@ -278,9 +295,11 @@ export function DonationForm() {
                     value={field.value}
                     onValueChange={(value) => field.onChange(value === "" ? "" : value)}
                   >
-                    <SelectTrigger aria-invalid={Boolean(form.formState.errors.paymentMethod)}>
-                      <SelectValue placeholder={t("fields.paymentMethodPlaceholder")} />
-                    </SelectTrigger>
+                    <FormControl>
+                      <SelectTrigger aria-invalid={Boolean(form.formState.errors.paymentMethod)}>
+                        <SelectValue placeholder={t("fields.paymentMethodPlaceholder")} />
+                      </SelectTrigger>
+                    </FormControl>
                     <SelectContent>
                       {PAYMENT_METHODS.map((method) => (
                         <SelectItem key={method} value={method}>
@@ -301,11 +320,13 @@ export function DonationForm() {
             render={({ field }) => (
               <FormItem>
                 <FormLabel>{t("fields.paymentRef")}</FormLabel>
-                <Input
-                  {...field}
-                  placeholder={t("fields.paymentRefPlaceholder")}
-                  aria-invalid={Boolean(form.formState.errors.paymentRef)}
-                />
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder={t("fields.paymentRefPlaceholder")}
+                    aria-invalid={Boolean(form.formState.errors.paymentRef)}
+                  />
+                </FormControl>
                 <p className="text-xs text-on-surface-variant">{t("fields.paymentRefHint")}</p>
                 <FormMessage />
               </FormItem>
@@ -354,7 +375,10 @@ export function DonationForm() {
             {allocationFields.length > 0 ? (
               <ul className="space-y-3">
                 {allocationFields.map((fieldItem, index) => (
-                  <li key={fieldItem.id} className="grid gap-3 md:grid-cols-[1fr_200px_auto]">
+                  <li
+                    key={fieldItem.id}
+                    className="grid gap-3 md:grid-cols-[minmax(0,1fr)_200px_auto]"
+                  >
                     <FormField
                       control={form.control}
                       name={`allocations.${index}.fundId`}
@@ -378,14 +402,13 @@ export function DonationForm() {
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel>{t("fields.allocationAmount")}</FormLabel>
-                          <AmountInput
-                            value={field.value}
-                            onChange={field.onChange}
-                            invalid={Boolean(
-                              form.formState.errors.allocations?.[index]?.amountCents,
-                            )}
-                            placeholder={t("fields.amountPlaceholder")}
-                          />
+                          <FormControl>
+                            <AmountInput
+                              value={field.value}
+                              onChange={(nextValue) => field.onChange(nextValue)}
+                              placeholder={t("fields.amountPlaceholder")}
+                            />
+                          </FormControl>
                           <FormMessage />
                         </FormItem>
                       )}
@@ -563,66 +586,6 @@ function ConstituentPicker({ value, selected, onSelect, invalid }: ConstituentPi
       </PopoverContent>
     </Popover>
   );
-}
-
-interface AmountInputProps {
-  value: number | null | undefined;
-  onChange: (value: number | null) => void;
-  invalid: boolean;
-  placeholder?: string;
-}
-
-function AmountInput({ value, onChange, invalid, placeholder }: AmountInputProps) {
-  const [raw, setRaw] = useState<string>(() => centsToDisplay(value));
-  const lastValueRef = useRef<number | null | undefined>(value);
-
-  useEffect(() => {
-    if (value !== lastValueRef.current) {
-      lastValueRef.current = value;
-      setRaw(centsToDisplay(value));
-    }
-  }, [value]);
-
-  return (
-    <div className="relative">
-      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-on-surface-variant">
-        €
-      </span>
-      <Input
-        type="text"
-        inputMode="decimal"
-        value={raw}
-        placeholder={placeholder}
-        aria-invalid={invalid}
-        className="pl-7 font-mono tabular-nums"
-        onChange={(e) => {
-          const next = e.target.value;
-          setRaw(next);
-          const parsed = parseAmount(next);
-          lastValueRef.current = parsed;
-          onChange(parsed);
-        }}
-        onBlur={() => {
-          const parsed = parseAmount(raw);
-          lastValueRef.current = parsed;
-          setRaw(centsToDisplay(parsed));
-        }}
-      />
-    </div>
-  );
-}
-
-function centsToDisplay(value: number | null | undefined): string {
-  if (value === null || value === undefined || Number.isNaN(value)) return "";
-  return (value / 100).toFixed(2);
-}
-
-function parseAmount(raw: string): number | null {
-  const trimmed = raw.trim().replace(/\s/g, "").replace(",", ".");
-  if (trimmed === "") return null;
-  const parsed = Number(trimmed);
-  if (!Number.isFinite(parsed) || parsed < 0) return null;
-  return Math.round(parsed * 100);
 }
 
 function parseDateString(val: string): string | undefined {

--- a/packages/web/src/components/shared/amount-input.test.tsx
+++ b/packages/web/src/components/shared/amount-input.test.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+
+import { AmountInput } from "@/components/shared/amount-input";
+import { render, screen, userEvent } from "../../tests/test-utils";
+
+describe("AmountInput", () => {
+  function ControlledAmountInput() {
+    const [value, setValue] = useState<number | null>(null);
+
+    return (
+      <div>
+        <AmountInput
+          value={value}
+          onChange={(nextValue, meta) => {
+            if (meta.isValid) {
+              setValue(nextValue);
+            }
+          }}
+          placeholder="0.00"
+        />
+        <button type="button" onClick={() => setValue(4500)}>
+          sync
+        </button>
+      </div>
+    );
+  }
+
+  it("parses decimal values and normalizes them on blur", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<AmountInput value={null} onChange={onChange} placeholder="0.00" />);
+
+    const input = screen.getByPlaceholderText("0.00");
+
+    await user.type(input, "12,34");
+
+    expect(onChange).toHaveBeenLastCalledWith(1234, {
+      raw: "12,34",
+      isValid: true,
+      isEmpty: false,
+    });
+
+    await user.tab();
+
+    expect(input).toHaveValue("12.34");
+  });
+
+  it("preserves invalid raw values and reports invalid metadata", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<AmountInput value={null} onChange={onChange} placeholder="0.00" />);
+
+    const input = screen.getByPlaceholderText("0.00");
+    await user.type(input, "12.345");
+
+    expect(onChange).toHaveBeenLastCalledWith(null, {
+      raw: "12.345",
+      isValid: false,
+      isEmpty: true,
+    });
+
+    await user.tab();
+
+    expect(input).toHaveValue("12.345");
+  });
+
+  it("syncs external controlled value updates without clobbering typing", async () => {
+    const user = userEvent.setup();
+
+    render(<ControlledAmountInput />);
+
+    await user.click(screen.getByRole("button", { name: "sync" }));
+
+    expect(screen.getByPlaceholderText("0.00")).toHaveValue("45.00");
+  });
+});

--- a/packages/web/src/components/shared/amount-input.tsx
+++ b/packages/web/src/components/shared/amount-input.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { forwardRef, useEffect, useRef, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export interface AmountInputChangeMeta {
+  isEmpty: boolean;
+  isValid: boolean;
+  raw: string;
+}
+
+export interface AmountInputProps {
+  value: number | null | undefined;
+  onChange: (value: number | null, meta: AmountInputChangeMeta) => void;
+  placeholder?: string;
+  className?: string;
+  currencySymbol?: string;
+  id?: string;
+  name?: string;
+  disabled?: boolean;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean;
+}
+
+interface ParsedAmount {
+  isValid: boolean;
+  value: number | null;
+}
+
+export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(function AmountInput(
+  {
+    value,
+    onChange,
+    placeholder,
+    className,
+    currencySymbol = "€",
+    id,
+    name,
+    disabled,
+    "aria-describedby": ariaDescribedBy,
+    "aria-invalid": ariaInvalid,
+  },
+  ref,
+) {
+  const [raw, setRaw] = useState<string>(() => centsToDisplay(value));
+  const lastPropValueRef = useRef<number | null | undefined>(value);
+  const rawRef = useRef(raw);
+
+  useEffect(() => {
+    rawRef.current = raw;
+  }, [raw]);
+
+  useEffect(() => {
+    if (Object.is(value, lastPropValueRef.current)) return;
+    lastPropValueRef.current = value;
+
+    if (typeof value === "number" && Number.isNaN(value)) {
+      return;
+    }
+
+    const parsedCurrentRaw = parseAmountInput(rawRef.current);
+    if (parsedCurrentRaw.isValid && Object.is(parsedCurrentRaw.value, value ?? null)) {
+      return;
+    }
+
+    setRaw(centsToDisplay(value));
+  }, [value]);
+
+  function propagate(nextRaw: string) {
+    const parsed = parseAmountInput(nextRaw);
+    onChange(parsed.value, {
+      raw: nextRaw,
+      isValid: parsed.isValid,
+      isEmpty: parsed.value === null,
+    });
+    return parsed;
+  }
+
+  return (
+    <div className="relative">
+      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-on-surface-variant">
+        {currencySymbol}
+      </span>
+      <Input
+        ref={ref}
+        id={id}
+        name={name}
+        type="text"
+        inputMode="decimal"
+        value={raw}
+        disabled={disabled}
+        placeholder={placeholder}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={ariaInvalid}
+        className={cn("pl-12 font-mono tabular-nums", className)}
+        onChange={(event) => {
+          const nextRaw = event.target.value;
+          setRaw(nextRaw);
+          propagate(nextRaw);
+        }}
+        onBlur={() => {
+          const parsed = propagate(raw);
+          if (parsed.isValid) {
+            setRaw(centsToDisplay(parsed.value));
+          }
+        }}
+      />
+    </div>
+  );
+});
+
+export function centsToDisplay(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "";
+  return (value / 100).toFixed(2);
+}
+
+export function parseAmountInput(raw: string): ParsedAmount {
+  const normalized = raw.trim().replace(/\s/g, "").replace(",", ".");
+
+  if (normalized === "") {
+    return { value: null, isValid: true };
+  }
+
+  if (!/^(\d+(\.\d{0,2})?|\.\d{1,2})$/.test(normalized)) {
+    return { value: null, isValid: false };
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return { value: null, isValid: false };
+  }
+
+  return { value: Math.round(parsed * 100), isValid: true };
+}

--- a/packages/web/src/tests/mocks.ts
+++ b/packages/web/src/tests/mocks.ts
@@ -1,0 +1,21 @@
+import { vi } from "vitest";
+
+export const mockRouter = {
+  push: vi.fn(),
+  refresh: vi.fn(),
+  back: vi.fn(),
+  replace: vi.fn(),
+  prefetch: vi.fn(),
+};
+
+export const mockToast = {
+  success: vi.fn(),
+  error: vi.fn(),
+};
+
+export const mockApiClient = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+};

--- a/packages/web/src/tests/setup.tsx
+++ b/packages/web/src/tests/setup.tsx
@@ -1,0 +1,91 @@
+import "@testing-library/jest-dom/vitest";
+
+import React from "react";
+import { afterEach, beforeEach, vi } from "vitest";
+
+import messages from "../../messages/en.json";
+import { mockApiClient, mockRouter, mockToast } from "./mocks";
+
+type MessageValue = string | Record<string, unknown>;
+
+function lookupMessage(path: string): string {
+  const parts = path.split(".");
+  let current: MessageValue | undefined = messages as unknown as MessageValue;
+
+  for (const part of parts) {
+    if (!current || typeof current === "string" || !(part in current)) {
+      return path;
+    }
+    current = (current as Record<string, MessageValue>)[part];
+  }
+
+  return typeof current === "string" ? current : path;
+}
+
+function interpolate(message: string, values?: Record<string, unknown>) {
+  if (!values) return message;
+
+  return message.replace(/\{(\w+)\}/g, (_, key: string) => String(values[key] ?? `{${key}}`));
+}
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) =>
+    React.createElement("a", { href, ...props }, children),
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "en",
+  useTranslations: (namespace?: string) => (key: string, values?: Record<string, unknown>) =>
+    interpolate(lookupMessage(namespace ? `${namespace}.${key}` : key), values),
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  toast: mockToast,
+  Toaster: () => null,
+}));
+
+vi.mock("@/lib/api/client-browser", () => ({
+  createClientApiClient: () => mockApiClient,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+if (!window.ResizeObserver) {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+if (!window.HTMLElement.prototype.scrollIntoView) {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+}

--- a/packages/web/src/tests/test-utils.tsx
+++ b/packages/web/src/tests/test-utils.tsx
@@ -1,0 +1,4 @@
+export { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+export { default as userEvent } from "@testing-library/user-event";
+
+export { mockApiClient, mockRouter, mockToast } from "./mocks";

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "incremental": true,
+    "types": ["vitest/globals"],
     "plugins": [{ "name": "next" }],
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(dirname, "src"),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    setupFiles: ["src/tests/setup.tsx"],
+    testTimeout: 15_000,
+    hookTimeout: 15_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)(lightningcss@1.32.0)
 
   packages/api:
     dependencies:
@@ -268,12 +268,27 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.4
         version: 4.2.2
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.8.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.1.2
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.1.2
         version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       tailwindcss:
         specifier: ^4.1.4
         version: 4.2.2
@@ -341,9 +356,15 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -522,6 +543,18 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@biomejs/biome@2.4.11':
     resolution: {integrity: sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==}
     engines: {node: '>=14.21.3'}
@@ -574,6 +607,34 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -2545,6 +2606,38 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -2608,6 +2701,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2627,6 +2724,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -2634,12 +2735,22 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -2696,6 +2807,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -2749,6 +2864,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
@@ -2780,11 +2899,22 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   csv-parse@5.6.0:
     resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2799,6 +2929,9 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -2806,6 +2939,10 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -2831,6 +2968,12 @@ packages:
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2957,6 +3100,10 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -2971,12 +3118,32 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -3088,10 +3255,17 @@ packages:
   fontkit@2.0.4:
     resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gel@2.2.0:
     resolution: {integrity: sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==}
@@ -3102,9 +3276,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
@@ -3113,8 +3295,28 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -3127,11 +3329,27 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   icu-minify@4.9.1:
     resolution: {integrity: sha512-6NkfF9GHHFouqnz+wuiLjCWQiyxoEyJ5liUv4Jxxo/8wyhV7MY0L0iTEGDAVEa4aAD58WqTxFMa20S5nyMjwNw==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3159,6 +3377,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -3179,6 +3400,18 @@ packages:
 
   js-md5@0.8.3:
     resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
@@ -3293,6 +3526,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
@@ -3306,13 +3542,33 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
     hasBin: true
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -3410,6 +3666,9 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3438,6 +3697,9 @@ packages:
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -3589,11 +3851,19 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
@@ -3613,6 +3883,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-promise-suspense@0.3.4:
     resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
@@ -3663,6 +3936,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -3712,6 +3989,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3725,6 +4008,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3829,6 +4116,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   stripe@22.0.1:
     resolution: {integrity: sha512-Yw764pZ6s8Xu4CtUZdD5uWOkw6gc9xzO9OKylCuj1gMhMDLbyGbDtaPNNSFE4mB6njYSHESYIVbF1iIzUfAl2g==}
     engines: {node: '>=18'}
@@ -3858,6 +4149,9 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -3905,6 +4199,13 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
@@ -3912,6 +4213,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4068,6 +4377,27 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
@@ -4089,6 +4419,25 @@ packages:
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -4112,7 +4461,17 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -4648,6 +5007,16 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
+
   '@biomejs/biome@2.4.11':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.4.11
@@ -4682,6 +5051,26 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.11':
     optional: true
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -6337,6 +6726,42 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.17':
@@ -6413,6 +6838,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -6430,11 +6857,19 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   asn1.js@5.4.1:
     dependencies:
@@ -6444,6 +6879,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
 
@@ -6497,6 +6934,11 @@ snapshots:
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   camelcase@5.3.1: {}
 
@@ -6552,6 +6994,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@12.1.0: {}
 
   commander@4.1.1: {}
@@ -6574,9 +7020,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
   csv-parse@5.6.0: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   debug@4.4.3:
     dependencies:
@@ -6584,9 +7042,13 @@ snapshots:
 
   decamelize@1.2.0: {}
 
+  decimal.js@10.6.0: {}
+
   deep-eql@5.0.2: {}
 
   deepmerge@4.3.1: {}
+
+  delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
 
@@ -6601,6 +7063,10 @@ snapshots:
   dfa@1.2.0: {}
 
   dijkstrajs@1.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -6652,6 +7118,12 @@ snapshots:
       pg: 8.20.0
       react: 19.2.5
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -6665,9 +7137,26 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   env-paths@3.0.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild-register@3.6.0(esbuild@0.19.12):
     dependencies:
@@ -6901,8 +7390,18 @@ snapshots:
       unicode-properties: 1.4.1
       unicode-trie: 2.0.0
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gel@2.2.0:
     dependencies:
@@ -6917,7 +7416,25 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.7:
     dependencies:
@@ -6929,7 +7446,23 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
 
   html-to-text@9.0.5:
     dependencies:
@@ -6954,11 +7487,31 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   icu-minify@4.9.1:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.4
 
   ieee754@1.2.1: {}
+
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -6991,6 +7544,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
@@ -7002,6 +7557,36 @@ snapshots:
   joycon@3.1.1: {}
 
   js-md5@0.8.3: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   json-schema-ref-resolver@3.0.0:
     dependencies:
@@ -7095,6 +7680,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.3.5: {}
 
   lucide-react@1.8.0(react@19.2.5):
@@ -7103,11 +7690,23 @@ snapshots:
 
   luxon@3.7.2: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   mime@3.0.0: {}
+
+  min-indent@1.0.1: {}
 
   minimalistic-assert@1.0.1: {}
 
@@ -7223,6 +7822,8 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
+  nwsapi@2.2.23: {}
+
   object-assign@4.1.1: {}
 
   obliterator@2.0.5: {}
@@ -7242,6 +7843,10 @@ snapshots:
   p-try@2.2.0: {}
 
   pako@0.2.9: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseley@0.12.1:
     dependencies:
@@ -7382,9 +7987,17 @@ snapshots:
 
   prettier@3.8.2: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
+
+  punycode@2.3.1: {}
 
   qrcode@1.5.4:
     dependencies:
@@ -7402,6 +8015,8 @@ snapshots:
   react-hook-form@7.72.1(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  react-is@17.0.2: {}
 
   react-promise-suspense@0.3.4:
     dependencies:
@@ -7445,6 +8060,11 @@ snapshots:
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
 
@@ -7508,6 +8128,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.0:
@@ -7517,6 +8141,10 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -7635,6 +8263,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   stripe@22.0.1(@types/node@25.6.0):
     optionalDependencies:
       '@types/node': 25.6.0
@@ -7655,6 +8287,8 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@3.5.0: {}
 
@@ -7691,9 +8325,23 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -7817,7 +8465,7 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vitest@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0):
+  vitest@2.1.9(@types/node@22.19.17)(jsdom@25.0.1)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))
@@ -7841,6 +8489,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -7851,6 +8500,23 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-module@2.0.1: {}
 
@@ -7872,6 +8538,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## What changed
- extracted a shared `AmountInput` used by campaign, donation, and public campaign forms
- hardened amount parsing and accessibility wiring (`aria-invalid`, `aria-describedby`, invalid/raw input handling)
- tightened dashboard, campaign detail, and public campaign layouts for mobile-first consistency
- added frontend integration coverage with Vitest and Testing Library for the shared amount input and key forms

## Why
Issue #95 called for eliminating divergent amount-input behavior, closing silent frontend regressions with tests, and aligning the Phase 1 surfaces with the Givernance design system.

## Impact
- form amount fields now share one behavior and one accessibility contract
- invalid decimal input is preserved for users and surfaced consistently to validation flows
- empty states and spacing are more consistent across dashboard and campaign surfaces
- web frontend regressions now fail in CI through integration coverage

## Validation
- `pnpm --filter @givernance/web test`
- `pnpm lint`
- `pnpm typecheck`
