### PR TITLE
feat(api): self-serve signup backend (issue #108)

### DIFF
--- a/packages/api/migrations/0022_invitation_purpose.sql
+++ b/packages/api/migrations/0022_invitation_purpose.sql
@@ -1,0 +1,12 @@
+-- 0022_invitation_purpose.sql
+-- Adds `purpose` discriminator to `invitations` to prevent cross-contamination
+-- between the team-invite flow and the self-serve signup verification flow
+-- (SEC-1 / DATA-3 from the #117 review). Existing rows are back-filled to
+-- 'team_invite' (the pre-0021 invite semantics).
+
+ALTER TABLE invitations
+    ADD COLUMN IF NOT EXISTS purpose VARCHAR(32) NOT NULL DEFAULT 'team_invite',
+    ADD CONSTRAINT invitations_purpose_chk
+        CHECK (purpose IN ('team_invite', 'signup_verification'));
+
+CREATE INDEX IF NOT EXISTS invitations_purpose_idx ON invitations (purpose);

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1744502420000,
       "tag": "0021_tenant_onboarding_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1744502421000,
+      "tag": "0022_invitation_purpose",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -49,6 +49,8 @@ const EnvSchema = Type.Object({
   KEYCLOAK_ADMIN_CLIENT_SECRET: Type.Optional(Type.String({ minLength: 1 })),
   /** hCaptcha server-side secret used by the public signup flow (ADR-016 / issue #108). */
   HCAPTCHA_SECRET: Type.Optional(Type.String({ minLength: 1 })),
+  /** Explicit override for CAPTCHA enforcement — `disabled` fails open, `prod` fails closed. */
+  CAPTCHA_MODE: Type.Optional(Type.Union([Type.Literal("disabled"), Type.Literal("prod")])),
   /** HTTP port */
   PORT: Type.Number({ default: 4000 }),
   /** HTTP bind address */

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -47,6 +47,8 @@ const EnvSchema = Type.Object({
   KEYCLOAK_ADMIN_CLIENT_ID: Type.String({ minLength: 1, default: "givernance-admin" }),
   /** Service-account client secret used for Keycloak Admin API calls. */
   KEYCLOAK_ADMIN_CLIENT_SECRET: Type.Optional(Type.String({ minLength: 1 })),
+  /** hCaptcha server-side secret used by the public signup flow (ADR-016 / issue #108). */
+  HCAPTCHA_SECRET: Type.Optional(Type.String({ minLength: 1 })),
   /** HTTP port */
   PORT: Type.Number({ default: 4000 }),
   /** HTTP bind address */

--- a/packages/api/src/lib/captcha.ts
+++ b/packages/api/src/lib/captcha.ts
@@ -1,0 +1,67 @@
+/**
+ * CAPTCHA verification helper (issue #108 / ADR-016 §8 anti-abuse).
+ *
+ * Uses hCaptcha's server-side verification endpoint. The helper fails
+ * **open** in `NODE_ENV=test` (so integration tests don't need a real
+ * hCaptcha account) and **closed** everywhere else — if the secret is
+ * unset or the provider is unreachable, the request is rejected.
+ */
+
+import { env } from "../env.js";
+
+export interface CaptchaResult {
+  ok: boolean;
+  reason?: "missing_secret" | "missing_token" | "provider_rejected" | "provider_unreachable";
+}
+
+export interface CaptchaVerifier {
+  verify(token: string | undefined, ip?: string): Promise<CaptchaResult>;
+}
+
+const HCAPTCHA_URL = "https://hcaptcha.com/siteverify";
+
+interface VerifierConfig {
+  secret?: string;
+  /** Inject for tests. */
+  fetchImpl?: typeof fetch;
+  /** NODE_ENV, used to decide fail-open behaviour in tests. */
+  mode?: "test" | "prod";
+}
+
+export function createCaptchaVerifier(config: VerifierConfig = {}): CaptchaVerifier {
+  const mode = config.mode ?? (process.env.NODE_ENV === "test" ? "test" : "prod");
+  const secret = config.secret ?? env.HCAPTCHA_SECRET;
+  const fetchImpl = config.fetchImpl ?? fetch;
+
+  return {
+    async verify(token, ip) {
+      if (mode === "test") {
+        // Dev / CI fail-open: accept any token, including undefined.
+        return { ok: true };
+      }
+      if (!secret) {
+        return { ok: false, reason: "missing_secret" };
+      }
+      if (!token) {
+        return { ok: false, reason: "missing_token" };
+      }
+      try {
+        const body = new URLSearchParams({ secret, response: token });
+        if (ip) body.set("remoteip", ip);
+        const res = await fetchImpl(HCAPTCHA_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body,
+        });
+        if (!res.ok) return { ok: false, reason: "provider_unreachable" };
+        const json = (await res.json()) as { success: boolean };
+        return json.success ? { ok: true } : { ok: false, reason: "provider_rejected" };
+      } catch {
+        return { ok: false, reason: "provider_unreachable" };
+      }
+    },
+  };
+}
+
+/** Default verifier bound to the process env. */
+export const defaultCaptchaVerifier = createCaptchaVerifier();

--- a/packages/api/src/lib/captcha.ts
+++ b/packages/api/src/lib/captcha.ts
@@ -24,18 +24,31 @@ interface VerifierConfig {
   secret?: string;
   /** Inject for tests. */
   fetchImpl?: typeof fetch;
-  /** NODE_ENV, used to decide fail-open behaviour in tests. */
-  mode?: "test" | "prod";
+  /** Verification mode. Defaults: `disabled` in tests or when `CAPTCHA_MODE=disabled`; `prod` otherwise. */
+  mode?: "disabled" | "prod";
+}
+
+/**
+ * Resolve the CAPTCHA mode. Priority: explicit config > `CAPTCHA_MODE` env >
+ * `NODE_ENV === "test"` default. An explicit `CAPTCHA_MODE=disabled` on a
+ * staging/preview environment is logged at boot so operators see the knob.
+ */
+function resolveMode(configMode: VerifierConfig["mode"]): "disabled" | "prod" {
+  if (configMode) return configMode;
+  const envMode = process.env.CAPTCHA_MODE;
+  if (envMode === "disabled" || envMode === "prod") return envMode;
+  if (process.env.NODE_ENV === "test") return "disabled";
+  return "prod";
 }
 
 export function createCaptchaVerifier(config: VerifierConfig = {}): CaptchaVerifier {
-  const mode = config.mode ?? (process.env.NODE_ENV === "test" ? "test" : "prod");
+  const mode = resolveMode(config.mode);
   const secret = config.secret ?? env.HCAPTCHA_SECRET;
   const fetchImpl = config.fetchImpl ?? fetch;
 
   return {
     async verify(token, ip) {
-      if (mode === "test") {
+      if (mode === "disabled") {
         // Dev / CI fail-open: accept any token, including undefined.
         return { ok: true };
       }

--- a/packages/api/src/modules/invitations/routes.ts
+++ b/packages/api/src/modules/invitations/routes.ts
@@ -84,6 +84,7 @@ export async function invitationRoutes(app: FastifyInstance) {
             email: body.email,
             role: (body.role as "org_admin" | "user" | "viewer") ?? "user",
             invitedById: inviter?.id ?? null,
+            purpose: "team_invite",
             expiresAt,
           })
           .returning();
@@ -122,11 +123,19 @@ export async function invitationRoutes(app: FastifyInstance) {
       const { token } = request.params as { token: string };
       const body = request.body as { firstName: string; lastName: string };
 
-      // Step 1: Look up invitation without tenant context (no FORCE RLS on invitations)
+      // Step 1: Look up invitation without tenant context (no FORCE RLS on invitations).
+      // Filter to purpose='team_invite' so self-serve signup-verification tokens
+      // cannot be consumed here (SEC-1 / DATA-3, review of PR #117).
       const [invitation] = await db
         .select()
         .from(invitations)
-        .where(and(eq(invitations.token, token), isNull(invitations.acceptedAt)));
+        .where(
+          and(
+            eq(invitations.token, token),
+            eq(invitations.purpose, "team_invite"),
+            isNull(invitations.acceptedAt),
+          ),
+        );
 
       if (!invitation) {
         return reply

--- a/packages/api/src/modules/signup/routes.ts
+++ b/packages/api/src/modules/signup/routes.ts
@@ -2,18 +2,29 @@
  * Public self-serve signup routes (issue #108 / ADR-016).
  *
  * All endpoints are unauthenticated and rate-limited. CAPTCHA is fail-open
- * in NODE_ENV=test (see `lib/captcha.ts`), fail-closed elsewhere.
+ * in `CAPTCHA_MODE=disabled` (or `NODE_ENV=test`), fail-closed elsewhere.
+ *
+ * Review pass (PR #117):
+ *  - SEC-5 / ENG-4: slug_taken + email_in_use → 409 with a single generic
+ *    "Signup could not be completed" message (no enumeration oracle).
+ *  - SEC-6: verify collapses all failure paths to 410 generic.
+ *  - SEC-10: resend is rate-limited per-email via a Redis bucket in
+ *    addition to the per-IP Fastify rate limit.
+ *  - ENG-5: dropped the `checkEmail: Literal(true)` field from the 201
+ *    response — 201 already means "verification required".
+ *  - ENG-6: captcha failure → 400 generic, reason is logged internally.
  */
 
 import { createHash } from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { defaultCaptchaVerifier } from "../../lib/captcha.js";
+import { redis } from "../../lib/redis.js";
 import {
   DataResponse,
   ErrorResponses,
-  problemDetail,
   ProblemDetailSchema,
+  problemDetail,
   UuidSchema,
 } from "../../lib/schemas.js";
 import { lookupTenantForEmail, resendVerification, signup, verifySignup } from "./service.js";
@@ -46,7 +57,6 @@ const VerifyBody = Type.Object({
 const SignupResponse = Type.Object({
   tenantId: UuidSchema,
   email: Type.String(),
-  checkEmail: Type.Literal(true),
 });
 
 const VerifyResponse = Type.Object({
@@ -63,7 +73,6 @@ const LookupQuery = Type.Object({
 const LookupResponse = Type.Object({
   hasExistingTenant: Type.Boolean(),
   hint: Type.Union([Type.Literal("contact_admin"), Type.Literal("create_new")]),
-  orgSlug: Type.Optional(Type.String()),
 });
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -76,6 +85,20 @@ function hashIp(ip: string | undefined): string | undefined {
 
 function clientIp(request: FastifyRequest): string | undefined {
   return request.ip ?? undefined;
+}
+
+/**
+ * Per-email rate limit for the resend endpoint, on top of the per-IP Fastify
+ * limit. Defends against a botnet spamming a single victim's inbox (SEC-10).
+ * Returns `true` when the request is allowed, `false` when the bucket is full.
+ */
+async function acceptResendForEmail(email: string): Promise<boolean> {
+  const key = `signup:resend:email:${email.trim().toLowerCase()}`;
+  const hits = await redis.incr(key);
+  if (hits === 1) {
+    await redis.expire(key, 60 * 60); // 1h window
+  }
+  return hits <= 3; // max 3 resends per email per hour globally
 }
 
 // ─── Routes ─────────────────────────────────────────────────────────────────
@@ -92,6 +115,8 @@ export async function signupRoutes(app: FastifyInstance) {
         headers: CaptchaHeader,
         response: {
           201: DataResponse(SignupResponse),
+          400: ProblemDetailSchema,
+          409: ProblemDetailSchema,
           422: ProblemDetailSchema,
           429: Type.Any(),
           ...ErrorResponses,
@@ -114,9 +139,11 @@ export async function signupRoutes(app: FastifyInstance) {
         clientIp(request),
       );
       if (!captcha.ok) {
+        request.log.warn({ reason: captcha.reason }, "signup.captcha_rejected");
+        // Generic message — don't tell the attacker which gate failed.
         return reply
-          .status(422)
-          .send(problemDetail(422, "CAPTCHA Required", "A valid CAPTCHA token is required."));
+          .status(400)
+          .send(problemDetail(400, "Signup rejected", "Signup could not be completed."));
       }
 
       const ipHash = hashIp(clientIp(request));
@@ -125,41 +152,29 @@ export async function signupRoutes(app: FastifyInstance) {
           ? request.headers["user-agent"].slice(0, 512)
           : undefined;
 
-      const result = await signup({
-        ...body,
-        ipHash,
-        userAgent,
-      });
+      const result = await signup({ ...body, ipHash, userAgent });
 
       if (!result.ok) {
-        const reasonMap: Record<string, { title: string; detail: string }> = {
-          disposable_email: {
-            title: "Email not accepted",
-            detail: "The email address provided is not accepted for signup.",
-          },
-          invalid_slug: {
-            title: "Invalid organization URL",
-            detail: "The organization URL is invalid, reserved, or uses a non-ASCII prefix.",
-          },
-          slug_taken: {
-            title: "Organization URL already taken",
-            detail:
-              "Another organization is already using this URL. Please choose a different one.",
-          },
-          email_in_use: {
-            title: "Organization already exists",
-            detail:
-              "An organization with this email domain is already on Givernance — ask an admin to invite you.",
-          },
-        };
-        const mapped = reasonMap[result.error.kind];
+        request.log.info({ reason: result.error.kind }, "signup.rejected");
+        if (result.error.kind === "invalid_slug") {
+          return reply
+            .status(422)
+            .send(
+              problemDetail(
+                422,
+                "Invalid organization URL",
+                "The organization URL is invalid, reserved, or uses a non-ASCII prefix.",
+              ),
+            );
+        }
+        // Both slug_taken and email_in_use → 409 + generic message (SEC-5).
         return reply
-          .status(422)
+          .status(409)
           .send(
             problemDetail(
-              422,
-              mapped?.title ?? "Signup rejected",
-              mapped?.detail ?? "Signup rejected",
+              409,
+              "Signup could not be completed",
+              "Signup could not be completed. If you believe this is an error, please contact support.",
             ),
           );
       }
@@ -168,7 +183,6 @@ export async function signupRoutes(app: FastifyInstance) {
         data: {
           tenantId: result.tenantId,
           email: result.email,
-          checkEmail: true as const,
         },
       });
     },
@@ -191,7 +205,12 @@ export async function signupRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const { email } = request.body as { email: string };
-      // Never leak whether the email matched anything — always 204.
+      const allowed = await acceptResendForEmail(email);
+      if (!allowed) {
+        // Silently accept — the endpoint cannot be used as an enumeration or
+        // spam-amplification oracle.
+        return reply.status(204).send();
+      }
       await resendVerification(email);
       return reply.status(204).send();
     },
@@ -208,7 +227,6 @@ export async function signupRoutes(app: FastifyInstance) {
         response: {
           201: DataResponse(VerifyResponse),
           410: ProblemDetailSchema,
-          422: ProblemDetailSchema,
           ...ErrorResponses,
         },
       },
@@ -224,20 +242,17 @@ export async function signupRoutes(app: FastifyInstance) {
       const result = await verifySignup({ ...body, ipHash, userAgent });
 
       if (!result.ok) {
-        if (result.error.kind === "invalid_or_expired") {
-          return reply
-            .status(410)
-            .send(
-              problemDetail(
-                410,
-                "Verification expired",
-                "The verification link has expired or is invalid.",
-              ),
-            );
-        }
+        // SEC-6: collapse all failure modes into one generic 410 to remove
+        // the status-code enumeration oracle.
         return reply
-          .status(422)
-          .send(problemDetail(422, "Already verified", "This tenant has already been verified."));
+          .status(410)
+          .send(
+            problemDetail(
+              410,
+              "Verification expired",
+              "This verification link is invalid or has already been used. Please start signup again.",
+            ),
+          );
       }
 
       return reply.status(201).send({

--- a/packages/api/src/modules/signup/routes.ts
+++ b/packages/api/src/modules/signup/routes.ts
@@ -1,0 +1,275 @@
+/**
+ * Public self-serve signup routes (issue #108 / ADR-016).
+ *
+ * All endpoints are unauthenticated and rate-limited. CAPTCHA is fail-open
+ * in NODE_ENV=test (see `lib/captcha.ts`), fail-closed elsewhere.
+ */
+
+import { createHash } from "node:crypto";
+import { Type } from "@sinclair/typebox";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { defaultCaptchaVerifier } from "../../lib/captcha.js";
+import {
+  DataResponse,
+  ErrorResponses,
+  problemDetail,
+  ProblemDetailSchema,
+  UuidSchema,
+} from "../../lib/schemas.js";
+import { lookupTenantForEmail, resendVerification, signup, verifySignup } from "./service.js";
+
+// ─── Request / response shapes ──────────────────────────────────────────────
+
+const SignupBody = Type.Object({
+  orgName: Type.String({ minLength: 2, maxLength: 255 }),
+  slug: Type.String({ minLength: 2, maxLength: 50 }),
+  firstName: Type.String({ minLength: 1, maxLength: 255 }),
+  lastName: Type.String({ minLength: 1, maxLength: 255 }),
+  email: Type.String({ format: "email", maxLength: 255 }),
+  country: Type.Optional(Type.String({ maxLength: 2 })),
+});
+
+const CaptchaHeader = Type.Object({
+  "x-captcha-token": Type.Optional(Type.String({ maxLength: 4096 })),
+});
+
+const ResendBody = Type.Object({
+  email: Type.String({ format: "email", maxLength: 255 }),
+});
+
+const VerifyBody = Type.Object({
+  token: Type.String({ format: "uuid" }),
+  firstName: Type.String({ minLength: 1, maxLength: 255 }),
+  lastName: Type.String({ minLength: 1, maxLength: 255 }),
+});
+
+const SignupResponse = Type.Object({
+  tenantId: UuidSchema,
+  email: Type.String(),
+  checkEmail: Type.Literal(true),
+});
+
+const VerifyResponse = Type.Object({
+  tenantId: UuidSchema,
+  userId: UuidSchema,
+  slug: Type.String(),
+  provisionalUntil: Type.String({ format: "date-time" }),
+});
+
+const LookupQuery = Type.Object({
+  email: Type.String({ format: "email", maxLength: 255 }),
+});
+
+const LookupResponse = Type.Object({
+  hasExistingTenant: Type.Boolean(),
+  hint: Type.Union([Type.Literal("contact_admin"), Type.Literal("create_new")]),
+  orgSlug: Type.Optional(Type.String()),
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** SHA-256 hash of the client IP so we don't log raw addresses (docs/17). */
+function hashIp(ip: string | undefined): string | undefined {
+  if (!ip) return undefined;
+  return createHash("sha256").update(ip).digest("hex").slice(0, 32);
+}
+
+function clientIp(request: FastifyRequest): string | undefined {
+  return request.ip ?? undefined;
+}
+
+// ─── Routes ─────────────────────────────────────────────────────────────────
+
+export async function signupRoutes(app: FastifyInstance) {
+  /** POST /v1/public/signup — create a provisional self-serve tenant. */
+  app.post(
+    "/public/signup",
+    {
+      config: { rateLimit: { max: 5, timeWindow: "1 hour" } },
+      schema: {
+        tags: ["Public Signup"],
+        body: SignupBody,
+        headers: CaptchaHeader,
+        response: {
+          201: DataResponse(SignupResponse),
+          422: ProblemDetailSchema,
+          429: Type.Any(),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const body = request.body as {
+        orgName: string;
+        slug: string;
+        firstName: string;
+        lastName: string;
+        email: string;
+        country?: string;
+      };
+      const headers = request.headers as { "x-captcha-token"?: string };
+
+      const captcha = await defaultCaptchaVerifier.verify(
+        headers["x-captcha-token"],
+        clientIp(request),
+      );
+      if (!captcha.ok) {
+        return reply
+          .status(422)
+          .send(problemDetail(422, "CAPTCHA Required", "A valid CAPTCHA token is required."));
+      }
+
+      const ipHash = hashIp(clientIp(request));
+      const userAgent =
+        typeof request.headers["user-agent"] === "string"
+          ? request.headers["user-agent"].slice(0, 512)
+          : undefined;
+
+      const result = await signup({
+        ...body,
+        ipHash,
+        userAgent,
+      });
+
+      if (!result.ok) {
+        const reasonMap: Record<string, { title: string; detail: string }> = {
+          disposable_email: {
+            title: "Email not accepted",
+            detail: "The email address provided is not accepted for signup.",
+          },
+          invalid_slug: {
+            title: "Invalid organization URL",
+            detail: "The organization URL is invalid, reserved, or uses a non-ASCII prefix.",
+          },
+          slug_taken: {
+            title: "Organization URL already taken",
+            detail:
+              "Another organization is already using this URL. Please choose a different one.",
+          },
+          email_in_use: {
+            title: "Organization already exists",
+            detail:
+              "An organization with this email domain is already on Givernance — ask an admin to invite you.",
+          },
+        };
+        const mapped = reasonMap[result.error.kind];
+        return reply
+          .status(422)
+          .send(
+            problemDetail(
+              422,
+              mapped?.title ?? "Signup rejected",
+              mapped?.detail ?? "Signup rejected",
+            ),
+          );
+      }
+
+      return reply.status(201).send({
+        data: {
+          tenantId: result.tenantId,
+          email: result.email,
+          checkEmail: true as const,
+        },
+      });
+    },
+  );
+
+  /** POST /v1/public/signup/resend — re-emit the verification email. */
+  app.post(
+    "/public/signup/resend",
+    {
+      config: { rateLimit: { max: 3, timeWindow: "1 hour" } },
+      schema: {
+        tags: ["Public Signup"],
+        body: ResendBody,
+        response: {
+          204: Type.Null(),
+          429: Type.Any(),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { email } = request.body as { email: string };
+      // Never leak whether the email matched anything — always 204.
+      await resendVerification(email);
+      return reply.status(204).send();
+    },
+  );
+
+  /** POST /v1/public/signup/verify — complete the signup flow. */
+  app.post(
+    "/public/signup/verify",
+    {
+      config: { rateLimit: { max: 20, timeWindow: "15 minutes" } },
+      schema: {
+        tags: ["Public Signup"],
+        body: VerifyBody,
+        response: {
+          201: DataResponse(VerifyResponse),
+          410: ProblemDetailSchema,
+          422: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const body = request.body as { token: string; firstName: string; lastName: string };
+      const ipHash = hashIp(clientIp(request));
+      const userAgent =
+        typeof request.headers["user-agent"] === "string"
+          ? request.headers["user-agent"].slice(0, 512)
+          : undefined;
+
+      const result = await verifySignup({ ...body, ipHash, userAgent });
+
+      if (!result.ok) {
+        if (result.error.kind === "invalid_or_expired") {
+          return reply
+            .status(410)
+            .send(
+              problemDetail(
+                410,
+                "Verification expired",
+                "The verification link has expired or is invalid.",
+              ),
+            );
+        }
+        return reply
+          .status(422)
+          .send(problemDetail(422, "Already verified", "This tenant has already been verified."));
+      }
+
+      return reply.status(201).send({
+        data: {
+          tenantId: result.tenantId,
+          userId: result.userId,
+          slug: result.slug,
+          provisionalUntil: result.provisionalUntil,
+        },
+      });
+    },
+  );
+
+  /** GET /v1/public/tenants/lookup?email=... — tenant discovery hint for the login flow. */
+  app.get(
+    "/public/tenants/lookup",
+    {
+      config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
+      schema: {
+        tags: ["Public Signup"],
+        querystring: LookupQuery,
+        response: {
+          200: DataResponse(LookupResponse),
+          429: Type.Any(),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { email } = request.query as { email: string };
+      const result = await lookupTenantForEmail(email);
+      return reply.status(200).send({ data: result });
+    },
+  );
+}

--- a/packages/api/src/modules/signup/service.ts
+++ b/packages/api/src/modules/signup/service.ts
@@ -5,7 +5,26 @@
  * audit + outbox emission at each state transition. Keycloak provisioning
  * (Organization creation + invite) lands with issue #114 once the realm
  * is on Keycloak 26; until then the verification token lives on an
- * `invitations` row keyed by a random uuid.
+ * `invitations` row with `purpose='signup_verification'` (migration 0022).
+ *
+ * Review pass (PR #117):
+ *  - SEC-1 / DATA-3: invitations carry `purpose='signup_verification'`;
+ *    the team-invite endpoint filters to `purpose='team_invite'`.
+ *  - SEC-5 / ENG-4: slug / domain conflicts return 409; error messages
+ *    collapsed to a single generic "Signup could not be completed".
+ *  - SEC-6: verify endpoint collapses "expired" / "already verified" /
+ *    "unknown token" into one 410 generic to kill the enumeration oracle.
+ *  - SEC-7: outbox `payload` + audit `newValues` no longer carry the raw
+ *    verification token; the email worker looks it up by invitation id.
+ *  - DATA-1: 23505 unique violations on slug/domain are mapped to 409
+ *    results instead of a 500.
+ *  - DATA-2: `email_in_use` now also triggers when a `users.email` row
+ *    exists in any tenant — covers the existing-user case from ADR-016.
+ *  - DATA-7: `cleanupUnverifiedTenants` re-asserts invariants inside the
+ *    DELETE's WHERE (atomic with any concurrent verify).
+ *  - ENG-2: dropped the dead `disposable_email` branch.
+ *  - ENG-9: `verifySignup` reads the invitation FOR UPDATE + catches the
+ *    `users_one_first_admin_per_org` unique-violation → `already_verified`.
  */
 
 import { randomUUID } from "node:crypto";
@@ -20,17 +39,15 @@ import {
   users,
 } from "@givernance/shared/schema";
 import { validateTenantSlug } from "@givernance/shared/validators";
-import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, lt, sql } from "drizzle-orm";
 import { db } from "../../lib/db.js";
 
 const PROVISIONAL_GRACE_DAYS = 7;
 const VERIFICATION_TTL_HOURS = 24;
 
 export type SignupError =
-  | { kind: "disposable_email" }
   | { kind: "invalid_slug"; reason: "syntax" | "reserved" | "punycode" }
-  | { kind: "slug_taken" }
-  | { kind: "email_in_use"; hint: string };
+  | { kind: "conflict"; hint: "slug_taken" | "email_in_use" };
 
 export type SignupResult =
   | { ok: true; tenantId: string; email: string; verificationToken: string }
@@ -48,26 +65,39 @@ export interface SignupInput {
 }
 
 /**
- * Split an email into local / domain (lowercased). Returns `null` on a
- * trivially invalid value — the TypeBox schema catches format, this is
- * defence-in-depth.
+ * Normalise a domain: lowercase + IDN-canonical via URL parsing (Node's
+ * built-in IDNA). Returns `null` if the input cannot be resolved — the
+ * caller treats that as validation failure. (SEC-11)
  */
+function normaliseDomain(domain: string): string | null {
+  try {
+    return new URL(`https://${domain.trim().toLowerCase()}/`).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/** Split an email into local / domain. Returns `null` on a trivially invalid value. */
 function splitEmail(email: string): { local: string; domain: string } | null {
   const at = email.lastIndexOf("@");
   if (at < 1 || at === email.length - 1) return null;
-  return {
-    local: email.slice(0, at).toLowerCase(),
-    domain: email.slice(at + 1).toLowerCase(),
-  };
+  const domain = normaliseDomain(email.slice(at + 1));
+  if (!domain) return null;
+  return { local: email.slice(0, at).toLowerCase(), domain };
 }
 
-/**
- * Generate a verification token. Uses `randomUUID()` because the underlying
- * `invitations.token` column is `uuid`. 122 bits of entropy — plenty for a
- * 24h single-use verification token.
- */
+/** 122-bit random token — stored as the `invitations.token` uuid. */
 function generateVerificationToken(): string {
   return randomUUID();
+}
+
+/** Is the given error a Postgres unique-violation (23505)? */
+function isUniqueViolation(err: unknown, constraintHint?: RegExp): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { code?: string; constraint?: string; message?: string };
+  if (e.code !== "23505") return false;
+  if (!constraintHint) return true;
+  return constraintHint.test(e.constraint ?? "") || constraintHint.test(e.message ?? "");
 }
 
 // ─── Signup ─────────────────────────────────────────────────────────────────
@@ -75,42 +105,44 @@ function generateVerificationToken(): string {
 export async function signup(input: SignupInput): Promise<SignupResult> {
   const parsedEmail = splitEmail(input.email);
   if (!parsedEmail) {
-    return { ok: false, error: { kind: "disposable_email" } };
+    // Malformed email slipped past the route validator — treat as a generic
+    // conflict rather than introducing a new distinct error code.
+    return { ok: false, error: { kind: "conflict", hint: "email_in_use" } };
   }
+  const normalisedEmail = input.email.trim().toLowerCase();
+  const normalisedOrgName = input.orgName.trim().normalize("NFC");
 
-  // Slug: validator may normalise (trim + lowercase) and returns the canonical value.
   const slugCheck = validateTenantSlug(input.slug);
   if (!slugCheck.ok) {
     return { ok: false, error: { kind: "invalid_slug", reason: slugCheck.reason } };
   }
   const canonicalSlug = slugCheck.slug;
 
-  // Reject disposable / personal domains outright — this blocks the obvious
-  // signup abuse vector (hundreds of gmail aliases). Personal-email users
-  // can still be invited into a tenant by an existing admin.
-  if (isPersonalEmailDomain(parsedEmail.domain)) {
-    // We allow signups from personal email, but we block the orgs themselves
-    // from claiming domains. So personal-email signup IS allowed. Only block
-    // known disposable-email providers here.
-    // Upstream we have a curated list (`personal-email-domains.ts`) that
-    // includes both categories; filtering out disposables specifically is a
-    // follow-up (we'll add a separate `DISPOSABLE_EMAIL_DOMAINS` list).
-    // For now: allow personal emails, block nothing extra.
-  }
-
-  // Existing-slug short-circuit.
+  // Preflight: existing-slug short-circuit. The INSERT below also has the
+  // UNIQUE constraint for race safety (see catch on 23505).
   const [existingSlug] = await db
     .select({ id: tenants.id })
     .from(tenants)
     .where(eq(tenants.slug, canonicalSlug))
     .limit(1);
   if (existingSlug) {
-    return { ok: false, error: { kind: "slug_taken" } };
+    return { ok: false, error: { kind: "conflict", hint: "slug_taken" } };
   }
 
-  // "Your org is already on Givernance" detection: if the signup email's
-  // domain is a *verified* custom domain, nudge the user to ask the existing
-  // admin for an invitation rather than creating a second provisional tenant.
+  // Existing-user short-circuit: if the email already belongs to a user in
+  // any tenant, surface `email_in_use` rather than creating a duplicate
+  // provisional row that would 23505 at Keycloak-bind time (DATA-2).
+  const [existingUser] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(sql`lower(${users.email}) = ${normalisedEmail}`)
+    .limit(1);
+  if (existingUser) {
+    return { ok: false, error: { kind: "conflict", hint: "email_in_use" } };
+  }
+
+  // Domain-already-claimed check (enterprise tenants). Skipped for personal-
+  // email domains.
   if (!isPersonalEmailDomain(parsedEmail.domain)) {
     const [claimedDomain] = await db
       .select({ orgId: tenantDomains.orgId })
@@ -118,93 +150,101 @@ export async function signup(input: SignupInput): Promise<SignupResult> {
       .where(and(eq(tenantDomains.domain, parsedEmail.domain), eq(tenantDomains.state, "verified")))
       .limit(1);
     if (claimedDomain) {
-      return {
-        ok: false,
-        error: {
-          kind: "email_in_use",
-          hint: "your_organization_already_on_givernance",
-        },
-      };
+      return { ok: false, error: { kind: "conflict", hint: "email_in_use" } };
     }
   }
 
   const token = generateVerificationToken();
   const expiresAt = new Date(Date.now() + VERIFICATION_TTL_HOURS * 60 * 60 * 1000);
 
-  // All state changes happen in one transaction. Tenants has no RLS (admin-
-  // managed only), so we don't need withTenantContext — but outbox_events
-  // does, and we set the GUC to the freshly-inserted tenant id.
-  const tenantId = await db.transaction(async (tx) => {
-    const [tenant] = await tx
-      .insert(tenants)
-      .values({
-        name: input.orgName,
-        slug: canonicalSlug,
-        status: "provisional" as TenantStatus,
-        createdVia: "self_serve",
-      })
-      .returning({ id: tenants.id });
-
-    // biome-ignore lint/style/noNonNullAssertion: returning() always yields one row
-    const t = tenant!;
-
-    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${t.id}, true)`);
-
-    // Verification token stored as an invitations row. The invitation
-    // doubles as the "first admin will be created on verify" signal:
-    // role=org_admin, email=signup email, orgId=new tenant id.
-    await tx.insert(invitations).values({
-      orgId: t.id,
-      email: input.email.trim().toLowerCase(),
-      role: "org_admin",
-      token,
-      expiresAt,
-    });
-
-    await tx.insert(outboxEvents).values([
-      {
-        tenantId: t.id,
-        type: "tenant.self_signup_started",
-        payload: {
-          tenantId: t.id,
+  try {
+    const result = await db.transaction(async (tx) => {
+      const [tenant] = await tx
+        .insert(tenants)
+        .values({
+          name: normalisedOrgName,
           slug: canonicalSlug,
-          orgName: input.orgName,
-          email: input.email,
+          status: "provisional" as TenantStatus,
+          createdVia: "self_serve",
+        })
+        .returning({ id: tenants.id });
+
+      // biome-ignore lint/style/noNonNullAssertion: returning() always yields one row
+      const t = tenant!;
+
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${t.id}, true)`);
+
+      const [invitation] = await tx
+        .insert(invitations)
+        .values({
+          orgId: t.id,
+          email: normalisedEmail,
+          role: "org_admin",
+          token,
+          purpose: "signup_verification",
+          expiresAt,
+        })
+        .returning({ id: invitations.id });
+      // biome-ignore lint/style/noNonNullAssertion: returning() always yields one row
+      const invitationId = invitation!.id;
+
+      await tx.insert(outboxEvents).values([
+        {
+          tenantId: t.id,
+          type: "tenant.self_signup_started",
+          payload: {
+            tenantId: t.id,
+            slug: canonicalSlug,
+            emailDomain: parsedEmail.domain,
+            country: input.country,
+          },
+        },
+        {
+          tenantId: t.id,
+          type: "tenant.signup_verification_requested",
+          payload: {
+            // SEC-7: no raw token in the outbox. The email worker looks up
+            // the token by invitation id inside its own transaction.
+            tenantId: t.id,
+            invitationId,
+            expiresAt: expiresAt.toISOString(),
+          },
+        },
+      ]);
+
+      await tx.insert(auditLogs).values({
+        orgId: t.id,
+        userId: null,
+        action: "tenant.self_signup_started",
+        resourceType: "tenant",
+        resourceId: t.id,
+        newValues: {
+          slug: canonicalSlug,
+          emailDomain: parsedEmail.domain,
           country: input.country,
         },
-      },
-      {
-        tenantId: t.id,
-        type: "tenant.signup_verification_requested",
-        payload: {
-          tenantId: t.id,
-          email: input.email,
-          verificationToken: token,
-          expiresAt: expiresAt.toISOString(),
-        },
-      },
-    ]);
+        ipHash: input.ipHash,
+        userAgent: input.userAgent,
+      });
 
-    await tx.insert(auditLogs).values({
-      orgId: t.id,
-      userId: null,
-      action: "tenant.self_signup_started",
-      resourceType: "tenant",
-      resourceId: t.id,
-      newValues: { slug: canonicalSlug, email: input.email, country: input.country },
-      ipHash: input.ipHash,
-      userAgent: input.userAgent,
+      return t.id;
     });
 
-    return t.id;
-  });
-
-  return {
-    ok: true,
-    tenantId,
-    email: input.email.trim().toLowerCase(),
-    verificationToken: token,
-  };
+    return {
+      ok: true,
+      tenantId: result,
+      email: normalisedEmail,
+      verificationToken: token,
+    };
+  } catch (err) {
+    if (isUniqueViolation(err, /tenants_slug/)) {
+      return { ok: false, error: { kind: "conflict", hint: "slug_taken" } };
+    }
+    if (isUniqueViolation(err, /users|invitations_token/)) {
+      return { ok: false, error: { kind: "conflict", hint: "email_in_use" } };
+    }
+    throw err;
+  }
 }
 
 // ─── Resend verification ────────────────────────────────────────────────────
@@ -215,8 +255,8 @@ export type ResendResult =
 
 /**
  * Re-emit a verification token for a provisional tenant. Silently returns
- * `{ok: true}` even when the email doesn't match anything — to avoid
- * leaking which emails have pending signups.
+ * `{ok: false}` if nothing matches — the route always responds 204 so the
+ * endpoint cannot be used as an email-enumeration oracle.
  */
 export async function resendVerification(email: string): Promise<ResendResult> {
   const normalised = email.trim().toLowerCase();
@@ -228,17 +268,20 @@ export async function resendVerification(email: string): Promise<ResendResult> {
       invitationId: invitations.id,
       invitationToken: invitations.token,
       expiresAt: invitations.expiresAt,
+      createdAt: invitations.createdAt,
     })
     .from(invitations)
     .innerJoin(tenants, eq(invitations.orgId, tenants.id))
     .where(
       and(
         eq(invitations.email, normalised),
+        eq(invitations.purpose, "signup_verification"),
         isNull(invitations.acceptedAt),
         eq(tenants.status, "provisional"),
         eq(tenants.createdVia, "self_serve"),
       ),
     )
+    .orderBy(sql`${invitations.createdAt} DESC`)
     .limit(1);
 
   if (rows.length === 0) {
@@ -264,8 +307,7 @@ export async function resendVerification(email: string): Promise<ResendResult> {
       type: "tenant.signup_verification_resent",
       payload: {
         tenantId: row.tenantId,
-        email: normalised,
-        verificationToken: newToken,
+        invitationId: row.invitationId,
         expiresAt: expiresAt.toISOString(),
       },
     });
@@ -276,8 +318,6 @@ export async function resendVerification(email: string): Promise<ResendResult> {
 
 // ─── Verify ─────────────────────────────────────────────────────────────────
 
-export type VerifyError = { kind: "invalid_or_expired" } | { kind: "already_verified" };
-
 export type VerifyResult =
   | {
       ok: true;
@@ -286,7 +326,7 @@ export type VerifyResult =
       slug: string;
       provisionalUntil: string;
     }
-  | { ok: false; error: VerifyError };
+  | { ok: false };
 
 export interface VerifyInput {
   token: string;
@@ -297,114 +337,130 @@ export interface VerifyInput {
 }
 
 export async function verifySignup(input: VerifyInput): Promise<VerifyResult> {
-  return db.transaction(async (tx) => {
-    // Lookup the invitation without a tenant context (the signup flow is
-    // pre-auth; the token is the credential). `invitations` has RLS but
-    // the test/dev DB connects as the owner role (BYPASSRLS per ADR-009),
-    // and the prod API also reads invitations before resolving the tenant.
-    const [row] = await tx
-      .select({
-        invitationId: invitations.id,
-        orgId: invitations.orgId,
-        email: invitations.email,
-        role: invitations.role,
-        expiresAt: invitations.expiresAt,
-        acceptedAt: invitations.acceptedAt,
-        tenantSlug: tenants.slug,
-        tenantStatus: tenants.status,
-        createdVia: tenants.createdVia,
-      })
-      .from(invitations)
-      .innerJoin(tenants, eq(invitations.orgId, tenants.id))
-      .where(and(eq(invitations.token, input.token), eq(tenants.createdVia, "self_serve")))
-      .limit(1);
+  const firstName = input.firstName.trim();
+  const lastName = input.lastName.trim();
 
-    if (!row) {
-      return { ok: false, error: { kind: "invalid_or_expired" } } as const;
-    }
-    if (row.acceptedAt) {
-      return { ok: false, error: { kind: "already_verified" } } as const;
-    }
-    if (row.expiresAt < new Date()) {
-      return { ok: false, error: { kind: "invalid_or_expired" } } as const;
-    }
+  try {
+    return await db.transaction(async (tx) => {
+      // FOR UPDATE so concurrent verifies serialise on the invitation row
+      // (ENG-9). If the invitation doesn't match, the caller gets a generic
+      // 410 (no status-code enumeration oracle — SEC-6).
+      const [row] = await tx
+        .select({
+          invitationId: invitations.id,
+          orgId: invitations.orgId,
+          email: invitations.email,
+          role: invitations.role,
+          expiresAt: invitations.expiresAt,
+          acceptedAt: invitations.acceptedAt,
+          tenantSlug: tenants.slug,
+          tenantStatus: tenants.status,
+          createdVia: tenants.createdVia,
+        })
+        .from(invitations)
+        .innerJoin(tenants, eq(invitations.orgId, tenants.id))
+        .where(
+          and(
+            eq(invitations.token, input.token),
+            eq(invitations.purpose, "signup_verification"),
+            eq(tenants.createdVia, "self_serve"),
+          ),
+        )
+        .for("update")
+        .limit(1);
 
-    const provisionalUntil = new Date(Date.now() + PROVISIONAL_GRACE_DAYS * 24 * 60 * 60 * 1000);
+      if (!row || row.acceptedAt || row.expiresAt < new Date()) {
+        return { ok: false } as const;
+      }
 
-    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${row.orgId}, true)`);
+      const provisionalUntil = new Date(Date.now() + PROVISIONAL_GRACE_DAYS * 24 * 60 * 60 * 1000);
 
-    await tx
-      .update(tenants)
-      .set({ status: "active", verifiedAt: new Date(), updatedAt: new Date() })
-      .where(eq(tenants.id, row.orgId));
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${row.orgId}, true)`);
 
-    const [newUser] = await tx
-      .insert(users)
-      .values({
+      await tx
+        .update(tenants)
+        .set({
+          status: "active",
+          verifiedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(tenants.id, row.orgId),
+            // Don't accidentally resurrect suspended/archived tenants.
+            eq(tenants.status, "provisional"),
+          ),
+        );
+
+      const [newUser] = await tx
+        .insert(users)
+        .values({
+          orgId: row.orgId,
+          email: row.email,
+          firstName,
+          lastName,
+          role: "org_admin",
+          firstAdmin: true,
+          provisionalUntil,
+        })
+        .returning({ id: users.id });
+
+      // biome-ignore lint/style/noNonNullAssertion: returning() yields one row for single insert
+      const u = newUser!;
+
+      await tx
+        .update(invitations)
+        .set({ acceptedAt: new Date() })
+        .where(eq(invitations.id, row.invitationId));
+
+      await tx.insert(outboxEvents).values([
+        {
+          tenantId: row.orgId,
+          type: "tenant.verified",
+          payload: { tenantId: row.orgId, slug: row.tenantSlug },
+        },
+        {
+          tenantId: row.orgId,
+          type: "user.jit_provisioned",
+          payload: { userId: u.id, orgId: row.orgId, firstAdmin: true },
+        },
+      ]);
+
+      await tx.insert(auditLogs).values({
         orgId: row.orgId,
-        email: row.email,
-        firstName: input.firstName,
-        lastName: input.lastName,
-        role: "org_admin",
-        firstAdmin: true,
-        provisionalUntil,
-      })
-      .returning({ id: users.id });
+        userId: u.id,
+        action: "tenant.verified",
+        resourceType: "tenant",
+        resourceId: row.orgId,
+        newValues: { status: "active", firstAdmin: u.id },
+        ipHash: input.ipHash,
+        userAgent: input.userAgent,
+      });
 
-    // biome-ignore lint/style/noNonNullAssertion: returning() yields one row for single insert
-    const u = newUser!;
-
-    await tx
-      .update(invitations)
-      .set({ acceptedAt: new Date() })
-      .where(eq(invitations.id, row.invitationId));
-
-    await tx.insert(outboxEvents).values([
-      {
+      return {
+        ok: true as const,
         tenantId: row.orgId,
-        type: "tenant.verified",
-        payload: { tenantId: row.orgId, slug: row.tenantSlug },
-      },
-      {
-        tenantId: row.orgId,
-        type: "user.jit_provisioned",
-        payload: { userId: u.id, orgId: row.orgId, email: row.email, firstAdmin: true },
-      },
-    ]);
-
-    await tx.insert(auditLogs).values({
-      orgId: row.orgId,
-      userId: u.id,
-      action: "tenant.verified",
-      resourceType: "tenant",
-      resourceId: row.orgId,
-      newValues: { status: "active", firstAdmin: u.id },
-      ipHash: input.ipHash,
-      userAgent: input.userAgent,
+        userId: u.id,
+        slug: row.tenantSlug,
+        provisionalUntil: provisionalUntil.toISOString(),
+      };
     });
-
-    return {
-      ok: true,
-      tenantId: row.orgId,
-      userId: u.id,
-      slug: row.tenantSlug,
-      provisionalUntil: provisionalUntil.toISOString(),
-    } as const;
-  });
+  } catch (err) {
+    // If two verify calls race past the row-lock (unlikely but defensive),
+    // the unique partial index `users_one_first_admin_per_org` fires. Treat
+    // that the same way as a stale token — one generic failure response.
+    if (isUniqueViolation(err, /users_one_first_admin_per_org/)) {
+      return { ok: false };
+    }
+    throw err;
+  }
 }
 
 // ─── Tenant lookup ──────────────────────────────────────────────────────────
 
 export interface TenantLookupResult {
   hasExistingTenant: boolean;
-  /** Opaque hint the frontend can render: "contact_admin" | "create_new" */
   hint: "contact_admin" | "create_new";
-  /**
-   * Slug of the existing tenant, if any. Never returned when the email's
-   * domain is personal — otherwise we'd create an enumeration oracle across
-   * the gmail.com / outlook.com user population.
-   */
-  orgSlug?: string;
 }
 
 export async function lookupTenantForEmail(email: string): Promise<TenantLookupResult> {
@@ -412,19 +468,19 @@ export async function lookupTenantForEmail(email: string): Promise<TenantLookupR
   if (!parsed) return { hasExistingTenant: false, hint: "create_new" };
 
   if (isPersonalEmailDomain(parsed.domain)) {
-    // Personal-email domains: never leak org existence.
     return { hasExistingTenant: false, hint: "create_new" };
   }
 
   const [claimed] = await db
-    .select({ orgId: tenantDomains.orgId, slug: tenants.slug })
+    .select({ orgId: tenantDomains.orgId })
     .from(tenantDomains)
-    .innerJoin(tenants, eq(tenantDomains.orgId, tenants.id))
     .where(and(eq(tenantDomains.domain, parsed.domain), eq(tenantDomains.state, "verified")))
     .limit(1);
 
   if (claimed) {
-    return { hasExistingTenant: true, hint: "contact_admin", orgSlug: claimed.slug };
+    // SEC-9: do NOT return the org's slug publicly. The hint "contact_admin"
+    // tells the frontend to nudge the user without leaking the tenant identity.
+    return { hasExistingTenant: true, hint: "contact_admin" };
   }
   return { hasExistingTenant: false, hint: "create_new" };
 }
@@ -433,35 +489,50 @@ export async function lookupTenantForEmail(email: string): Promise<TenantLookupR
 
 /**
  * Delete `provisional` + `self_serve` tenants whose verification token
- * expired ≥ cutoff hours ago and whose `verified_at` is still null. Returns
- * the number of tenants reaped. Intended to run on a 1h cron via BullMQ.
+ * expired ≥ cutoff hours ago. Intended to run on a 1h cron via BullMQ.
+ *
+ * Atomic (DATA-7): the DELETE's WHERE re-asserts `status='provisional' AND
+ * verified_at IS NULL`, so a verify call racing the cleanup cannot lose a
+ * freshly-activated tenant.
  */
 export async function cleanupUnverifiedTenants(
   cutoffHours = VERIFICATION_TTL_HOURS,
 ): Promise<number> {
   const cutoff = new Date(Date.now() - cutoffHours * 60 * 60 * 1000);
 
-  // Find tenants to delete. Tenant delete cascades to invitations, users,
-  // tenant_domains, tenant_admin_disputes (migration 0021).
-  const rows = await db
+  // First, find candidates — only tenants whose latest signup-verification
+  // invitation is older than cutoff count. MAX(invitations.expiresAt) handles
+  // the "freshly resent" case: a resend within the last hour bumps expiresAt
+  // forward, keeping the tenant alive.
+  const candidates = await db
     .select({ id: tenants.id })
     .from(tenants)
-    .leftJoin(invitations, eq(tenants.id, invitations.orgId))
+    .innerJoin(invitations, eq(tenants.id, invitations.orgId))
     .where(
       and(
         eq(tenants.status, "provisional"),
         eq(tenants.createdVia, "self_serve"),
         isNull(tenants.verifiedAt),
-        or(
-          sql`${tenants.createdAt} < ${cutoff.toISOString()}`,
-          sql`${invitations.expiresAt} < ${cutoff.toISOString()}`,
-        ),
+        eq(invitations.purpose, "signup_verification"),
+        lt(invitations.expiresAt, cutoff),
       ),
     );
 
-  if (rows.length === 0) return 0;
+  if (candidates.length === 0) return 0;
 
-  const ids = [...new Set(rows.map((r) => r.id))];
-  await db.delete(tenants).where(inArray(tenants.id, ids));
-  return ids.length;
+  const ids = [...new Set(candidates.map((r) => r.id))];
+  // Atomic re-assertion of invariants — even if a verify tx raced the SELECT
+  // above, a verified tenant is skipped here.
+  const deleted = await db
+    .delete(tenants)
+    .where(
+      and(
+        inArray(tenants.id, ids),
+        eq(tenants.status, "provisional"),
+        isNull(tenants.verifiedAt),
+        eq(tenants.createdVia, "self_serve"),
+      ),
+    )
+    .returning({ id: tenants.id });
+  return deleted.length;
 }

--- a/packages/api/src/modules/signup/service.ts
+++ b/packages/api/src/modules/signup/service.ts
@@ -1,0 +1,467 @@
+/**
+ * Self-serve signup service (issue #108 / ADR-016).
+ *
+ * Three core flows — signup → verify → lookup + a resend helper — with
+ * audit + outbox emission at each state transition. Keycloak provisioning
+ * (Organization creation + invite) lands with issue #114 once the realm
+ * is on Keycloak 26; until then the verification token lives on an
+ * `invitations` row keyed by a random uuid.
+ */
+
+import { randomUUID } from "node:crypto";
+import { isPersonalEmailDomain } from "@givernance/shared/constants";
+import {
+  auditLogs,
+  invitations,
+  outboxEvents,
+  type TenantStatus,
+  tenantDomains,
+  tenants,
+  users,
+} from "@givernance/shared/schema";
+import { validateTenantSlug } from "@givernance/shared/validators";
+import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { db } from "../../lib/db.js";
+
+const PROVISIONAL_GRACE_DAYS = 7;
+const VERIFICATION_TTL_HOURS = 24;
+
+export type SignupError =
+  | { kind: "disposable_email" }
+  | { kind: "invalid_slug"; reason: "syntax" | "reserved" | "punycode" }
+  | { kind: "slug_taken" }
+  | { kind: "email_in_use"; hint: string };
+
+export type SignupResult =
+  | { ok: true; tenantId: string; email: string; verificationToken: string }
+  | { ok: false; error: SignupError };
+
+export interface SignupInput {
+  orgName: string;
+  slug: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  country?: string;
+  ipHash?: string;
+  userAgent?: string;
+}
+
+/**
+ * Split an email into local / domain (lowercased). Returns `null` on a
+ * trivially invalid value — the TypeBox schema catches format, this is
+ * defence-in-depth.
+ */
+function splitEmail(email: string): { local: string; domain: string } | null {
+  const at = email.lastIndexOf("@");
+  if (at < 1 || at === email.length - 1) return null;
+  return {
+    local: email.slice(0, at).toLowerCase(),
+    domain: email.slice(at + 1).toLowerCase(),
+  };
+}
+
+/**
+ * Generate a verification token. Uses `randomUUID()` because the underlying
+ * `invitations.token` column is `uuid`. 122 bits of entropy — plenty for a
+ * 24h single-use verification token.
+ */
+function generateVerificationToken(): string {
+  return randomUUID();
+}
+
+// ─── Signup ─────────────────────────────────────────────────────────────────
+
+export async function signup(input: SignupInput): Promise<SignupResult> {
+  const parsedEmail = splitEmail(input.email);
+  if (!parsedEmail) {
+    return { ok: false, error: { kind: "disposable_email" } };
+  }
+
+  // Slug: validator may normalise (trim + lowercase) and returns the canonical value.
+  const slugCheck = validateTenantSlug(input.slug);
+  if (!slugCheck.ok) {
+    return { ok: false, error: { kind: "invalid_slug", reason: slugCheck.reason } };
+  }
+  const canonicalSlug = slugCheck.slug;
+
+  // Reject disposable / personal domains outright — this blocks the obvious
+  // signup abuse vector (hundreds of gmail aliases). Personal-email users
+  // can still be invited into a tenant by an existing admin.
+  if (isPersonalEmailDomain(parsedEmail.domain)) {
+    // We allow signups from personal email, but we block the orgs themselves
+    // from claiming domains. So personal-email signup IS allowed. Only block
+    // known disposable-email providers here.
+    // Upstream we have a curated list (`personal-email-domains.ts`) that
+    // includes both categories; filtering out disposables specifically is a
+    // follow-up (we'll add a separate `DISPOSABLE_EMAIL_DOMAINS` list).
+    // For now: allow personal emails, block nothing extra.
+  }
+
+  // Existing-slug short-circuit.
+  const [existingSlug] = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(eq(tenants.slug, canonicalSlug))
+    .limit(1);
+  if (existingSlug) {
+    return { ok: false, error: { kind: "slug_taken" } };
+  }
+
+  // "Your org is already on Givernance" detection: if the signup email's
+  // domain is a *verified* custom domain, nudge the user to ask the existing
+  // admin for an invitation rather than creating a second provisional tenant.
+  if (!isPersonalEmailDomain(parsedEmail.domain)) {
+    const [claimedDomain] = await db
+      .select({ orgId: tenantDomains.orgId })
+      .from(tenantDomains)
+      .where(and(eq(tenantDomains.domain, parsedEmail.domain), eq(tenantDomains.state, "verified")))
+      .limit(1);
+    if (claimedDomain) {
+      return {
+        ok: false,
+        error: {
+          kind: "email_in_use",
+          hint: "your_organization_already_on_givernance",
+        },
+      };
+    }
+  }
+
+  const token = generateVerificationToken();
+  const expiresAt = new Date(Date.now() + VERIFICATION_TTL_HOURS * 60 * 60 * 1000);
+
+  // All state changes happen in one transaction. Tenants has no RLS (admin-
+  // managed only), so we don't need withTenantContext — but outbox_events
+  // does, and we set the GUC to the freshly-inserted tenant id.
+  const tenantId = await db.transaction(async (tx) => {
+    const [tenant] = await tx
+      .insert(tenants)
+      .values({
+        name: input.orgName,
+        slug: canonicalSlug,
+        status: "provisional" as TenantStatus,
+        createdVia: "self_serve",
+      })
+      .returning({ id: tenants.id });
+
+    // biome-ignore lint/style/noNonNullAssertion: returning() always yields one row
+    const t = tenant!;
+
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${t.id}, true)`);
+
+    // Verification token stored as an invitations row. The invitation
+    // doubles as the "first admin will be created on verify" signal:
+    // role=org_admin, email=signup email, orgId=new tenant id.
+    await tx.insert(invitations).values({
+      orgId: t.id,
+      email: input.email.trim().toLowerCase(),
+      role: "org_admin",
+      token,
+      expiresAt,
+    });
+
+    await tx.insert(outboxEvents).values([
+      {
+        tenantId: t.id,
+        type: "tenant.self_signup_started",
+        payload: {
+          tenantId: t.id,
+          slug: canonicalSlug,
+          orgName: input.orgName,
+          email: input.email,
+          country: input.country,
+        },
+      },
+      {
+        tenantId: t.id,
+        type: "tenant.signup_verification_requested",
+        payload: {
+          tenantId: t.id,
+          email: input.email,
+          verificationToken: token,
+          expiresAt: expiresAt.toISOString(),
+        },
+      },
+    ]);
+
+    await tx.insert(auditLogs).values({
+      orgId: t.id,
+      userId: null,
+      action: "tenant.self_signup_started",
+      resourceType: "tenant",
+      resourceId: t.id,
+      newValues: { slug: canonicalSlug, email: input.email, country: input.country },
+      ipHash: input.ipHash,
+      userAgent: input.userAgent,
+    });
+
+    return t.id;
+  });
+
+  return {
+    ok: true,
+    tenantId,
+    email: input.email.trim().toLowerCase(),
+    verificationToken: token,
+  };
+}
+
+// ─── Resend verification ────────────────────────────────────────────────────
+
+export type ResendResult =
+  | { ok: true; tenantId: string; email: string; verificationToken: string }
+  | { ok: false };
+
+/**
+ * Re-emit a verification token for a provisional tenant. Silently returns
+ * `{ok: true}` even when the email doesn't match anything — to avoid
+ * leaking which emails have pending signups.
+ */
+export async function resendVerification(email: string): Promise<ResendResult> {
+  const normalised = email.trim().toLowerCase();
+
+  const rows = await db
+    .select({
+      tenantId: tenants.id,
+      status: tenants.status,
+      invitationId: invitations.id,
+      invitationToken: invitations.token,
+      expiresAt: invitations.expiresAt,
+    })
+    .from(invitations)
+    .innerJoin(tenants, eq(invitations.orgId, tenants.id))
+    .where(
+      and(
+        eq(invitations.email, normalised),
+        isNull(invitations.acceptedAt),
+        eq(tenants.status, "provisional"),
+        eq(tenants.createdVia, "self_serve"),
+      ),
+    )
+    .limit(1);
+
+  if (rows.length === 0) {
+    return { ok: false };
+  }
+
+  const row = rows[0];
+  if (!row) return { ok: false };
+
+  const newToken = generateVerificationToken();
+  const expiresAt = new Date(Date.now() + VERIFICATION_TTL_HOURS * 60 * 60 * 1000);
+
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${row.tenantId}, true)`);
+
+    await tx
+      .update(invitations)
+      .set({ token: newToken, expiresAt })
+      .where(eq(invitations.id, row.invitationId));
+
+    await tx.insert(outboxEvents).values({
+      tenantId: row.tenantId,
+      type: "tenant.signup_verification_resent",
+      payload: {
+        tenantId: row.tenantId,
+        email: normalised,
+        verificationToken: newToken,
+        expiresAt: expiresAt.toISOString(),
+      },
+    });
+  });
+
+  return { ok: true, tenantId: row.tenantId, email: normalised, verificationToken: newToken };
+}
+
+// ─── Verify ─────────────────────────────────────────────────────────────────
+
+export type VerifyError = { kind: "invalid_or_expired" } | { kind: "already_verified" };
+
+export type VerifyResult =
+  | {
+      ok: true;
+      tenantId: string;
+      userId: string;
+      slug: string;
+      provisionalUntil: string;
+    }
+  | { ok: false; error: VerifyError };
+
+export interface VerifyInput {
+  token: string;
+  firstName: string;
+  lastName: string;
+  ipHash?: string;
+  userAgent?: string;
+}
+
+export async function verifySignup(input: VerifyInput): Promise<VerifyResult> {
+  return db.transaction(async (tx) => {
+    // Lookup the invitation without a tenant context (the signup flow is
+    // pre-auth; the token is the credential). `invitations` has RLS but
+    // the test/dev DB connects as the owner role (BYPASSRLS per ADR-009),
+    // and the prod API also reads invitations before resolving the tenant.
+    const [row] = await tx
+      .select({
+        invitationId: invitations.id,
+        orgId: invitations.orgId,
+        email: invitations.email,
+        role: invitations.role,
+        expiresAt: invitations.expiresAt,
+        acceptedAt: invitations.acceptedAt,
+        tenantSlug: tenants.slug,
+        tenantStatus: tenants.status,
+        createdVia: tenants.createdVia,
+      })
+      .from(invitations)
+      .innerJoin(tenants, eq(invitations.orgId, tenants.id))
+      .where(and(eq(invitations.token, input.token), eq(tenants.createdVia, "self_serve")))
+      .limit(1);
+
+    if (!row) {
+      return { ok: false, error: { kind: "invalid_or_expired" } } as const;
+    }
+    if (row.acceptedAt) {
+      return { ok: false, error: { kind: "already_verified" } } as const;
+    }
+    if (row.expiresAt < new Date()) {
+      return { ok: false, error: { kind: "invalid_or_expired" } } as const;
+    }
+
+    const provisionalUntil = new Date(Date.now() + PROVISIONAL_GRACE_DAYS * 24 * 60 * 60 * 1000);
+
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${row.orgId}, true)`);
+
+    await tx
+      .update(tenants)
+      .set({ status: "active", verifiedAt: new Date(), updatedAt: new Date() })
+      .where(eq(tenants.id, row.orgId));
+
+    const [newUser] = await tx
+      .insert(users)
+      .values({
+        orgId: row.orgId,
+        email: row.email,
+        firstName: input.firstName,
+        lastName: input.lastName,
+        role: "org_admin",
+        firstAdmin: true,
+        provisionalUntil,
+      })
+      .returning({ id: users.id });
+
+    // biome-ignore lint/style/noNonNullAssertion: returning() yields one row for single insert
+    const u = newUser!;
+
+    await tx
+      .update(invitations)
+      .set({ acceptedAt: new Date() })
+      .where(eq(invitations.id, row.invitationId));
+
+    await tx.insert(outboxEvents).values([
+      {
+        tenantId: row.orgId,
+        type: "tenant.verified",
+        payload: { tenantId: row.orgId, slug: row.tenantSlug },
+      },
+      {
+        tenantId: row.orgId,
+        type: "user.jit_provisioned",
+        payload: { userId: u.id, orgId: row.orgId, email: row.email, firstAdmin: true },
+      },
+    ]);
+
+    await tx.insert(auditLogs).values({
+      orgId: row.orgId,
+      userId: u.id,
+      action: "tenant.verified",
+      resourceType: "tenant",
+      resourceId: row.orgId,
+      newValues: { status: "active", firstAdmin: u.id },
+      ipHash: input.ipHash,
+      userAgent: input.userAgent,
+    });
+
+    return {
+      ok: true,
+      tenantId: row.orgId,
+      userId: u.id,
+      slug: row.tenantSlug,
+      provisionalUntil: provisionalUntil.toISOString(),
+    } as const;
+  });
+}
+
+// ─── Tenant lookup ──────────────────────────────────────────────────────────
+
+export interface TenantLookupResult {
+  hasExistingTenant: boolean;
+  /** Opaque hint the frontend can render: "contact_admin" | "create_new" */
+  hint: "contact_admin" | "create_new";
+  /**
+   * Slug of the existing tenant, if any. Never returned when the email's
+   * domain is personal — otherwise we'd create an enumeration oracle across
+   * the gmail.com / outlook.com user population.
+   */
+  orgSlug?: string;
+}
+
+export async function lookupTenantForEmail(email: string): Promise<TenantLookupResult> {
+  const parsed = splitEmail(email);
+  if (!parsed) return { hasExistingTenant: false, hint: "create_new" };
+
+  if (isPersonalEmailDomain(parsed.domain)) {
+    // Personal-email domains: never leak org existence.
+    return { hasExistingTenant: false, hint: "create_new" };
+  }
+
+  const [claimed] = await db
+    .select({ orgId: tenantDomains.orgId, slug: tenants.slug })
+    .from(tenantDomains)
+    .innerJoin(tenants, eq(tenantDomains.orgId, tenants.id))
+    .where(and(eq(tenantDomains.domain, parsed.domain), eq(tenantDomains.state, "verified")))
+    .limit(1);
+
+  if (claimed) {
+    return { hasExistingTenant: true, hint: "contact_admin", orgSlug: claimed.slug };
+  }
+  return { hasExistingTenant: false, hint: "create_new" };
+}
+
+// ─── Cleanup: unverified provisional tenants ────────────────────────────────
+
+/**
+ * Delete `provisional` + `self_serve` tenants whose verification token
+ * expired ≥ cutoff hours ago and whose `verified_at` is still null. Returns
+ * the number of tenants reaped. Intended to run on a 1h cron via BullMQ.
+ */
+export async function cleanupUnverifiedTenants(
+  cutoffHours = VERIFICATION_TTL_HOURS,
+): Promise<number> {
+  const cutoff = new Date(Date.now() - cutoffHours * 60 * 60 * 1000);
+
+  // Find tenants to delete. Tenant delete cascades to invitations, users,
+  // tenant_domains, tenant_admin_disputes (migration 0021).
+  const rows = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .leftJoin(invitations, eq(tenants.id, invitations.orgId))
+    .where(
+      and(
+        eq(tenants.status, "provisional"),
+        eq(tenants.createdVia, "self_serve"),
+        isNull(tenants.verifiedAt),
+        or(
+          sql`${tenants.createdAt} < ${cutoff.toISOString()}`,
+          sql`${invitations.expiresAt} < ${cutoff.toISOString()}`,
+        ),
+      ),
+    );
+
+  if (rows.length === 0) return 0;
+
+  const ids = [...new Set(rows.map((r) => r.id))];
+  await db.delete(tenants).where(inArray(tenants.id, ids));
+  return ids.length;
+}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -28,6 +28,12 @@ import { authPlugin } from "./plugins/auth.js";
 /** Create and configure the Fastify server instance */
 export async function createServer() {
   const app = Fastify({
+    // Trust proxy headers (X-Forwarded-For, X-Real-IP) so rate-limit keying
+    // and `ipHash` use the real client IP instead of the LB's internal IP
+    // (ADR-016 §8, PR #117 review SEC-3 / ENG-1). Production deployments can
+    // tighten this to an explicit CIDR via env (`TRUST_PROXY`) if the LB is
+    // on a fixed subnet.
+    trustProxy: process.env.TRUST_PROXY ?? true,
     logger: {
       level: env.LOG_LEVEL,
       base: { service: "givernance-api", env: process.env.NODE_ENV },

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -19,6 +19,7 @@ import { paymentRoutes, stripeWebhookRoute } from "./modules/payments/routes.js"
 import { pledgeRoutes } from "./modules/pledges/routes.js";
 import { publicDonationRoutes } from "./modules/public/routes.js";
 import { reportsRoutes } from "./modules/reports/routes.js";
+import { signupRoutes } from "./modules/signup/routes.js";
 import { tenantRoutes } from "./modules/tenants/routes.js";
 import { userRoutes } from "./modules/users/routes.js";
 import { auditPlugin } from "./plugins/audit.js";
@@ -107,6 +108,7 @@ export async function createServer() {
   await app.register(paymentRoutes, { prefix: "/v1" });
   await app.register(stripeWebhookRoute, { prefix: "/v1" });
   await app.register(publicDonationRoutes, { prefix: "/v1" });
+  await app.register(signupRoutes, { prefix: "/v1" });
   await app.register(reportsRoutes, { prefix: "/v1" });
   await app.register(impersonationRoutes, { prefix: "/v1" });
 

--- a/packages/api/src/tests/integration/signup.test.ts
+++ b/packages/api/src/tests/integration/signup.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Integration coverage for the public self-serve signup flow (issue #108).
+ *
+ * Exercises the four endpoints + the cleanup helper end-to-end against
+ * the real test DB (migration 0021 applied). CAPTCHA fails open in
+ * NODE_ENV=test so no external provider is hit.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  auditLogs,
+  invitations,
+  outboxEvents,
+  tenantDomains,
+  tenants,
+  users,
+} from "@givernance/shared/schema";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { redis } from "../../lib/redis.js";
+import { cleanupUnverifiedTenants } from "../../modules/signup/service.js";
+import { createServer } from "../../server.js";
+
+let app: FastifyInstance;
+
+/** Use a suite-unique prefix so signup slugs don't collide across runs. */
+const RUN = `sg${Date.now().toString(36)}${Math.floor(Math.random() * 1_000_000).toString(36)}`;
+const slug = (name: string) => `${RUN}-${name}`.slice(0, 48);
+
+/** Names we create in each test — cleaned up in `afterEach`. */
+const createdTenantSlugs = new Set<string>();
+
+function registerSlug(name: string): string {
+  const s = slug(name);
+  createdTenantSlugs.add(s);
+  return s;
+}
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+});
+
+beforeEach(async () => {
+  // Clear any rate-limiter state from Redis so signup/resend limits don't
+  // poison successive tests. `@fastify/rate-limit` stores counters under keys
+  // prefixed with the raw route + IP.
+  const keys = await redis.keys("*rate-limit*");
+  if (keys.length > 0) {
+    await redis.del(...keys);
+  }
+  // Also flush the db of previous test's runs' residue.
+  await redis.flushdb();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+afterEach(async () => {
+  if (createdTenantSlugs.size === 0) return;
+  const slugList = [...createdTenantSlugs];
+  const rows = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(inArray(tenants.slug, slugList));
+  const ids = rows.map((r) => r.id);
+  if (ids.length > 0) {
+    // audit_logs has ON DELETE RESTRICT on org_id AND an immutability trigger
+    // that blocks DELETE. Temporarily disable the trigger so test fixtures
+    // can be torn down; re-enable it immediately after. This matches the
+    // pattern that other integration tests would use if they generated audit
+    // logs — production never runs without the trigger.
+    await db.execute(sql`ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_immutable`);
+    try {
+      await db.delete(auditLogs).where(inArray(auditLogs.orgId, ids));
+    } finally {
+      await db.execute(sql`ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_immutable`);
+    }
+    await db.delete(outboxEvents).where(inArray(outboxEvents.tenantId, ids));
+    await db.delete(tenants).where(inArray(tenants.id, ids));
+  }
+  createdTenantSlugs.clear();
+});
+
+describe("POST /v1/public/signup", () => {
+  it("creates a provisional tenant + invitation + outbox events, returns 201", async () => {
+    const slugA = registerSlug("happy");
+    const email = `admin+${slugA}@example.org`;
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup",
+      headers: { "x-captcha-token": "test-token" },
+      payload: {
+        orgName: "Happy NGO",
+        slug: slugA,
+        firstName: "Happy",
+        lastName: "Admin",
+        email,
+        country: "FR",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { tenantId: string; email: string; checkEmail: true } }>();
+    expect(body.data.checkEmail).toBe(true);
+
+    const [tenant] = await db.select().from(tenants).where(eq(tenants.id, body.data.tenantId));
+    expect(tenant?.status).toBe("provisional");
+    expect(tenant?.createdVia).toBe("self_serve");
+    expect(tenant?.verifiedAt).toBeNull();
+    expect(tenant?.slug).toBe(slugA);
+
+    const [invite] = await db
+      .select()
+      .from(invitations)
+      .where(and(eq(invitations.orgId, body.data.tenantId), eq(invitations.email, email)));
+    expect(invite).toBeDefined();
+    expect(invite?.role).toBe("org_admin");
+    expect(invite?.acceptedAt).toBeNull();
+
+    const { rows: events } = await db.execute<{ type: string }>(
+      sql`SELECT type FROM outbox_events WHERE tenant_id = ${body.data.tenantId} ORDER BY created_at ASC`,
+    );
+    const types = events.map((r) => r.type);
+    expect(types).toContain("tenant.self_signup_started");
+    expect(types).toContain("tenant.signup_verification_requested");
+  });
+
+  it("rejects a reserved slug with 422", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup",
+      headers: { "x-captcha-token": "test-token" },
+      payload: {
+        orgName: "Admin NGO",
+        slug: "admin",
+        firstName: "A",
+        lastName: "B",
+        email: `admin+admin@example.org`,
+      },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it("rejects a duplicate slug with 422", async () => {
+    const slugD = registerSlug("dup");
+    const base = {
+      orgName: "Dup NGO",
+      slug: slugD,
+      firstName: "D",
+      lastName: "U",
+      email: `admin+${slugD}@example.org`,
+    };
+    const first = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup",
+      headers: { "x-captcha-token": "test-token" },
+      payload: base,
+    });
+    expect(first.statusCode).toBe(201);
+
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup",
+      headers: { "x-captcha-token": "test-token" },
+      payload: { ...base, email: `other+${slugD}@example.org` },
+    });
+    expect(second.statusCode).toBe(422);
+  });
+
+  it("rejects when the signup email's domain is already claimed by a verified tenant (422)", async () => {
+    // Seed an existing "big NGO" tenant with a verified domain.
+    const existingSlug = registerSlug("existing");
+    const [existingTenant] = await db
+      .insert(tenants)
+      .values({
+        name: "Existing NGO",
+        slug: existingSlug,
+        status: "active",
+        createdVia: "enterprise",
+      })
+      .returning({ id: tenants.id });
+    if (!existingTenant) throw new Error("seed failed");
+    const domain = `${RUN}.ngo`;
+    await db.insert(tenantDomains).values({
+      orgId: existingTenant.id,
+      domain,
+      state: "verified",
+      dnsTxtValue: `givernance-verify=${RUN}-padding-padding-padding`,
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup",
+      headers: { "x-captcha-token": "test-token" },
+      payload: {
+        orgName: "Competing NGO",
+        slug: registerSlug("compete"),
+        firstName: "C",
+        lastName: "O",
+        email: `alice@${domain}`,
+      },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it("allows a personal-email (gmail) signup since personal domains cannot claim tenant identity", async () => {
+    const slugP = registerSlug("personal");
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup",
+      headers: { "x-captcha-token": "test-token" },
+      payload: {
+        orgName: "Small NGO",
+        slug: slugP,
+        firstName: "Small",
+        lastName: "Admin",
+        email: `tresorier+${slugP}@gmail.com`,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+});
+
+describe("POST /v1/public/signup/resend", () => {
+  it("re-emits the verification token and outbox event when the email matches a provisional tenant", async () => {
+    const slugR = registerSlug("resend");
+    const email = `admin+${slugR}@example.org`;
+
+    await app.inject({
+      method: "POST",
+      url: "/v1/public/signup",
+      headers: { "x-captcha-token": "test-token" },
+      payload: {
+        orgName: "Resend NGO",
+        slug: slugR,
+        firstName: "R",
+        lastName: "E",
+        email,
+      },
+    });
+
+    const [invBefore] = await db
+      .select({ id: invitations.id, token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.email, email));
+    expect(invBefore).toBeDefined();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup/resend",
+      payload: { email },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const [invAfter] = await db
+      .select({ id: invitations.id, token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.email, email));
+    expect(invAfter?.token).not.toBe(invBefore?.token);
+  });
+
+  it("returns 204 even when the email is unknown (no enumeration oracle)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup/resend",
+      payload: { email: `never-registered-${RUN}@example.org` },
+    });
+    expect(res.statusCode).toBe(204);
+  });
+});
+
+describe("POST /v1/public/signup/verify", () => {
+  async function createSignup(
+    name: string,
+  ): Promise<{ tenantId: string; email: string; token: string }> {
+    const s = registerSlug(name);
+    const email = `admin+${s}@example.org`;
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup",
+      headers: { "x-captcha-token": "test-token" },
+      payload: {
+        orgName: `${name} NGO`,
+        slug: s,
+        firstName: "First",
+        lastName: "Last",
+        email,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const tenantId = res.json<{ data: { tenantId: string } }>().data.tenantId;
+    const [inv] = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.email, email));
+    return { tenantId, email, token: inv?.token ?? "" };
+  }
+
+  it("transitions the tenant to active + JIT-creates the first admin with provisional flag", async () => {
+    const { tenantId, email, token } = await createSignup("verify-happy");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup/verify",
+      payload: { token, firstName: "Alice", lastName: "Anderson" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { userId: string; provisionalUntil: string } }>();
+
+    const [tenant] = await db.select().from(tenants).where(eq(tenants.id, tenantId));
+    expect(tenant?.status).toBe("active");
+    expect(tenant?.verifiedAt).not.toBeNull();
+
+    const [user] = await db.select().from(users).where(eq(users.id, body.data.userId));
+    expect(user?.email).toBe(email);
+    expect(user?.firstAdmin).toBe(true);
+    expect(user?.provisionalUntil).not.toBeNull();
+    expect(user?.role).toBe("org_admin");
+
+    const [inv] = await db
+      .select({ acceptedAt: invitations.acceptedAt })
+      .from(invitations)
+      .where(eq(invitations.email, email));
+    expect(inv?.acceptedAt).not.toBeNull();
+  });
+
+  it("returns 422 when the same token is used twice", async () => {
+    const { token } = await createSignup("verify-twice");
+    const first = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup/verify",
+      payload: { token, firstName: "A", lastName: "B" },
+    });
+    expect(first.statusCode).toBe(201);
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup/verify",
+      payload: { token, firstName: "A", lastName: "B" },
+    });
+    expect(second.statusCode).toBe(422);
+  });
+
+  it("returns 410 when the token is unknown", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/public/signup/verify",
+      payload: {
+        token: "00000000-0000-0000-0000-000000000000",
+        firstName: "A",
+        lastName: "B",
+      },
+    });
+    expect(res.statusCode).toBe(410);
+  });
+});
+
+describe("GET /v1/public/tenants/lookup", () => {
+  it("returns contact_admin when the domain is already claimed", async () => {
+    const existingSlug = registerSlug("lookup-existing");
+    const [existing] = await db
+      .insert(tenants)
+      .values({
+        name: "Lookup NGO",
+        slug: existingSlug,
+        status: "active",
+        createdVia: "enterprise",
+      })
+      .returning({ id: tenants.id });
+    if (!existing) throw new Error("seed failed");
+    const domain = `${RUN}-lookup.ngo`;
+    await db.insert(tenantDomains).values({
+      orgId: existing.id,
+      domain,
+      state: "verified",
+      dnsTxtValue: `givernance-verify=${RUN}-lookup-padding-padding-xx`,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/public/tenants/lookup?email=${encodeURIComponent(`bob@${domain}`)}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { hasExistingTenant: boolean; hint: string; orgSlug?: string };
+    }>();
+    expect(body.data.hasExistingTenant).toBe(true);
+    expect(body.data.hint).toBe("contact_admin");
+    expect(body.data.orgSlug).toBe(existingSlug);
+  });
+
+  it("returns create_new for a personal-email domain even if someone has a gmail.com claim", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/public/tenants/lookup?email=${encodeURIComponent("someone@gmail.com")}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { hasExistingTenant: boolean; hint: string };
+    }>();
+    expect(body.data.hasExistingTenant).toBe(false);
+    expect(body.data.hint).toBe("create_new");
+  });
+});
+
+describe("cleanupUnverifiedTenants", () => {
+  it("deletes provisional self-serve tenants whose verification token has expired", async () => {
+    // Seed an expired provisional tenant directly.
+    const s = registerSlug("cleanup");
+    const [tenant] = await db
+      .insert(tenants)
+      .values({ name: "Cleanup NGO", slug: s, status: "provisional", createdVia: "self_serve" })
+      .returning({ id: tenants.id });
+    if (!tenant) throw new Error("seed failed");
+    const tid = tenant.id;
+    const expired = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    await db.insert(invitations).values({
+      orgId: tid,
+      email: `expired+${s}@example.org`,
+      role: "org_admin",
+      token: randomUUID(),
+      expiresAt: expired,
+    });
+    // Back-date the tenant's createdAt so the cutoff filter picks it up.
+    await db.execute(
+      sql`UPDATE tenants SET created_at = ${expired.toISOString()} WHERE id = ${tid}`,
+    );
+
+    const reaped = await cleanupUnverifiedTenants(24);
+    expect(reaped).toBeGreaterThanOrEqual(1);
+
+    const [check] = await db.select({ id: tenants.id }).from(tenants).where(eq(tenants.id, tid));
+    expect(check).toBeUndefined();
+    createdTenantSlugs.delete(s);
+  });
+
+  it("does NOT delete active tenants", async () => {
+    const s = registerSlug("cleanup-active");
+    const [tenant] = await db
+      .insert(tenants)
+      .values({
+        name: "Active NGO",
+        slug: s,
+        status: "active",
+        createdVia: "self_serve",
+        verifiedAt: new Date(),
+      })
+      .returning({ id: tenants.id });
+    if (!tenant) throw new Error("seed failed");
+
+    await cleanupUnverifiedTenants(24);
+
+    const [check] = await db
+      .select({ id: tenants.id })
+      .from(tenants)
+      .where(eq(tenants.id, tenant.id));
+    expect(check).toBeDefined();
+  });
+});

--- a/packages/api/src/tests/integration/signup.test.ts
+++ b/packages/api/src/tests/integration/signup.test.ts
@@ -44,15 +44,15 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  // Clear any rate-limiter state from Redis so signup/resend limits don't
-  // poison successive tests. `@fastify/rate-limit` stores counters under keys
-  // prefixed with the raw route + IP.
+  // Clear any rate-limiter + per-email signup counters from Redis so the
+  // 5/hour limits don't poison successive tests. Scoped deletes only — a
+  // full `flushdb` would destroy unrelated test fixtures (ENG-3).
   const keys = await redis.keys("*rate-limit*");
-  if (keys.length > 0) {
-    await redis.del(...keys);
+  const resendKeys = await redis.keys("signup:resend:*");
+  const all = [...keys, ...resendKeys];
+  if (all.length > 0) {
+    await redis.del(...all);
   }
-  // Also flush the db of previous test's runs' residue.
-  await redis.flushdb();
 });
 
 afterAll(async () => {
@@ -105,8 +105,8 @@ describe("POST /v1/public/signup", () => {
     });
 
     expect(res.statusCode).toBe(201);
-    const body = res.json<{ data: { tenantId: string; email: string; checkEmail: true } }>();
-    expect(body.data.checkEmail).toBe(true);
+    const body = res.json<{ data: { tenantId: string; email: string } }>();
+    expect(body.data.email).toBe(email);
 
     const [tenant] = await db.select().from(tenants).where(eq(tenants.id, body.data.tenantId));
     expect(tenant?.status).toBe("provisional");
@@ -146,7 +146,7 @@ describe("POST /v1/public/signup", () => {
     expect(res.statusCode).toBe(422);
   });
 
-  it("rejects a duplicate slug with 422", async () => {
+  it("rejects a duplicate slug with 409", async () => {
     const slugD = registerSlug("dup");
     const base = {
       orgName: "Dup NGO",
@@ -169,10 +169,10 @@ describe("POST /v1/public/signup", () => {
       headers: { "x-captcha-token": "test-token" },
       payload: { ...base, email: `other+${slugD}@example.org` },
     });
-    expect(second.statusCode).toBe(422);
+    expect(second.statusCode).toBe(409);
   });
 
-  it("rejects when the signup email's domain is already claimed by a verified tenant (422)", async () => {
+  it("rejects when the signup email's domain is already claimed by a verified tenant (409)", async () => {
     // Seed an existing "big NGO" tenant with a verified domain.
     const existingSlug = registerSlug("existing");
     const [existingTenant] = await db
@@ -205,7 +205,7 @@ describe("POST /v1/public/signup", () => {
         email: `alice@${domain}`,
       },
     });
-    expect(res.statusCode).toBe(422);
+    expect(res.statusCode).toBe(409);
   });
 
   it("allows a personal-email (gmail) signup since personal domains cannot claim tenant identity", async () => {
@@ -329,7 +329,7 @@ describe("POST /v1/public/signup/verify", () => {
     expect(inv?.acceptedAt).not.toBeNull();
   });
 
-  it("returns 422 when the same token is used twice", async () => {
+  it("returns 410 when the same token is used twice", async () => {
     const { token } = await createSignup("verify-twice");
     const first = await app.inject({
       method: "POST",
@@ -342,7 +342,8 @@ describe("POST /v1/public/signup/verify", () => {
       url: "/v1/public/signup/verify",
       payload: { token, firstName: "A", lastName: "B" },
     });
-    expect(second.statusCode).toBe(422);
+    // SEC-6: collapsed to a single 410 for every failure mode.
+    expect(second.statusCode).toBe(410);
   });
 
   it("returns 410 when the token is unknown", async () => {
@@ -386,11 +387,12 @@ describe("GET /v1/public/tenants/lookup", () => {
     });
     expect(res.statusCode).toBe(200);
     const body = res.json<{
-      data: { hasExistingTenant: boolean; hint: string; orgSlug?: string };
+      data: { hasExistingTenant: boolean; hint: string };
     }>();
     expect(body.data.hasExistingTenant).toBe(true);
     expect(body.data.hint).toBe("contact_admin");
-    expect(body.data.orgSlug).toBe(existingSlug);
+    // SEC-9: we do NOT leak the orgSlug publicly.
+    expect((body.data as Record<string, unknown>).orgSlug).toBeUndefined();
   });
 
   it("returns create_new for a personal-email domain even if someone has a gmail.com claim", async () => {
@@ -423,6 +425,7 @@ describe("cleanupUnverifiedTenants", () => {
       email: `expired+${s}@example.org`,
       role: "org_admin",
       token: randomUUID(),
+      purpose: "signup_verification",
       expiresAt: expired,
     });
     // Back-date the tenant's createdAt so the cutoff filter picks it up.

--- a/packages/api/src/tests/integration/tenant-onboarding-schema.test.ts
+++ b/packages/api/src/tests/integration/tenant-onboarding-schema.test.ts
@@ -221,19 +221,22 @@ describe("validateTenantSlug", () => {
 
 describe.sequential("tenants back-fill (migration 0021)", () => {
   it("existing seeded tenants have status='active' and created_via='enterprise'", async () => {
+    // Filter to the shared test-suite tenants only — other suites (e.g. the
+    // public-signup flow) legitimately create `provisional` rows in parallel,
+    // so a full-table scan here would be flaky.
     const rows = await db
       .select({
         id: tenants.id,
         status: tenants.status,
         createdVia: tenants.createdVia,
       })
-      .from(tenants);
-    // Every pre-existing tenant row inherits the new defaults from the migration.
+      .from(tenants)
+      .where(sql`${tenants.id} IN (${ONBOARD_A}, ${ONBOARD_B})`);
     for (const row of rows) {
       expect(row.status).toBe("active");
       expect(row.createdVia).toBe("enterprise");
     }
-    expect(rows.length).toBeGreaterThanOrEqual(2);
+    expect(rows.length).toBe(2);
   });
 
   it("existing users have first_admin=false after migration", async () => {

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -148,7 +148,17 @@ export const users = pgTable(
 
 // ─── Invitations ──────────────────────────────────────────────────────────────
 
-/** Invitations — pending email invitations for new users (email sending in Phase 2) */
+/** Purpose discriminator for invitation rows — team invite vs self-serve signup verification (migration 0022). */
+export const INVITATION_PURPOSE_VALUES = ["team_invite", "signup_verification"] as const;
+export type InvitationPurpose = (typeof INVITATION_PURPOSE_VALUES)[number];
+
+/**
+ * Invitations — pending email invitations for new users (team_invite) and
+ * self-serve signup verification tokens (signup_verification). The `purpose`
+ * discriminator (migration 0022) prevents cross-contamination: the
+ * `/v1/invitations/:token/accept` endpoint filters to `team_invite` and the
+ * `/v1/public/signup/verify` endpoint filters to `signup_verification`.
+ */
 export const invitations = pgTable(
   "invitations",
   {
@@ -160,6 +170,10 @@ export const invitations = pgTable(
     role: userRoleEnum("role").notNull().default("user"),
     token: uuid("token").notNull().defaultRandom().unique(),
     invitedById: uuid("invited_by_id").references(() => users.id, { onDelete: "set null" }),
+    purpose: varchar("purpose", { length: 32 })
+      .notNull()
+      .default("team_invite")
+      .$type<InvitationPurpose>(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     acceptedAt: timestamp("accepted_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -167,6 +181,7 @@ export const invitations = pgTable(
   (table) => [
     index("invitations_org_id_idx").on(table.orgId),
     index("invitations_token_idx").on(table.token),
+    index("invitations_purpose_idx").on(table.purpose),
   ],
 );
 


### PR DESCRIPTION
Closes #108.

Ships the four public endpoints that let a tiny NPO on personal email bring up a provisional tenant in under five minutes — the SMB track of the ADR-016 hybrid onboarding model.

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| \`POST\` | \`/v1/public/signup\` | Create provisional tenant + verification token. CAPTCHA-gated (fail-open in test), rate-limited 5/hour per IP. |
| \`POST\` | \`/v1/public/signup/resend\` | Rotate verification token. Always 204 — no enumeration oracle. |
| \`POST\` | \`/v1/public/signup/verify\` | Token → active tenant + JIT first-admin with \`provisional_until = now + 7d\`. |
| \`GET\` | \`/v1/public/tenants/lookup?email=…\` | Returns \`{hasExistingTenant, hint, orgSlug?}\`. Personal-email domains always return \`create_new\` to block cross-consumer enumeration. |

## Infra

- \`lib/captcha.ts\` — hCaptcha verifier, fail-open in test / fail-closed elsewhere.
- \`modules/signup/service.ts\` — shared service (\`signup\`, \`resendVerification\`, \`verifySignup\`, \`lookupTenantForEmail\`, \`cleanupUnverifiedTenants\`).
- \`HCAPTCHA_SECRET\` env var (optional).
- Route registered in \`server.ts\` under \`/v1\`.

## Keycloak note

Issue #108 describes a "Keycloak Admin API → create Organization + invite user with OTP Required Action" step. The dev realm is still on Keycloak 24 (no Organizations API), and the Admin client from #107 will wire those calls when #114 upgrades the realm. This PR mediates verification via an \`invitations\` row acting as the token — same outside contract, swappable internally.

## Test plan

- [x] \`pnpm run format\` / \`lint\` / \`typecheck\` / \`build\` — green
- [x] \`pnpm test\` — 290/290 passing
- [x] 14 new integration tests in \`signup.test.ts\` cover happy path, reserved/duplicate slug, domain-already-claimed, personal-email, resend (success + enumeration-safe 204), verify (double-consume, unknown token), lookup (claimed + personal-email), cleanup (happy + active-tenant-safe)
- [x] Back-fill assertion in \`tenant-onboarding-schema.test.ts\` scoped to its own seeded tenants so it stays stable under parallel signup tests

## Architecture

- **ADR-016** — SMB self-serve track.
- **ADR-009** — Scaleway Postgres + RLS patterns preserved.
- **ADR-013** — constants used via \`@givernance/shared/constants\` only.

## Out of scope

- Frontend pages (#109).
- Enterprise domain/IdP provisioning (#110).
- Real Keycloak Organization creation during signup (#114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)