### PR TITLE
feat(auth): Keycloak Admin API client (issue #107)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,13 @@ KEYCLOAK_CLIENT_ID=givernance-web
 KEYCLOAK_CLIENT_SECRET=ci-test-secret-do-not-use-in-production
 KEYCLOAK_ISSUER=http://localhost:8080/realms/givernance
 KEYCLOAK_JWKS_URL=http://localhost:8080/realms/givernance/protocol/openid-connect/certs
+# Service-account client used by the API for Keycloak Admin API calls (ADR-016 / issue #107).
+# `KEYCLOAK_ADMIN_URL` defaults to `KEYCLOAK_URL`; set it only when fronted separately.
+# Leave `KEYCLOAK_ADMIN_CLIENT_SECRET` unset to disable the admin client (endpoints that
+# need it will return a typed error rather than crash at boot).
+KEYCLOAK_ADMIN_CLIENT_ID=givernance-admin
+KEYCLOAK_ADMIN_CLIENT_SECRET=ci-test-admin-secret-do-not-use-in-production
+# KEYCLOAK_ADMIN_URL=http://localhost:8080
 
 # --- Auth -------------------------------------------------------
 # `KEYCLOAK_ISSUER` / `KEYCLOAK_JWKS_URL` are optional explicit overrides.

--- a/docs/21-authentication-sso.md
+++ b/docs/21-authentication-sso.md
@@ -210,6 +210,12 @@ KEYCLOAK_CLIENT_ID=givernance-web
 KEYCLOAK_CLIENT_SECRET=ci-test-secret-do-not-use-in-production
 KEYCLOAK_ISSUER=http://localhost:8080/realms/givernance
 KEYCLOAK_JWKS_URL=http://localhost:8080/realms/givernance/protocol/openid-connect/certs
+# Admin API service account (issue #107) — used by the API server to provision
+# Organizations, Identity Providers, and invitations. Leave the secret unset
+# to disable the admin client entirely.
+KEYCLOAK_ADMIN_CLIENT_ID=givernance-admin
+KEYCLOAK_ADMIN_CLIENT_SECRET=ci-test-admin-secret-do-not-use-in-production
+# KEYCLOAK_ADMIN_URL=http://localhost:8080  # defaults to KEYCLOAK_URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:4000
 API_URL=http://localhost:4000

--- a/infra/keycloak/realm-givernance.json
+++ b/infra/keycloak/realm-givernance.json
@@ -47,9 +47,10 @@
       "serviceAccountClientId": "givernance-admin",
       "clientRoles": {
         "realm-management": [
-          "manage-realm",
           "manage-users",
           "manage-identity-providers",
+          "query-users",
+          "query-clients",
           "view-clients"
         ]
       }

--- a/infra/keycloak/realm-givernance.json
+++ b/infra/keycloak/realm-givernance.json
@@ -40,6 +40,19 @@
         }
       ],
       "realmRoles": ["super_admin"]
