### PR TITLE
feat(tenants): schema foundation for hybrid onboarding (issue #106, ADR-016)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -51,6 +51,7 @@
               "level": "error",
               "options": {
                 "paths": {
+                  "@givernance/shared": "Importing the @givernance/shared root barrel in packages/web is forbidden (ADR-013). Use a specific subpath like @givernance/shared/validators or @givernance/shared/constants.",
                   "@givernance/shared/schema": "Importing Drizzle schema in packages/web is forbidden (ADR-013). Use @/models/ for API response types.",
                   "@givernance/shared/events": "Importing domain events in packages/web is forbidden (ADR-013). Events are backend-only.",
                   "@givernance/shared/jobs": "Importing job definitions in packages/web is forbidden (ADR-013). Jobs are backend-only."

--- a/docs/03-data-model.md
+++ b/docs/03-data-model.md
@@ -64,17 +64,78 @@ CREATE TABLE orgs (
 #### `users`
 ```sql
 CREATE TABLE users (
-    id              UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
-    org_id          UUID NOT NULL REFERENCES orgs(id),
-    keycloak_sub    UUID UNIQUE NOT NULL,           -- KC subject claim
-    email           TEXT NOT NULL,
-    display_name    TEXT NOT NULL,
-    role            TEXT NOT NULL,                 -- see §5 RBAC
-    is_active       BOOLEAN NOT NULL DEFAULT true,
-    last_login_at   TIMESTAMPTZ,
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    UNIQUE (org_id, email)
+    id                UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    org_id            UUID NOT NULL REFERENCES orgs(id),
+    keycloak_sub      UUID UNIQUE NOT NULL,           -- KC subject claim
+    email             TEXT NOT NULL,
+    display_name      TEXT NOT NULL,
+    role              TEXT NOT NULL,                 -- see §5 RBAC
+    is_active         BOOLEAN NOT NULL DEFAULT true,
+    last_login_at     TIMESTAMPTZ,
+    -- Self-serve tenant provisioning (migration 0021 / ADR-016)
+    first_admin       BOOLEAN NOT NULL DEFAULT false, -- first admin of a self-serve tenant
+    provisional_until TIMESTAMPTZ,                    -- non-null => provisional org_admin; dispute window open
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (org_id, email),
+    CHECK (provisional_until IS NULL OR first_admin = true)
 );
+```
+
+#### `tenants` lifecycle columns (migration 0021 / ADR-016)
+
+On top of the legacy `orgs`/`tenants` columns, the hybrid onboarding model adds:
+
+```sql
+ALTER TABLE tenants
+    ADD COLUMN status          VARCHAR(50) NOT NULL DEFAULT 'active'
+        CHECK (status IN ('provisional','active','suspended','archived')),
+    ADD COLUMN created_via     VARCHAR(32) NOT NULL DEFAULT 'enterprise'
+        CHECK (created_via IN ('self_serve','enterprise','invitation')),
+    ADD COLUMN verified_at     TIMESTAMPTZ,
+    ADD COLUMN keycloak_org_id TEXT,             -- Keycloak 26 Organization id (bound 1:1)
+    ADD COLUMN primary_domain  VARCHAR(255);     -- convenience; source of truth = tenant_domains
+```
+
+See [`docs/22-tenant-onboarding.md`](./22-tenant-onboarding.md) §4 for the full spec and `docs/15-infra-adr.md` ADR-016 for the decision.
+
+#### `tenant_domains` (ADR-016)
+```sql
+CREATE TABLE tenant_domains (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id         UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    domain         VARCHAR(255) NOT NULL CHECK (domain = lower(domain)),
+    state          VARCHAR(32)  NOT NULL DEFAULT 'pending_dns'
+                   CHECK (state IN ('pending_dns','verified','revoked')),
+    dns_txt_value  VARCHAR(128) NOT NULL,
+    verified_at    TIMESTAMPTZ,
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+-- Partial unique: a domain is globally unique while active; revoked rows free the slot.
+CREATE UNIQUE INDEX tenant_domains_active_domain_uniq
+    ON tenant_domains (domain) WHERE state <> 'revoked';
+```
+
+Personal/consumer email domains (gmail, outlook, proton, …) are rejected at the API validator layer via `@givernance/shared/constants/personal-email-domains`. Reserved tenant slugs (`admin`, `api`, `login`, …) live in `@givernance/shared/constants/reserved-slugs`.
+
+#### `tenant_admin_disputes` (ADR-016, provisional-admin grace period)
+```sql
+CREATE TABLE tenant_admin_disputes (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id               UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    disputer_id          UUID NOT NULL REFERENCES users(id),
+    provisional_admin_id UUID NOT NULL REFERENCES users(id),
+    reason               TEXT,
+    resolution           VARCHAR(32)
+                         CHECK (resolution IS NULL OR
+                                resolution IN ('kept','replaced','escalated_to_support')),
+    resolved_at          TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (disputer_id <> provisional_admin_id)
+);
+-- One open dispute per tenant at most; closed disputes (resolution set) don't block a new one.
+CREATE UNIQUE INDEX tenant_admin_disputes_one_open_per_tenant
+    ON tenant_admin_disputes (org_id) WHERE resolution IS NULL;
 ```
 
 #### `audit_log`

--- a/packages/api/migrations/0021_tenant_onboarding_schema.sql
+++ b/packages/api/migrations/0021_tenant_onboarding_schema.sql
@@ -10,28 +10,41 @@
 --
 -- Existing tenants are back-filled with status='active' / created_via='enterprise'
 -- so the Phase 1 super-admin-provisioned rows keep working unchanged.
+--
+-- Naming: every new constraint / index is explicitly named so integration
+-- tests can assert against stable error strings (see
+-- `tenant-onboarding-schema.test.ts`). A future migration that renames a
+-- constraint MUST update the matching test regex.
 
 -- ─── tenants: lifecycle + provenance ──────────────────────────────────────────
 
 ALTER TABLE tenants
     ADD COLUMN IF NOT EXISTS created_via      VARCHAR(32)  NOT NULL DEFAULT 'enterprise',
     ADD COLUMN IF NOT EXISTS verified_at      TIMESTAMPTZ,
-    ADD COLUMN IF NOT EXISTS keycloak_org_id  TEXT,
+    ADD COLUMN IF NOT EXISTS keycloak_org_id  VARCHAR(64),
     ADD COLUMN IF NOT EXISTS primary_domain   VARCHAR(255);
 
--- Existing `status` column uses VARCHAR(50) DEFAULT 'active' with no CHECK constraint.
--- Keep the width unchanged and add the CHECK + back-fill the new vocabulary.
-UPDATE tenants SET status = 'active' WHERE status IS NULL;
-
+-- Existing `status` column is NOT NULL DEFAULT 'active' (migration 0002) so
+-- the legacy rows are already at 'active'; column defaults cover the new
+-- columns. We add the CHECK constraints directly without a back-fill UPDATE.
 ALTER TABLE tenants
     ADD CONSTRAINT tenants_status_chk
         CHECK (status IN ('provisional','active','suspended','archived')),
     ADD CONSTRAINT tenants_created_via_chk
         CHECK (created_via IN ('self_serve','enterprise','invitation')),
-    -- primary_domain, if set, must be a lowercase host (coarse check — validators
-    -- enforce the fine-grained syntax at the API layer).
     ADD CONSTRAINT tenants_primary_domain_lower_chk
-        CHECK (primary_domain IS NULL OR primary_domain = lower(primary_domain));
+        CHECK (primary_domain IS NULL OR primary_domain = lower(primary_domain)),
+    -- Keycloak 26 Organization ids are UUIDs. Reject anything else to
+    -- prevent typos from silently binding a tenant to the wrong KC org.
+    ADD CONSTRAINT tenants_keycloak_org_id_uuid_chk
+        CHECK (keycloak_org_id IS NULL
+               OR keycloak_org_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'),
+    -- Self-serve tenants must either be provisional or have been verified.
+    -- Enterprise/invitation rows can be in any state (super-admin drives them).
+    ADD CONSTRAINT tenants_self_serve_requires_verification_chk
+        CHECK (created_via <> 'self_serve'
+               OR status = 'provisional'
+               OR verified_at IS NOT NULL);
 
 -- One Keycloak Organization id per tenant at most.
 CREATE UNIQUE INDEX IF NOT EXISTS tenants_keycloak_org_id_uniq
@@ -49,6 +62,12 @@ ALTER TABLE users
     ADD CONSTRAINT users_provisional_requires_first_admin_chk
         CHECK (provisional_until IS NULL OR first_admin = true);
 
+-- At most one first_admin per tenant. If the provisional admin is replaced
+-- via a dispute, the replacement swap MUST flip the old first_admin=false
+-- in the same transaction. Prevents privilege-escalation via dup flags.
+CREATE UNIQUE INDEX IF NOT EXISTS users_one_first_admin_per_org
+    ON users (org_id) WHERE first_admin = true;
+
 -- ─── tenant_domains ──────────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS tenant_domains (
@@ -63,10 +82,14 @@ CREATE TABLE IF NOT EXISTS tenant_domains (
 
     CONSTRAINT tenant_domains_state_chk
         CHECK (state IN ('pending_dns','verified','revoked')),
-    -- Domain is always stored lowercase; keep the column narrow enough to be
-    -- a btree key without TOAST.
+    -- Domain is always stored lowercase.
     CONSTRAINT tenant_domains_lowercase_chk
-        CHECK (domain = lower(domain))
+        CHECK (domain = lower(domain)),
+    -- DNS TXT tokens must carry real entropy (≥32 chars). The generator ships
+    -- base64url of 24+ random bytes (=> 32 chars); the floor here rejects any
+    -- bypass that would let a weak token verify a domain.
+    CONSTRAINT tenant_domains_dns_txt_entropy_chk
+        CHECK (length(dns_txt_value) >= 32)
 );
 
 -- A domain claim is globally unique — once `ngo.fr` is bound to Org A,
@@ -75,32 +98,70 @@ CREATE TABLE IF NOT EXISTS tenant_domains (
 CREATE UNIQUE INDEX IF NOT EXISTS tenant_domains_active_domain_uniq
     ON tenant_domains (domain) WHERE state <> 'revoked';
 
+-- DNS TXT values must be unique across active rows too, so two domains
+-- cannot accidentally share the same proof token.
+CREATE UNIQUE INDEX IF NOT EXISTS tenant_domains_active_txt_uniq
+    ON tenant_domains (dns_txt_value) WHERE state <> 'revoked';
+
 CREATE INDEX IF NOT EXISTS tenant_domains_org_id_idx ON tenant_domains (org_id);
 CREATE INDEX IF NOT EXISTS tenant_domains_state_idx  ON tenant_domains (state);
+-- Hot-path index for "give me this tenant's verified domains" (Home IdP Discovery,
+-- login-side domain lookup). Partial covers the common case cheaply.
+CREATE INDEX IF NOT EXISTS tenant_domains_verified_by_org_idx
+    ON tenant_domains (org_id) WHERE state = 'verified';
 
 ALTER TABLE tenant_domains ENABLE  ROW LEVEL SECURITY;
 ALTER TABLE tenant_domains FORCE   ROW LEVEL SECURITY;
 
+-- FOR ALL + WITH CHECK ensures RLS applies to SELECT/INSERT/UPDATE/DELETE,
+-- and that a bug in the API layer cannot write a row with the wrong org_id.
 CREATE POLICY tenant_isolation ON tenant_domains
-    USING (org_id = app_current_organization_id());
+    FOR ALL
+    USING      (org_id = app_current_organization_id())
+    WITH CHECK (org_id = app_current_organization_id());
+
+-- Auto-maintain updated_at on every write.
+CREATE OR REPLACE FUNCTION tenant_domains_set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER tenant_domains_updated_at_trg
+    BEFORE UPDATE ON tenant_domains
+    FOR EACH ROW EXECUTE FUNCTION tenant_domains_set_updated_at();
 
 -- ─── tenant_admin_disputes ───────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS tenant_admin_disputes (
     id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     org_id                  UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
-    disputer_id             UUID NOT NULL REFERENCES users(id),
-    provisional_admin_id    UUID NOT NULL REFERENCES users(id),
-    reason                  TEXT,
+    -- ON DELETE SET NULL so GDPR Art. 17 user erasures don't fail on FK.
+    -- The dispute row is retained with the NULL placeholder for audit.
+    disputer_id             UUID REFERENCES users(id) ON DELETE SET NULL,
+    provisional_admin_id    UUID REFERENCES users(id) ON DELETE SET NULL,
+    reason                  VARCHAR(2000),
     resolution              VARCHAR(32),
     resolved_at             TIMESTAMPTZ,
+    resolved_by             UUID REFERENCES users(id) ON DELETE SET NULL,
     created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
 
     CONSTRAINT tenant_admin_disputes_resolution_chk
         CHECK (resolution IS NULL
                OR resolution IN ('kept','replaced','escalated_to_support')),
+    -- disputer and provisional admin must be different *when both are
+    -- non-null*. GDPR erasure may null them independently.
     CONSTRAINT tenant_admin_disputes_different_actors_chk
-        CHECK (disputer_id <> provisional_admin_id)
+        CHECK (disputer_id IS NULL
+               OR provisional_admin_id IS NULL
+               OR disputer_id <> provisional_admin_id),
+    -- resolution and resolved_at must co-exist.
+    CONSTRAINT tenant_admin_disputes_resolved_consistency_chk
+        CHECK ((resolution IS NULL AND resolved_at IS NULL)
+               OR (resolution IS NOT NULL AND resolved_at IS NOT NULL))
 );
 
 -- One open dispute per tenant at most. Closed disputes (resolution set)
@@ -115,4 +176,26 @@ ALTER TABLE tenant_admin_disputes ENABLE  ROW LEVEL SECURITY;
 ALTER TABLE tenant_admin_disputes FORCE   ROW LEVEL SECURITY;
 
 CREATE POLICY tenant_isolation ON tenant_admin_disputes
-    USING (org_id = app_current_organization_id());
+    FOR ALL
+    USING      (org_id = app_current_organization_id())
+    WITH CHECK (org_id = app_current_organization_id());
+
+CREATE OR REPLACE FUNCTION tenant_admin_disputes_set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER tenant_admin_disputes_updated_at_trg
+    BEFORE UPDATE ON tenant_admin_disputes
+    FOR EACH ROW EXECUTE FUNCTION tenant_admin_disputes_set_updated_at();
+
+-- ─── Explicit grants to givernance_app ───────────────────────────────────────
+-- Matches the pattern from migrations 0008, 0009, 0010, 0017, 0018.
+-- ALTER DEFAULT PRIVILEGES from 0005 handles the common case, but explicit
+-- grants are robust to environments where migrations were historically
+-- run as a different role.
+GRANT SELECT, INSERT, UPDATE, DELETE ON tenant_domains         TO givernance_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON tenant_admin_disputes  TO givernance_app;

--- a/packages/api/migrations/0021_tenant_onboarding_schema.sql
+++ b/packages/api/migrations/0021_tenant_onboarding_schema.sql
@@ -1,0 +1,118 @@
+-- 0021_tenant_onboarding_schema.sql
+-- Foundation for the Tenant Onboarding & Multi-Tenancy milestone (ADR-016).
+--
+-- 1. Extends `tenants` with lifecycle + provenance columns so the self-serve
+--    and enterprise tracks can share one table.
+-- 2. Adds `first_admin` + `provisional_until` on `users` for the 7-day
+--    provisional-admin grace period (doc 22 §3.1, §4.4).
+-- 3. Creates `tenant_domains` (domain claim + DNS TXT verification state)
+--    and `tenant_admin_disputes` (grace-period dispute log).
+--
+-- Existing tenants are back-filled with status='active' / created_via='enterprise'
+-- so the Phase 1 super-admin-provisioned rows keep working unchanged.
+
+-- ─── tenants: lifecycle + provenance ──────────────────────────────────────────
+
+ALTER TABLE tenants
+    ADD COLUMN IF NOT EXISTS created_via      VARCHAR(32)  NOT NULL DEFAULT 'enterprise',
+    ADD COLUMN IF NOT EXISTS verified_at      TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS keycloak_org_id  TEXT,
+    ADD COLUMN IF NOT EXISTS primary_domain   VARCHAR(255);
+
+-- Existing `status` column uses VARCHAR(50) DEFAULT 'active' with no CHECK constraint.
+-- Keep the width unchanged and add the CHECK + back-fill the new vocabulary.
+UPDATE tenants SET status = 'active' WHERE status IS NULL;
+
+ALTER TABLE tenants
+    ADD CONSTRAINT tenants_status_chk
+        CHECK (status IN ('provisional','active','suspended','archived')),
+    ADD CONSTRAINT tenants_created_via_chk
+        CHECK (created_via IN ('self_serve','enterprise','invitation')),
+    -- primary_domain, if set, must be a lowercase host (coarse check — validators
+    -- enforce the fine-grained syntax at the API layer).
+    ADD CONSTRAINT tenants_primary_domain_lower_chk
+        CHECK (primary_domain IS NULL OR primary_domain = lower(primary_domain));
+
+-- One Keycloak Organization id per tenant at most.
+CREATE UNIQUE INDEX IF NOT EXISTS tenants_keycloak_org_id_uniq
+    ON tenants (keycloak_org_id)
+    WHERE keycloak_org_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS tenants_status_idx       ON tenants (status);
+CREATE INDEX IF NOT EXISTS tenants_created_via_idx  ON tenants (created_via);
+
+-- ─── users: provisional-admin flags ──────────────────────────────────────────
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS first_admin       BOOLEAN     NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS provisional_until TIMESTAMPTZ,
+    ADD CONSTRAINT users_provisional_requires_first_admin_chk
+        CHECK (provisional_until IS NULL OR first_admin = true);
+
+-- ─── tenant_domains ──────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS tenant_domains (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id          UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    domain          VARCHAR(255) NOT NULL,
+    state           VARCHAR(32)  NOT NULL DEFAULT 'pending_dns',
+    dns_txt_value   VARCHAR(128) NOT NULL,
+    verified_at     TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT tenant_domains_state_chk
+        CHECK (state IN ('pending_dns','verified','revoked')),
+    -- Domain is always stored lowercase; keep the column narrow enough to be
+    -- a btree key without TOAST.
+    CONSTRAINT tenant_domains_lowercase_chk
+        CHECK (domain = lower(domain))
+);
+
+-- A domain claim is globally unique — once `ngo.fr` is bound to Org A,
+-- no other tenant can claim it. Revoked claims release the slot. Partial
+-- unique index avoids a dependency on btree_gist that EXCLUDE would need.
+CREATE UNIQUE INDEX IF NOT EXISTS tenant_domains_active_domain_uniq
+    ON tenant_domains (domain) WHERE state <> 'revoked';
+
+CREATE INDEX IF NOT EXISTS tenant_domains_org_id_idx ON tenant_domains (org_id);
+CREATE INDEX IF NOT EXISTS tenant_domains_state_idx  ON tenant_domains (state);
+
+ALTER TABLE tenant_domains ENABLE  ROW LEVEL SECURITY;
+ALTER TABLE tenant_domains FORCE   ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON tenant_domains
+    USING (org_id = app_current_organization_id());
+
+-- ─── tenant_admin_disputes ───────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS tenant_admin_disputes (
+    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id                  UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    disputer_id             UUID NOT NULL REFERENCES users(id),
+    provisional_admin_id    UUID NOT NULL REFERENCES users(id),
+    reason                  TEXT,
+    resolution              VARCHAR(32),
+    resolved_at             TIMESTAMPTZ,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT tenant_admin_disputes_resolution_chk
+        CHECK (resolution IS NULL
+               OR resolution IN ('kept','replaced','escalated_to_support')),
+    CONSTRAINT tenant_admin_disputes_different_actors_chk
+        CHECK (disputer_id <> provisional_admin_id)
+);
+
+-- One open dispute per tenant at most. Closed disputes (resolution set)
+-- don't block a new one. Partial unique index avoids btree_gist.
+CREATE UNIQUE INDEX IF NOT EXISTS tenant_admin_disputes_one_open_per_tenant
+    ON tenant_admin_disputes (org_id) WHERE resolution IS NULL;
+
+CREATE INDEX IF NOT EXISTS tenant_admin_disputes_org_id_idx
+    ON tenant_admin_disputes (org_id);
+
+ALTER TABLE tenant_admin_disputes ENABLE  ROW LEVEL SECURITY;
+ALTER TABLE tenant_admin_disputes FORCE   ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON tenant_admin_disputes
+    USING (org_id = app_current_organization_id());

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1744502419000,
       "tag": "0020_rls_empty_string_fix",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1744502420000,
+      "tag": "0021_tenant_onboarding_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/tests/integration/tenant-onboarding-schema.test.ts
+++ b/packages/api/src/tests/integration/tenant-onboarding-schema.test.ts
@@ -2,57 +2,106 @@
  * Integration + unit coverage for the Tenant Onboarding schema foundation
  * landed by migration 0021 (issue #106 / ADR-016).
  *
- * - Unit: `isPersonalEmailDomain`, `isReservedSlug`, `validateTenantSlug`.
- * - DB: post-migrate back-fill, RLS isolation on `tenant_domains` +
- *   `tenant_admin_disputes`, partial-unique indexes, CHECK constraints.
+ * Notes on the test surface:
+ * - Unit-level assertions for pure functions live here (not in a separate
+ *   shared-package suite) because the repo does not yet have a shared-package
+ *   vitest config; splitting is a follow-up (#ENG-8).
+ * - DB assertions run as the `givernance` owner role (BYPASSRLS per ADR-009
+ *   / docs/03-data-model.md §4.1). RLS behaviour is validated end-to-end by
+ *   API-level tests written against `givernance_app` in issues #108 + #110.
+ * - Each DB sub-suite is `describe.sequential` to lock in the intended
+ *   per-`it` state transitions.
+ * - Constraint names are stable error-string API; if migration 0021 is ever
+ *   superseded, the matching regex in each `.rejects.toThrow` MUST be updated.
  */
 
-import { isPersonalEmailDomain, isReservedSlug } from "@givernance/shared/constants";
+import {
+  isPersonalEmailDomain,
+  isReservedSlug,
+  PERSONAL_EMAIL_DOMAINS,
+  RESERVED_SLUGS,
+} from "@givernance/shared/constants";
 import { tenantAdminDisputes, tenantDomains, tenants, users } from "@givernance/shared/schema";
 import { validateTenantSlug } from "@givernance/shared/validators";
 import { and, eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { db, withTenantContext } from "../../lib/db.js";
-import { ensureTestTenants, ORG_A, ORG_B } from "../helpers/auth.js";
+import { ensureTestTenants } from "../helpers/auth.js";
 
-// A stable pair of user ids used for dispute rows. Created in this test's
-// beforeAll — not part of the shared auth helpers because other suites don't
-// need them.
-const DISPUTE_USER_A_FIRST_ADMIN = "00000000-0000-0000-0000-00000000ca01";
-const DISPUTE_USER_A_DISPUTER = "00000000-0000-0000-0000-00000000ca02";
-const DISPUTE_USER_B_FIRST_ADMIN = "00000000-0000-0000-0000-00000000cb01";
+// Dedicated tenants for this suite so shared fixtures (ORG_A, ORG_B) aren't
+// polluted with our ad-hoc users and dispute rows.
+const ONBOARD_A = "00000000-0000-0000-0000-0000000c0a01";
+const ONBOARD_B = "00000000-0000-0000-0000-0000000c0a02";
+const CASCADE_ORG = "00000000-0000-0000-0000-0000000c0a03";
+
+const USER_A_FIRST_ADMIN = "00000000-0000-0000-0000-00000000ca01";
+const USER_A_DISPUTER = "00000000-0000-0000-0000-00000000ca02";
+const USER_B_FIRST_ADMIN = "00000000-0000-0000-0000-00000000cb01";
+
+// Unique suffix per test run to keep domain / dns_txt fixtures collision-free
+// across reruns and parallel files.
+const RUN = `${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+const d = (name: string) => `${name}-${RUN}.test`;
+const txt = (tag: string) => `givernance-verify=${RUN}-${tag}-padding-padding-xx`;
 
 beforeAll(async () => {
   await ensureTestTenants();
 
-  // Seed two minimal users for dispute scenarios. Inserts are owner-role
-  // (no RLS context) which is how the tests already seed data.
+  // Dedicated per-suite tenants.
+  await db.execute(sql`
+    INSERT INTO tenants (id, name, slug, status, created_via)
+    VALUES
+      (${ONBOARD_A}, 'Onboarding Suite A', 'onboard-suite-a', 'active', 'enterprise'),
+      (${ONBOARD_B}, 'Onboarding Suite B', 'onboard-suite-b', 'active', 'enterprise')
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+  // Defensive cleanup from any prior partial run before we seed.
+  await db.execute(sql`
+    DELETE FROM tenant_admin_disputes WHERE org_id IN (${ONBOARD_A}, ${ONBOARD_B}, ${CASCADE_ORG})
+  `);
+  await db.execute(sql`
+    DELETE FROM tenant_domains WHERE org_id IN (${ONBOARD_A}, ${ONBOARD_B}, ${CASCADE_ORG})
+  `);
+  await db.execute(sql`
+    DELETE FROM users WHERE id IN (${USER_A_FIRST_ADMIN}, ${USER_A_DISPUTER}, ${USER_B_FIRST_ADMIN})
+  `);
+
   await db.execute(sql`
     INSERT INTO users (id, org_id, email, first_name, last_name, role, first_admin)
     VALUES
-      (${DISPUTE_USER_A_FIRST_ADMIN}, ${ORG_A}, 'first-a@example.org', 'First', 'AdminA', 'org_admin', true),
-      (${DISPUTE_USER_A_DISPUTER},    ${ORG_A}, 'disp-a@example.org',  'Disp',  'A',      'user',      false),
-      (${DISPUTE_USER_B_FIRST_ADMIN}, ${ORG_B}, 'first-b@example.org', 'First', 'AdminB', 'org_admin', true)
-    ON CONFLICT (id) DO NOTHING
+      (${USER_A_FIRST_ADMIN}, ${ONBOARD_A}, 'first-a@example.org', 'First', 'AdminA', 'org_admin', true),
+      (${USER_A_DISPUTER},    ${ONBOARD_A}, 'disp-a@example.org',  'Disp',  'A',      'user',      false),
+      (${USER_B_FIRST_ADMIN}, ${ONBOARD_B}, 'first-b@example.org', 'First', 'AdminB', 'org_admin', true)
   `);
 });
 
 afterAll(async () => {
-  // Clean up rows this suite wrote. We keep the two test tenants (shared).
-  await db.execute(sql`DELETE FROM tenant_admin_disputes WHERE org_id IN (${ORG_A}, ${ORG_B})`);
-  await db.execute(sql`DELETE FROM tenant_domains WHERE org_id IN (${ORG_A}, ${ORG_B})`);
-  await db.execute(sql`
-    DELETE FROM users WHERE id IN (
-      ${DISPUTE_USER_A_FIRST_ADMIN}, ${DISPUTE_USER_A_DISPUTER}, ${DISPUTE_USER_B_FIRST_ADMIN}
-    )
+  // Each statement wrapped so a transient failure doesn't silently leak data.
+  const safe = async (s: ReturnType<typeof sql>) => {
+    try {
+      await db.execute(s);
+    } catch {
+      /* best-effort cleanup */
+    }
+  };
+  await safe(
+    sql`DELETE FROM tenant_admin_disputes WHERE org_id IN (${ONBOARD_A}, ${ONBOARD_B}, ${CASCADE_ORG})`,
+  );
+  await safe(
+    sql`DELETE FROM tenant_domains WHERE org_id IN (${ONBOARD_A}, ${ONBOARD_B}, ${CASCADE_ORG})`,
+  );
+  await safe(sql`
+    DELETE FROM users WHERE id IN (${USER_A_FIRST_ADMIN}, ${USER_A_DISPUTER}, ${USER_B_FIRST_ADMIN})
   `);
+  await safe(sql`DELETE FROM tenants WHERE id IN (${ONBOARD_A}, ${ONBOARD_B}, ${CASCADE_ORG})`);
 });
 
 // ─── Unit — constants ────────────────────────────────────────────────────────
 
 describe("isPersonalEmailDomain", () => {
   it("flags common consumer domains across locales", () => {
-    for (const d of [
+    for (const x of [
       "gmail.com",
       "GMAIL.COM",
       "  outlook.com  ",
@@ -61,13 +110,13 @@ describe("isPersonalEmailDomain", () => {
       "web.de",
       "libero.it",
     ]) {
-      expect(isPersonalEmailDomain(d)).toBe(true);
+      expect(isPersonalEmailDomain(x)).toBe(true);
     }
   });
 
   it("does not flag actual nonprofit domains", () => {
-    for (const d of ["croix-rouge.fr", "amnesty.org", "wwf.de", "unicef.ch"]) {
-      expect(isPersonalEmailDomain(d)).toBe(false);
+    for (const x of ["croix-rouge.fr", "amnesty.org", "wwf.de", "unicef.ch"]) {
+      expect(isPersonalEmailDomain(x)).toBe(false);
     }
   });
 
@@ -77,9 +126,33 @@ describe("isPersonalEmailDomain", () => {
   });
 });
 
+describe("PERSONAL_EMAIL_DOMAINS invariants", () => {
+  it("has no duplicates", () => {
+    expect(new Set(PERSONAL_EMAIL_DOMAINS).size).toBe(PERSONAL_EMAIL_DOMAINS.length);
+  });
+  it("only contains lowercase entries", () => {
+    expect(PERSONAL_EMAIL_DOMAINS.every((x) => x === x.toLowerCase())).toBe(true);
+  });
+});
+
 describe("isReservedSlug", () => {
-  it("flags routing/platform slugs", () => {
-    for (const s of ["admin", "API", "  billing  ", "select-organization", "www"]) {
+  it("flags routing/platform/auth slugs", () => {
+    for (const s of [
+      "admin",
+      "API",
+      "  billing  ",
+      "select-organization",
+      "www",
+      "oauth",
+      "saml",
+      "well-known",
+      "stripe",
+      "keycloak",
+      "campaigns",
+      "constituents",
+      "donations",
+      "users",
+    ]) {
       expect(isReservedSlug(s)).toBe(true);
     }
   });
@@ -91,40 +164,62 @@ describe("isReservedSlug", () => {
   });
 });
 
+describe("RESERVED_SLUGS invariants", () => {
+  it("has no duplicates", () => {
+    expect(new Set(RESERVED_SLUGS).size).toBe(RESERVED_SLUGS.length);
+  });
+  it("only contains lowercase entries (except the one documented dotted exception)", () => {
+    // `.well-known` carries a leading dot by RFC 8615 convention; it's still
+    // lowercase but not matched by [a-z] alone, so we check manually.
+    expect(RESERVED_SLUGS.every((s) => s === s.toLowerCase())).toBe(true);
+  });
+});
+
 // ─── Unit — validator ────────────────────────────────────────────────────────
 
 describe("validateTenantSlug", () => {
-  it("accepts well-formed slugs", () => {
-    for (const s of ["ac", "amnesty", "amnesty-fr", "a1b2c3", "ngo-france-001"]) {
-      expect(validateTenantSlug(s)).toEqual({ ok: true });
-    }
+  it("accepts well-formed slugs and returns the canonical value", () => {
+    expect(validateTenantSlug("ac")).toEqual({ ok: true, slug: "ac" });
+    expect(validateTenantSlug("amnesty-fr")).toEqual({ ok: true, slug: "amnesty-fr" });
+    expect(validateTenantSlug("ngo-france-001")).toEqual({
+      ok: true,
+      slug: "ngo-france-001",
+    });
   });
 
-  it("normalises input before validating (trim + lowercase)", () => {
-    // Uppercase + surrounding whitespace is fine — the validator lowercases first.
-    expect(validateTenantSlug("  Amnesty  ")).toEqual({ ok: true });
-    expect(validateTenantSlug("NGO-France")).toEqual({ ok: true });
+  it("normalises input before validating (trim + lowercase) and returns the canonical slug", () => {
+    expect(validateTenantSlug("  Amnesty  ")).toEqual({ ok: true, slug: "amnesty" });
+    expect(validateTenantSlug("NGO-France")).toEqual({ ok: true, slug: "ngo-france" });
   });
 
-  it("rejects too-short, leading/trailing dash, symbols, spaces", () => {
+  it("rejects too-short, leading/trailing dash, symbols, spaces as syntax", () => {
     for (const s of ["a", "  a  ", "-ngo", "ngo-", "n go", "ngo!", "un_der"]) {
       expect(validateTenantSlug(s)).toEqual({ ok: false, reason: "syntax" });
     }
   });
 
-  it("rejects reserved slugs with a distinct reason", () => {
-    expect(validateTenantSlug("admin")).toEqual({ ok: false, reason: "reserved" });
-    expect(validateTenantSlug("API")).toEqual({ ok: false, reason: "reserved" });
-  });
-
   it("rejects slugs longer than 50 chars", () => {
     expect(validateTenantSlug("a".repeat(51))).toEqual({ ok: false, reason: "syntax" });
+  });
+
+  it("rejects reserved slugs with the 'reserved' reason", () => {
+    expect(validateTenantSlug("admin")).toEqual({ ok: false, reason: "reserved" });
+    expect(validateTenantSlug("API")).toEqual({ ok: false, reason: "reserved" });
+    expect(validateTenantSlug("campaigns")).toEqual({ ok: false, reason: "reserved" });
+  });
+
+  it("rejects IDNA punycode (xn--) prefix with the 'punycode' reason", () => {
+    expect(validateTenantSlug("xn--pple-43d")).toEqual({ ok: false, reason: "punycode" });
+    expect(validateTenantSlug("XN--ASCII-LOOKS-LIKE")).toEqual({
+      ok: false,
+      reason: "punycode",
+    });
   });
 });
 
 // ─── DB — tenants back-fill after migration ──────────────────────────────────
 
-describe("tenants back-fill (migration 0021)", () => {
+describe.sequential("tenants back-fill (migration 0021)", () => {
   it("existing seeded tenants have status='active' and created_via='enterprise'", async () => {
     const rows = await db
       .select({
@@ -132,9 +227,7 @@ describe("tenants back-fill (migration 0021)", () => {
         status: tenants.status,
         createdVia: tenants.createdVia,
       })
-      .from(tenants)
-      .where(sql`${tenants.id} IN (${ORG_A}, ${ORG_B})`);
-
+      .from(tenants);
     // Every pre-existing tenant row inherits the new defaults from the migration.
     for (const row of rows) {
       expect(row.status).toBe("active");
@@ -143,122 +236,212 @@ describe("tenants back-fill (migration 0021)", () => {
     expect(rows.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("existing users have first_admin=false after migration", async () => {
+    // All pre-existing users (not the ones this suite seeded) must have the
+    // new column defaulted to false; a NULL here would mean the migration
+    // forgot the NOT NULL default.
+    const { rows } = await db.execute<{ anyNull: boolean }>(
+      sql`SELECT bool_or(first_admin IS NULL) AS "anyNull" FROM users`,
+    );
+    expect(rows[0]?.anyNull).toBe(false);
+  });
+
   it("tenants.status CHECK rejects an unknown status", async () => {
-    // Direct SQL: Drizzle typing would catch this at compile time, but the DB
-    // must also enforce it.
     await expect(
-      db.execute(sql`UPDATE tenants SET status = 'bogus' WHERE id = ${ORG_A}`),
+      db.execute(sql`UPDATE tenants SET status = 'bogus' WHERE id = ${ONBOARD_A}`),
     ).rejects.toThrow(/tenants_status_chk/);
   });
 
   it("tenants.created_via CHECK rejects an unknown provenance", async () => {
     await expect(
-      db.execute(sql`UPDATE tenants SET created_via = 'martian' WHERE id = ${ORG_A}`),
+      db.execute(sql`UPDATE tenants SET created_via = 'martian' WHERE id = ${ONBOARD_A}`),
     ).rejects.toThrow(/tenants_created_via_chk/);
+  });
+
+  it("tenants.primary_domain CHECK rejects uppercase", async () => {
+    await expect(
+      db.execute(sql`UPDATE tenants SET primary_domain = 'UPPER.org' WHERE id = ${ONBOARD_A}`),
+    ).rejects.toThrow(/tenants_primary_domain_lower_chk/);
+  });
+
+  it("tenants.keycloak_org_id CHECK rejects non-UUID values", async () => {
+    await expect(
+      db.execute(sql`UPDATE tenants SET keycloak_org_id = 'not-a-uuid' WHERE id = ${ONBOARD_A}`),
+    ).rejects.toThrow(/tenants_keycloak_org_id_uuid_chk/);
+  });
+
+  it("self-serve tenants require either provisional status or a verified_at", async () => {
+    await expect(
+      db.execute(sql`
+        UPDATE tenants
+        SET created_via = 'self_serve', status = 'active', verified_at = NULL
+        WHERE id = ${ONBOARD_A}
+      `),
+    ).rejects.toThrow(/tenants_self_serve_requires_verification_chk/);
+  });
+
+  it("tenants.keycloak_org_id partial unique index enforces one-per-tenant", async () => {
+    const KC_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    await db.execute(sql`
+      UPDATE tenants SET keycloak_org_id = ${KC_ID} WHERE id = ${ONBOARD_A}
+    `);
+    await expect(
+      db.execute(sql`UPDATE tenants SET keycloak_org_id = ${KC_ID} WHERE id = ${ONBOARD_B}`),
+    ).rejects.toThrow(/tenants_keycloak_org_id_uniq/);
+    // NULLs are allowed to coexist (partial index scope).
+    await expect(
+      db.execute(sql`UPDATE tenants SET keycloak_org_id = NULL WHERE id = ${ONBOARD_A}`),
+    ).resolves.not.toThrow();
   });
 });
 
 // ─── DB — tenant_domains ─────────────────────────────────────────────────────
-//
-// Note: the test suite connects as the `givernance` owner role (BYPASSRLS per
-// ADR-016 / docs/03-data-model.md §4.1), so RLS policies do not filter reads
-// here. End-to-end tenant isolation is covered by API-level tests written
-// against the `givernance_app` role. These tests focus on structural correctness
-// (inserts succeed, constraints fire, partial indexes behave).
 
-describe("tenant_domains", () => {
+describe.sequential("tenant_domains", () => {
   it("accepts inserts under each tenant context", async () => {
-    await withTenantContext(ORG_A, async (tx) => {
+    await withTenantContext(ONBOARD_A, async (tx) => {
       await tx.insert(tenantDomains).values({
-        orgId: ORG_A,
-        domain: "ngo-a-rls.test",
-        dnsTxtValue: "givernance-verify=aaa",
+        orgId: ONBOARD_A,
+        domain: d("ngo-a"),
+        dnsTxtValue: txt("a"),
       });
     });
-    await withTenantContext(ORG_B, async (tx) => {
+    await withTenantContext(ONBOARD_B, async (tx) => {
       await tx.insert(tenantDomains).values({
-        orgId: ORG_B,
-        domain: "ngo-b-rls.test",
-        dnsTxtValue: "givernance-verify=bbb",
+        orgId: ONBOARD_B,
+        domain: d("ngo-b"),
+        dnsTxtValue: txt("b"),
       });
     });
 
     const rows = await db
       .select({ orgId: tenantDomains.orgId, domain: tenantDomains.domain })
       .from(tenantDomains)
-      .where(sql`${tenantDomains.domain} IN ('ngo-a-rls.test', 'ngo-b-rls.test')`);
+      .where(sql`${tenantDomains.domain} IN (${d("ngo-a")}, ${d("ngo-b")})`);
 
-    expect(rows.some((r) => r.domain === "ngo-a-rls.test" && r.orgId === ORG_A)).toBe(true);
-    expect(rows.some((r) => r.domain === "ngo-b-rls.test" && r.orgId === ORG_B)).toBe(true);
+    expect(rows.some((r) => r.domain === d("ngo-a") && r.orgId === ONBOARD_A)).toBe(true);
+    expect(rows.some((r) => r.domain === d("ngo-b") && r.orgId === ONBOARD_B)).toBe(true);
   });
 
   it("partial unique index rejects a second active claim of the same domain", async () => {
-    const dup = `dup-${Date.now()}.test`;
-    await withTenantContext(ORG_A, async (tx) => {
+    const dup = d("dup");
+    await withTenantContext(ONBOARD_A, async (tx) => {
       await tx.insert(tenantDomains).values({
-        orgId: ORG_A,
+        orgId: ONBOARD_A,
         domain: dup,
-        dnsTxtValue: "givernance-verify=ddd",
+        dnsTxtValue: txt("dup-a"),
       });
     });
 
     await expect(
-      withTenantContext(ORG_B, async (tx) => {
+      withTenantContext(ONBOARD_B, async (tx) => {
         await tx.insert(tenantDomains).values({
-          orgId: ORG_B,
+          orgId: ONBOARD_B,
           domain: dup,
-          dnsTxtValue: "givernance-verify=eee",
+          dnsTxtValue: txt("dup-b"),
         });
       }),
     ).rejects.toThrow(/tenant_domains_active_domain_uniq/);
   });
 
   it("revoked rows free the domain slot", async () => {
-    const d = `revoked-${Date.now()}.test`;
-    await withTenantContext(ORG_A, async (tx) => {
+    const revd = d("revoked");
+    await withTenantContext(ONBOARD_A, async (tx) => {
       await tx.insert(tenantDomains).values({
-        orgId: ORG_A,
-        domain: d,
-        dnsTxtValue: "givernance-verify=111",
+        orgId: ONBOARD_A,
+        domain: revd,
+        dnsTxtValue: txt("rev-a"),
         state: "revoked",
       });
     });
-
-    // Another tenant can now claim it because only non-revoked rows enter the
-    // partial unique index.
     await expect(
-      withTenantContext(ORG_B, async (tx) => {
+      withTenantContext(ONBOARD_B, async (tx) => {
         await tx.insert(tenantDomains).values({
-          orgId: ORG_B,
-          domain: d,
-          dnsTxtValue: "givernance-verify=222",
+          orgId: ONBOARD_B,
+          domain: revd,
+          dnsTxtValue: txt("rev-b"),
         });
       }),
     ).resolves.not.toThrow();
   });
 
+  it("active DNS TXT values are unique globally", async () => {
+    const dom1 = d("txt-uniq-1");
+    const dom2 = d("txt-uniq-2");
+    const sharedTxt = txt("shared-txt");
+    await withTenantContext(ONBOARD_A, async (tx) => {
+      await tx
+        .insert(tenantDomains)
+        .values({ orgId: ONBOARD_A, domain: dom1, dnsTxtValue: sharedTxt });
+    });
+    await expect(
+      withTenantContext(ONBOARD_B, async (tx) => {
+        await tx
+          .insert(tenantDomains)
+          .values({ orgId: ONBOARD_B, domain: dom2, dnsTxtValue: sharedTxt });
+      }),
+    ).rejects.toThrow(/tenant_domains_active_txt_uniq/);
+  });
+
   it("CHECK forces lowercase domains", async () => {
     await expect(
-      withTenantContext(ORG_A, async (tx) => {
-        await tx.insert(tenantDomains).values({
-          orgId: ORG_A,
-          domain: "UPPER.test",
-          dnsTxtValue: "givernance-verify=xxx",
-        });
+      withTenantContext(ONBOARD_A, async (tx) => {
+        await tx
+          .insert(tenantDomains)
+          .values({ orgId: ONBOARD_A, domain: "UPPER.test", dnsTxtValue: txt("upper") });
       }),
     ).rejects.toThrow(/tenant_domains_lowercase_chk/);
+  });
+
+  it("CHECK rejects low-entropy DNS TXT values", async () => {
+    await expect(
+      withTenantContext(ONBOARD_A, async (tx) => {
+        await tx
+          .insert(tenantDomains)
+          .values({ orgId: ONBOARD_A, domain: d("weak"), dnsTxtValue: "short" });
+      }),
+    ).rejects.toThrow(/tenant_domains_dns_txt_entropy_chk/);
+  });
+
+  it("updated_at advances on every UPDATE (trigger)", async () => {
+    const dom = d("trg");
+    await withTenantContext(ONBOARD_A, async (tx) => {
+      await tx
+        .insert(tenantDomains)
+        .values({ orgId: ONBOARD_A, domain: dom, dnsTxtValue: txt("trg") });
+    });
+    const [before] = await db
+      .select({ at: tenantDomains.updatedAt })
+      .from(tenantDomains)
+      .where(eq(tenantDomains.domain, dom));
+
+    // Small delay to observe a distinct timestamp.
+    await new Promise((r) => setTimeout(r, 50));
+
+    await withTenantContext(ONBOARD_A, async (tx) => {
+      await tx
+        .update(tenantDomains)
+        .set({ state: "verified", verifiedAt: new Date() })
+        .where(eq(tenantDomains.domain, dom));
+    });
+
+    const [after] = await db
+      .select({ at: tenantDomains.updatedAt })
+      .from(tenantDomains)
+      .where(eq(tenantDomains.domain, dom));
+    expect(after?.at?.getTime()).toBeGreaterThan(before?.at?.getTime() ?? 0);
   });
 });
 
 // ─── DB — tenant_admin_disputes ──────────────────────────────────────────────
 
-describe("tenant_admin_disputes", () => {
+describe.sequential("tenant_admin_disputes", () => {
   it("accepts an open dispute under the tenant context", async () => {
-    await withTenantContext(ORG_A, async (tx) => {
+    await withTenantContext(ONBOARD_A, async (tx) => {
       await tx.insert(tenantAdminDisputes).values({
-        orgId: ORG_A,
-        disputerId: DISPUTE_USER_A_DISPUTER,
-        provisionalAdminId: DISPUTE_USER_A_FIRST_ADMIN,
+        orgId: ONBOARD_A,
+        disputerId: USER_A_DISPUTER,
+        provisionalAdminId: USER_A_FIRST_ADMIN,
         reason: "Not actually the director",
       });
     });
@@ -266,17 +449,17 @@ describe("tenant_admin_disputes", () => {
     const rows = await db
       .select({ orgId: tenantAdminDisputes.orgId, resolution: tenantAdminDisputes.resolution })
       .from(tenantAdminDisputes)
-      .where(eq(tenantAdminDisputes.orgId, ORG_A));
-    expect(rows.some((r) => r.orgId === ORG_A && r.resolution === null)).toBe(true);
+      .where(eq(tenantAdminDisputes.orgId, ONBOARD_A));
+    expect(rows.some((r) => r.orgId === ONBOARD_A && r.resolution === null)).toBe(true);
   });
 
   it("one-open-per-tenant partial unique index rejects a second open dispute", async () => {
     await expect(
-      withTenantContext(ORG_A, async (tx) => {
+      withTenantContext(ONBOARD_A, async (tx) => {
         await tx.insert(tenantAdminDisputes).values({
-          orgId: ORG_A,
-          disputerId: DISPUTE_USER_A_DISPUTER,
-          provisionalAdminId: DISPUTE_USER_A_FIRST_ADMIN,
+          orgId: ONBOARD_A,
+          disputerId: USER_A_DISPUTER,
+          provisionalAdminId: USER_A_FIRST_ADMIN,
           reason: "Second open dispute should fail",
         });
       }),
@@ -284,57 +467,107 @@ describe("tenant_admin_disputes", () => {
   });
 
   it("allows a new dispute after the previous one is resolved", async () => {
-    // Resolve the open one first.
-    await withTenantContext(ORG_A, async (tx) => {
+    await withTenantContext(ONBOARD_A, async (tx) => {
       await tx
         .update(tenantAdminDisputes)
         .set({ resolution: "kept", resolvedAt: new Date() })
-        .where(and(eq(tenantAdminDisputes.orgId, ORG_A), sql`resolution IS NULL`));
+        .where(and(eq(tenantAdminDisputes.orgId, ONBOARD_A), sql`resolution IS NULL`));
     });
 
     await expect(
-      withTenantContext(ORG_A, async (tx) => {
+      withTenantContext(ONBOARD_A, async (tx) => {
         await tx.insert(tenantAdminDisputes).values({
-          orgId: ORG_A,
-          disputerId: DISPUTE_USER_A_DISPUTER,
-          provisionalAdminId: DISPUTE_USER_A_FIRST_ADMIN,
+          orgId: ONBOARD_A,
+          disputerId: USER_A_DISPUTER,
+          provisionalAdminId: USER_A_FIRST_ADMIN,
           reason: "New dispute after closure",
         });
       }),
     ).resolves.not.toThrow();
   });
 
-  it("rejects a dispute where disputer equals provisional admin", async () => {
+  it("rejects a dispute where disputer equals provisional admin (when both set)", async () => {
     await expect(
-      withTenantContext(ORG_B, async (tx) => {
+      withTenantContext(ONBOARD_B, async (tx) => {
         await tx.insert(tenantAdminDisputes).values({
-          orgId: ORG_B,
-          disputerId: DISPUTE_USER_B_FIRST_ADMIN,
-          provisionalAdminId: DISPUTE_USER_B_FIRST_ADMIN,
+          orgId: ONBOARD_B,
+          disputerId: USER_B_FIRST_ADMIN,
+          provisionalAdminId: USER_B_FIRST_ADMIN,
           reason: "Self-dispute",
         });
       }),
     ).rejects.toThrow(/tenant_admin_disputes_different_actors_chk/);
   });
 
+  it("rejects resolution set without resolved_at (and vice-versa)", async () => {
+    await expect(
+      db.execute(
+        sql`UPDATE tenant_admin_disputes SET resolution = 'kept', resolved_at = NULL WHERE org_id = ${ONBOARD_A}`,
+      ),
+    ).rejects.toThrow(/tenant_admin_disputes_resolved_consistency_chk/);
+  });
+
   it("CHECK rejects unknown resolution values", async () => {
     await expect(
       db.execute(
-        sql`UPDATE tenant_admin_disputes SET resolution = 'bogus' WHERE org_id = ${ORG_A}`,
+        sql`UPDATE tenant_admin_disputes SET resolution = 'bogus' WHERE org_id = ${ONBOARD_A}`,
       ),
     ).rejects.toThrow(/tenant_admin_disputes_resolution_chk/);
   });
+
+  it("serialises concurrent open-dispute inserts — exactly one wins", async () => {
+    // First, resolve any open dispute so the tenant starts the race clean.
+    await db.execute(sql`
+      UPDATE tenant_admin_disputes
+      SET resolution = 'kept', resolved_at = now()
+      WHERE org_id = ${ONBOARD_B} AND resolution IS NULL
+    `);
+
+    const insert = () =>
+      withTenantContext(ONBOARD_B, async (tx) => {
+        await tx.insert(tenantAdminDisputes).values({
+          orgId: ONBOARD_B,
+          disputerId: USER_A_DISPUTER, // different tenant, but owner role bypasses the FK tenant link
+          provisionalAdminId: USER_B_FIRST_ADMIN,
+          reason: "Concurrent",
+        });
+      });
+
+    const results = await Promise.allSettled([insert(), insert()]);
+    const fulfilled = results.filter((r) => r.status === "fulfilled").length;
+    const rejected = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilled).toBe(1);
+    expect(rejected).toBe(1);
+    const rejectedResult = results.find((r): r is PromiseRejectedResult => r.status === "rejected");
+    expect(rejectedResult).toBeDefined();
+    expect(String(rejectedResult?.reason)).toMatch(/tenant_admin_disputes_one_open_per_tenant/);
+  });
 });
 
-// ─── DB — users.first_admin + provisional_until ──────────────────────────────
+// ─── DB — users.first_admin one-per-org invariant ────────────────────────────
 
-describe("users provisional-admin fields", () => {
+describe.sequential("users_one_first_admin_per_org", () => {
+  it("rejects a second first_admin=true user in the same org", async () => {
+    // USER_A_FIRST_ADMIN already carries first_admin=true.
+    const EXTRA = "00000000-0000-0000-0000-00000000ca99";
+    await expect(
+      db.execute(sql`
+        INSERT INTO users (id, org_id, email, first_name, last_name, role, first_admin)
+        VALUES (${EXTRA}, ${ONBOARD_A}, 'second-admin@example.org', 'Second', 'Admin', 'org_admin', true)
+      `),
+    ).rejects.toThrow(/users_one_first_admin_per_org/);
+  });
+});
+
+// ─── DB — users.provisional-admin fields ─────────────────────────────────────
+
+describe.sequential("users provisional-admin fields", () => {
   it("CHECK prevents provisional_until without first_admin", async () => {
     await expect(
       db.execute(sql`
         UPDATE users
         SET first_admin = false, provisional_until = now() + interval '7 days'
-        WHERE id = ${DISPUTE_USER_A_DISPUTER}
+        WHERE id = ${USER_A_DISPUTER}
       `),
     ).rejects.toThrow(/users_provisional_requires_first_admin_chk/);
   });
@@ -344,15 +577,89 @@ describe("users provisional-admin fields", () => {
       db.execute(sql`
         UPDATE users
         SET provisional_until = now() + interval '7 days'
-        WHERE id = ${DISPUTE_USER_A_FIRST_ADMIN}
+        WHERE id = ${USER_A_FIRST_ADMIN}
       `),
     ).resolves.not.toThrow();
 
     const [row] = await db
       .select({ first: users.firstAdmin, until: users.provisionalUntil })
       .from(users)
-      .where(eq(users.id, DISPUTE_USER_A_FIRST_ADMIN));
+      .where(eq(users.id, USER_A_FIRST_ADMIN));
     expect(row?.first).toBe(true);
     expect(row?.until).toBeTruthy();
+  });
+
+  it("allows a past-dated provisional_until — expiry is policed by the API, not the DB", async () => {
+    await expect(
+      db.execute(sql`
+        UPDATE users SET provisional_until = now() - interval '1 day'
+        WHERE id = ${USER_A_FIRST_ADMIN}
+      `),
+    ).resolves.not.toThrow();
+  });
+});
+
+// ─── DB — cascade + user erasure ─────────────────────────────────────────────
+
+describe.sequential("tenant delete cascade", () => {
+  it("deleting a tenant cascades its domains and disputes", async () => {
+    // Seed an ephemeral tenant + two users + a domain + a dispute.
+    const U1 = "00000000-0000-0000-0000-00000000cc01";
+    const U2 = "00000000-0000-0000-0000-00000000cc02";
+    await db.execute(sql`
+      INSERT INTO tenants (id, name, slug, status, created_via)
+      VALUES (${CASCADE_ORG}, 'Cascade Org', 'cascade-org', 'active', 'enterprise')
+    `);
+    await db.execute(sql`
+      INSERT INTO users (id, org_id, email, first_name, last_name, role, first_admin)
+      VALUES
+        (${U1}, ${CASCADE_ORG}, 'u1@c.org', 'U', '1', 'org_admin', true),
+        (${U2}, ${CASCADE_ORG}, 'u2@c.org', 'U', '2', 'user', false)
+    `);
+    await withTenantContext(CASCADE_ORG, async (tx) => {
+      await tx.insert(tenantDomains).values({
+        orgId: CASCADE_ORG,
+        domain: d("cascade"),
+        dnsTxtValue: txt("cascade"),
+      });
+      await tx.insert(tenantAdminDisputes).values({
+        orgId: CASCADE_ORG,
+        disputerId: U2,
+        provisionalAdminId: U1,
+        reason: "cascade-test",
+      });
+    });
+
+    await db.execute(sql`DELETE FROM tenants WHERE id = ${CASCADE_ORG}`);
+
+    const { rows: domRows } = await db.execute<{ c: number }>(
+      sql`SELECT COUNT(*)::int AS c FROM tenant_domains WHERE org_id = ${CASCADE_ORG}`,
+    );
+    const { rows: dispRows } = await db.execute<{ c: number }>(
+      sql`SELECT COUNT(*)::int AS c FROM tenant_admin_disputes WHERE org_id = ${CASCADE_ORG}`,
+    );
+    expect(domRows[0]?.c).toBe(0);
+    expect(dispRows[0]?.c).toBe(0);
+  });
+
+  it("user deletion nullifies dispute FKs rather than failing", async () => {
+    // Create a throwaway user, attach to an existing open or resolved dispute.
+    const THROW = "00000000-0000-0000-0000-00000000cc99";
+    await db.execute(sql`
+      INSERT INTO users (id, org_id, email, first_name, last_name, role, first_admin)
+      VALUES (${THROW}, ${ONBOARD_B}, 'throw@b.org', 'Throw', 'Away', 'user', false)
+    `);
+    await db.execute(sql`
+      INSERT INTO tenant_admin_disputes (org_id, disputer_id, provisional_admin_id, reason, resolution, resolved_at)
+      VALUES (${ONBOARD_B}, ${THROW}, ${USER_B_FIRST_ADMIN}, 'erasure', 'kept', now())
+    `);
+
+    // GDPR erasure of the user should succeed even though the dispute references them.
+    await expect(db.execute(sql`DELETE FROM users WHERE id = ${THROW}`)).resolves.not.toThrow();
+
+    const { rows } = await db.execute<{ disputer_id: string | null }>(
+      sql`SELECT disputer_id FROM tenant_admin_disputes WHERE reason = 'erasure' AND org_id = ${ONBOARD_B}`,
+    );
+    expect(rows[0]?.disputer_id).toBeNull();
   });
 });

--- a/packages/api/src/tests/integration/tenant-onboarding-schema.test.ts
+++ b/packages/api/src/tests/integration/tenant-onboarding-schema.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Integration + unit coverage for the Tenant Onboarding schema foundation
+ * landed by migration 0021 (issue #106 / ADR-016).
+ *
+ * - Unit: `isPersonalEmailDomain`, `isReservedSlug`, `validateTenantSlug`.
+ * - DB: post-migrate back-fill, RLS isolation on `tenant_domains` +
+ *   `tenant_admin_disputes`, partial-unique indexes, CHECK constraints.
+ */
+
+import { isPersonalEmailDomain, isReservedSlug } from "@givernance/shared/constants";
+import { tenantAdminDisputes, tenantDomains, tenants, users } from "@givernance/shared/schema";
+import { validateTenantSlug } from "@givernance/shared/validators";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, withTenantContext } from "../../lib/db.js";
+import { ensureTestTenants, ORG_A, ORG_B } from "../helpers/auth.js";
+
+// A stable pair of user ids used for dispute rows. Created in this test's
+// beforeAll — not part of the shared auth helpers because other suites don't
+// need them.
+const DISPUTE_USER_A_FIRST_ADMIN = "00000000-0000-0000-0000-00000000ca01";
+const DISPUTE_USER_A_DISPUTER = "00000000-0000-0000-0000-00000000ca02";
+const DISPUTE_USER_B_FIRST_ADMIN = "00000000-0000-0000-0000-00000000cb01";
+
+beforeAll(async () => {
+  await ensureTestTenants();
+
+  // Seed two minimal users for dispute scenarios. Inserts are owner-role
+  // (no RLS context) which is how the tests already seed data.
+  await db.execute(sql`
+    INSERT INTO users (id, org_id, email, first_name, last_name, role, first_admin)
+    VALUES
+      (${DISPUTE_USER_A_FIRST_ADMIN}, ${ORG_A}, 'first-a@example.org', 'First', 'AdminA', 'org_admin', true),
+      (${DISPUTE_USER_A_DISPUTER},    ${ORG_A}, 'disp-a@example.org',  'Disp',  'A',      'user',      false),
+      (${DISPUTE_USER_B_FIRST_ADMIN}, ${ORG_B}, 'first-b@example.org', 'First', 'AdminB', 'org_admin', true)
+    ON CONFLICT (id) DO NOTHING
+  `);
+});
+
+afterAll(async () => {
+  // Clean up rows this suite wrote. We keep the two test tenants (shared).
+  await db.execute(sql`DELETE FROM tenant_admin_disputes WHERE org_id IN (${ORG_A}, ${ORG_B})`);
+  await db.execute(sql`DELETE FROM tenant_domains WHERE org_id IN (${ORG_A}, ${ORG_B})`);
+  await db.execute(sql`
+    DELETE FROM users WHERE id IN (
+      ${DISPUTE_USER_A_FIRST_ADMIN}, ${DISPUTE_USER_A_DISPUTER}, ${DISPUTE_USER_B_FIRST_ADMIN}
+    )
+  `);
+});
+
+// ─── Unit — constants ────────────────────────────────────────────────────────
+
+describe("isPersonalEmailDomain", () => {
+  it("flags common consumer domains across locales", () => {
+    for (const d of [
+      "gmail.com",
+      "GMAIL.COM",
+      "  outlook.com  ",
+      "proton.me",
+      "orange.fr",
+      "web.de",
+      "libero.it",
+    ]) {
+      expect(isPersonalEmailDomain(d)).toBe(true);
+    }
+  });
+
+  it("does not flag actual nonprofit domains", () => {
+    for (const d of ["croix-rouge.fr", "amnesty.org", "wwf.de", "unicef.ch"]) {
+      expect(isPersonalEmailDomain(d)).toBe(false);
+    }
+  });
+
+  it("does not flag empty or whitespace-only input as personal", () => {
+    expect(isPersonalEmailDomain("")).toBe(false);
+    expect(isPersonalEmailDomain("   ")).toBe(false);
+  });
+});
+
+describe("isReservedSlug", () => {
+  it("flags routing/platform slugs", () => {
+    for (const s of ["admin", "API", "  billing  ", "select-organization", "www"]) {
+      expect(isReservedSlug(s)).toBe(true);
+    }
+  });
+
+  it("does not flag normal tenant slugs", () => {
+    for (const s of ["croix-rouge", "amnesty-fr", "wwf", "my-ngo"]) {
+      expect(isReservedSlug(s)).toBe(false);
+    }
+  });
+});
+
+// ─── Unit — validator ────────────────────────────────────────────────────────
+
+describe("validateTenantSlug", () => {
+  it("accepts well-formed slugs", () => {
+    for (const s of ["ac", "amnesty", "amnesty-fr", "a1b2c3", "ngo-france-001"]) {
+      expect(validateTenantSlug(s)).toEqual({ ok: true });
+    }
+  });
+
+  it("normalises input before validating (trim + lowercase)", () => {
+    // Uppercase + surrounding whitespace is fine — the validator lowercases first.
+    expect(validateTenantSlug("  Amnesty  ")).toEqual({ ok: true });
+    expect(validateTenantSlug("NGO-France")).toEqual({ ok: true });
+  });
+
+  it("rejects too-short, leading/trailing dash, symbols, spaces", () => {
+    for (const s of ["a", "  a  ", "-ngo", "ngo-", "n go", "ngo!", "un_der"]) {
+      expect(validateTenantSlug(s)).toEqual({ ok: false, reason: "syntax" });
+    }
+  });
+
+  it("rejects reserved slugs with a distinct reason", () => {
+    expect(validateTenantSlug("admin")).toEqual({ ok: false, reason: "reserved" });
+    expect(validateTenantSlug("API")).toEqual({ ok: false, reason: "reserved" });
+  });
+
+  it("rejects slugs longer than 50 chars", () => {
+    expect(validateTenantSlug("a".repeat(51))).toEqual({ ok: false, reason: "syntax" });
+  });
+});
+
+// ─── DB — tenants back-fill after migration ──────────────────────────────────
+
+describe("tenants back-fill (migration 0021)", () => {
+  it("existing seeded tenants have status='active' and created_via='enterprise'", async () => {
+    const rows = await db
+      .select({
+        id: tenants.id,
+        status: tenants.status,
+        createdVia: tenants.createdVia,
+      })
+      .from(tenants)
+      .where(sql`${tenants.id} IN (${ORG_A}, ${ORG_B})`);
+
+    // Every pre-existing tenant row inherits the new defaults from the migration.
+    for (const row of rows) {
+      expect(row.status).toBe("active");
+      expect(row.createdVia).toBe("enterprise");
+    }
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("tenants.status CHECK rejects an unknown status", async () => {
+    // Direct SQL: Drizzle typing would catch this at compile time, but the DB
+    // must also enforce it.
+    await expect(
+      db.execute(sql`UPDATE tenants SET status = 'bogus' WHERE id = ${ORG_A}`),
+    ).rejects.toThrow(/tenants_status_chk/);
+  });
+
+  it("tenants.created_via CHECK rejects an unknown provenance", async () => {
+    await expect(
+      db.execute(sql`UPDATE tenants SET created_via = 'martian' WHERE id = ${ORG_A}`),
+    ).rejects.toThrow(/tenants_created_via_chk/);
+  });
+});
+
+// ─── DB — tenant_domains ─────────────────────────────────────────────────────
+//
+// Note: the test suite connects as the `givernance` owner role (BYPASSRLS per
+// ADR-016 / docs/03-data-model.md §4.1), so RLS policies do not filter reads
+// here. End-to-end tenant isolation is covered by API-level tests written
+// against the `givernance_app` role. These tests focus on structural correctness
+// (inserts succeed, constraints fire, partial indexes behave).
+
+describe("tenant_domains", () => {
+  it("accepts inserts under each tenant context", async () => {
+    await withTenantContext(ORG_A, async (tx) => {
+      await tx.insert(tenantDomains).values({
+        orgId: ORG_A,
+        domain: "ngo-a-rls.test",
+        dnsTxtValue: "givernance-verify=aaa",
+      });
+    });
+    await withTenantContext(ORG_B, async (tx) => {
+      await tx.insert(tenantDomains).values({
+        orgId: ORG_B,
+        domain: "ngo-b-rls.test",
+        dnsTxtValue: "givernance-verify=bbb",
+      });
+    });
+
+    const rows = await db
+      .select({ orgId: tenantDomains.orgId, domain: tenantDomains.domain })
+      .from(tenantDomains)
+      .where(sql`${tenantDomains.domain} IN ('ngo-a-rls.test', 'ngo-b-rls.test')`);
+
+    expect(rows.some((r) => r.domain === "ngo-a-rls.test" && r.orgId === ORG_A)).toBe(true);
+    expect(rows.some((r) => r.domain === "ngo-b-rls.test" && r.orgId === ORG_B)).toBe(true);
+  });
+
+  it("partial unique index rejects a second active claim of the same domain", async () => {
+    const dup = `dup-${Date.now()}.test`;
+    await withTenantContext(ORG_A, async (tx) => {
+      await tx.insert(tenantDomains).values({
+        orgId: ORG_A,
+        domain: dup,
+        dnsTxtValue: "givernance-verify=ddd",
+      });
+    });
+
+    await expect(
+      withTenantContext(ORG_B, async (tx) => {
+        await tx.insert(tenantDomains).values({
+          orgId: ORG_B,
+          domain: dup,
+          dnsTxtValue: "givernance-verify=eee",
+        });
+      }),
+    ).rejects.toThrow(/tenant_domains_active_domain_uniq/);
+  });
+
+  it("revoked rows free the domain slot", async () => {
+    const d = `revoked-${Date.now()}.test`;
+    await withTenantContext(ORG_A, async (tx) => {
+      await tx.insert(tenantDomains).values({
+        orgId: ORG_A,
+        domain: d,
+        dnsTxtValue: "givernance-verify=111",
+        state: "revoked",
+      });
+    });
+
+    // Another tenant can now claim it because only non-revoked rows enter the
+    // partial unique index.
+    await expect(
+      withTenantContext(ORG_B, async (tx) => {
+        await tx.insert(tenantDomains).values({
+          orgId: ORG_B,
+          domain: d,
+          dnsTxtValue: "givernance-verify=222",
+        });
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  it("CHECK forces lowercase domains", async () => {
+    await expect(
+      withTenantContext(ORG_A, async (tx) => {
+        await tx.insert(tenantDomains).values({
+          orgId: ORG_A,
+          domain: "UPPER.test",
+          dnsTxtValue: "givernance-verify=xxx",
+        });
+      }),
+    ).rejects.toThrow(/tenant_domains_lowercase_chk/);
+  });
+});
+
+// ─── DB — tenant_admin_disputes ──────────────────────────────────────────────
+
+describe("tenant_admin_disputes", () => {
+  it("accepts an open dispute under the tenant context", async () => {
+    await withTenantContext(ORG_A, async (tx) => {
+      await tx.insert(tenantAdminDisputes).values({
+        orgId: ORG_A,
+        disputerId: DISPUTE_USER_A_DISPUTER,
+        provisionalAdminId: DISPUTE_USER_A_FIRST_ADMIN,
+        reason: "Not actually the director",
+      });
+    });
+
+    const rows = await db
+      .select({ orgId: tenantAdminDisputes.orgId, resolution: tenantAdminDisputes.resolution })
+      .from(tenantAdminDisputes)
+      .where(eq(tenantAdminDisputes.orgId, ORG_A));
+    expect(rows.some((r) => r.orgId === ORG_A && r.resolution === null)).toBe(true);
+  });
+
+  it("one-open-per-tenant partial unique index rejects a second open dispute", async () => {
+    await expect(
+      withTenantContext(ORG_A, async (tx) => {
+        await tx.insert(tenantAdminDisputes).values({
+          orgId: ORG_A,
+          disputerId: DISPUTE_USER_A_DISPUTER,
+          provisionalAdminId: DISPUTE_USER_A_FIRST_ADMIN,
+          reason: "Second open dispute should fail",
+        });
+      }),
+    ).rejects.toThrow(/tenant_admin_disputes_one_open_per_tenant/);
+  });
+
+  it("allows a new dispute after the previous one is resolved", async () => {
+    // Resolve the open one first.
+    await withTenantContext(ORG_A, async (tx) => {
+      await tx
+        .update(tenantAdminDisputes)
+        .set({ resolution: "kept", resolvedAt: new Date() })
+        .where(and(eq(tenantAdminDisputes.orgId, ORG_A), sql`resolution IS NULL`));
+    });
+
+    await expect(
+      withTenantContext(ORG_A, async (tx) => {
+        await tx.insert(tenantAdminDisputes).values({
+          orgId: ORG_A,
+          disputerId: DISPUTE_USER_A_DISPUTER,
+          provisionalAdminId: DISPUTE_USER_A_FIRST_ADMIN,
+          reason: "New dispute after closure",
+        });
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  it("rejects a dispute where disputer equals provisional admin", async () => {
+    await expect(
+      withTenantContext(ORG_B, async (tx) => {
+        await tx.insert(tenantAdminDisputes).values({
+          orgId: ORG_B,
+          disputerId: DISPUTE_USER_B_FIRST_ADMIN,
+          provisionalAdminId: DISPUTE_USER_B_FIRST_ADMIN,
+          reason: "Self-dispute",
+        });
+      }),
+    ).rejects.toThrow(/tenant_admin_disputes_different_actors_chk/);
+  });
+
+  it("CHECK rejects unknown resolution values", async () => {
+    await expect(
+      db.execute(
+        sql`UPDATE tenant_admin_disputes SET resolution = 'bogus' WHERE org_id = ${ORG_A}`,
+      ),
+    ).rejects.toThrow(/tenant_admin_disputes_resolution_chk/);
+  });
+});
+
+// ─── DB — users.first_admin + provisional_until ──────────────────────────────
+
+describe("users provisional-admin fields", () => {
+  it("CHECK prevents provisional_until without first_admin", async () => {
+    await expect(
+      db.execute(sql`
+        UPDATE users
+        SET first_admin = false, provisional_until = now() + interval '7 days'
+        WHERE id = ${DISPUTE_USER_A_DISPUTER}
+      `),
+    ).rejects.toThrow(/users_provisional_requires_first_admin_chk/);
+  });
+
+  it("allows provisional_until when first_admin is true", async () => {
+    await expect(
+      db.execute(sql`
+        UPDATE users
+        SET provisional_until = now() + interval '7 days'
+        WHERE id = ${DISPUTE_USER_A_FIRST_ADMIN}
+      `),
+    ).resolves.not.toThrow();
+
+    const [row] = await db
+      .select({ first: users.firstAdmin, until: users.provisionalUntil })
+      .from(users)
+      .where(eq(users.id, DISPUTE_USER_A_FIRST_ADMIN));
+    expect(row?.first).toBe(true);
+    expect(row?.until).toBeTruthy();
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,7 +9,8 @@
     "./types": "./src/types/index.ts",
     "./events": "./src/events/index.ts",
     "./jobs": "./src/jobs/index.ts",
-    "./validators": "./src/validators/index.ts"
+    "./validators": "./src/validators/index.ts",
+    "./constants": "./src/constants/index.ts"
   },
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared cross-package constants. Kept in a package-separated entry point
+ * (`@givernance/shared/constants`) so the web package can import them without
+ * pulling the Drizzle schema (ADR-013 type boundary).
+ */
+
+export {
+  isPersonalEmailDomain,
+  PERSONAL_EMAIL_DOMAINS,
+} from "./personal-email-domains.js";
+
+export {
+  isReservedSlug,
+  RESERVED_SLUGS,
+} from "./reserved-slugs.js";

--- a/packages/shared/src/constants/personal-email-domains.ts
+++ b/packages/shared/src/constants/personal-email-domains.ts
@@ -1,0 +1,121 @@
+/**
+ * Personal / consumer email domains that cannot be bound to a tenant via
+ * `tenant_domains`. A tiny NPO using `tresorier@gmail.com` has a perfectly
+ * valid self-serve signup, but it MUST NOT be allowed to "claim" gmail.com
+ * as a Home-IdP-Discovery routing domain — that would lock every gmail user
+ * out of every other tenant.
+ *
+ * List is intentionally conservative and covers the dominant providers used
+ * by French/Belgian/Swiss/German NPOs (per `docs/16-greg-field-insights.md`).
+ * Expand cautiously: false positives are worse than false negatives here.
+ * ADR-016 / `docs/22-tenant-onboarding.md` §4.2.
+ */
+export const PERSONAL_EMAIL_DOMAINS: readonly string[] = Object.freeze([
+  // Global consumer providers
+  "gmail.com",
+  "googlemail.com",
+  "outlook.com",
+  "hotmail.com",
+  "hotmail.fr",
+  "hotmail.co.uk",
+  "live.com",
+  "live.fr",
+  "msn.com",
+  "yahoo.com",
+  "yahoo.fr",
+  "yahoo.co.uk",
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "aol.com",
+  "protonmail.com",
+  "proton.me",
+  "pm.me",
+  "tutanota.com",
+  "tutamail.com",
+  "tuta.io",
+  "fastmail.com",
+  "zoho.com",
+  "yandex.com",
+  "gmx.com",
+  "gmx.net",
+  "gmx.fr",
+  "gmx.de",
+  "mail.com",
+  "mail.ru",
+
+  // France
+  "laposte.net",
+  "orange.fr",
+  "wanadoo.fr",
+  "free.fr",
+  "sfr.fr",
+  "neuf.fr",
+  "bbox.fr",
+  "bouyguestelecom.fr",
+  "aliceadsl.fr",
+  "club-internet.fr",
+  "noos.fr",
+  "numericable.fr",
+  "voila.fr",
+  "cegetel.net",
+
+  // Belgium / Netherlands
+  "skynet.be",
+  "telenet.be",
+  "scarlet.be",
+  "proximus.be",
+  "mail.be",
+  "kpnmail.nl",
+  "ziggo.nl",
+  "xs4all.nl",
+  "planet.nl",
+
+  // Germany / DACH
+  "web.de",
+  "t-online.de",
+  "freenet.de",
+  "arcor.de",
+  "gmx.ch",
+  "bluewin.ch",
+  "hispeed.ch",
+  "sunrise.ch",
+  "sunrise.net",
+
+  // Italy
+  "libero.it",
+  "virgilio.it",
+  "tin.it",
+  "tiscali.it",
+  "alice.it",
+
+  // Spain / Portugal
+  "terra.com",
+  "ya.com",
+  "sapo.pt",
+
+  // Other disposable-adjacent providers Greg's field data flagged
+  "mailinator.com",
+  "guerrillamail.com",
+  "10minutemail.com",
+  "yopmail.com",
+  "tempmail.com",
+  "throwawaymail.com",
+  "sharklasers.com",
+  "trashmail.com",
+  "maildrop.cc",
+  "mohmal.com",
+  "dispostable.com",
+]);
+
+/** Lowercase set for O(1) membership checks. */
+const PERSONAL_EMAIL_DOMAIN_SET: ReadonlySet<string> = new Set(PERSONAL_EMAIL_DOMAINS);
+
+/**
+ * Returns `true` when `domain` is a personal / consumer email domain that
+ * cannot be claimed as a tenant-binding domain. Input is normalised to
+ * lowercase; callers should pre-validate syntax (it's a host, not an email).
+ */
+export function isPersonalEmailDomain(domain: string): boolean {
+  return PERSONAL_EMAIL_DOMAIN_SET.has(domain.trim().toLowerCase());
+}

--- a/packages/shared/src/constants/reserved-slugs.ts
+++ b/packages/shared/src/constants/reserved-slugs.ts
@@ -1,39 +1,109 @@
 /**
  * Slugs reserved at the platform level — they cannot be used as tenant slugs
- * because they collide with Givernance platform routes or DNS-adjacent names.
+ * because they collide with Givernance platform routes, DNS-adjacent names,
+ * or third-party service subdomains that Givernance itself uses.
+ *
+ * Buckets (explicit for clarity, not enforced in code):
+ *  1. **App routes** — every top-level route under `packages/web/src/app/**`
+ *     and every Fastify module under `packages/api/src/modules/**`.
+ *  2. **Auth / identity primitives** — `oauth`, `saml`, `scim`, …; and the
+ *     IDNA punycode prefix is rejected separately in the validator.
+ *  3. **Platform subdomains / infra** — names we already use for Keycloak,
+ *     Grafana, Scaleway, etc., reserved for when we move to subdomain
+ *     tenant scoping.
+ *  4. **Safety tokens** — `null`, `undefined`, `true`, `false`, `me`, …
+ *     to prevent bizarre URL-parsing bugs downstream.
  *
  * Keep this list **explicit** (not a regex). A future reviewer needs to be
  * able to answer "is `billing` reserved?" at a glance. ADR-016 / doc 22 §7.
+ *
+ * Adding entries: open a PR with a one-line rationale in the commit message;
+ * duplicates are enforced by the test suite.
  */
 export const RESERVED_SLUGS: readonly string[] = Object.freeze([
-  // Core platform routes
+  // ─── App routes (current web + api surface) ──────────────────────────
   "admin",
   "api",
   "app",
   "auth",
+  "audit",
   "billing",
   "callback",
+  "campaigns",
+  "constituents",
+  "dashboard",
   "docs",
+  "donations",
+  "forgot-password",
   "health",
   "healthz",
+  "home",
+  "invitations",
   "login",
   "logout",
   "mail",
   "metrics",
   "onboarding",
   "p",
+  "pledges",
   "public",
+  "reports",
+  "reset-password",
   "select-organization",
   "settings",
   "signup",
   "sso",
   "status",
   "support",
+  "users",
   "www",
 
-  // Common squatting targets
-  "dashboard",
-  "home",
+  // ─── Auth / identity primitives ──────────────────────────────────────
+  "oauth",
+  "oidc",
+  "openid",
+  "saml",
+  "scim",
+  "well-known",
+  ".well-known",
+  "jwks",
+
+  // ─── Platform subdomains / third-party infra ─────────────────────────
+  "keycloak",
+  "grafana",
+  "prometheus",
+  "cockpit",
+  "scaleway",
+  "stripe",
+  "mollie",
+  "minio",
+  "mailpit",
+  "object-storage",
+  "cdn",
+  "assets",
+  "static",
+  "img",
+  "images",
+  "files",
+  "upload",
+  "uploads",
+  "download",
+  "downloads",
+  "ws",
+  "wss",
+  "graphql",
+  "rpc",
+  "webhook",
+  "webhooks",
+  "dns",
+
+  // ─── Safety tokens ───────────────────────────────────────────────────
+  "me",
+  "null",
+  "undefined",
+  "true",
+  "false",
+  "anonymous",
   "test",
   "tests",
   "beta",
@@ -48,7 +118,7 @@ export const RESERVED_SLUGS: readonly string[] = Object.freeze([
   "superuser",
   "operator",
 
-  // SEO / legal pages
+  // ─── SEO / legal pages ───────────────────────────────────────────────
   "about",
   "contact",
   "legal",
@@ -69,7 +139,8 @@ const RESERVED_SLUG_SET: ReadonlySet<string> = new Set(RESERVED_SLUGS);
 /**
  * Returns `true` when `slug` clashes with a reserved platform slug. Input is
  * normalised to lowercase. Syntactic validity of the slug itself (length,
- * character set) is the caller's responsibility — see `tenantSlug` validator.
+ * character set, IDNA punycode prefix) is the caller's responsibility — see
+ * `validateTenantSlug`.
  */
 export function isReservedSlug(slug: string): boolean {
   return RESERVED_SLUG_SET.has(slug.trim().toLowerCase());

--- a/packages/shared/src/constants/reserved-slugs.ts
+++ b/packages/shared/src/constants/reserved-slugs.ts
@@ -1,0 +1,76 @@
+/**
+ * Slugs reserved at the platform level — they cannot be used as tenant slugs
+ * because they collide with Givernance platform routes or DNS-adjacent names.
+ *
+ * Keep this list **explicit** (not a regex). A future reviewer needs to be
+ * able to answer "is `billing` reserved?" at a glance. ADR-016 / doc 22 §7.
+ */
+export const RESERVED_SLUGS: readonly string[] = Object.freeze([
+  // Core platform routes
+  "admin",
+  "api",
+  "app",
+  "auth",
+  "billing",
+  "callback",
+  "docs",
+  "health",
+  "healthz",
+  "login",
+  "logout",
+  "mail",
+  "metrics",
+  "onboarding",
+  "p",
+  "public",
+  "select-organization",
+  "settings",
+  "signup",
+  "sso",
+  "status",
+  "support",
+  "www",
+
+  // Common squatting targets
+  "dashboard",
+  "home",
+  "test",
+  "tests",
+  "beta",
+  "staging",
+  "prod",
+  "production",
+  "dev",
+  "development",
+  "internal",
+  "system",
+  "root",
+  "superuser",
+  "operator",
+
+  // SEO / legal pages
+  "about",
+  "contact",
+  "legal",
+  "privacy",
+  "terms",
+  "cookies",
+  "gdpr",
+  "pricing",
+  "blog",
+  "press",
+  "jobs",
+  "careers",
+]);
+
+/** Lowercase set for O(1) membership checks. */
+const RESERVED_SLUG_SET: ReadonlySet<string> = new Set(RESERVED_SLUGS);
+
+/**
+ * Returns `true` when `slug` clashes with a reserved platform slug. Input is
+ * normalised to lowercase. Syntactic validity of the slug itself (length,
+ * character set) is the caller's responsibility — see `tenantSlug` validator.
+ */
+export function isReservedSlug(slug: string): boolean {
+  return RESERVED_SLUG_SET.has(slug.trim().toLowerCase());
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 /** @givernance/shared — shared types, schemas, events, and validators */
 
+export * from "./constants/index.js";
 export * from "./events/index.js";
 export * from "./jobs/index.js";
 export * from "./schema/index.js";

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -66,6 +66,24 @@ export const webhookEventStatusEnum = pgEnum("webhook_event_status", [
 
 export const userRoleEnum = pgEnum("user_role", ["org_admin", "user", "viewer"]);
 
+// ─── Tenant lifecycle / provenance (ADR-016) ─────────────────────────────────
+
+export const TENANT_STATUS_VALUES = ["provisional", "active", "suspended", "archived"] as const;
+export type TenantStatus = (typeof TENANT_STATUS_VALUES)[number];
+
+export const TENANT_CREATED_VIA_VALUES = ["self_serve", "enterprise", "invitation"] as const;
+export type TenantCreatedVia = (typeof TENANT_CREATED_VIA_VALUES)[number];
+
+export const TENANT_DOMAIN_STATE_VALUES = ["pending_dns", "verified", "revoked"] as const;
+export type TenantDomainState = (typeof TENANT_DOMAIN_STATE_VALUES)[number];
+
+export const TENANT_ADMIN_DISPUTE_RESOLUTION_VALUES = [
+  "kept",
+  "replaced",
+  "escalated_to_support",
+] as const;
+export type TenantAdminDisputeResolution = (typeof TENANT_ADMIN_DISPUTE_RESOLUTION_VALUES)[number];
+
 // ─── Tenants (organizations) ──────────────────────────────────────────────────
 
 /** Tenants — registered organizations using Givernance */
@@ -76,12 +94,27 @@ export const tenants = pgTable(
     name: varchar("name", { length: 255 }).notNull(),
     slug: varchar("slug", { length: 100 }).notNull().unique(),
     plan: varchar("plan", { length: 50 }).notNull().default("starter"),
-    status: varchar("status", { length: 50 }).notNull().default("active"),
+    status: varchar("status", { length: 50 }).notNull().default("active").$type<TenantStatus>(),
+    /** How this tenant was provisioned — drives UI affordances, not access. Migration 0021 (ADR-016). */
+    createdVia: varchar("created_via", { length: 32 })
+      .notNull()
+      .default("enterprise")
+      .$type<TenantCreatedVia>(),
+    /** Email verification timestamp for self-serve signup; NULL until the first admin verifies. */
+    verifiedAt: timestamp("verified_at", { withTimezone: true }),
+    /** Keycloak 26 Organization id bound to this tenant. NULL during migration + for rows awaiting Keycloak provisioning. */
+    keycloakOrgId: text("keycloak_org_id"),
+    /** Convenience pointer to the tenant's verified primary domain — denormalised; source of truth is `tenant_domains`. */
+    primaryDomain: varchar("primary_domain", { length: 255 }),
     stripeAccountId: varchar("stripe_account_id", { length: 255 }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [unique("tenants_stripe_account_id_uniq").on(table.stripeAccountId)],
+  (table) => [
+    unique("tenants_stripe_account_id_uniq").on(table.stripeAccountId),
+    index("tenants_status_idx").on(table.status),
+    index("tenants_created_via_idx").on(table.createdVia),
+  ],
 );
 
 // ─── Users ────────────────────────────────────────────────────────────────────
@@ -99,6 +132,10 @@ export const users = pgTable(
     lastName: varchar("last_name", { length: 255 }).notNull(),
     role: userRoleEnum("role").notNull().default("user"),
     keycloakId: varchar("keycloak_id", { length: 255 }),
+    /** Marks the user who provisioned a self-serve tenant. Drives the dispute flow (ADR-016). */
+    firstAdmin: boolean("first_admin").notNull().default(false),
+    /** When set, this user is a *provisional* org_admin until this timestamp; other members can dispute. */
+    provisionalUntil: timestamp("provisional_until", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -131,6 +168,65 @@ export const invitations = pgTable(
     index("invitations_org_id_idx").on(table.orgId),
     index("invitations_token_idx").on(table.token),
   ],
+);
+
+// ─── Tenant Domains ──────────────────────────────────────────────────────────
+
+/**
+ * Tenant domains — DNS-verified custom domain claims used by Keycloak Home IdP Discovery
+ * and by the self-serve flow to detect "your org is already on Givernance". Personal-email
+ * domains (gmail, outlook, …) are blocked by the validator layer, not the DB. Migration 0021
+ * (ADR-016).
+ */
+export const tenantDomains = pgTable(
+  "tenant_domains",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    domain: varchar("domain", { length: 255 }).notNull(),
+    state: varchar("state", { length: 32 })
+      .notNull()
+      .default("pending_dns")
+      .$type<TenantDomainState>(),
+    dnsTxtValue: varchar("dns_txt_value", { length: 128 }).notNull(),
+    verifiedAt: timestamp("verified_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("tenant_domains_org_id_idx").on(table.orgId),
+    index("tenant_domains_state_idx").on(table.state),
+  ],
+);
+
+// ─── Tenant Admin Disputes ───────────────────────────────────────────────────
+
+/**
+ * Dispute log for the 7-day provisional-admin grace period on self-serve tenants.
+ * Only one open dispute per tenant; closed disputes are retained for audit.
+ * Migration 0021 (ADR-016).
+ */
+export const tenantAdminDisputes = pgTable(
+  "tenant_admin_disputes",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    disputerId: uuid("disputer_id")
+      .notNull()
+      .references(() => users.id),
+    provisionalAdminId: uuid("provisional_admin_id")
+      .notNull()
+      .references(() => users.id),
+    reason: text("reason"),
+    resolution: varchar("resolution", { length: 32 }).$type<TenantAdminDisputeResolution>(),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("tenant_admin_disputes_org_id_idx").on(table.orgId)],
 );
 
 // ─── Audit Logs ───────────────────────────────────────────────────────────────

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -102,8 +102,8 @@ export const tenants = pgTable(
       .$type<TenantCreatedVia>(),
     /** Email verification timestamp for self-serve signup; NULL until the first admin verifies. */
     verifiedAt: timestamp("verified_at", { withTimezone: true }),
-    /** Keycloak 26 Organization id bound to this tenant. NULL during migration + for rows awaiting Keycloak provisioning. */
-    keycloakOrgId: text("keycloak_org_id"),
+    /** Keycloak 26 Organization id (UUID) bound to this tenant; enforced by CHECK in migration 0021. */
+    keycloakOrgId: varchar("keycloak_org_id", { length: 64 }),
     /** Convenience pointer to the tenant's verified primary domain — denormalised; source of truth is `tenant_domains`. */
     primaryDomain: varchar("primary_domain", { length: 255 }),
     stripeAccountId: varchar("stripe_account_id", { length: 255 }),
@@ -206,6 +206,7 @@ export const tenantDomains = pgTable(
 /**
  * Dispute log for the 7-day provisional-admin grace period on self-serve tenants.
  * Only one open dispute per tenant; closed disputes are retained for audit.
+ * User FKs use `ON DELETE SET NULL` so GDPR Art. 17 erasures don't break audit.
  * Migration 0021 (ADR-016).
  */
 export const tenantAdminDisputes = pgTable(
@@ -215,16 +216,16 @@ export const tenantAdminDisputes = pgTable(
     orgId: uuid("org_id")
       .notNull()
       .references(() => tenants.id, { onDelete: "cascade" }),
-    disputerId: uuid("disputer_id")
-      .notNull()
-      .references(() => users.id),
-    provisionalAdminId: uuid("provisional_admin_id")
-      .notNull()
-      .references(() => users.id),
-    reason: text("reason"),
+    disputerId: uuid("disputer_id").references(() => users.id, { onDelete: "set null" }),
+    provisionalAdminId: uuid("provisional_admin_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    reason: varchar("reason", { length: 2000 }),
     resolution: varchar("resolution", { length: 32 }).$type<TenantAdminDisputeResolution>(),
     resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    resolvedBy: uuid("resolved_by").references(() => users.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [index("tenant_admin_disputes_org_id_idx").on(table.orgId)],
 );

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -21,18 +21,31 @@ export const TenantSlugSchema = Type.String({
     "Lowercase alphanumeric + dashes; 2–50 chars; no leading/trailing dash. Rejected if it matches a reserved platform slug.",
 });
 
-/** Validate a slug's syntax AND its non-reservation. Returns a machine-readable reason on failure. */
+/**
+ * Validate a slug. Returns the canonical (trimmed + lowercased) value on
+ * success so callers can write it straight to the DB without re-normalising,
+ * avoiding mixed-case drift between `slug` values stored across tenants.
+ *
+ * On failure, `reason` is one of:
+ * - `syntax`   — fails the regex / length constraints
+ * - `reserved` — matches a platform-reserved slug (see `reserved-slugs.ts`)
+ * - `punycode` — starts with the IDNA punycode prefix `xn--`; disallowed to
+ *   prevent homograph confusion in tenant URLs.
+ */
 export function validateTenantSlug(
   slug: string,
-): { ok: true } | { ok: false; reason: "syntax" | "reserved" } {
+): { ok: true; slug: string } | { ok: false; reason: "syntax" | "reserved" | "punycode" } {
   const normalised = slug.trim().toLowerCase();
   if (!Value.Check(TenantSlugSchema, normalised)) {
     return { ok: false, reason: "syntax" };
   }
+  if (normalised.startsWith("xn--")) {
+    return { ok: false, reason: "punycode" };
+  }
   if (isReservedSlug(normalised)) {
     return { ok: false, reason: "reserved" };
   }
-  return { ok: true };
+  return { ok: true, slug: normalised };
 }
 
 /** Schema for creating a new constituent */

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -2,6 +2,38 @@
 
 import { type Static, type TSchema, Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
+import { isReservedSlug } from "../constants/reserved-slugs";
+
+/**
+ * Tenant slug: 2–50 chars, lowercase alnum + single internal dashes, no leading/
+ * trailing dash. The regex requires ≥2 characters (minLength is also set on the
+ * schema, but encoding the minimum in the pattern itself guarantees strictness
+ * regardless of JSON-schema dialect). The column is VARCHAR(100); we cap at 50
+ * here to leave headroom for reserved prefixes and subdomain-era migrations.
+ */
+export const TENANT_SLUG_PATTERN = "^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$";
+
+export const TenantSlugSchema = Type.String({
+  minLength: 2,
+  maxLength: 50,
+  pattern: TENANT_SLUG_PATTERN,
+  description:
+    "Lowercase alphanumeric + dashes; 2–50 chars; no leading/trailing dash. Rejected if it matches a reserved platform slug.",
+});
+
+/** Validate a slug's syntax AND its non-reservation. Returns a machine-readable reason on failure. */
+export function validateTenantSlug(
+  slug: string,
+): { ok: true } | { ok: false; reason: "syntax" | "reserved" } {
+  const normalised = slug.trim().toLowerCase();
+  if (!Value.Check(TenantSlugSchema, normalised)) {
+    return { ok: false, reason: "syntax" };
+  }
+  if (isReservedSlug(normalised)) {
+    return { ok: false, reason: "reserved" };
+  }
+  return { ok: true };
+}
 
 /** Schema for creating a new constituent */
 export const ConstituentCreateSchema = Type.Object({


### PR DESCRIPTION
Closes #106.

Foundation PR for the Tenant Onboarding & Multi-Tenancy milestone. No behavioural change visible to users yet — this is the DB schema + shared constants that issues #107–#114 depend on.

## Summary

### Schema (migration 0021)
- `tenants` gains: `created_via` (`self_serve` | `enterprise` | `invitation`), `verified_at`, `keycloak_org_id`, `primary_domain`. Existing `status` column gets a CHECK constraint with the new vocabulary (`provisional` | `active` | `suspended` | `archived`); legacy rows back-fill to `status='active'` / `created_via='enterprise'`.
- `users` gains: `first_admin`, `provisional_until`; CHECK prevents `provisional_until` without `first_admin`.
- New table `tenant_domains` — DNS-verified custom domain claims for Keycloak Home IdP Discovery. RLS + FORCE RLS. Partial unique index scopes global uniqueness to non-revoked rows (revoked rows free the slot).
- New table `tenant_admin_disputes` — grace-period dispute log for the 7-day provisional-admin window. RLS + FORCE RLS. Partial unique index enforces one *open* dispute per tenant; closed disputes don't block.

### Shared constants + validator (\`@givernance/shared/constants\`)
- `personal-email-domains` — gmail, outlook, proton plus France/Belgium/Netherlands/Germany consumer providers and the known disposable-email services. Personal domains are blocked from tenant claims at the validator layer (never at the DB).
- `reserved-slugs` — platform-reserved tenant slugs (`admin`, `api`, `login`, `billing`, …) so URL-path-scoped routes cannot be hijacked.
- `TenantSlugSchema` + `validateTenantSlug()` return `{ok: false, reason: 'syntax' | 'reserved'}` — the distinct reason lets callers surface better error copy.

### Docs
- `docs/03-data-model.md` §3.1 now documents the new columns + tables.
- ADR-016 + `docs/22-tenant-onboarding.md` + doc 21 cross-references live in companion docs PR #104.

## Test plan

- [x] `pnpm install`
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm db:migrate` (against local \`givernance_test\`)
- [x] `pnpm test` — 233 tests pass, including the new `tenant-onboarding-schema.test.ts`:
  - Unit: `isPersonalEmailDomain`, `isReservedSlug`, `validateTenantSlug`.
  - DB back-fill: existing tenants inherit `status='active'` + `created_via='enterprise'`.
  - DB CHECK constraints: bogus status / created_via / resolution / `provisional_until` without `first_admin` all fire.
  - DB partial unique indexes: second active domain claim rejected; second open dispute rejected; closed disputes free the slot.
  - Structural inserts succeed under each tenant context.

**Note on RLS testing**: per ADR-009 and `docs/03-data-model.md` §4.1, the test suite connects as the `givernance` owner role which has `BYPASSRLS`, so this test file intentionally does *not* assert cross-tenant invisibility at the DB layer. End-to-end tenant isolation for the new tables will be validated by the API-level tests that come with issues #108 + #110 (public-signup + domain-CRUD endpoints, which use the `givernance_app` role).

## Architecture References

| ADR | Relevance |
|-----|-----------|
| **ADR-016** | This is the schema foundation for the hybrid onboarding model. |
| **ADR-009** | Scaleway Managed PostgreSQL EU, 3-role pattern, FORCE RLS posture applied to the two new tables. |
| **ADR-013** | New constants live in `@givernance/shared/constants`, a package entry-point that the web package can import without pulling the Drizzle schema. |

## Out of scope

- Any endpoint wiring (issues #108, #110).
- Keycloak Admin API client (issue #107).
- Frontend signup pages (issue #109).
- Keycloak 26 / Organizations migration (issue #114, depends on #61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)