### PR TITLE
docs: ADR-016 hybrid tenant onboarding + doc 22 + update doc 21

### DIFF
--- a/docs/15-infra-adr.md
+++ b/docs/15-infra-adr.md
@@ -916,4 +916,84 @@ This provides compile-time checks that all translation keys exist. Missing keys 
 
 ---
 
+## ADR-016: Tenant Onboarding & Multi-Tenancy — Hybrid Self-Serve + Enterprise Model
+
+- **Status**: Proposed
+- **Date**: 2026-04-23
+- **Deciders**: Magino (founder/architect), team design session 2026-04-23
+- **Related**: `docs/21-authentication-sso.md`, `docs/22-tenant-onboarding.md`, Spike [#80](https://github.com/purposestack/givernance/issues/80), ADR-009 (data residency), ADR-011 (layered frontend), ADR-013 (type boundary)
+
+### Context
+
+Phase 1 shipped a super-admin-only tenant provisioning path (`POST /v1/tenants` guarded by `requireAdminSecret`) and a Keycloak OIDC login flow (`docs/21-authentication-sso.md`). Spike #80 chose a shared Keycloak realm with groups + attributes (Option A) and concluded that a Givernance platform operator would provision every tenant from the back-office. That design is correct for the enterprise segment but does **not** cover the long tail of tiny European NPOs that Givernance targets:
+
+- Most French associations under 20 staff have **no corporate email domain** — they run on gmail / outlook / proton personal inboxes (`greg-field-insights` §3, team design session 2026-04-23).
+- Super-admin-only provisioning does not scale from 5 pilots to hundreds of tenants, and it is a conversion-killer for a self-serve SMB segment.
+- The earlier (now-deprecated) "5-step onboarding wizard" from issue #33 predates the SSO-only decision and cannot be resurrected as-is.
+
+The team design session (2026-04-23) reopened these questions and concluded that **both paths must coexist**: enterprise tenants whose admin is provisioned by a platform operator, and SMB tenants who self-serve from a public signup form using personal email.
+
+### Decision
+
+Givernance adopts a **hybrid tenant onboarding model** with three tenant tracks, all living in the same shared Keycloak realm and same PostgreSQL cluster:
+
+| Track | Who creates the tenant | First-admin identity | IdP federation | Example |
+|---|---|---|---|---|
+| **Self-serve (SMB)** | Public signup form; first user becomes *provisional* `org_admin` | Personal email, OTP-verified via Keycloak | None — Keycloak local authenticator (password / magic link) | Tiny French NPO using `tresorier@gmail.com` |
+| **Enterprise SSO** | Givernance super-admin from the back-office | Domain-verified corporate email, JIT-provisioned from IdP claims | Per-tenant OIDC / SAML IdP (Entra, Okta, Google Workspace) wired to the shared realm | Red Cross France, Médecins du Monde |
+| **Invitation-join** | Another tenant's `org_admin` invites the user by email | The invited email (personal or corporate) | Inherits the target tenant's IdP (if any) | Volunteer board member joining an existing NPO |
+
+All three tracks produce the same domain model: a `tenants` row, an optional `tenant_domains` row set (enterprise only), and `users` rows created **Just-In-Time** on first SSO login via trusted Keycloak JWT claims (`sub`, `email`, `org_id`, `role`). RLS isolation on `org_id` remains the sole tenancy boundary at the database layer.
+
+**Platform primitives adopted**:
+
+1. **Keycloak Organizations** (Keycloak 26+) replaces the ad-hoc groups-and-attributes approach from Spike #80. Organizations is GA as of Keycloak 26.0 and provides first-class org entities with domain-based IdP routing, per-org IdP bindings, and invitation flows.
+2. **URL-path tenant scoping** (`app.givernance.app/<org-slug>/…`) — **not** subdomain scoping. One wildcard TLS cert, no DNS propagation delay at tenant creation, no cross-subdomain cookie leakage. Subdomain routing is reserved for a future Enterprise tier where perception matters (Cloudflare for SaaS).
+3. **Provisional `org_admin` with grace period** — on self-serve, the first user is `org_admin` for 7 days; other verified users from the same domain can dispute within that window. Destructive actions (delete-org, export-all) are gated behind verification.
+4. **No credit card at signup** — 30-day trial, then card *or* annual invoice at conversion. This matches the NPO segment's procurement realities.
+5. **Disposable-email + IP/ASN rate limits** as first-order abuse filters. Payment is **not** used as a signup filter; it is reserved for conversion.
+6. **Post-login organization picker** — a single user can belong to multiple tenants; `org_id` is minted into the access token at picker time and re-minted on switch. Refresh token is user-scoped.
+
+### Rationale
+
+- **Two-track design reflects customer reality.** Treating the long-tail SMB as an afterthought on top of an enterprise-first design yields worst-of-both-worlds UX. Treating enterprise as an afterthought on top of SMB fails audits. Two tracks with shared infrastructure is the 2026 consensus (WorkOS Organizations, Clerk Organizations, Stytch B2B).
+- **Keycloak Organizations over custom group/attribute plumbing.** The groups-and-attributes approach chosen in Spike #80 predates Keycloak 26. For a product starting to add tenants in 2026, Organizations is the right primitive: fewer custom mappers, native Home IdP Discovery, built-in invitation templates, actively developed.
+- **URL-path over subdomain** avoids wildcard-TLS provisioning, cross-subdomain cookie pitfalls, and per-tenant DNS operations — and it unlocks *instant* tenant creation, which the self-serve flow requires.
+- **Provisional admin with grace period** prevents the "random intern becomes org_admin" failure mode without blocking legitimate self-serve signup.
+- **RLS unchanged** — this ADR adds primitives around identity but leaves the data-layer tenancy model (single shared database, `org_id`-scoped RLS, 3-role Postgres pattern) exactly as decided in ADR-009.
+- **Card-at-conversion, not signup** — nonprofit budgets are annual and board-approved; card-at-signup is a conversion killer for this segment (ProfitWell / Baymard SMB benchmarks). Reserve card-at-signup for a future high-abuse scenario.
+
+### Rejected alternatives
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| Super-admin-only provisioning (Spike #80 as-is) | Strong control; simple model | Does not scale; kills SMB conversion; blocks self-serve pilots | Rejected — retained as the enterprise track only |
+| First-user-becomes-admin with no safeguards (2026-04-23 naive variant) | Dead simple | Random employee can lock out real admins; no path to revoke | Rejected — replaced by provisional-admin-with-grace-period |
+| Paywall at signup as anti-abuse filter | Eliminates bots; validates intent | Conversion-killer for SMB NPOs; EU dark-pattern regulations (DGCCRF / ACM enforcement) | Rejected — moved to conversion event |
+| Subdomain-per-tenant (`<ngo>.givernance.app`) from day one | Enterprise perception; strong isolation | Wildcard TLS operations, cross-subdomain cookie issues, delayed provisioning | Rejected for MVP — reserved for future Enterprise tier with Cloudflare for SaaS |
+| One Keycloak realm per tenant | Hard IdP isolation; per-realm branding | Thousands of realms = operational explosion; tested by Spike #80 and rejected | Rejected — retained only as the self-hosted "dedicated realm" escape hatch |
+| Keycloak groups + attributes (Spike #80 Option A) | Works today; no Keycloak 26 upgrade needed | Requires custom domain routing, custom mappers, manual invitation plumbing; Organizations supersedes it | Rejected for net-new work — existing groups/attributes in the dev seed will be migrated |
+| Email domain as sole tenant-binding authority | Zero UX friction | Personal-email orgs locked out; someone at `intern@ngo.fr` cannot bind BigCorp; no DNS proof | Rejected — domain is one signal of many, with DNS TXT as the hard gate for enterprise |
+
+### Consequences
+
+- **Keycloak upgrade required** — infra target becomes Keycloak 26.x. Issue #61 (split Keycloak DB) becomes a prerequisite; migrating the dev realm seed from groups/attributes to Organizations is scheduled in this milestone.
+- **Schema additions** — `tenants` gets `status` ∈ `provisional | active | suspended | archived`, `verified_at`, `created_via` ∈ `self_serve | enterprise | invitation`; new tables `tenant_domains` (domain + DNS TXT verification state), `tenant_admin_disputes` (grace-period dispute log). Existing Phase 1 `tenants` schema is kept backward-compatible.
+- **API additions** — `POST /v1/public/signup`, `POST /v1/public/email-verify`, `POST /v1/admin/tenants/:id/provision-idp`, `GET /v1/users/me/organizations`, `POST /v1/session/switch-org`, `POST /v1/tenants/:id/domains`, `POST /v1/tenants/:id/domains/:domain/verify`. All enterprise-admin endpoints on the existing `packages/api/src/modules/admin/` / `…/tenants/` boundaries; self-serve endpoints live under a new `public` module that skips tenant context until the target org is resolved.
+- **Frontend additions** — public signup/verify pages, organization picker screen, back-office admin screens for tenants+domains+IdP config, provisional-admin banner in the app shell (reusing the impersonation banner pattern from PR #73).
+- **Docs 21 update** — `docs/21-authentication-sso.md` is refactored to reference this ADR + `docs/22-tenant-onboarding.md` instead of embedding the obsolete super-admin-only flow.
+- **Issue #80 remains open** as an architectural context doc; implementation issues under the new milestone "Tenant Onboarding & Multi-Tenancy" replace it.
+- **Issue #78** (onboarding wizard Steps 2–4) is rebaselined on the hybrid flow; Step 1 becomes the public signup form, Step 5 becomes the provisional-admin welcome.
+- **Issue #33** (old 5-step wizard) is closed as superseded.
+- **Abuse surface** — new public endpoints require rate limiting (Fastify `@fastify/rate-limit`, Redis store), disposable-email blocklist, CAPTCHA (hCaptcha) on signup, and an audit trail of every signup attempt (`audit_logs.action = 'tenant.signup_attempted'`).
+- **GDPR posture** — signup form collects minimal PII (email + display name); country/legal-type asked in-product after signup; DPO email collected at verification step, aligning with Phase 2 GDPR consent work in #78.
+
+### Revisit criteria
+
+- If self-serve abuse (fake tenants, spam sends) exceeds a threshold (e.g., > 5% of new tenants flagged in 30 days), evaluate moving to "payment card at signup" for self-serve track only.
+- If multi-domain orgs (one NPO with `ngo.fr` and `ngo.org` both valid) are not well-served by Keycloak Organizations (edge cases in domain verification or Home IdP Discovery), revisit the Organizations adoption.
+- If subdomain-per-tenant demand from enterprise tenants emerges before the Cloudflare-for-SaaS investment is justified, we either ship a coarser DNS-per-tenant flow or keep URL-path scoping and defer.
+
+---
+
 *This document is curated to show only active architectural decisions. Superseded decisions are removed for clarity.*

--- a/docs/21-authentication-sso.md
+++ b/docs/21-authentication-sso.md
@@ -1,26 +1,32 @@
 # 21 — Authentication & Single Sign-On (SSO)
 
-> **Status**: Approved (Phase 1)
-> **Related**: `02-reference-architecture.md` §3.2 & §6, `06-security-compliance.md`, `15-infra-adr.md` (ADR-009), `19-impersonation.md`
-> **Context**: PR #73 (Sprint 4: Auth UI & App Shell); Spike [#80](https://github.com/purposestack/givernance/issues/80) — Multi-Tenant SSO Onboarding Architecture
+> **Status**: Approved (Phase 1); extended by ADR-016 / `docs/22-tenant-onboarding.md` (Phase 2 hybrid onboarding)
+> **Related**: `02-reference-architecture.md` §3.2 & §6, `06-security-compliance.md`, `15-infra-adr.md` (ADR-009, ADR-016), `19-impersonation.md`, `22-tenant-onboarding.md`
+> **Context**: PR #73 (Sprint 4: Auth UI & App Shell); Spike [#80](https://github.com/purposestack/givernance/issues/80) — Multi-Tenant SSO Onboarding Architecture; design session 2026-04-23 — hybrid self-serve + enterprise tracks
 
 ## 1. Overview
 Givernance uses **OpenID Connect (OIDC)** via **Keycloak** as the sole authentication mechanism. Local username/password forms and the former "self-service onboarding wizard" (organisation creation, team invite, data residency selection, GDPR parameters) have been intentionally discarded in favour of a 100% SSO-driven flow. This centralises identity management, simplifies GDPR compliance (no password storage), and enables enterprise-grade features (MFA, SAML federation) out of the box.
 
 ### 1.1 Onboarding model at a glance
 
-| Concern | Previous model (deprecated) | Current model (Spike #80) |
-|---|---|---|
-| Tenant creation | Anonymous visitor fills a 5-step signup wizard | **Givernance Super Admin** creates the tenant from the back-office |
-| Identity Provider configuration | Implicit (local password) | Super Admin configures the per-tenant OIDC/SAML connection (Entra ID, Okta, Google Workspace, …) in the shared Keycloak realm |
-| User account creation | Manual invite → user sets password | **Just-In-Time (JIT) provisioning** runs on first SSO login from Keycloak JWT claims (`sub`, `email`, `org_id`, `role`). Email validation is deferred to Phase 2. |
-| Data residency choice | Per-org selector in the wizard | **No longer a user choice** — governed centrally by ADR-009 (Scaleway Managed PostgreSQL EU, RLS-based isolation; supersedes ADR-006) |
-| Salesforce / CSV import at signup | Step 3 of the wizard | Deferred to the **Migration epic**, post-login |
-| Tenant URL routing | Generic app URL | Tenant is addressed by subdomain (`https://<tenant>.givernance.app`, or `.org` where appropriate); local development simulates this with `?namespace=<tenant>` |
+The tenant-provisioning model has evolved twice. Spike #80 moved from a legacy self-service wizard to super-admin-only provisioning. ADR-016 (2026-04-23) added a self-serve track alongside the enterprise one to serve the long tail of small NPOs without corporate email domains. The table below reflects the **current (Phase 2) hybrid model**; see [`docs/22-tenant-onboarding.md`](./22-tenant-onboarding.md) for the full specification.
 
-## 2. Tenant Onboarding Architecture (Spike #80)
+| Concern | Legacy wizard (pre-#80) | Enterprise track (ADR-016) | Self-serve track (ADR-016, new) |
+|---|---|---|---|
+| Tenant creation | Anonymous 5-step wizard | **Givernance super-admin** creates the tenant from the back-office | Anonymous visitor completes `/signup`; tenant row is `status='provisional'` until email verification |
+| Identity Provider | Implicit (local password) | Super-admin wires per-tenant OIDC/SAML (Entra, Okta, Google Workspace) via Keycloak Admin API + Home IdP Discovery | Keycloak realm local authenticator (magic link / OTP) — no federated IdP |
+| First-admin identity | Manual invite → user sets password | Domain-verified corporate email, JIT-provisioned from IdP claims | First verified user, granted **provisional `org_admin`** for a 7-day dispute window |
+| Data residency | Per-org selector | Centralised by ADR-009 (Scaleway Managed PostgreSQL EU, RLS-based) | Same — not a user choice |
+| Salesforce / CSV import | Wizard step 3 | Deferred to the Migration epic | Deferred to the Migration epic |
+| Tenant URL routing | Generic app URL | `app.givernance.app/<slug>/…` (URL-path scoping per ADR-016) | Same |
 
-### 2.1 Option A — shared realm with groups/attributes (MVP choice)
+Subdomain routing (`<tenant>.givernance.app`) is **deferred**; it is reserved for a future Enterprise tier over Cloudflare for SaaS.
+
+## 2. Tenant Onboarding Architecture
+
+> **Phase 2 update**: the groups-and-attributes approach below was Spike #80's MVP choice. ADR-016 supersedes that with **Keycloak Organizations** (Keycloak 26+) and adds a self-serve track. The sections below describe the *current implementation surface* (what PR #73 shipped) plus the *target state* from ADR-016. See [`docs/22-tenant-onboarding.md`](./22-tenant-onboarding.md) for the full Phase 2 spec including data model, API surface, and rollout plan.
+
+### 2.1 Option A — shared realm with groups/attributes (Phase 1 MVP, in-code today)
 
 Givernance operates **one shared Keycloak realm per deployment** (`givernance` for SaaS; see `02-reference-architecture.md` §3.2). Tenant membership is represented through:
 
@@ -29,6 +35,16 @@ Givernance operates **one shared Keycloak realm per deployment** (`givernance` f
 - **Per-tenant Identity Provider federation** (Entra ID, Okta, Google Workspace, or Keycloak local for smoke tests), routed via `kc_idp_hint` or email-domain alias on the login page.
 
 Because the realm is shared, thousands of small European NPOs can be onboarded without multiplying realms, clients, redirect URI configuration, or admin overhead. Tenant isolation is enforced at the application layer (`org_id` claim → PostgreSQL RLS, see `02-reference-architecture.md` §6).
+
+### 2.1.bis Target state — Keycloak Organizations (Phase 2, per ADR-016)
+
+Keycloak 26 introduced a first-class `Organization` primitive with built-in domain-based IdP routing (Home IdP Discovery), per-org IdP bindings, and invitation flows. ADR-016 adopts this primitive and migrates the dev realm seed away from the ad-hoc group/attribute plumbing. Concretely:
+
+- Each Givernance tenant maps 1:1 to a Keycloak Organization identified by `tenants.keycloak_org_id`.
+- Per-tenant IdP bindings are attached to the Organization rather than injected via a custom authenticator.
+- Domain-based routing uses Keycloak's Home IdP Discovery, removing the need for custom `kc_idp_hint` wiring in the app.
+- `org_id`, `role`, and `email` remain the trusted claims; the `givernance-web` client keeps its protocol mappers unchanged.
+- Migration is covered by PR #10 of the rollout in [`docs/22-tenant-onboarding.md`](./22-tenant-onboarding.md) §10 and depends on [issue #61](https://github.com/purposestack/givernance/issues/61) (Keycloak DB split).
 
 ### 2.2 Option B — dedicated realm per tenant (future evolution)
 

--- a/docs/22-tenant-onboarding.md
+++ b/docs/22-tenant-onboarding.md
@@ -1,0 +1,273 @@
+# 22 — Tenant Onboarding & Multi-Tenancy
+
+> **Status**: Proposed (Phase 2)
+> **Related**: [`docs/15-infra-adr.md`](./15-infra-adr.md) ADR-016, [`docs/21-authentication-sso.md`](./21-authentication-sso.md), [`docs/19-impersonation.md`](./19-impersonation.md), Spike [#80](https://github.com/purposestack/givernance/issues/80)
+> **Context**: team design session 2026-04-23 reopened Spike #80 to add a self-serve track for SMB NPOs without a corporate email domain.
+
+## 1. Why this document exists
+
+Givernance targets ~2-to-200-staff European nonprofits. The customer base splits into three segments with very different onboarding needs:
+
+- **SMB NPOs** (the long tail) — 2–20 staff, often using personal gmail, no corporate IT, price-sensitive, non-technical admin.
+- **Mid-market NPOs** — 20–60 staff, Google Workspace or Microsoft 365, 1–2 admins, can handle a supported onboarding call.
+- **Enterprise NPOs / federations** — 60+ staff, dedicated IT, existing SSO (Entra, Okta), domain-verification reflexes, procurement driven by a DPO.
+
+Designing for only one of these segments is a known failure mode (documented in the 2026-04-23 transcript). This document specifies the hybrid flow that serves all three without duplicating infrastructure.
+
+## 2. Concepts & vocabulary
+
+| Term | Meaning in Givernance |
+|---|---|
+| **Tenant** | A row in `tenants` with its own `org_id`; the RLS boundary for all tenant-scoped data. |
+| **Organization** | Business-facing synonym for tenant. Keycloak 26's first-class `Organization` entity maps 1:1 to a Givernance tenant. |
+| **Track** | How a tenant came into existence: `self_serve` / `enterprise` / `invitation`. Stored as `tenants.created_via`. Drives UI affordances but not data access. |
+| **Tenant domain** | A DNS domain claimed by a tenant (e.g., `croix-rouge.fr`). Verified via DNS TXT. Used for Home IdP Discovery. Optional. |
+| **IdP binding** | A per-tenant OIDC/SAML identity provider (Entra, Okta, Google Workspace) registered in the shared Keycloak realm and bound to the tenant's Keycloak Organization. |
+| **Provisional admin** | The first user of a self-serve tenant; holds `org_admin` role for a 7-day grace period during which other verified members can dispute. |
+| **Home IdP Discovery** | Keycloak's email-domain → IdP routing at the login screen. Supersedes the custom `kc_idp_hint` plumbing from Spike #80. |
+| **JIT provisioning** | On first successful SSO login, the Givernance `users` row is created from trusted JWT claims — never before. |
+| **Org picker** | Post-login interstitial screen listing the tenants the authenticated user belongs to; chosen tenant is minted into a short-lived access token. |
+
+## 3. Onboarding tracks at a glance
+
+### 3.1 Self-serve (SMB) track
+
+```mermaid
+sequenceDiagram
+    actor User as Anonymous visitor
+    participant Web as Next.js Web
+    participant API as Givernance API
+    participant KC as Keycloak (shared realm)
+    participant DB as PostgreSQL
+    participant Mail as Email provider
+
+    User->>Web: Visit /signup, submit {orgName, firstName, lastName, email}
+    Web->>API: POST /v1/public/signup (CAPTCHA verified)
+    API->>API: Disposable-email + rate-limit + IP/ASN checks
+    API->>DB: INSERT tenants(status='provisional', created_via='self_serve')
+    API->>KC: Admin API → create Organization + invite user with OTP-required action
+    API->>DB: INSERT audit_logs(action='tenant.self_signup_started')
+    API->>Mail: Send email with one-click verification + 6-digit code
+    API-->>Web: 201 { tenantId, checkEmail: true }
+    Web-->>User: "Check your email to finish signing up"
+
+    User->>Mail: Click verification link
+    Mail-->>Web: GET /signup/verify?token=...
+    Web->>KC: Finish Required Action (email OTP)
+    KC-->>Web: Authorization code (PKCE)
+    Web->>KC: Token exchange
+    KC-->>Web: JWT (org_id, email, sub)
+    Web->>API: GET /v1/users/me
+    API->>DB: JIT INSERT users(role='org_admin', first_admin=true)
+    API->>DB: UPDATE tenants SET verified_at=now(), status='active'
+    Web-->>User: Redirect to /<org-slug>/dashboard + provisional-admin banner
+```
+
+Notable behaviours:
+
+- Tenant row is created **before** verification, with `status='provisional'`; it is reaped after 24h if verification never completes (BullMQ cleanup job).
+- `users.role='org_admin'` is granted on first login; `users.first_admin=true` is kept for dispute logic.
+- The provisional banner is removed after 7 days OR when a second admin is added via invitation, whichever first.
+- No credit card involved.
+
+### 3.2 Enterprise SSO track
+
+```mermaid
+sequenceDiagram
+    actor SA as Givernance Super Admin
+    participant Back as Back-office Web
+    participant API as Givernance API
+    participant DB as PostgreSQL
+    participant KC as Keycloak (Admin API)
+    participant Cust as NPO IT admin
+
+    SA->>Back: Create tenant form (name, slug, primary domain, plan)
+    Back->>API: POST /v1/admin/tenants
+    API->>DB: INSERT tenants(status='provisional', created_via='enterprise')
+    API->>KC: Create Organization (alias = slug)
+    API->>DB: INSERT tenant_domains(state='pending_dns')
+    API-->>Back: 201 { tenantId, dnsTxtRecord }
+    Back-->>SA: "Ask <cust> to publish TXT record: <value>"
+
+    SA->>Cust: Share DNS TXT value + IdP bootstrap guide
+    Cust->>Cust: Publish DNS TXT; share IdP metadata URL/client
+    SA->>Back: Enter IdP metadata + test
+    Back->>API: POST /v1/admin/tenants/:id/provision-idp
+    API->>KC: Create IdP instance + bind to Organization
+    API->>KC: Link domain → Organization for Home IdP Discovery
+    API->>DB: UPDATE tenant_domains SET state='verified'
+    API->>DB: UPDATE tenants SET status='active'
+    API-->>Back: 200 { loginUrl }
+    SA-->>Cust: Deliver the tenant URL + invite first admin
+```
+
+The NPO's users then follow the JIT flow (same as §2.4 of `docs/21-authentication-sso.md`), but their `org_admin` role comes from the IdP claim mapping, not from self-serve privilege elevation.
+
+### 3.3 Invitation-join track
+
+Existing invitations flow (see [`packages/api/src/modules/invitations/routes.ts`](../packages/api/src/modules/invitations/routes.ts)) is extended:
+
+1. `org_admin` invites an email from **Settings → Team**.
+2. Invitation email carries a Keycloak-hosted accept link; invitee authenticates via the tenant's bound IdP (if any) or the realm's local authenticator (magic link / password).
+3. On successful auth, JIT-provisions a `users` row in the target tenant with the role specified on the invitation.
+4. If the invitee is already in a Keycloak Organization, they now belong to **two** (or more) — the Org picker handles that.
+
+## 4. Data model additions
+
+### 4.1 `tenants` changes
+
+```sql
+ALTER TABLE tenants
+  ADD COLUMN status           VARCHAR(32) NOT NULL DEFAULT 'provisional'
+      CHECK (status IN ('provisional','active','suspended','archived')),
+  ADD COLUMN created_via      VARCHAR(32) NOT NULL DEFAULT 'enterprise'
+      CHECK (created_via IN ('self_serve','enterprise','invitation')),
+  ADD COLUMN verified_at      TIMESTAMPTZ,
+  ADD COLUMN keycloak_org_id  TEXT,            -- Keycloak Organization id
+  ADD COLUMN primary_domain   VARCHAR(255);
+```
+
+Existing `status` column (`VARCHAR(50) DEFAULT 'active'`) is migrated by setting `status='active'` for all pre-existing rows.
+
+### 4.2 `tenant_domains`
+
+```sql
+CREATE TABLE tenant_domains (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+  org_id          UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  domain          VARCHAR(255) NOT NULL,
+  state           VARCHAR(32) NOT NULL DEFAULT 'pending_dns'
+                  CHECK (state IN ('pending_dns','verified','revoked')),
+  dns_txt_value   VARCHAR(128) NOT NULL,
+  verified_at     TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (domain)                                  -- domain claim is global
+);
+CREATE INDEX ON tenant_domains (org_id);
+```
+
+Personal email domains (gmail, outlook, proton, …) are rejected at the API level and **cannot** be stored — the block list lives in `@givernance/shared/constants/personal-email-domains.ts`.
+
+### 4.3 `tenant_admin_disputes` (grace-period dispute log)
+
+```sql
+CREATE TABLE tenant_admin_disputes (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+  org_id          UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  disputer_id     UUID NOT NULL REFERENCES users(id),
+  provisional_admin_id UUID NOT NULL REFERENCES users(id),
+  reason          TEXT,
+  resolved_at     TIMESTAMPTZ,
+  resolution      VARCHAR(32)
+                  CHECK (resolution IN ('kept','replaced','escalated_to_support')),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Every other member of the tenant can open one dispute during the 7-day provisional window. Resolution is manual (support triage) for the first pilot deployments.
+
+### 4.4 `users` changes
+
+```sql
+ALTER TABLE users
+  ADD COLUMN first_admin  BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN provisional_until TIMESTAMPTZ;
+```
+
+## 5. API surface
+
+All new endpoints respect the RLS 3-role pattern:
+
+- **Public endpoints** run without tenant context (no `withTenantContext`), do their own `org_id` resolution after disposable-email / rate-limit checks, and emit audit events via a system actor.
+- **Super-admin endpoints** use `requireSuperAdmin` guard (to be extended with the back-office auth introduced by PR #73) and may bypass RLS via the owner role.
+- **Self endpoints** use the standard `requireAuth` + `withTenantContext(request.auth.orgId)`.
+
+| Endpoint | Caller | Purpose |
+|---|---|---|
+| `POST /v1/public/signup` | Anonymous + CAPTCHA | Self-serve tenant creation with provisional admin |
+| `POST /v1/public/signup/resend` | Anonymous | Re-send verification email; rate-limited per email+IP |
+| `POST /v1/public/signup/verify` | Anonymous | Complete the Keycloak Required Action from the email link |
+| `GET /v1/public/tenants/lookup?email=…` | Anonymous | Return `{ hasExistingTenant, hint }` for the login flow; used by Home IdP Discovery hint + "join your existing org" nudge |
+| `POST /v1/admin/tenants` | `super_admin` | Enterprise-track tenant creation; returns DNS TXT to publish |
+| `POST /v1/admin/tenants/:id/provision-idp` | `super_admin` | Create + bind the tenant's OIDC/SAML IdP via Keycloak Admin API |
+| `POST /v1/tenants/:id/domains` | `org_admin` | Claim a domain on an existing tenant |
+| `POST /v1/tenants/:id/domains/:domain/verify` | `org_admin` | Trigger DNS TXT lookup and transition to `verified` |
+| `GET /v1/users/me/organizations` | `requireAuth` | List organizations the user belongs to (for the Org picker) |
+| `POST /v1/session/switch-org` | `requireAuth` | Re-mint a short-lived JWT for the target org; revokes the previous access token |
+| `POST /v1/tenants/:id/admin-dispute` | `requireAuth` (any tenant member) | Open a dispute against the provisional admin within the 7-day window |
+
+Notes on the Keycloak Admin API integration:
+
+- Admin API base URL + service-account credentials live in `KEYCLOAK_ADMIN_URL` + `KEYCLOAK_ADMIN_CLIENT_ID` / `KEYCLOAK_ADMIN_CLIENT_SECRET` — **different from** the realm client used for user auth.
+- All Admin API calls go through a small `keycloakAdminClient` helper in `packages/api/src/lib/keycloak-admin.ts` with exponential-backoff retry and a circuit breaker (rate-limit aware).
+- Integration tests stub this helper; a single e2e smoke test against a real Keycloak container runs in `.github/workflows/ci.yml` gated by `KEYCLOAK_E2E=1`.
+
+## 6. Frontend flows
+
+### 6.1 Public signup form
+
+- Single page `/signup` with fields: organization name, first & last name, email, country (pre-selected from IP geolocation, editable), legal type (dropdown seeded from `docs/16-greg-field-insights.md`), GDPR micro-consent.
+- Organization slug auto-generated from name; collision check runs client-side against `GET /v1/public/tenants/lookup`.
+- hCaptcha widget; CAPTCHA token sent as `x-captcha-token` header.
+- On submit: 201 → success screen "Check your email". Error states: disposable email → specific message; existing tenant on domain → deep-link to their login.
+
+### 6.2 Email verification landing
+
+- `/signup/verify?token=…` completes the Keycloak Required Action in a server component.
+- On success: user is logged in, redirected to `/<org-slug>/dashboard` with a **provisional-admin banner** rendered by the app shell (reuse the impersonation banner pattern from PR #73).
+
+### 6.3 Organization picker
+
+- Interstitial `/select-organization` shown when `GET /v1/users/me/organizations` returns > 1 org.
+- One card per tenant: logo, name, role badge, last-visited timestamp.
+- Keyboard-navigable; default selection = last-used tenant from the `gv-last-org` cookie.
+- Submitting calls `POST /v1/session/switch-org` and redirects to `/<slug>/dashboard`.
+
+### 6.4 Back-office: tenant management
+
+- Route group `(admin)` gated by `requireRole('super_admin')`.
+- Screens: `/admin/tenants` (list + filters), `/admin/tenants/new` (enterprise-track creation form), `/admin/tenants/:id` (overview, domains tab, IdP tab, users tab, lifecycle tab).
+- Uses the existing `/v1/admin/tenants/:orgId/snapshot` for audit exports.
+- Suspend / archive actions are **soft** — no hard delete in MVP.
+
+## 7. URL routing
+
+- Authenticated app routes live under `/<org-slug>/…` (see §6 of ADR-016). App shell reads the slug from the route, resolves the tenant on every request, and re-mints the access token on `POST /v1/session/switch-org`.
+- Reserved slugs (block list in `@givernance/shared/constants/reserved-slugs.ts`): `admin`, `api`, `auth`, `login`, `signup`, `select-organization`, `p`, `public`, `settings`, `status`, `onboarding`, `www`, `mail`, `signup`, `billing`, `health`, `docs`.
+- Subdomain routing (`<slug>.givernance.app`) stays **deferred**. When it becomes necessary (enterprise tier), Cloudflare for SaaS is the planned delivery path.
+
+## 8. Security & compliance
+
+- **Abuse filters on `/v1/public/signup`**: disposable-email blocklist, per-IP rate limit (5/hour, 20/day), per-ASN rate limit for known hosting providers, hCaptcha enterprise challenge on threshold breach.
+- **Audit trail**: every state transition on a tenant (`provisional → active`, `active → suspended`, `domain pending_dns → verified`, `org_admin dispute → resolution`) is logged with `actor`, `target`, `reason`, `ip_hash`.
+- **GDPR**: signup form is minimal-PII; DPO email collected at verification step; data-residency decision is platform-wide (ADR-009) and never per tenant.
+- **Back-channel logout** — the Keycloak back-channel logout endpoint from #76 MUST be wired before this flow reaches production, so a super-admin revoking a compromised tenant's session propagates within the access-token TTL.
+- **Impersonation** — the "log in as" support action from #24 must know about multi-tenancy: a Givernance support agent impersonating a user in org A must never carry an `act` claim into org B. The Org picker enforces this.
+
+## 9. Testing strategy
+
+- **Unit**: disposable-email blocklist, slug collision, reserved-slug rejection, DNS TXT parser, personal-email detection.
+- **Integration (API)**: every endpoint in §5 with cross-tenant isolation cases, rate-limit-exceeded cases, 422 on personal-domain claim, 409 on duplicate-domain claim, provisional-admin dispute happy + expired paths.
+- **E2E smoke** (Keycloak + DB, gated): full self-serve signup → verify → dashboard round-trip, plus enterprise-track IdP provisioning against a mocked OIDC provider.
+- **Load**: 100 concurrent signups from distinct IPs to confirm rate-limit store (Redis) holds up.
+
+## 10. Migration & rollout
+
+1. Ship the ADR + this doc (PR #1).
+2. Land schema migrations + personal-email constants + reserved-slugs constants (PR #2).
+3. Keycloak Admin API client + service account (PR #3).
+4. Self-serve signup + verification endpoints + email templates (PR #4).
+5. Public signup page + verify landing page (PR #5).
+6. Enterprise track — domain CRUD + IdP provisioning endpoints (PR #6).
+7. Back-office UI for tenants + domains + IdP (PR #7).
+8. Organization picker + `switch-org` endpoint (PR #8).
+9. Provisional-admin banner + dispute flow (PR #9).
+10. Migrate local dev realm seed from groups/attributes to Keycloak Organizations, upgrade Keycloak container to 26.x (PR #10).
+
+Phases 1–5 are blocking for the first external SMB pilot; phases 6–10 are blocking for the first enterprise pilot. Issue #61 (split Keycloak DB) is a prerequisite for the Keycloak 26 upgrade in PR #10.
+
+## 11. Open questions
+
+- **SIREN / RNA lookup** for French NPOs at signup — cross-check the organization against the public registry, offer "this looks like <name> — confirm" UX. Out of scope for the first pilot; tracked as a follow-up.
+- **Magic link vs 6-digit OTP** as the default self-serve authenticator — both are supported by Keycloak; picking one default keeps the flow simple. Current proposal: email magic link as default, OTP as fallback for users blocked by email-filter / link-rewriting.
+- **Multi-tenant billing** — when a platform user (consultant) belongs to 5 NPOs, which tenant is billed for the seat? MVP: each tenant bills independently; consultants have one "seat" per tenant they're in.


### PR DESCRIPTION
## Summary

- **ADR-016** (in `docs/15-infra-adr.md`) records the Phase 2 decision from the 2026-04-23 team design session: three tenant tracks (self-serve SMB / enterprise SSO / invitation-join) sharing one Keycloak realm and one Scaleway Postgres cluster, adopting Keycloak 26 **Organizations** as the tenancy primitive and **URL-path scoping** instead of subdomains.
- **docs/22-tenant-onboarding.md** is the full Phase 2 spec — tracks, data model additions (`tenants.status`, `tenants.created_via`, `tenants.verified_at`, `tenants.keycloak_org_id`, `tenant_domains`, `tenant_admin_disputes`, `users.first_admin`), API surface, frontend flows, reserved slugs, security/compliance, test strategy, and a 10-PR rollout plan.
- **docs/21-authentication-sso.md** is updated to cross-reference ADR-016 + doc 22 and a new §2.1.bis describes the Keycloak Organizations target state so the Phase 1 doc and Phase 2 doc don't disagree on the primitive.

## Why this exists

Spike #80 chose a super-admin-only tenant provisioning model that is correct for enterprise but does not scale to the long tail of small European NPOs targeted by Givernance — they have no corporate email domain and cannot wait for a platform operator to provision each tenant. The team design session (transcript 2026-04-23) reopened the question; ADR-016 is the resulting decision.

This PR is **docs-only, no code change**. It unblocks the implementation issues filed against the new "Tenant Onboarding & Multi-Tenancy" milestone.

## Decisions captured

- Hybrid three-track model (self-serve / enterprise / invitation-join).
- Keycloak 26 **Organizations** supersedes groups+attributes for new work.
- URL-path scoping (`app.givernance.app/<slug>/…`) beats subdomain for MVP.
- Provisional `org_admin` + 7-day dispute window replaces "first-user-becomes-admin with no safeguards".
- No card at signup; card *or* annual invoice at conversion.
- Personal email domains (gmail, outlook, proton, …) cannot claim a domain; invite-only tenants for that segment.
- DNS TXT verification on enterprise domain claims.
- Post-login Org picker for one-user-multiple-tenants; `POST /v1/session/switch-org` re-mints a short-lived access token.

## Rejected alternatives (summary)

See ADR-016 §Rejected alternatives — includes the super-admin-only model, naive first-user-admin, paywall-at-signup, subdomain-per-tenant-from-day-one, one-realm-per-tenant, and legacy groups-and-attributes.

## Test plan

Docs PR — no code. Manual review checklist:

- [ ] ADR-016 renders correctly and internal links resolve.
- [ ] `docs/22-tenant-onboarding.md` renders correctly; mermaid diagrams render.
- [ ] `docs/21-authentication-sso.md` still makes sense as a Phase 1 reference; the §2.1.bis addition is the only architectural new material.
- [ ] No stale references to the deprecated "5-step wizard" outside explicit "legacy" callouts.

## Follow-ups

- Implementation issues #104–#112 (to be created under the new milestone) will reference this ADR / doc.
- Issue #78 (Phase 2 onboarding wizard) will be rebaselined against the new spec.
- Issue #80 stays open as the spike of record; its content is now architectural context for ADR-016.
- Issue #33 (legacy 5-step wizard) is superseded; to be closed once this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)