### PR TITLE
Phase 1 / Sprint 5: add tenant snapshot export endpoint

### DIFF
--- a/packages/api/src/lib/guards.ts
+++ b/packages/api/src/lib/guards.ts
@@ -55,6 +55,38 @@ export async function requireSuperAdmin(request: FastifyRequest, reply: FastifyR
   }
 }
 
+/** Guard: require super_admin, or org_admin accessing their own tenant-scoped admin route */
+export async function requireSuperAdminOrOwnOrgAdmin(request: FastifyRequest, reply: FastifyReply) {
+  if (!request.auth?.userId) {
+    return reply.status(401).send({
+      type: "https://httpproblems.com/http-status/401",
+      title: "Unauthorized",
+      status: 401,
+      detail: "Authentication required",
+    });
+  }
+
+  if (request.auth.roles.includes("super_admin")) {
+    return;
+  }
+
+  const params = request.params as { orgId?: string };
+  if (
+    request.auth.role === "org_admin" &&
+    request.auth.orgId &&
+    request.auth.orgId === params.orgId
+  ) {
+    return;
+  }
+
+  return reply.status(403).send({
+    type: "https://httpproblems.com/http-status/403",
+    title: "Forbidden",
+    status: 403,
+    detail: "super_admin or owning org_admin role required",
+  });
+}
+
 /** Guard: require x-admin-secret header matching ADMIN_SECRET env var (timing-safe) */
 export async function requireAdminSecret(request: FastifyRequest, reply: FastifyReply) {
   const secret = request.headers["x-admin-secret"] as string | undefined;

--- a/packages/api/src/modules/tenants/routes.ts
+++ b/packages/api/src/modules/tenants/routes.ts
@@ -5,7 +5,7 @@ import { Type } from "@sinclair/typebox";
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { db } from "../../lib/db.js";
-import { requireAdminSecret } from "../../lib/guards.js";
+import { requireAdminSecret, requireSuperAdminOrOwnOrgAdmin } from "../../lib/guards.js";
 import { resolveTranslations } from "../../lib/i18n.js";
 import {
   DataArrayResponseNoPagination,
@@ -14,6 +14,7 @@ import {
   IdParams,
   UuidSchema,
 } from "../../lib/schemas.js";
+import { getTenantSnapshot } from "./service.js";
 
 const CreateTenantBody = Type.Object({
   name: Type.String({ minLength: 1, maxLength: 255 }),
@@ -32,7 +33,89 @@ const TenantResponse = Type.Object({
   updatedAt: Type.String(),
 });
 
+const OrgIdParams = Type.Object({ orgId: UuidSchema });
+
+const SnapshotCampaignResponse = Type.Object({
+  id: UuidSchema,
+  orgId: UuidSchema,
+  name: Type.String(),
+  type: Type.String(),
+  status: Type.String(),
+  parentId: Type.Union([UuidSchema, Type.Null()]),
+  costCents: Type.Union([Type.Integer(), Type.Null()]),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+});
+
+const SnapshotConstituentResponse = Type.Object({
+  id: UuidSchema,
+  orgId: UuidSchema,
+  firstName: Type.String(),
+  lastName: Type.String(),
+  email: Type.Union([Type.String(), Type.Null()]),
+  phone: Type.Union([Type.String(), Type.Null()]),
+  type: Type.String(),
+  tags: Type.Union([Type.Array(Type.String()), Type.Null()]),
+  deletedAt: Type.Union([Type.String(), Type.Null()]),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+});
+
+const SnapshotDonationResponse = Type.Object({
+  id: UuidSchema,
+  orgId: UuidSchema,
+  constituentId: UuidSchema,
+  amountCents: Type.Integer(),
+  currency: Type.String(),
+  campaignId: Type.Union([UuidSchema, Type.Null()]),
+  paymentMethod: Type.Union([Type.String(), Type.Null()]),
+  paymentRef: Type.Union([Type.String(), Type.Null()]),
+  donatedAt: Type.String(),
+  fiscalYear: Type.Union([Type.Integer(), Type.Null()]),
+  receiptNumber: Type.Union([Type.String(), Type.Null()]),
+  receiptAmount: Type.Union([Type.String(), Type.Number(), Type.Null()]),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+});
+
+const TenantSnapshotResponse = Type.Object({
+  orgId: UuidSchema,
+  exportedAt: Type.String(),
+  campaigns: Type.Array(SnapshotCampaignResponse),
+  constituents: Type.Array(SnapshotConstituentResponse),
+  donations: Type.Array(SnapshotDonationResponse),
+});
+
 export async function tenantRoutes(app: FastifyInstance) {
+  /** GET /v1/admin/tenants/:orgId/snapshot — export tenant data as JSON */
+  app.get(
+    "/admin/tenants/:orgId/snapshot",
+    {
+      preHandler: requireSuperAdminOrOwnOrgAdmin,
+      schema: {
+        tags: ["Admin"],
+        params: OrgIdParams,
+        response: { 200: DataResponse(TenantSnapshotResponse), ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const { orgId } = request.params as { orgId: string };
+      const snapshot = await getTenantSnapshot(orgId);
+
+      if (!snapshot) {
+        const t = resolveTranslations(request);
+        return reply.status(404).send({
+          type: "https://httpproblems.com/http-status/404",
+          title: "Not Found",
+          status: 404,
+          detail: t("errors.notFound", { resource: t("resources.tenant") }),
+        });
+      }
+
+      return reply.send({ data: snapshot });
+    },
+  );
+
   /** POST /v1/tenants — create a new organization (platform admin only) */
   app.post(
     "/tenants",

--- a/packages/api/src/modules/tenants/service.ts
+++ b/packages/api/src/modules/tenants/service.ts
@@ -1,0 +1,39 @@
+import { campaigns, constituents, donations, tenants } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import { withTenantContext } from "../../lib/db.js";
+
+/** Export a tenant-scoped JSON snapshot for backup / GL handoff demo flows */
+export async function getTenantSnapshot(orgId: string) {
+  return withTenantContext(orgId, async (tx) => {
+    const [tenant] = await tx.select({ id: tenants.id }).from(tenants).where(eq(tenants.id, orgId));
+    if (!tenant) {
+      return null;
+    }
+
+    const [campaignRows, constituentRows, donationRows] = await Promise.all([
+      tx
+        .select()
+        .from(campaigns)
+        .where(eq(campaigns.orgId, orgId))
+        .orderBy(sql`${campaigns.createdAt} ASC`),
+      tx
+        .select()
+        .from(constituents)
+        .where(eq(constituents.orgId, orgId))
+        .orderBy(sql`${constituents.createdAt} ASC`),
+      tx
+        .select()
+        .from(donations)
+        .where(eq(donations.orgId, orgId))
+        .orderBy(sql`${donations.donatedAt} ASC`, sql`${donations.createdAt} ASC`),
+    ]);
+
+    return {
+      orgId,
+      exportedAt: new Date().toISOString(),
+      campaigns: campaignRows,
+      constituents: constituentRows,
+      donations: donationRows,
+    };
+  });
+}

--- a/packages/api/src/tests/integration/reports.test.ts
+++ b/packages/api/src/tests/integration/reports.test.ts
@@ -3,9 +3,10 @@ import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
-import { authHeader, ensureTestTenants, ORG_A, signToken, signTokenB } from "../helpers/auth.js";
+import { authHeader, ensureTestTenants, signToken, signTokenB } from "../helpers/auth.js";
 
 let app: FastifyInstance;
+const REPORTS_ORG = "00000000-0000-0000-0000-000000000124";
 
 const thisYear = new Date().getFullYear();
 const lastYear = thisYear - 1;
@@ -16,8 +17,13 @@ beforeAll(async () => {
   app = await createServer();
   await app.ready();
   await ensureTestTenants();
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug)
+        VALUES (${REPORTS_ORG}, 'Reports Org', 'reports-org')
+        ON CONFLICT (id) DO NOTHING`,
+  );
 
-  const tokenA = signToken(app);
+  const tokenA = signToken(app, { org_id: REPORTS_ORG });
 
   // Create constituents for lifecycle tests
   const lybuntRes = await app.inject({
@@ -67,18 +73,18 @@ beforeAll(async () => {
     INSERT INTO donations (org_id, constituent_id, amount_cents, currency, donated_at)
     VALUES
       -- LYBUNT donor: donated last year only
-      (${ORG_A}, ${lybuntId}, 5000, 'EUR', ${`${lastYear}-06-15`}::timestamptz),
+      (${REPORTS_ORG}, ${lybuntId}, 5000, 'EUR', ${`${lastYear}-06-15`}::timestamptz),
       -- SYBUNT donor: donated two years ago only
-      (${ORG_A}, ${sybuntId}, 3000, 'EUR', ${`${twoYearsAgo}-03-10`}::timestamptz),
+      (${REPORTS_ORG}, ${sybuntId}, 3000, 'EUR', ${`${twoYearsAgo}-03-10`}::timestamptz),
       -- Active donor: donated this year (should NOT appear in either report)
-      (${ORG_A}, ${activeId}, 10000, 'EUR', ${`${thisYear}-01-20`}::timestamptz),
+      (${REPORTS_ORG}, ${activeId}, 10000, 'EUR', ${`${thisYear}-01-20`}::timestamptz),
       -- Active donor also donated last year
-      (${ORG_A}, ${activeId}, 8000, 'EUR', ${`${lastYear}-11-05`}::timestamptz),
+      (${REPORTS_ORG}, ${activeId}, 8000, 'EUR', ${`${lastYear}-11-05`}::timestamptz),
       -- MultiYear donor: donated last year + two years ago (LYBUNT, total = 12000)
-      (${ORG_A}, ${multiYearId}, 7000, 'EUR', ${`${lastYear}-04-01`}::timestamptz),
-      (${ORG_A}, ${multiYearId}, 5000, 'EUR', ${`${twoYearsAgo}-09-20`}::timestamptz),
+      (${REPORTS_ORG}, ${multiYearId}, 7000, 'EUR', ${`${lastYear}-04-01`}::timestamptz),
+      (${REPORTS_ORG}, ${multiYearId}, 5000, 'EUR', ${`${twoYearsAgo}-09-20`}::timestamptz),
       -- Ancient donor: donated 3 years ago only (SYBUNT boundary, total = 2500)
-      (${ORG_A}, ${ancientId}, 2500, 'EUR', ${`${threeYearsAgo}-12-01`}::timestamptz)
+      (${REPORTS_ORG}, ${ancientId}, 2500, 'EUR', ${`${threeYearsAgo}-12-01`}::timestamptz)
   `);
 });
 
@@ -90,7 +96,7 @@ afterAll(async () => {
 
 describe("LYBUNT Report", () => {
   it("GET /v1/reports/lybunt returns donors from last year who did not donate this year", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/lybunt",
@@ -106,7 +112,7 @@ describe("LYBUNT Report", () => {
   });
 
   it("includes multi-year donor with correct totalDonatedCents (last year donations only)", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/lybunt",
@@ -122,7 +128,7 @@ describe("LYBUNT Report", () => {
   });
 
   it("does not include ancient-only donor (no last year donations)", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/lybunt",
@@ -136,7 +142,7 @@ describe("LYBUNT Report", () => {
   });
 
   it("Lybunt donor totalDonatedCents is correct", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/lybunt",
@@ -150,7 +156,7 @@ describe("LYBUNT Report", () => {
   });
 
   it("GET /v1/reports/lybunt accepts year query parameter", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     const res = await app.inject({
       method: "GET",
       url: `/v1/reports/lybunt?year=${lastYear}`,
@@ -178,7 +184,7 @@ describe("LYBUNT Report", () => {
 
 describe("SYBUNT Report", () => {
   it("GET /v1/reports/sybunt returns donors from any past year who did not donate this year", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/sybunt",
@@ -194,7 +200,7 @@ describe("SYBUNT Report", () => {
   });
 
   it("includes ancient-only donor (SYBUNT boundary — 3+ years ago)", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/sybunt",
@@ -209,7 +215,7 @@ describe("SYBUNT Report", () => {
   });
 
   it("multi-year donor totalDonatedCents aggregates all past donations", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/sybunt",
@@ -225,7 +231,7 @@ describe("SYBUNT Report", () => {
   });
 
   it("Sybunt donor totalDonatedCents is correct", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/sybunt",
@@ -285,7 +291,7 @@ describe("Reports RLS tenant isolation", () => {
 
 describe("PII export audit trail", () => {
   it("reports.lybunt_exported outbox event is emitted on GET /v1/reports/lybunt", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     await app.inject({
       method: "GET",
       url: "/v1/reports/lybunt",
@@ -294,7 +300,7 @@ describe("PII export audit trail", () => {
 
     const rows = await db.execute(
       sql`SELECT type, payload FROM outbox_events
-          WHERE tenant_id = ${ORG_A} AND type = 'reports.lybunt_exported'
+          WHERE tenant_id = ${REPORTS_ORG} AND type = 'reports.lybunt_exported'
           ORDER BY created_at DESC LIMIT 1`,
     );
 
@@ -306,7 +312,7 @@ describe("PII export audit trail", () => {
   });
 
   it("reports.sybunt_exported outbox event is emitted on GET /v1/reports/sybunt", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: REPORTS_ORG });
     await app.inject({
       method: "GET",
       url: "/v1/reports/sybunt",
@@ -315,7 +321,7 @@ describe("PII export audit trail", () => {
 
     const rows = await db.execute(
       sql`SELECT type, payload FROM outbox_events
-          WHERE tenant_id = ${ORG_A} AND type = 'reports.sybunt_exported'
+          WHERE tenant_id = ${REPORTS_ORG} AND type = 'reports.sybunt_exported'
           ORDER BY created_at DESC LIMIT 1`,
     );
 
@@ -331,7 +337,7 @@ describe("PII export audit trail", () => {
 
 describe("Reports RBAC — non-admin forbidden", () => {
   it("GET /v1/reports/lybunt with viewer role returns 403", async () => {
-    const token = signToken(app, { role: "viewer" });
+    const token = signToken(app, { org_id: REPORTS_ORG, role: "viewer" });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/lybunt",
@@ -342,7 +348,7 @@ describe("Reports RBAC — non-admin forbidden", () => {
   });
 
   it("GET /v1/reports/sybunt with user role returns 403", async () => {
-    const token = signToken(app, { role: "user" });
+    const token = signToken(app, { org_id: REPORTS_ORG, role: "user" });
     const res = await app.inject({
       method: "GET",
       url: "/v1/reports/sybunt",

--- a/packages/api/src/tests/integration/tenant-snapshot.test.ts
+++ b/packages/api/src/tests/integration/tenant-snapshot.test.ts
@@ -1,0 +1,143 @@
+import { sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { createServer } from "../../server.js";
+import { authHeader, ensureTestTenants, signToken, signTokenB } from "../helpers/auth.js";
+
+let app: FastifyInstance;
+const SNAPSHOT_ORG = "00000000-0000-0000-0000-000000000123";
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug)
+        VALUES (${SNAPSHOT_ORG}, 'Snapshot Org', 'snapshot-org')
+        ON CONFLICT (id) DO NOTHING`,
+  );
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe("Tenant snapshot export", () => {
+  it("GET /v1/admin/tenants/:orgId/snapshot exports campaigns, constituents, and donations for the owning org admin", async () => {
+    const tokenA = signToken(app, { org_id: SNAPSHOT_ORG });
+
+    const constituentRes = await app.inject({
+      method: "POST",
+      url: "/v1/constituents?force=true",
+      headers: authHeader(tokenA),
+      payload: {
+        firstName: "Snapshot",
+        lastName: "Donor",
+        email: `snapshot-${Date.now()}@example.org`,
+        type: "donor",
+      },
+    });
+    expect(constituentRes.statusCode).toBe(201);
+    const constituentId = constituentRes.json<{ data: { id: string } }>().data.id;
+
+    const campaignRes = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(tokenA),
+      payload: {
+        name: `Snapshot Campaign ${Date.now()}`,
+        type: "digital",
+      },
+    });
+    expect(campaignRes.statusCode).toBe(201);
+    const campaignId = campaignRes.json<{ data: { id: string } }>().data.id;
+
+    const donationRes = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId,
+        campaignId,
+        amountCents: 4200,
+        currency: "EUR",
+        paymentMethod: "bank_transfer",
+        paymentRef: `SNAP-${Date.now()}-${Math.random()}`,
+      },
+    });
+    expect(donationRes.statusCode).toBe(201);
+    const donationId = donationRes.json<{ data: { id: string } }>().data.id;
+
+    const snapshotRes = await app.inject({
+      method: "GET",
+      url: `/v1/admin/tenants/${SNAPSHOT_ORG}/snapshot`,
+      headers: authHeader(tokenA),
+    });
+
+    expect(snapshotRes.statusCode).toBe(200);
+    const body = snapshotRes.json<{
+      data: {
+        orgId: string;
+        exportedAt: string;
+        campaigns: Array<{ id: string; orgId: string }>;
+        constituents: Array<{ id: string; orgId: string }>;
+        donations: Array<{
+          id: string;
+          orgId: string;
+          constituentId: string;
+          campaignId: string | null;
+        }>;
+      };
+    }>();
+
+    expect(body.data.orgId).toBe(SNAPSHOT_ORG);
+    expect(body.data.exportedAt).toBeTruthy();
+    expect(
+      body.data.campaigns.some(
+        (campaign) => campaign.id === campaignId && campaign.orgId === SNAPSHOT_ORG,
+      ),
+    ).toBe(true);
+    expect(
+      body.data.constituents.some(
+        (constituent) => constituent.id === constituentId && constituent.orgId === SNAPSHOT_ORG,
+      ),
+    ).toBe(true);
+    expect(
+      body.data.donations.some(
+        (donation) =>
+          donation.id === donationId &&
+          donation.orgId === SNAPSHOT_ORG &&
+          donation.constituentId === constituentId &&
+          donation.campaignId === campaignId,
+      ),
+    ).toBe(true);
+  });
+
+  it("forbids an org admin from exporting another tenant's snapshot", async () => {
+    const tokenB = signTokenB(app);
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/admin/tenants/${SNAPSHOT_ORG}/snapshot`,
+      headers: authHeader(tokenB),
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("allows a super_admin to export another tenant's snapshot", async () => {
+    const superAdminToken = signTokenB(app, {
+      role: "viewer",
+      realm_access: { roles: ["super_admin"] },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/admin/tenants/${SNAPSHOT_ORG}/snapshot`,
+      headers: authHeader(superAdminToken),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { orgId: string } }>().data.orgId).toBe(SNAPSHOT_ORG);
+  });
+});


### PR DESCRIPTION
## What changed
- added `GET /v1/admin/tenants/:orgId/snapshot` for JSON tenant exports used for the Phase 1 demo backup / GL handoff flow
- added a tenant snapshot service that aggregates `campaigns`, `constituents`, and `donations` for one org
- added an access guard that allows `super_admin`, or an `org_admin` only for their own tenant
- added an integration test for the new snapshot endpoint
- isolated the reports integration suite onto its own tenant fixture so `pnpm test` stays deterministic repo-wide

## Why
Issue #23 requires a Phase 1 export endpoint for MVP demo readiness. For the demo we simplify the GL export into a full JSON tenant snapshot that supports accounting handoff simulation and partial SAR / portability access.

## Validation
- `pnpm lint`
- `pnpm test`