+    },
+    {
+      "username": "service-account-givernance-admin",
+      "enabled": true,
+      "serviceAccountClientId": "givernance-admin",
+      "clientRoles": {
+        "realm-management": [
+          "manage-realm",
+          "manage-users",
+          "manage-identity-providers",
+          "view-clients"
+        ]
+      }
     }
   ],
   "roles": {
@@ -55,6 +68,18 @@
     ]
   },
   "clients": [
+    {
+      "clientId": "givernance-admin",
+      "enabled": true,
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "ci-test-admin-secret-do-not-use-in-production",
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "description": "Service-account client for Keycloak Admin API calls from the Givernance backend (ADR-016 / issue #107). Scoped to realm-management roles: manage-realm, manage-users, manage-identity-providers, view-clients."
+    },
     {
       "clientId": "givernance-web",
       "enabled": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,6 +31,7 @@
     "jose": "^6.2.2",
     "nats.ws": "^1.29.2",
     "pg": "^8.13.1",
+    "pino": "10.3.1",
     "stripe": "^22.0.1"
   },
   "devDependencies": {

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -79,4 +79,20 @@ if (process.env.NODE_ENV === "production" && !value.DATABASE_URL_APP) {
   process.exit(1);
 }
 
+if (process.env.NODE_ENV === "production" && !value.KEYCLOAK_ADMIN_CLIENT_SECRET) {
+  console.error(
+    "[api] KEYCLOAK_ADMIN_CLIENT_SECRET is strictly required in production for tenant onboarding (ADR-016 / issue #107).",
+  );
+  process.exit(1);
+}
+
+const adminUrl = value.KEYCLOAK_ADMIN_URL ?? value.KEYCLOAK_URL;
+const isLocalHost = /^(https?:\/\/)?(localhost|127\.0\.0\.1|0\.0\.0\.0)(:|$|\/)/i.test(adminUrl);
+if (process.env.NODE_ENV === "production" && !adminUrl.startsWith("https://") && !isLocalHost) {
+  console.error(
+    `[api] Keycloak admin URL must be HTTPS in production (got '${adminUrl}') — client-credentials over cleartext leaks the admin secret.`,
+  );
+  process.exit(1);
+}
+
 export const env: ApiEnv = value;

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -41,6 +41,12 @@ const EnvSchema = Type.Object({
   KEYCLOAK_ISSUER: Type.Optional(Type.String({ minLength: 1 })),
   /** Optional explicit JWKS URL override */
   KEYCLOAK_JWKS_URL: Type.Optional(Type.String({ minLength: 1 })),
+  /** Keycloak Admin API base URL (defaults to KEYCLOAK_URL). Used by the admin client (ADR-016). */
+  KEYCLOAK_ADMIN_URL: Type.Optional(Type.String({ minLength: 1 })),
+  /** Service-account client id used for Keycloak Admin API calls. */
+  KEYCLOAK_ADMIN_CLIENT_ID: Type.String({ minLength: 1, default: "givernance-admin" }),
+  /** Service-account client secret used for Keycloak Admin API calls. */
+  KEYCLOAK_ADMIN_CLIENT_SECRET: Type.Optional(Type.String({ minLength: 1 })),
   /** HTTP port */
   PORT: Type.Number({ default: 4000 }),
   /** HTTP bind address */

--- a/packages/api/src/lib/keycloak-admin.test.ts
+++ b/packages/api/src/lib/keycloak-admin.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for the Keycloak Admin API client (issue #107).
+ *
+ * Fetch is fully stubbed. Tests exercise:
+ *  - token caching + early refresh + refresh on 401
+ *  - exponential-backoff retry on 5xx / 429 / network errors
+ *  - non-retryable 4xx paths
+ *  - circuit breaker (closed → open → half-open transition)
+ *  - every public helper (createOrganization, addOrgDomain, attachUserToOrg,
+ *    sendInvitation, bindIdpToOrganization, createIdentityProvider, …)
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CircuitOpenError,
+  createKeycloakAdminClient,
+  KeycloakAdminError,
+} from "./keycloak-admin.js";
+
+type StubCall = { url: string; init: RequestInit };
+
+interface Harness {
+  client: ReturnType<typeof createKeycloakAdminClient>;
+  calls: StubCall[];
+  enqueue: (responder: (call: StubCall) => Response | Promise<Response>) => void;
+  advanceTime: (ms: number) => void;
+}
+
+function makeHarness(
+  overrides: Partial<Parameters<typeof createKeycloakAdminClient>[0]> = {},
+): Harness {
+  const calls: StubCall[] = [];
+  const responders: Array<(call: StubCall) => Response | Promise<Response>> = [];
+  let timeMs = 1_000_000;
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const call: StubCall = { url, init: init ?? {} };
+    calls.push(call);
+    const responder = responders.shift();
+    if (!responder) {
+      throw new Error(`Unexpected fetch to ${url} — no responder enqueued`);
+    }
+    return responder(call);
+  };
+
+  const client = createKeycloakAdminClient({
+    baseUrl: "http://kc.test",
+    realm: "givernance",
+    clientId: "givernance-admin",
+    clientSecret: "sekret",
+    fetchImpl,
+    nowMs: () => timeMs,
+    initialBackoffMs: 1, // keep retry delays tiny in tests
+    ...overrides,
+  });
+
+  return {
+    client,
+    calls,
+    enqueue: (r) => responders.push(r),
+    advanceTime: (ms) => {
+      timeMs += ms;
+    },
+  };
+}
+
+const tokenResponse = (body: { access_token?: string; expires_in?: number } = {}): Response =>
+  new Response(
+    JSON.stringify({
+      access_token: body.access_token ?? "tok-1",
+      expires_in: body.expires_in ?? 60,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+
+const okJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const noContent = (): Response => new Response(null, { status: 204 });
+
+// The harness ships with `initialBackoffMs: 1` so real timers are fine and
+// keep tests simple (no need for runAllTimersAsync pump points).
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("token cache", () => {
+  it("fetches a token once and reuses it across calls", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => noContent());
+    h.enqueue(() => noContent());
+
+    await h.client.deleteIdentityProvider("one");
+    await h.client.deleteIdentityProvider("two");
+
+    const tokenCalls = h.calls.filter((c) => c.url.includes("/protocol/openid-connect/token"));
+    expect(tokenCalls).toHaveLength(1);
+    expect(h.calls[1]?.init.headers).toMatchObject({ Authorization: "Bearer tok-1" });
+  });
+
+  it("refreshes the token when it approaches expiry (30s safety margin)", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ access_token: "tok-a", expires_in: 60 }));
+    h.enqueue(() => noContent());
+    h.enqueue(() => tokenResponse({ access_token: "tok-b", expires_in: 60 }));
+    h.enqueue(() => noContent());
+
+    await h.client.deleteIdentityProvider("one");
+    // After the safety-margin elapses, the next call triggers a token refresh.
+    h.advanceTime(31_000);
+    await h.client.deleteIdentityProvider("two");
+
+    const tokenCalls = h.calls.filter((c) => c.url.includes("/protocol/openid-connect/token"));
+    expect(tokenCalls).toHaveLength(2);
+    expect(h.calls.at(-1)?.init.headers).toMatchObject({ Authorization: "Bearer tok-b" });
+  });
+
+  it("re-acquires the token on a 401 response and retries the request", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    // First admin call gets a 401 → client invalidates and retries with a fresh token.
+    h.enqueue(() => new Response(null, { status: 401 }));
+    h.enqueue(() => tokenResponse({ access_token: "tok-2", expires_in: 300 }));
+    h.enqueue(() => noContent());
+
+    await h.client.deleteIdentityProvider("one");
+
+    const tokenCalls = h.calls.filter((c) => c.url.includes("/protocol/openid-connect/token"));
+    expect(tokenCalls).toHaveLength(2);
+    expect(h.calls.at(-1)?.init.headers).toMatchObject({ Authorization: "Bearer tok-2" });
+  });
+});
+
+describe("retry + non-retryable errors", () => {
+  it("retries transient 5xx up to maxAttempts with jittered backoff", async () => {
+    const h = makeHarness({ maxAttempts: 3 });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response("boom", { status: 502 }));
+    h.enqueue(() => new Response("still boom", { status: 503 }));
+    h.enqueue(() => noContent());
+
+    await expect(h.client.deleteIdentityProvider("one")).resolves.toBeUndefined();
+
+    const deleteCalls = h.calls.filter((c) => c.init.method === "DELETE");
+    expect(deleteCalls).toHaveLength(3);
+  });
+
+  it("treats 429 as retryable", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response("slow", { status: 429 }));
+    h.enqueue(() => noContent());
+
+    await h.client.deleteIdentityProvider("one");
+  });
+
+  it("does NOT retry 4xx (other than 401/429)", async () => {
+    const h = makeHarness({ maxAttempts: 5 });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response("bad", { status: 400 }));
+
+    await expect(h.client.deleteIdentityProvider("one")).rejects.toBeInstanceOf(KeycloakAdminError);
+    const deleteCalls = h.calls.filter((c) => c.init.method === "DELETE");
+    expect(deleteCalls).toHaveLength(1);
+  });
+
+  it("retries a thrown network error and eventually succeeds", async () => {
+    const h = makeHarness({ maxAttempts: 3 });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => {
+      throw new TypeError("fetch failed");
+    });
+    h.enqueue(() => noContent());
+
+    await h.client.deleteIdentityProvider("one");
+  });
+});
+
+describe("circuit breaker", () => {
+  it("opens after `circuitFailureThreshold` consecutive failures, then rejects fast", async () => {
+    const h = makeHarness({
+      circuitFailureThreshold: 2,
+      maxAttempts: 1, // stop retrying inside a single request
+    });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response(null, { status: 500 }));
+    h.enqueue(() => new Response(null, { status: 500 }));
+
+    await expect(h.client.deleteIdentityProvider("one")).rejects.toBeInstanceOf(KeycloakAdminError);
+    await expect(h.client.deleteIdentityProvider("two")).rejects.toBeInstanceOf(KeycloakAdminError);
+    expect(h.client._circuitState()).toBe("open");
+
+    // No network call — fails fast.
+    await expect(h.client.deleteIdentityProvider("three")).rejects.toBeInstanceOf(CircuitOpenError);
+    const nAfter = h.calls.length;
+    await expect(h.client.deleteIdentityProvider("four")).rejects.toBeInstanceOf(CircuitOpenError);
+    expect(h.calls.length).toBe(nAfter);
+  });
+
+  it("moves to half-open after circuitOpenMs and a successful request closes it", async () => {
+    const h = makeHarness({ circuitFailureThreshold: 1, maxAttempts: 1, circuitOpenMs: 30_000 });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response(null, { status: 500 }));
+
+    await expect(h.client.deleteIdentityProvider("one")).rejects.toBeInstanceOf(KeycloakAdminError);
+    expect(h.client._circuitState()).toBe("open");
+
+    h.advanceTime(30_000);
+    expect(h.client._circuitState()).toBe("half-open");
+
+    h.enqueue(() => noContent());
+    await h.client.deleteIdentityProvider("two");
+    expect(h.client._circuitState()).toBe("closed");
+  });
+});
+
+describe("typed helpers", () => {
+  it("createOrganization round-trips through an alias lookup when the POST response is empty", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    // 201 with empty body
+    h.enqueue(() => new Response(null, { status: 201 }));
+    h.enqueue(() => okJson([{ id: "kc-org-1", name: "NGO France", alias: "ngo-france" }]));
+
+    const org = await h.client.createOrganization({ name: "NGO France", alias: "ngo-france" });
+    expect(org).toEqual({ id: "kc-org-1", name: "NGO France", alias: "ngo-france" });
+  });
+
+  it("getOrganization returns null on 404 rather than throwing", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response("nope", { status: 404 }));
+    await expect(h.client.getOrganization("missing")).resolves.toBeNull();
+  });
+
+  it("addOrgDomain lowercases the domain and POSTs to /domains", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => noContent());
+
+    await h.client.addOrgDomain("org-1", "NGO.FR");
+    const call = h.calls.at(-1);
+    expect(call?.url).toBe("http://kc.test/admin/realms/givernance/organizations/org-1/domains");
+    expect(JSON.parse(String(call?.init.body))).toEqual({ name: "ngo.fr", verified: true });
+  });
+
+  it("attachUserToOrg, sendInvitation, bindIdpToOrganization hit the right paths", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => noContent());
+    h.enqueue(() => noContent());
+    h.enqueue(() => noContent());
+
+    await h.client.attachUserToOrg("org-1", "user-1");
+    await h.client.sendInvitation("org-1", "bob@ngo.fr");
+    await h.client.bindIdpToOrganization("org-1", { alias: "entra" });
+
+    const paths = h.calls
+      .slice(1)
+      .map((c) => c.url.replace("http://kc.test/admin/realms/givernance", ""));
+    expect(paths).toEqual([
+      "/organizations/org-1/members",
+      "/organizations/org-1/members/invite-user",
+      "/organizations/org-1/identity-providers",
+    ]);
+  });
+
+  it("createIdentityProvider + deleteIdentityProvider hit /identity-provider/instances", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => noContent());
+    h.enqueue(() => noContent());
+
+    await h.client.createIdentityProvider({
+      alias: "entra",
+      providerId: "oidc",
+      config: { clientId: "abc" },
+    });
+    await h.client.deleteIdentityProvider("entra");
+
+    const body = JSON.parse(String(h.calls[1]?.init.body));
+    expect(body).toMatchObject({ alias: "entra", providerId: "oidc", enabled: true });
+    expect(h.calls[2]?.init.method).toBe("DELETE");
+    expect(h.calls[2]?.url).toContain("/identity-provider/instances/entra");
+  });
+});

