### PR TITLE
[codex] Add settings snapshot export UI

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -117,6 +117,24 @@
       "fallbackUser": "user"
     }
   },
+  "settings": {
+    "title": "Settings",
+    "subtitle": "Minimal organisation settings surface for the MVP demo.",
+    "breadcrumbRoot": "Dashboard",
+    "snapshot": {
+      "badge": "ADM-001 MVP",
+      "title": "Data export (GDPR / GL)",
+      "description": "Download a JSON snapshot of the organisation data for portability, archival, or general-ledger handoff needs.",
+      "help": "The exported file contains the tenant snapshot returned by the admin API.",
+      "exportCta": "Download organisation JSON export",
+      "exportLoading": "Generating export…",
+      "adminOnly": "Export is only available to organisation admins.",
+      "successToast": "Snapshot export downloaded.",
+      "errorGeneric": "Unable to download the export right now.",
+      "errorProblem": "Export failed (HTTP {status}).",
+      "lastDownloaded": "Last download: {value}"
+    }
+  },
   "dashboard": {
     "greeting": "Good Morning{name, select, empty {} other {, {name}}}",
     "subtitle": "Here is your organisation's activity today.",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -117,6 +117,24 @@
       "fallbackUser": "utilisateur"
     }
   },
+  "settings": {
+    "title": "Paramètres",
+    "subtitle": "Configuration minimale de l'organisation pour la démo MVP.",
+    "breadcrumbRoot": "Tableau de bord",
+    "snapshot": {
+      "badge": "ADM-001 MVP",
+      "title": "Export des données (RGPD / GL)",
+      "description": "Téléchargez un snapshot JSON des données de l'organisation pour les besoins de portabilité, d'archivage ou de handoff comptable.",
+      "help": "Le fichier exporté contient le snapshot renvoyé par l'API d'administration du tenant.",
+      "exportCta": "Télécharger l'export JSON de l'organisation",
+      "exportLoading": "Génération de l'export…",
+      "adminOnly": "Export réservé aux administrateurs de l'organisation.",
+      "successToast": "Export snapshot téléchargé.",
+      "errorGeneric": "Impossible de télécharger l'export pour le moment.",
+      "errorProblem": "L'export a échoué (HTTP {status}).",
+      "lastDownloaded": "Dernier téléchargement : {value}"
+    }
+  },
   "dashboard": {
     "greeting": "Bonjour{name, select, empty {} other {, {name}}}",
     "subtitle": "Voici l'activité de votre organisation aujourd'hui.",

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -1,26 +1,25 @@
 import { getTranslations } from "next-intl/server";
-
+import { SettingsSnapshotPanel } from "@/components/settings/settings-snapshot-panel";
+import { PageHeader } from "@/components/shared/page-header";
 import { requireAuth } from "@/lib/auth/guards";
 
 /**
  * Settings page — protected, requires authentication.
- * Placeholder for Phase 2 implementation (ADM-001 org settings).
+ * Phase 1 exposes the minimum viable organisation settings surface
+ * needed for tenant snapshot export demo flows.
  */
 export default async function SettingsPage() {
-  await requireAuth();
-  const t = await getTranslations("appShell.sidebar");
+  const auth = await requireAuth();
+  const t = await getTranslations("settings");
 
   return (
-    <>
-      <div className="mb-8">
-        <h1 className="font-heading text-5xl font-normal leading-tight tracking-tight text-on-surface">
-          {t("settings")}
-        </h1>
-      </div>
-
-      <div className="rounded-2xl bg-surface-container-lowest p-8 shadow-card">
-        <p className="text-sm text-text-secondary">Settings page under construction.</p>
-      </div>
-    </>
+    <div className="space-y-8">
+      <PageHeader
+        title={t("title")}
+        description={t("subtitle")}
+        breadcrumbs={[{ label: t("breadcrumbRoot"), href: "/dashboard" }, { label: t("title") }]}
+      />
+      <SettingsSnapshotPanel orgId={auth.orgId} canExport={auth.roles.includes("org_admin")} />
+    </div>
   );
 }

--- a/packages/web/src/components/settings/settings-snapshot-panel.tsx
+++ b/packages/web/src/components/settings/settings-snapshot-panel.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Download, Lock } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { useAuth } from "@/lib/auth";
+
+interface TenantSnapshotResponse {
+  data: unknown;
+}
+
+interface SettingsSnapshotPanelProps {
+  orgId?: string;
+  canExport: boolean;
+}
+
+function formatSnapshotFilename(orgName: string | undefined, orgId: string) {
+  const base = (orgName ?? "organization")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const date = new Date().toISOString().slice(0, 10);
+
+  return `${base || "organization"}-${orgId}-snapshot-${date}.json`;
+}
+
+export function SettingsSnapshotPanel({ orgId, canExport }: SettingsSnapshotPanelProps) {
+  const t = useTranslations("settings");
+  const { user } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [lastDownloadedAt, setLastDownloadedAt] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const exportEnabled = Boolean(orgId) && canExport;
+
+  async function handleExport() {
+    if (!orgId || loading) return;
+
+    setLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const client = createClientApiClient();
+      const response = await client.get<TenantSnapshotResponse>(
+        `/v1/admin/tenants/${orgId}/snapshot`,
+      );
+      const json = JSON.stringify(response.data, null, 2);
+      const blob = new Blob([json], { type: "application/json;charset=utf-8" });
+      const objectUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+
+      link.href = objectUrl;
+      link.download = formatSnapshotFilename(user?.orgName, orgId);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(objectUrl);
+
+      const downloadedAt = new Date().toLocaleString();
+      setLastDownloadedAt(downloadedAt);
+      toast.success(t("snapshot.successToast"));
+    } catch (err) {
+      const message =
+        err instanceof ApiProblem
+          ? err.detail || t("snapshot.errorProblem", { status: err.status })
+          : t("snapshot.errorGeneric");
+
+      setErrorMessage(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <div className="inline-flex rounded-full bg-surface-container px-3 py-1 text-xs font-medium text-on-surface-variant">
+            {t("snapshot.badge")}
+          </div>
+          <h2 className="mt-4 font-heading text-2xl leading-tight text-on-surface">
+            {t("snapshot.title")}
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-on-surface-variant">
+            {t("snapshot.description")}
+          </p>
+          <p className="mt-4 text-sm text-on-surface-variant">{t("snapshot.help")}</p>
+
+          {lastDownloadedAt ? (
+            <p className="mt-3 text-sm text-on-surface-variant">
+              {t("snapshot.lastDownloaded", { value: lastDownloadedAt })}
+            </p>
+          ) : null}
+
+          {errorMessage ? <p className="mt-3 text-sm text-error">{errorMessage}</p> : null}
+        </div>
+
+        <div className="flex shrink-0 flex-col items-start gap-3">
+          {exportEnabled ? (
+            <Button onClick={handleExport} disabled={loading || !orgId}>
+              <Download size={16} aria-hidden="true" />
+              {loading ? t("snapshot.exportLoading") : t("snapshot.exportCta")}
+            </Button>
+          ) : (
+            <div className="inline-flex items-center gap-2 rounded-xl bg-surface-container px-4 py-3 text-sm text-on-surface-variant">
+              <Lock size={16} aria-hidden="true" />
+              <span>{t("snapshot.adminOnly")}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## What changed
- replace the placeholder `/settings` screen with a minimal Settings page for the MVP
- add a tenant snapshot export card wired to `GET /v1/admin/tenants/:orgId/snapshot`
- download the returned payload as a JSON file in the browser using `Blob` + `URL.createObjectURL`
- show the export action only for `org_admin` users and add `settings` translations in French and English

## Why
Issue #23 needs a basic Settings surface that can host the tenant export flow for demo and MVP purposes.

## Impact
Org admins can now open Dashboard > Settings and download their organisation snapshot JSON directly from the UI.

## Validation
- `pnpm lint`
- `pnpm typecheck`