--- a/packages/api/src/lib/keycloak-admin.test.ts
+++ b/packages/api/src/lib/keycloak-admin.test.ts
@@ -1,20 +1,25 @@
 /**
  * Unit tests for the Keycloak Admin API client (issue #107).
  *
- * Fetch is fully stubbed. Tests exercise:
- *  - token caching + early refresh + refresh on 401
- *  - exponential-backoff retry on 5xx / 429 / network errors
- *  - non-retryable 4xx paths
- *  - circuit breaker (closed → open → half-open transition)
- *  - every public helper (createOrganization, addOrgDomain, attachUserToOrg,
- *    sendInvitation, bindIdpToOrganization, createIdentityProvider, …)
+ * Fetch + clock + random are all injected so the suite is fully
+ * deterministic and CI-stable. Covers:
+ *  - token caching, expiry refresh with 30s margin, 401 rotation,
+ *    bad-secret 401/403 are non-retryable, in-flight dedup on cold cache.
+ *  - retry semantics: 5xx retried on GET/PUT/DELETE, POST not retried on
+ *    5xx (duplicate-side-effect safety), 429 retried everywhere, network
+ *    retried on idempotent methods, JSON-parse errors not retried.
+ *  - circuit breaker: closed → open, fail-fast, half-open single probe,
+ *    half-open failure re-arms timer (stays "open"), success closes.
+ *  - every public helper: method / URL / body shape.
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  _resetKeycloakAdminSingleton,
   CircuitOpenError,
   createKeycloakAdminClient,
   KeycloakAdminError,
+  KeycloakAuthError,
 } from "./keycloak-admin.js";
 
 type StubCall = { url: string; init: RequestInit };
@@ -51,7 +56,8 @@ function makeHarness(
     clientSecret: "sekret",
     fetchImpl,
     nowMs: () => timeMs,
-    initialBackoffMs: 1, // keep retry delays tiny in tests
+    randomImpl: () => 0, // deterministic jitter
+    initialBackoffMs: 1,
     ...overrides,
   });
 
@@ -74,20 +80,26 @@ const tokenResponse = (body: { access_token?: string; expires_in?: number } = {}
     { status: 200, headers: { "Content-Type": "application/json" } },
   );
 
-const okJson = (body: unknown): Response =>
+const okJson = (body: unknown, status = 200): Response =>
   new Response(JSON.stringify(body), {
-    status: 200,
+    status,
     headers: { "Content-Type": "application/json" },
   });
 
 const noContent = (): Response => new Response(null, { status: 204 });
 
-// The harness ships with `initialBackoffMs: 1` so real timers are fine and
-// keep tests simple (no need for runAllTimersAsync pump points).
+const created = (locationId: string): Response =>
+  new Response(null, {
+    status: 201,
+    headers: { Location: `http://kc.test/admin/realms/givernance/organizations/${locationId}` },
+  });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  _resetKeycloakAdminSingleton();
 });
+
+// ─── Token cache ────────────────────────────────────────────────────────────
 
 describe("token cache", () => {
   it("fetches a token once and reuses it across calls", async () => {
@@ -112,7 +124,6 @@ describe("token cache", () => {
     h.enqueue(() => noContent());
 
     await h.client.deleteIdentityProvider("one");
-    // After the safety-margin elapses, the next call triggers a token refresh.
     h.advanceTime(31_000);
     await h.client.deleteIdentityProvider("two");
 
@@ -121,10 +132,9 @@ describe("token cache", () => {
     expect(h.calls.at(-1)?.init.headers).toMatchObject({ Authorization: "Bearer tok-b" });
   });
 
-  it("re-acquires the token on a 401 response and retries the request", async () => {
+  it("re-acquires the token on an admin-API 401 and retries the request", async () => {
     const h = makeHarness();
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
-    // First admin call gets a 401 → client invalidates and retries with a fresh token.
     h.enqueue(() => new Response(null, { status: 401 }));
     h.enqueue(() => tokenResponse({ access_token: "tok-2", expires_in: 300 }));
     h.enqueue(() => noContent());
@@ -135,10 +145,44 @@ describe("token cache", () => {
     expect(tokenCalls).toHaveLength(2);
     expect(h.calls.at(-1)?.init.headers).toMatchObject({ Authorization: "Bearer tok-2" });
   });
+
+  it("treats a 401 at the token endpoint as non-retryable (bad secret)", async () => {
+    const h = makeHarness({ maxAttempts: 3 });
+    h.enqueue(() => new Response("bad secret", { status: 401 }));
+
+    await expect(h.client.deleteIdentityProvider("one")).rejects.toBeInstanceOf(KeycloakAuthError);
+    // No retries — only one fetch to /token.
+    const tokenCalls = h.calls.filter((c) => c.url.includes("/protocol/openid-connect/token"));
+    expect(tokenCalls).toHaveLength(1);
+  });
+
+  it("dedupes in-flight token fetches when multiple callers race on a cold cache", async () => {
+    const h = makeHarness();
+    h.enqueue(
+      async () =>
+        new Promise<Response>((resolve) =>
+          setTimeout(() => resolve(tokenResponse({ expires_in: 300 })), 5),
+        ),
+    );
+    h.enqueue(() => noContent());
+    h.enqueue(() => noContent());
+    h.enqueue(() => noContent());
+
+    await Promise.all([
+      h.client.deleteIdentityProvider("a"),
+      h.client.deleteIdentityProvider("b"),
+      h.client.deleteIdentityProvider("c"),
+    ]);
+
+    const tokenCalls = h.calls.filter((c) => c.url.includes("/protocol/openid-connect/token"));
+    expect(tokenCalls).toHaveLength(1);
+  });
 });
 
+// ─── Retry + non-retryable errors ───────────────────────────────────────────
+
 describe("retry + non-retryable errors", () => {
-  it("retries transient 5xx up to maxAttempts with jittered backoff", async () => {
+  it("retries transient 5xx on idempotent methods (DELETE)", async () => {
     const h = makeHarness({ maxAttempts: 3 });
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
     h.enqueue(() => new Response("boom", { status: 502 }));
@@ -146,18 +190,30 @@ describe("retry + non-retryable errors", () => {
     h.enqueue(() => noContent());
 
     await expect(h.client.deleteIdentityProvider("one")).resolves.toBeUndefined();
-
     const deleteCalls = h.calls.filter((c) => c.init.method === "DELETE");
     expect(deleteCalls).toHaveLength(3);
   });
 
-  it("treats 429 as retryable", async () => {
-    const h = makeHarness();
+  it("does NOT retry 5xx on POST (non-idempotent writes)", async () => {
+    const h = makeHarness({ maxAttempts: 5 });
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
-    h.enqueue(() => new Response("slow", { status: 429 }));
+    h.enqueue(() => new Response(null, { status: 502 }));
+
+    await expect(h.client.attachUserToOrg("org-1", "user-1")).rejects.toBeInstanceOf(
+      KeycloakAdminError,
+    );
+
+    const postCalls = h.calls.filter((c) => c.init.method === "POST" && c.url.includes("/members"));
+    expect(postCalls).toHaveLength(1);
+  });
+
+  it("retries 429 on POST (rate-limit is safe to retry)", async () => {
+    const h = makeHarness({ maxAttempts: 3 });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response(null, { status: 429 }));
     h.enqueue(() => noContent());
 
-    await h.client.deleteIdentityProvider("one");
+    await h.client.attachUserToOrg("org-1", "user-1");
   });
 
   it("does NOT retry 4xx (other than 401/429)", async () => {
@@ -170,7 +226,19 @@ describe("retry + non-retryable errors", () => {
     expect(deleteCalls).toHaveLength(1);
   });
 
-  it("retries a thrown network error and eventually succeeds", async () => {
+  it("does NOT retry a JSON parse failure on 200", async () => {
+    const h = makeHarness({ maxAttempts: 3 });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(
+      () => new Response("not-json", { status: 200, headers: { "Content-Type": "text/html" } }),
+    );
+
+    await expect(h.client.getOrganization("id-1")).rejects.toBeInstanceOf(SyntaxError);
+    const getCalls = h.calls.filter((c) => c.init.method === "GET");
+    expect(getCalls).toHaveLength(1);
+  });
+
+  it("retries a thrown network error on idempotent methods and eventually succeeds", async () => {
     const h = makeHarness({ maxAttempts: 3 });
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
     h.enqueue(() => {
@@ -180,13 +248,29 @@ describe("retry + non-retryable errors", () => {
 
     await h.client.deleteIdentityProvider("one");
   });
+
+  it("throws the last error after exhausting retries", async () => {
+    const h = makeHarness({ maxAttempts: 2 });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response("bad-gateway", { status: 502 }));
+    h.enqueue(() => new Response("still-bad", { status: 503 }));
+
+    await expect(h.client.deleteIdentityProvider("one")).rejects.toMatchObject({
+      name: "KeycloakAdminError",
+      status: 503,
+    });
+    const deleteCalls = h.calls.filter((c) => c.init.method === "DELETE");
+    expect(deleteCalls).toHaveLength(2);
+  });
 });
 
+// ─── Circuit breaker ────────────────────────────────────────────────────────
+
 describe("circuit breaker", () => {
-  it("opens after `circuitFailureThreshold` consecutive failures, then rejects fast", async () => {
+  it("opens after `circuitFailureThreshold` consecutive 5xx failures, then rejects fast", async () => {
     const h = makeHarness({
       circuitFailureThreshold: 2,
-      maxAttempts: 1, // stop retrying inside a single request
+      maxAttempts: 1,
     });
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
     h.enqueue(() => new Response(null, { status: 500 }));
@@ -196,14 +280,25 @@ describe("circuit breaker", () => {
     await expect(h.client.deleteIdentityProvider("two")).rejects.toBeInstanceOf(KeycloakAdminError);
     expect(h.client._circuitState()).toBe("open");
 
-    // No network call — fails fast.
+    const nBefore = h.calls.length;
     await expect(h.client.deleteIdentityProvider("three")).rejects.toBeInstanceOf(CircuitOpenError);
-    const nAfter = h.calls.length;
-    await expect(h.client.deleteIdentityProvider("four")).rejects.toBeInstanceOf(CircuitOpenError);
-    expect(h.calls.length).toBe(nAfter);
+    expect(h.calls.length).toBe(nBefore);
   });
 
-  it("moves to half-open after circuitOpenMs and a successful request closes it", async () => {
+  it("does NOT count client 4xx toward the breaker", async () => {
+    const h = makeHarness({ circuitFailureThreshold: 2, maxAttempts: 1 });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response("not found", { status: 404 }));
+    h.enqueue(() => new Response("nope", { status: 404 }));
+    h.enqueue(() => new Response("still nope", { status: 404 }));
+
+    for (const id of ["a", "b", "c"]) {
+      await expect(h.client.getOrganization(id)).resolves.toBeNull();
+    }
+    expect(h.client._circuitState()).toBe("closed");
+  });
+
+  it("moves to half-open after circuitOpenMs and a successful probe closes it", async () => {
     const h = makeHarness({ circuitFailureThreshold: 1, maxAttempts: 1, circuitOpenMs: 30_000 });
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
     h.enqueue(() => new Response(null, { status: 500 }));
@@ -218,18 +313,49 @@ describe("circuit breaker", () => {
     await h.client.deleteIdentityProvider("two");
     expect(h.client._circuitState()).toBe("closed");
   });
+
+  it("failed half-open probe re-arms the timer (stays in 'open')", async () => {
+    const h = makeHarness({ circuitFailureThreshold: 1, maxAttempts: 1, circuitOpenMs: 30_000 });
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => new Response(null, { status: 500 }));
+
+    await expect(h.client.deleteIdentityProvider("one")).rejects.toBeInstanceOf(KeycloakAdminError);
+    h.advanceTime(30_000);
+
+    h.enqueue(() => new Response(null, { status: 500 }));
+    await expect(h.client.deleteIdentityProvider("two")).rejects.toBeInstanceOf(KeycloakAdminError);
+    expect(h.client._circuitState()).toBe("open");
+    // Immediately afterwards, the breaker must reject additional calls fast.
+    const nBefore = h.calls.length;
+    await expect(h.client.deleteIdentityProvider("three")).rejects.toBeInstanceOf(CircuitOpenError);
+    expect(h.calls.length).toBe(nBefore);
+  });
 });
 
+// ─── Typed helpers ──────────────────────────────────────────────────────────
+
 describe("typed helpers", () => {
-  it("createOrganization round-trips through an alias lookup when the POST response is empty", async () => {
+  it("createOrganization follows the Location header (not an alias search)", async () => {
     const h = makeHarness();
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
-    // 201 with empty body
-    h.enqueue(() => new Response(null, { status: 201 }));
-    h.enqueue(() => okJson([{ id: "kc-org-1", name: "NGO France", alias: "ngo-france" }]));
+    h.enqueue(() => created("kc-org-42"));
+    h.enqueue(() => okJson({ id: "kc-org-42", name: "NGO France", alias: "ngo-france" }));
 
     const org = await h.client.createOrganization({ name: "NGO France", alias: "ngo-france" });
-    expect(org).toEqual({ id: "kc-org-1", name: "NGO France", alias: "ngo-france" });
+    expect(org).toEqual({ id: "kc-org-42", name: "NGO France", alias: "ngo-france" });
+    // The follow-up GET uses the ID from Location, not a search.
+    expect(h.calls.at(-1)?.url).toBe(
+      "http://kc.test/admin/realms/givernance/organizations/kc-org-42",
+    );
+  });
+
+  it("createOrganization returns the body directly when the POST response has a body", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => okJson({ id: "kc-org-1", name: "NGO", alias: "ngo" }, 201));
+
+    const org = await h.client.createOrganization({ name: "NGO", alias: "ngo" });
+    expect(org).toMatchObject({ id: "kc-org-1", alias: "ngo" });
   });
 
   it("getOrganization returns null on 404 rather than throwing", async () => {
@@ -239,18 +365,28 @@ describe("typed helpers", () => {
     await expect(h.client.getOrganization("missing")).resolves.toBeNull();
   });
 
-  it("addOrgDomain lowercases the domain and POSTs to /domains", async () => {
+  it("deleteOrganization hits DELETE /organizations/:id", async () => {
     const h = makeHarness();
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
     h.enqueue(() => noContent());
 
-    await h.client.addOrgDomain("org-1", "NGO.FR");
-    const call = h.calls.at(-1);
-    expect(call?.url).toBe("http://kc.test/admin/realms/givernance/organizations/org-1/domains");
-    expect(JSON.parse(String(call?.init.body))).toEqual({ name: "ngo.fr", verified: true });
+    await h.client.deleteOrganization("org-1");
+    expect(h.calls.at(-1)?.url).toBe("http://kc.test/admin/realms/givernance/organizations/org-1");
+    expect(h.calls.at(-1)?.init.method).toBe("DELETE");
   });
 
-  it("attachUserToOrg, sendInvitation, bindIdpToOrganization hit the right paths", async () => {
+  it("addOrgDomain lowercases the domain and requires an explicit `verified` flag", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => noContent());
+
+    await h.client.addOrgDomain("org-1", "NGO.FR", { verified: false });
+    const call = h.calls.at(-1);
+    expect(call?.url).toBe("http://kc.test/admin/realms/givernance/organizations/org-1/domains");
+    expect(JSON.parse(String(call?.init.body))).toEqual({ name: "ngo.fr", verified: false });
+  });
+
+  it("attachUserToOrg, sendInvitation, bindIdpToOrganization send the right bodies", async () => {
     const h = makeHarness();
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
     h.enqueue(() => noContent());
@@ -261,14 +397,22 @@ describe("typed helpers", () => {
     await h.client.sendInvitation("org-1", "bob@ngo.fr");
     await h.client.bindIdpToOrganization("org-1", { alias: "entra" });
 
-    const paths = h.calls
-      .slice(1)
-      .map((c) => c.url.replace("http://kc.test/admin/realms/givernance", ""));
-    expect(paths).toEqual([
-      "/organizations/org-1/members",
-      "/organizations/org-1/members/invite-user",
-      "/organizations/org-1/identity-providers",
-    ]);
+    expect(JSON.parse(String(h.calls[1]?.init.body))).toEqual({ id: "user-1" });
+    expect(JSON.parse(String(h.calls[2]?.init.body))).toEqual({ email: "bob@ngo.fr" });
+    expect(JSON.parse(String(h.calls[3]?.init.body))).toEqual({ alias: "entra" });
+  });
+
+  it("percent-encodes path parameters", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(() => noContent());
+
+    await h.client.deleteIdentityProvider("ent/ra?bad#slashes");
+
+    const call = h.calls.at(-1);
+    expect(call?.url).toBe(
+      "http://kc.test/admin/realms/givernance/identity-provider/instances/ent%2Fra%3Fbad%23slashes",
+    );
   });
 
   it("createIdentityProvider + deleteIdentityProvider hit /identity-provider/instances", async () => {

--- a/packages/api/src/lib/keycloak-admin.ts
+++ b/packages/api/src/lib/keycloak-admin.ts
@@ -1,26 +1,37 @@
 /**
  * Keycloak Admin API client — issue #107 / ADR-016.
  *
- * Thin, typed wrapper around the Keycloak Admin REST API for operations the
- * Givernance API needs to perform on behalf of the platform (tenant
- * onboarding flow):
+ * Thin, typed wrapper around the Keycloak Admin REST API for the operations
+ * the Givernance API needs to perform during tenant onboarding:
  *
  *  - Organizations (Keycloak 26+): create, get, delete, add domain.
  *  - Identity Providers: create, bind to Organization.
- *  - Users: lookup by sub, attach to Organization.
- *  - Invitations: send via Organization invite endpoint.
+ *  - Members: attach, invite.
  *
  * Cross-cutting behaviour:
- *  - `client_credentials` access-token caching with early-refresh margin.
- *  - Exponential-backoff retry on transient errors (network + 5xx + 429).
- *  - Circuit breaker: opens for 30s after 5 consecutive failures; while
- *    open, every call fails fast with `CircuitOpenError`.
- *  - Structured pino logging on every request with latency + status code.
+ *  - `client_credentials` access-token caching with early-refresh safety
+ *    margin, in-flight deduplication so parallel callers don't stampede.
+ *  - Conservative retry policy: 5xx / 429 / network errors retried on
+ *    idempotent methods (GET, PUT, DELETE). **POST is retried only on
+ *    429 or token rotation (401 once)**, never on 5xx, to avoid duplicate
+ *    side-effects (e.g. two invitation emails).
+ *  - Circuit breaker: opens for 30s after N consecutive 5xx / network
+ *    failures, re-arms on a failed half-open probe. Client 4xx errors
+ *    (400, 403, 404) do NOT count toward the breaker.
+ *  - Structured pino logging on every request with latency + status code;
+ *    `Authorization` and `client_secret` are redacted at the logger level.
  *
- * The client is intentionally minimal. Organization-specific endpoints are
- * Keycloak 26+ and will only reach real infrastructure once issue #114
- * upgrades the realm — until then they are exercised by the stubbed-fetch
- * unit tests in `keycloak-admin.test.ts`.
+ * Security notes:
+ *  - All path parameters are `encodeURIComponent`-encoded.
+ *  - `addOrgDomain` takes `verified: boolean` explicitly; callers MUST pass
+ *    `verified: true` only after out-of-band DNS TXT verification (ADR-016).
+ *  - `createOrganization` recovers from empty 201 bodies via the `Location`
+ *    header (not alias search) so concurrent create/race can't hand back
+ *    someone else's org.
+ *
+ * Organization-specific endpoints are Keycloak 26+; they are exercised by
+ * stubbed-fetch unit tests in `keycloak-admin.test.ts`. The real e2e smoke
+ * test ships with issue #114 once the realm is upgraded.
  */
 
 import pino from "pino";
@@ -28,7 +39,20 @@ import { env } from "../env.js";
 
 // ─── Logger ──────────────────────────────────────────────────────────────────
 
-const logger = pino({ name: "keycloak-admin", level: env.LOG_LEVEL });
+const logger = pino({
+  name: "keycloak-admin",
+  level: env.LOG_LEVEL,
+  redact: {
+    paths: [
+      "*.headers.authorization",
+      "*.headers.Authorization",
+      "*.body.client_secret",
+      "accessToken",
+      "*.accessToken",
+    ],
+    censor: "[REDACTED]",
+  },
+});
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -47,7 +71,6 @@ export interface KeycloakIdentityProvider {
   config?: Record<string, string>;
 }
 
-/** One-of: either a new IdP config, or an existing alias to bind. */
 export interface BindIdpInput {
   alias: string;
 }
@@ -56,10 +79,19 @@ export class KeycloakAdminError extends Error {
   constructor(
     message: string,
     public readonly status: number,
-    public readonly url: string,
+    /** Path relative to the realm admin base (never the full URL with baseUrl). */
+    public readonly path: string,
   ) {
     super(message);
     this.name = "KeycloakAdminError";
+  }
+}
+
+/** Thrown on non-retryable errors at the token endpoint (bad secret, 403, etc.) */
+export class KeycloakAuthError extends KeycloakAdminError {
+  constructor(status: number, path: string) {
+    super(`Token endpoint returned ${status}`, status, path);
+    this.name = "KeycloakAuthError";
   }
 }
 
@@ -81,14 +113,18 @@ interface ClientConfig {
   fetchImpl?: typeof fetch;
   /** Current epoch milliseconds — injectable for deterministic tests. */
   nowMs?: () => number;
+  /** Injectable random for deterministic backoff in tests. Default: `Math.random`. */
+  randomImpl?: () => number;
   /** Failures required before the breaker opens (default 5). */
   circuitFailureThreshold?: number;
   /** Milliseconds the breaker stays open before entering half-open (default 30_000). */
   circuitOpenMs?: number;
   /** Max retry attempts on transient failures (default 3). */
   maxAttempts?: number;
-  /** Initial backoff in ms (default 200). Exponential: 200, 400, 800, … */
+  /** Initial backoff in ms (default 200). Exponential: 200, 400, 800, …, capped at `maxBackoffMs`. */
   initialBackoffMs?: number;
+  /** Hard cap on any single backoff window (default 10_000). */
+  maxBackoffMs?: number;
 }
 
 interface CachedToken {
@@ -106,7 +142,11 @@ export interface KeycloakAdminClient {
   }): Promise<KeycloakOrganization>;
   getOrganization(id: string): Promise<KeycloakOrganization | null>;
   deleteOrganization(id: string): Promise<void>;
-  addOrgDomain(orgId: string, domain: string): Promise<void>;
+  /**
+   * Add a domain to an Organization.
+   * @param verified   Only pass `true` after out-of-band DNS TXT verification (ADR-016 §DNS TXT).
+   */
+  addOrgDomain(orgId: string, domain: string, opts: { verified: boolean }): Promise<void>;
   attachUserToOrg(orgId: string, userId: string): Promise<void>;
   sendInvitation(orgId: string, email: string): Promise<void>;
   bindIdpToOrganization(orgId: string, input: BindIdpInput): Promise<void>;
@@ -117,24 +157,27 @@ export interface KeycloakAdminClient {
 
   // Test hooks
   _circuitState(): "closed" | "open" | "half-open";
-  _clearTokenCache(): void;
 }
 
 /**
  * Create a Keycloak Admin API client. Factory style (not a singleton) so tests
- * can instantiate isolated clients with injected fetch + clock.
+ * can instantiate isolated clients with injected fetch + clock + random.
  */
 export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminClient {
   const fetchImpl = config.fetchImpl ?? fetch;
   const now = config.nowMs ?? (() => Date.now());
+  const random = config.randomImpl ?? (() => Math.random());
   const failureThreshold = config.circuitFailureThreshold ?? 5;
   const openMs = config.circuitOpenMs ?? 30_000;
   const maxAttempts = config.maxAttempts ?? 3;
   const initialBackoffMs = config.initialBackoffMs ?? 200;
+  const maxBackoffMs = config.maxBackoffMs ?? 10_000;
 
   let cachedToken: CachedToken | null = null;
+  let inFlightToken: Promise<string> | null = null;
   let consecutiveFailures = 0;
   let circuitOpenedAtMs: number | null = null;
+  let halfOpenInFlight = false;
 
   // ─── Circuit breaker helpers ────────────────────────────────────────────
 
@@ -147,11 +190,25 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
   const recordSuccess = () => {
     consecutiveFailures = 0;
     circuitOpenedAtMs = null;
+    halfOpenInFlight = false;
   };
 
-  const recordFailure = () => {
+  /**
+   * Record a breaker-counting failure. Called only for 5xx / network failures,
+   * not for client 4xx errors. Transitions to "open" on threshold, and
+   * re-arms the timer on a failed half-open probe.
+   */
+  const recordBreakerFailure = () => {
+    const wasHalfOpen = circuitState() === "half-open";
     consecutiveFailures += 1;
-    if (consecutiveFailures >= failureThreshold) {
+    if (wasHalfOpen) {
+      // Failed probe — re-arm timer so we stay in `open`, not stuck `half-open`.
+      circuitOpenedAtMs = now();
+      halfOpenInFlight = false;
+      logger.warn({ consecutiveFailures }, "Keycloak admin half-open probe failed");
+      return;
+    }
+    if (consecutiveFailures >= failureThreshold && circuitOpenedAtMs === null) {
       circuitOpenedAtMs = now();
       logger.warn({ consecutiveFailures }, "Keycloak admin circuit opened");
     }
@@ -160,7 +217,8 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
   // ─── Token cache ────────────────────────────────────────────────────────
 
   const fetchToken = async (): Promise<string> => {
-    const url = `${config.baseUrl}/realms/${config.realm}/protocol/openid-connect/token`;
+    const path = `/realms/${config.realm}/protocol/openid-connect/token`;
+    const url = `${config.baseUrl}${path}`;
     const body = new URLSearchParams({
       grant_type: "client_credentials",
       client_id: config.clientId,
@@ -175,7 +233,8 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
     });
 
     if (!res.ok) {
-      throw new KeycloakAdminError(`Token endpoint returned ${res.status}`, res.status, url);
+      // 403 / 401 at the token endpoint = bad secret, not a rotation issue.
+      throw new KeycloakAuthError(res.status, path);
     }
 
     const tokenRes = (await res.json()) as { access_token: string; expires_in: number };
@@ -196,20 +255,47 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
     if (cachedToken && cachedToken.expiresAtMs > now()) {
       return cachedToken.accessToken;
     }
-    return fetchToken();
+    // In-flight dedup: parallel callers share a single `/token` request.
+    if (!inFlightToken) {
+      inFlightToken = fetchToken().finally(() => {
+        inFlightToken = null;
+      });
+    }
+    return inFlightToken;
   };
 
   // ─── Core request with retry + CB ──────────────────────────────────────
 
-  const isRetryable = (err: unknown): boolean => {
-    if (err instanceof KeycloakAdminError) {
-      // 401: token has probably rotated — retry once with a fresh token.
-      // 429: rate-limited.
-      // 5xx: transient upstream failure.
-      return err.status === 401 || err.status === 429 || (err.status >= 500 && err.status < 600);
+  /**
+   * `POST` is only retried on 429 or 401-one-shot. `GET`/`PUT`/`DELETE` are
+   * retried on any transient error.
+   */
+  const isRetryable = (err: unknown, method: string): boolean => {
+    if (err instanceof SyntaxError) {
+      // Malformed JSON on a 200 — not transient.
+      return false;
     }
-    // Network / fetch abort / DNS — assume retryable.
-    return true;
+    if (err instanceof KeycloakAuthError) {
+      // Bad client secret — don't loop.
+      return false;
+    }
+    if (err instanceof KeycloakAdminError) {
+      if (err.status === 401) return true; // token rotated — retry once with fresh token
+      if (err.status === 429) return true;
+      if (err.status >= 500 && err.status < 600) {
+        return method !== "POST"; // don't retry non-idempotent writes on 5xx
+      }
+      return false;
+    }
+    // Network / fetch abort / DNS — retry idempotent methods only.
+    return method !== "POST";
+  };
+
+  const countsTowardBreaker = (err: unknown): boolean => {
+    if (err instanceof KeycloakAdminError) {
+      return err.status >= 500 && err.status < 600;
+    }
+    return true; // network/DNS/abort count
   };
 
   const adminRequest = async <T>(
@@ -217,8 +303,13 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
     path: string,
     body?: unknown,
   ): Promise<T | null> => {
-    if (circuitState() === "open") {
+    const state = circuitState();
+    if (state === "open") {
       throw new CircuitOpenError();
+    }
+    if (state === "half-open") {
+      if (halfOpenInFlight) throw new CircuitOpenError();
+      halfOpenInFlight = true;
     }
 
     const url = `${config.baseUrl}/admin/realms/${config.realm}${path}`;
@@ -231,6 +322,11 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
       let result: { value: T | null } | null = null;
 
       try {
+        // If the token endpoint rejects our credentials (bad secret), it
+        // throws KeycloakAuthError which is non-retryable — that's the
+        // "bad config" path. A 401 on the admin API, by contrast, means
+        // the token we just sent was rejected mid-session (rotation); we
+        // invalidate the cache and retry.
         const token = await getToken();
         const started = now();
         const res = await fetchImpl(url, {
@@ -243,17 +339,20 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
         });
 
         const latencyMs = now() - started;
-        logger.debug({ method, url, status: res.status, latencyMs, attempt }, "kc-admin");
+        logger.debug({ method, path, status: res.status, latencyMs, attempt }, "kc-admin");
 
-        // Token probably expired — invalidate + retry once immediately.
         if (res.status === 401) {
           cachedToken = null;
-          err = new KeycloakAdminError("Unauthorized", 401, url);
+          err = new KeycloakAdminError("Unauthorized (token rotated)", 401, path);
+        } else if (res.status === 201 && res.headers.get("location")) {
+          // Honor the Location header for POST-create recovery.
+          const location = res.headers.get("location") as string;
+          result = { value: { __locationHeader: location } as unknown as T };
         } else if (!res.ok) {
           err = new KeycloakAdminError(
             `Admin API ${method} ${path} → ${res.status}`,
             res.status,
-            url,
+            path,
           );
         } else {
           if (res.status === 204) {
@@ -264,7 +363,10 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
           }
         }
       } catch (thrown) {
-        if (thrown instanceof CircuitOpenError) throw thrown;
+        if (thrown instanceof CircuitOpenError) {
+          halfOpenInFlight = false;
+          throw thrown;
+        }
         err = thrown;
       }
 
@@ -273,52 +375,78 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
         return result.value;
       }
 
-      // Error path — decide whether to retry or fail.
       lastErr = err;
-      if (!isRetryable(err) || attempt >= maxAttempts) {
-        recordFailure();
+      if (!isRetryable(err, method) || attempt >= maxAttempts) {
+        if (countsTowardBreaker(err)) {
+          recordBreakerFailure();
+        } else if (state === "half-open") {
+          // Non-breaker-counting 4xx during half-open probe: still release the
+          // slot but don't re-arm the timer. Leave the decision to the next caller.
+          halfOpenInFlight = false;
+        }
         throw err;
       }
 
-      // Exponential backoff with full jitter.
-      const delay = initialBackoffMs * 2 ** (attempt - 1);
-      const jittered = Math.floor(Math.random() * delay);
+      // Exponential backoff with equal jitter + hard cap.
+      const baseDelay = Math.min(initialBackoffMs * 2 ** (attempt - 1), maxBackoffMs);
+      const half = baseDelay / 2;
+      const jittered = Math.floor(half + random() * half);
       await new Promise((r) => setTimeout(r, jittered));
     }
 
-    recordFailure();
+    if (countsTowardBreaker(lastErr)) {
+      recordBreakerFailure();
+    }
     throw lastErr ?? new Error("unreachable");
   };
+
+  // ─── Helpers for path encoding ─────────────────────────────────────────
+
+  const e = encodeURIComponent;
 
   // ─── Public surface ────────────────────────────────────────────────────
 
   return {
     createOrganization: async ({ name, alias, attributes }) => {
-      const created = await adminRequest<KeycloakOrganization>("POST", `/organizations`, {
-        name,
-        alias,
-        attributes: attributes ?? {},
-      });
-      // Keycloak returns 201 + Location; fetch-by-alias to hydrate the id.
-      if (created) return created;
-      const listed = await adminRequest<KeycloakOrganization[]>(
-        "GET",
-        `/organizations?search=${encodeURIComponent(alias)}`,
+      const out = await adminRequest<KeycloakOrganization & { __locationHeader?: string }>(
+        "POST",
+        `/organizations`,
+        { name, alias, attributes: attributes ?? {} },
       );
-      const match = listed?.find((o) => o.alias === alias);
-      if (!match) {
+      if (!out) {
         throw new KeycloakAdminError(
-          `Organization '${alias}' not found after create`,
+          `Organization create returned no body and no Location header`,
           500,
-          "/organizations",
+          `/organizations`,
         );
       }
-      return match;
+      if (out.__locationHeader) {
+        // Extract the org id from the Location header and GET it by id — never search by alias.
+        const idMatch = out.__locationHeader.match(/\/organizations\/([^/]+)$/);
+        const id = idMatch?.[1];
+        if (!id) {
+          throw new KeycloakAdminError(
+            `Organization create Location header malformed: ${out.__locationHeader}`,
+            500,
+            `/organizations`,
+          );
+        }
+        const fetched = await adminRequest<KeycloakOrganization>("GET", `/organizations/${e(id)}`);
+        if (!fetched) {
+          throw new KeycloakAdminError(
+            `Organization ${id} missing after create`,
+            500,
+            `/organizations/${id}`,
+          );
+        }
+        return fetched;
+      }
+      return out;
     },
 
     getOrganization: async (id) => {
       try {
-        return await adminRequest<KeycloakOrganization>("GET", `/organizations/${id}`);
+        return await adminRequest<KeycloakOrganization>("GET", `/organizations/${e(id)}`);
       } catch (err) {
         if (err instanceof KeycloakAdminError && err.status === 404) return null;
         throw err;
@@ -326,30 +454,26 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
     },
 
     deleteOrganization: async (id) => {
-      await adminRequest<void>("DELETE", `/organizations/${id}`);
+      await adminRequest<void>("DELETE", `/organizations/${e(id)}`);
     },
 
-    addOrgDomain: async (orgId, domain) => {
-      await adminRequest<void>("POST", `/organizations/${orgId}/domains`, {
+    addOrgDomain: async (orgId, domain, { verified }) => {
+      await adminRequest<void>("POST", `/organizations/${e(orgId)}/domains`, {
         name: domain.toLowerCase(),
-        verified: true,
+        verified,
       });
     },
 
     attachUserToOrg: async (orgId, userId) => {
-      await adminRequest<void>("POST", `/organizations/${orgId}/members`, { id: userId });
+      await adminRequest<void>("POST", `/organizations/${e(orgId)}/members`, { id: userId });
     },
 
     sendInvitation: async (orgId, email) => {
-      await adminRequest<void>("POST", `/organizations/${orgId}/members/invite-user`, {
-        email,
-      });
+      await adminRequest<void>("POST", `/organizations/${e(orgId)}/members/invite-user`, { email });
     },
 
     bindIdpToOrganization: async (orgId, { alias }) => {
-      await adminRequest<void>("POST", `/organizations/${orgId}/identity-providers`, {
-        alias,
-      });
+      await adminRequest<void>("POST", `/organizations/${e(orgId)}/identity-providers`, { alias });
     },
 
     createIdentityProvider: async (idp) => {
@@ -362,13 +486,10 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
     },
 
     deleteIdentityProvider: async (alias) => {
-      await adminRequest<void>("DELETE", `/identity-provider/instances/${alias}`);
+      await adminRequest<void>("DELETE", `/identity-provider/instances/${e(alias)}`);
     },
 
     _circuitState: circuitState,
-    _clearTokenCache: () => {
-      cachedToken = null;
-    },
   };
 }
 
@@ -398,4 +519,9 @@ export function keycloakAdmin(): KeycloakAdminClient {
     clientSecret: env.KEYCLOAK_ADMIN_CLIENT_SECRET,
   });
   return singleton;
+}
+
+/** Test helper — resets the module-level singleton + token cache. */
+export function _resetKeycloakAdminSingleton(): void {
+  singleton = null;
 }

--- a/packages/api/src/lib/keycloak-admin.ts
+++ b/packages/api/src/lib/keycloak-admin.ts
@@ -1,0 +1,401 @@
+/**
+ * Keycloak Admin API client — issue #107 / ADR-016.
+ *
+ * Thin, typed wrapper around the Keycloak Admin REST API for operations the
+ * Givernance API needs to perform on behalf of the platform (tenant
+ * onboarding flow):
+ *
+ *  - Organizations (Keycloak 26+): create, get, delete, add domain.
+ *  - Identity Providers: create, bind to Organization.
+ *  - Users: lookup by sub, attach to Organization.
+ *  - Invitations: send via Organization invite endpoint.
+ *
+ * Cross-cutting behaviour:
+ *  - `client_credentials` access-token caching with early-refresh margin.
+ *  - Exponential-backoff retry on transient errors (network + 5xx + 429).
+ *  - Circuit breaker: opens for 30s after 5 consecutive failures; while
+ *    open, every call fails fast with `CircuitOpenError`.
+ *  - Structured pino logging on every request with latency + status code.
+ *
+ * The client is intentionally minimal. Organization-specific endpoints are
+ * Keycloak 26+ and will only reach real infrastructure once issue #114
+ * upgrades the realm — until then they are exercised by the stubbed-fetch
+ * unit tests in `keycloak-admin.test.ts`.
+ */
+
+import pino from "pino";
+import { env } from "../env.js";
+
+// ─── Logger ──────────────────────────────────────────────────────────────────
+
+const logger = pino({ name: "keycloak-admin", level: env.LOG_LEVEL });
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export interface KeycloakOrganization {
+  id: string;
+  name: string;
+  alias: string;
+  attributes?: Record<string, string[]>;
+  domains?: Array<{ name: string; verified: boolean }>;
+}
+
+export interface KeycloakIdentityProvider {
+  alias: string;
+  providerId: "oidc" | "saml";
+  enabled?: boolean;
+  config?: Record<string, string>;
+}
+
+/** One-of: either a new IdP config, or an existing alias to bind. */
+export interface BindIdpInput {
+  alias: string;
+}
+
+export class KeycloakAdminError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly url: string,
+  ) {
+    super(message);
+    this.name = "KeycloakAdminError";
+  }
+}
+
+export class CircuitOpenError extends Error {
+  constructor() {
+    super("Keycloak Admin API circuit breaker is open");
+    this.name = "CircuitOpenError";
+  }
+}
+
+// ─── Config + private state ──────────────────────────────────────────────────
+
+interface ClientConfig {
+  baseUrl: string;
+  realm: string;
+  clientId: string;
+  clientSecret: string;
+  /** Override for tests — default is global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Current epoch milliseconds — injectable for deterministic tests. */
+  nowMs?: () => number;
+  /** Failures required before the breaker opens (default 5). */
+  circuitFailureThreshold?: number;
+  /** Milliseconds the breaker stays open before entering half-open (default 30_000). */
+  circuitOpenMs?: number;
+  /** Max retry attempts on transient failures (default 3). */
+  maxAttempts?: number;
+  /** Initial backoff in ms (default 200). Exponential: 200, 400, 800, … */
+  initialBackoffMs?: number;
+}
+
+interface CachedToken {
+  accessToken: string;
+  /** Epoch ms at which the token becomes stale (with 30s safety margin). */
+  expiresAtMs: number;
+}
+
+export interface KeycloakAdminClient {
+  // Organizations (KC 26+)
+  createOrganization(input: {
+    name: string;
+    alias: string;
+    attributes?: Record<string, string[]>;
+  }): Promise<KeycloakOrganization>;
+  getOrganization(id: string): Promise<KeycloakOrganization | null>;
+  deleteOrganization(id: string): Promise<void>;
+  addOrgDomain(orgId: string, domain: string): Promise<void>;
+  attachUserToOrg(orgId: string, userId: string): Promise<void>;
+  sendInvitation(orgId: string, email: string): Promise<void>;
+  bindIdpToOrganization(orgId: string, input: BindIdpInput): Promise<void>;
+
+  // Identity Providers (KC 24+)
+  createIdentityProvider(idp: KeycloakIdentityProvider): Promise<void>;
+  deleteIdentityProvider(alias: string): Promise<void>;
+
+  // Test hooks
+  _circuitState(): "closed" | "open" | "half-open";
+  _clearTokenCache(): void;
+}
+
+/**
+ * Create a Keycloak Admin API client. Factory style (not a singleton) so tests
+ * can instantiate isolated clients with injected fetch + clock.
+ */
+export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminClient {
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const now = config.nowMs ?? (() => Date.now());
+  const failureThreshold = config.circuitFailureThreshold ?? 5;
+  const openMs = config.circuitOpenMs ?? 30_000;
+  const maxAttempts = config.maxAttempts ?? 3;
+  const initialBackoffMs = config.initialBackoffMs ?? 200;
+
+  let cachedToken: CachedToken | null = null;
+  let consecutiveFailures = 0;
+  let circuitOpenedAtMs: number | null = null;
+
+  // ─── Circuit breaker helpers ────────────────────────────────────────────
+
+  const circuitState = (): "closed" | "open" | "half-open" => {
+    if (circuitOpenedAtMs === null) return "closed";
+    if (now() - circuitOpenedAtMs >= openMs) return "half-open";
+    return "open";
+  };
+
+  const recordSuccess = () => {
+    consecutiveFailures = 0;
+    circuitOpenedAtMs = null;
+  };
+
+  const recordFailure = () => {
+    consecutiveFailures += 1;
+    if (consecutiveFailures >= failureThreshold) {
+      circuitOpenedAtMs = now();
+      logger.warn({ consecutiveFailures }, "Keycloak admin circuit opened");
+    }
+  };
+
+  // ─── Token cache ────────────────────────────────────────────────────────
+
+  const fetchToken = async (): Promise<string> => {
+    const url = `${config.baseUrl}/realms/${config.realm}/protocol/openid-connect/token`;
+    const body = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+    });
+
+    const started = now();
+    const res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+
+    if (!res.ok) {
+      throw new KeycloakAdminError(`Token endpoint returned ${res.status}`, res.status, url);
+    }
+
+    const tokenRes = (await res.json()) as { access_token: string; expires_in: number };
+    const ttlMs = tokenRes.expires_in * 1000;
+    const safetyMarginMs = 30_000;
+    cachedToken = {
+      accessToken: tokenRes.access_token,
+      expiresAtMs: now() + Math.max(ttlMs - safetyMarginMs, 1_000),
+    };
+    logger.debug(
+      { latencyMs: now() - started, ttlSec: tokenRes.expires_in },
+      "Keycloak admin token refreshed",
+    );
+    return tokenRes.access_token;
+  };
+
+  const getToken = async (): Promise<string> => {
+    if (cachedToken && cachedToken.expiresAtMs > now()) {
+      return cachedToken.accessToken;
+    }
+    return fetchToken();
+  };
+
+  // ─── Core request with retry + CB ──────────────────────────────────────
+
+  const isRetryable = (err: unknown): boolean => {
+    if (err instanceof KeycloakAdminError) {
+      // 401: token has probably rotated — retry once with a fresh token.
+      // 429: rate-limited.
+      // 5xx: transient upstream failure.
+      return err.status === 401 || err.status === 429 || (err.status >= 500 && err.status < 600);
+    }
+    // Network / fetch abort / DNS — assume retryable.
+    return true;
+  };
+
+  const adminRequest = async <T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T | null> => {
+    if (circuitState() === "open") {
+      throw new CircuitOpenError();
+    }
+
+    const url = `${config.baseUrl}/admin/realms/${config.realm}${path}`;
+    let attempt = 0;
+    let lastErr: unknown;
+
+    while (attempt < maxAttempts) {
+      attempt += 1;
+      let err: unknown;
+      let result: { value: T | null } | null = null;
+
+      try {
+        const token = await getToken();
+        const started = now();
+        const res = await fetchImpl(url, {
+          method,
+          headers: {
+            Authorization: `Bearer ${token}`,
+            ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+          },
+          body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+
+        const latencyMs = now() - started;
+        logger.debug({ method, url, status: res.status, latencyMs, attempt }, "kc-admin");
+
+        // Token probably expired — invalidate + retry once immediately.
+        if (res.status === 401) {
+          cachedToken = null;
+          err = new KeycloakAdminError("Unauthorized", 401, url);
+        } else if (!res.ok) {
+          err = new KeycloakAdminError(
+            `Admin API ${method} ${path} → ${res.status}`,
+            res.status,
+            url,
+          );
+        } else {
+          if (res.status === 204) {
+            result = { value: null };
+          } else {
+            const text = await res.text();
+            result = { value: text ? (JSON.parse(text) as T) : null };
+          }
+        }
+      } catch (thrown) {
+        if (thrown instanceof CircuitOpenError) throw thrown;
+        err = thrown;
+      }
+
+      if (result) {
+        recordSuccess();
+        return result.value;
+      }
+
+      // Error path — decide whether to retry or fail.
+      lastErr = err;
+      if (!isRetryable(err) || attempt >= maxAttempts) {
+        recordFailure();
+        throw err;
+      }
+
+      // Exponential backoff with full jitter.
+      const delay = initialBackoffMs * 2 ** (attempt - 1);
+      const jittered = Math.floor(Math.random() * delay);
+      await new Promise((r) => setTimeout(r, jittered));
+    }
+
+    recordFailure();
+    throw lastErr ?? new Error("unreachable");
+  };
+
+  // ─── Public surface ────────────────────────────────────────────────────
+
+  return {
+    createOrganization: async ({ name, alias, attributes }) => {
+      const created = await adminRequest<KeycloakOrganization>("POST", `/organizations`, {
+        name,
+        alias,
+        attributes: attributes ?? {},
+      });
+      // Keycloak returns 201 + Location; fetch-by-alias to hydrate the id.
+      if (created) return created;
+      const listed = await adminRequest<KeycloakOrganization[]>(
+        "GET",
+        `/organizations?search=${encodeURIComponent(alias)}`,
+      );
+      const match = listed?.find((o) => o.alias === alias);
+      if (!match) {
+        throw new KeycloakAdminError(
+          `Organization '${alias}' not found after create`,
+          500,
+          "/organizations",
+        );
+      }
+      return match;
+    },
+
+    getOrganization: async (id) => {
+      try {
+        return await adminRequest<KeycloakOrganization>("GET", `/organizations/${id}`);
+      } catch (err) {
+        if (err instanceof KeycloakAdminError && err.status === 404) return null;
+        throw err;
+      }
+    },
+
+    deleteOrganization: async (id) => {
+      await adminRequest<void>("DELETE", `/organizations/${id}`);
+    },
+
+    addOrgDomain: async (orgId, domain) => {
+      await adminRequest<void>("POST", `/organizations/${orgId}/domains`, {
+        name: domain.toLowerCase(),
+        verified: true,
+      });
+    },
+
+    attachUserToOrg: async (orgId, userId) => {
+      await adminRequest<void>("POST", `/organizations/${orgId}/members`, { id: userId });
+    },
+
+    sendInvitation: async (orgId, email) => {
+      await adminRequest<void>("POST", `/organizations/${orgId}/members/invite-user`, {
+        email,
+      });
+    },
+
+    bindIdpToOrganization: async (orgId, { alias }) => {
+      await adminRequest<void>("POST", `/organizations/${orgId}/identity-providers`, {
+        alias,
+      });
+    },
+
+    createIdentityProvider: async (idp) => {
+      await adminRequest<void>("POST", `/identity-provider/instances`, {
+        alias: idp.alias,
+        providerId: idp.providerId,
+        enabled: idp.enabled ?? true,
+        config: idp.config ?? {},
+      });
+    },
+
+    deleteIdentityProvider: async (alias) => {
+      await adminRequest<void>("DELETE", `/identity-provider/instances/${alias}`);
+    },
+
+    _circuitState: circuitState,
+    _clearTokenCache: () => {
+      cachedToken = null;
+    },
+  };
+}
+
+// ─── Default singleton (env-derived) ────────────────────────────────────────
+
+let singleton: KeycloakAdminClient | null = null;
+
+/**
+ * Lazy default client bound to the process env. Use this in Fastify route
+ * handlers. Tests should instantiate their own via `createKeycloakAdminClient`.
+ *
+ * Throws if `KEYCLOAK_ADMIN_CLIENT_SECRET` is unset — protects against
+ * accidentally trying to call the Admin API in an environment that hasn't
+ * been configured for it.
+ */
+export function keycloakAdmin(): KeycloakAdminClient {
+  if (singleton) return singleton;
+  if (!env.KEYCLOAK_ADMIN_CLIENT_SECRET) {
+    throw new Error(
+      "KEYCLOAK_ADMIN_CLIENT_SECRET is not configured — cannot use the Keycloak Admin client.",
+    );
+  }
+  singleton = createKeycloakAdminClient({
+    baseUrl: env.KEYCLOAK_ADMIN_URL ?? env.KEYCLOAK_URL,
+    realm: env.KEYCLOAK_REALM,
+    clientId: env.KEYCLOAK_ADMIN_CLIENT_ID,
+    clientSecret: env.KEYCLOAK_ADMIN_CLIENT_SECRET,
+  });
+  return singleton;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       pg:
         specifier: ^8.13.1
         version: 8.20.0
+      pino:
+        specifier: 10.3.1
+        version: 10.3.1
       stripe:
         specifier: ^22.0.1
         version: 22.0.1(@types/node@25.6.0)


### PR DESCRIPTION
Closes #107.

Foundation backend infra for ADR-016 — the typed, resilient client that every later onboarding endpoint will use to drive Keycloak Organizations, Identity Providers, members, and invitations.

## Summary

### Library
- `packages/api/src/lib/keycloak-admin.ts` — client-credentials token cache with 30s early-refresh margin + automatic retry on 401.
- Exponential backoff with full jitter; 3 attempts default; 401/429/5xx/network retryable; other 4xx throw immediately.
- Circuit breaker: 5 consecutive failures → 30s open → half-open → close on success; fail-fast with `CircuitOpenError` while open.
- Typed helpers: `createOrganization`, `getOrganization`, `deleteOrganization`, `addOrgDomain`, `attachUserToOrg`, `sendInvitation`, `bindIdpToOrganization`, `createIdentityProvider`, `deleteIdentityProvider`.
- pino structured logging on every request (method / url / status / latency / attempt).
- Factory (`createKeycloakAdminClient`) + env-bound singleton (`keycloakAdmin()`) that crashes loudly if the admin secret is unset.

### Realm seed + env
- `givernance-admin` service-account client added to `infra/keycloak/realm-givernance.json` with `realm-management` roles (`manage-realm`, `manage-users`, `manage-identity-providers`, `view-clients`).
- `KEYCLOAK_ADMIN_URL` / `KEYCLOAK_ADMIN_CLIENT_ID` / `KEYCLOAK_ADMIN_CLIENT_SECRET` added to `packages/api/src/env.ts`, `.env.example`, and `docs/21-authentication-sso.md` §6.
- `pino@10.3.1` added to the API package (already a dep of worker + relay).

## Test plan

- [x] 14 stubbed-fetch unit tests cover token cache (reuse, expiry refresh, 401 retry), retry semantics (5xx/429/4xx/network), circuit-breaker state transitions, and every public helper.
- [x] `pnpm run format` / `lint` / `typecheck` / `build` / `test` — 266/266 green.

## Out of scope

- Wiring public endpoints to the client (issues #108 + #110).
- Real Keycloak 26 e2e smoke test — the issue gates it by `KEYCLOAK_E2E=1`; the realm is still on Keycloak 24 until issue #114 ships. Stubbed-fetch unit tests cover the contract; the real e2e smoke lands with #114.

## Architecture

- **ADR-016** — first backend consumer of the hybrid onboarding model.
- **ADR-009** — Scaleway-hosted Keycloak; client talks to it via HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)