### PR TITLE
[codex] Integrate exchange rates into donations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,9 @@ NEXT_PUBLIC_API_URL=http://localhost:3000/api
 # STRIPE_SECRET_KEY=sk_test_your_key_here
 # STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 
+# --- Exchange rates ----------------------------------------------
+# EXCHANGE_RATE_API_KEY=your_exchangerate_api_key_here
+
 # --- Relay (outbox poller) --------------------------------------
 OUTBOX_POLL_INTERVAL_MS=500
 

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -65,6 +65,8 @@ const EnvSchema = Type.Object({
   STRIPE_SECRET_KEY: Type.Optional(Type.String({ minLength: 1 })),
   /** Stripe webhook endpoint secret (whsec_...) */
   STRIPE_WEBHOOK_SECRET: Type.Optional(Type.String({ minLength: 1 })),
+  /** ExchangeRate-API key used for currency conversion refreshes */
+  EXCHANGE_RATE_API_KEY: Type.Optional(Type.String({ minLength: 1 })),
 });
 
 export type ApiEnv = Static<typeof EnvSchema>;

--- a/packages/api/src/modules/campaigns/service.ts
+++ b/packages/api/src/modules/campaigns/service.ts
@@ -235,7 +235,7 @@ export async function getCampaignStats(orgId: string, campaignId: string) {
 
     const [stats] = await tx
       .select({
-        totalRaisedCents: sql<number>`COALESCE(SUM(${donations.amountCents}), 0)`,
+        totalRaisedCents: sql<number>`COALESCE(SUM(${donations.amountBaseCents}), 0)`,
         donationCount: sql<number>`COUNT(${donations.id})`,
         uniqueDonors: sql<number>`COUNT(DISTINCT ${donations.constituentId})`,
       })
@@ -263,7 +263,7 @@ export async function getCampaignRoi(orgId: string, campaignId: string) {
 
     const [stats] = await tx
       .select({
-        totalRaisedCents: sql<number>`COALESCE(SUM(${donations.amountCents}), 0)`,
+        totalRaisedCents: sql<number>`COALESCE(SUM(${donations.amountBaseCents}), 0)`,
       })
       .from(donations)
       .where(and(eq(donations.campaignId, campaignId), eq(donations.orgId, orgId)));

--- a/packages/api/src/modules/donations/service.ts
+++ b/packages/api/src/modules/donations/service.ts
@@ -6,10 +6,12 @@ import {
   donations,
   outboxEvents,
   receipts,
+  tenants,
 } from "@givernance/shared/schema";
 import type { Pagination } from "@givernance/shared/types";
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { withTenantContext } from "../../lib/db.js";
+import { ExchangeRateService } from "../finance/exchange-rate-service.js";
 
 /** Thrown when allocation amounts don't sum to the donation total */
 export class AllocationSumMismatchError extends Error {
@@ -196,13 +198,23 @@ export async function createDonation(orgId: string, userId: string, input: Donat
 
   return withTenantContext(orgId, async (tx) => {
     // Verify constituent belongs to this tenant (FK check alone doesn't enforce RLS)
-    const [constituent] = await tx
-      .select({ id: constituents.id })
-      .from(constituents)
-      .where(and(eq(constituents.id, input.constituentId), eq(constituents.orgId, orgId)));
+    const [constituent, tenant] = await Promise.all([
+      tx
+        .select({ id: constituents.id })
+        .from(constituents)
+        .where(and(eq(constituents.id, input.constituentId), eq(constituents.orgId, orgId))),
+      tx.select({ baseCurrency: tenants.baseCurrency }).from(tenants).where(eq(tenants.id, orgId)),
+    ]);
 
-    if (!constituent) return null;
-    const currency = input.currency ?? "EUR";
+    if (!constituent[0]) return null;
+    const currency = (input.currency ?? "EUR").toUpperCase();
+    const baseCurrency = (tenant[0]?.baseCurrency ?? "EUR").toUpperCase();
+    const exchangeRateService = new ExchangeRateService({ dbClient: tx });
+    const convertedAmount = await exchangeRateService.convertAmountCents(
+      input.amountCents,
+      currency,
+      baseCurrency,
+    );
 
     const [donation] = await tx
       .insert(donations)
@@ -211,8 +223,8 @@ export async function createDonation(orgId: string, userId: string, input: Donat
         constituentId: input.constituentId,
         amountCents: input.amountCents,
         currency,
-        exchangeRate: "1",
-        amountBaseCents: input.amountCents,
+        exchangeRate: convertedAmount.exchangeRate.toFixed(8),
+        amountBaseCents: convertedAmount.amountBaseCents,
         campaignId: input.campaignId,
         paymentMethod: input.paymentMethod,
         paymentRef: input.paymentRef,

--- a/packages/api/src/modules/finance/exchange-rate-service.test.ts
+++ b/packages/api/src/modules/finance/exchange-rate-service.test.ts
@@ -1,0 +1,101 @@
+import { exchangeRates } from "@givernance/shared/schema";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { db, withTenantContext } from "../../lib/db.js";
+import { ExchangeRateService } from "./exchange-rate-service.js";
+
+const ORG_ID = "00000000-0000-0000-0000-000000000125";
+
+beforeAll(async () => {
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, base_currency)
+        VALUES (${ORG_ID}, 'Exchange Rate Org', 'exchange-rate-org', 'CHF')
+        ON CONFLICT (id) DO UPDATE SET base_currency = 'CHF'`,
+  );
+});
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM exchange_rates WHERE currency IN ('EUR', 'USD')`);
+});
+
+describe("ExchangeRateService", () => {
+  it("returns the tenant base currency", async () => {
+    await withTenantContext(ORG_ID, async (tx) => {
+      const service = new ExchangeRateService({ dbClient: tx });
+      await expect(service.getOrgBaseCurrency(ORG_ID)).resolves.toBe("CHF");
+    });
+  });
+
+  it("stores and returns a remote rate when no local rate exists", async () => {
+    process.env.EXCHANGE_RATE_API_KEY = "test-key";
+    await db.delete(exchangeRates).where(
+      and(eq(exchangeRates.currency, "EUR"), eq(exchangeRates.baseCurrency, "CHF")),
+    );
+
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          conversion_rates: {
+            CHF: 0.95,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await withTenantContext(ORG_ID, async (tx) => {
+      const service = new ExchangeRateService({ dbClient: tx, fetchImpl });
+      const lookup = await service.getRate("EUR", "CHF");
+
+      expect(lookup.rate).toBe(0.95);
+      expect(lookup.source).toBe("api");
+    });
+
+    const [stored] = await db
+      .select({ rate: exchangeRates.rate })
+      .from(exchangeRates)
+      .where(and(eq(exchangeRates.currency, "EUR"), eq(exchangeRates.baseCurrency, "CHF")))
+      .limit(1);
+
+    expect(Number(stored?.rate)).toBe(0.95);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the latest local rate when the remote call fails", async () => {
+    process.env.EXCHANGE_RATE_API_KEY = "test-key";
+    await db.delete(exchangeRates).where(
+      and(eq(exchangeRates.currency, "USD"), eq(exchangeRates.baseCurrency, "CHF")),
+    );
+
+    await db
+      .insert(exchangeRates)
+      .values({
+        currency: "USD",
+        baseCurrency: "CHF",
+        rate: "0.88000000",
+        date: "2026-04-22",
+      })
+      .onConflictDoUpdate({
+        target: [exchangeRates.currency, exchangeRates.baseCurrency, exchangeRates.date],
+        set: { rate: "0.88000000", updatedAt: new Date() },
+      });
+
+    const warn = vi.fn();
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error("boom"));
+
+    await withTenantContext(ORG_ID, async (tx) => {
+      const service = new ExchangeRateService({
+        dbClient: tx,
+        fetchImpl,
+        logger: { warn },
+      });
+      const lookup = await service.getRate("USD", "CHF");
+
+      expect(lookup.rate).toBe(0.88);
+      expect(lookup.source).toBe("local_fallback");
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/modules/finance/exchange-rate-service.test.ts
+++ b/packages/api/src/modules/finance/exchange-rate-service.test.ts
@@ -1,6 +1,7 @@
+import { clearExchangeRateApiCache } from "@givernance/shared";
 import { exchangeRates } from "@givernance/shared/schema";
 import { and, eq, sql } from "drizzle-orm";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { db, withTenantContext } from "../../lib/db.js";
 import { ExchangeRateService } from "./exchange-rate-service.js";
 
@@ -12,6 +13,10 @@ beforeAll(async () => {
         VALUES (${ORG_ID}, 'Exchange Rate Org', 'exchange-rate-org', 'CHF')
         ON CONFLICT (id) DO UPDATE SET base_currency = 'CHF'`,
   );
+});
+
+beforeEach(() => {
+  clearExchangeRateApiCache();
 });
 
 afterAll(async () => {
@@ -28,9 +33,9 @@ describe("ExchangeRateService", () => {
 
   it("stores and returns a remote rate when no local rate exists", async () => {
     process.env.EXCHANGE_RATE_API_KEY = "test-key";
-    await db.delete(exchangeRates).where(
-      and(eq(exchangeRates.currency, "EUR"), eq(exchangeRates.baseCurrency, "CHF")),
-    );
+    await db
+      .delete(exchangeRates)
+      .where(and(eq(exchangeRates.currency, "EUR"), eq(exchangeRates.baseCurrency, "CHF")));
 
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
@@ -63,9 +68,9 @@ describe("ExchangeRateService", () => {
 
   it("falls back to the latest local rate when the remote call fails", async () => {
     process.env.EXCHANGE_RATE_API_KEY = "test-key";
-    await db.delete(exchangeRates).where(
-      and(eq(exchangeRates.currency, "USD"), eq(exchangeRates.baseCurrency, "CHF")),
-    );
+    await db
+      .delete(exchangeRates)
+      .where(and(eq(exchangeRates.currency, "USD"), eq(exchangeRates.baseCurrency, "CHF")));
 
     await db
       .insert(exchangeRates)
@@ -97,5 +102,53 @@ describe("ExchangeRateService", () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalled();
+  });
+
+  it("caches failed remote lookups for one hour to avoid repeated API calls", async () => {
+    process.env.EXCHANGE_RATE_API_KEY = "test-key";
+    await db
+      .delete(exchangeRates)
+      .where(and(eq(exchangeRates.currency, "USD"), eq(exchangeRates.baseCurrency, "CHF")));
+
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error("timeout"));
+
+    await withTenantContext(ORG_ID, async (tx) => {
+      const service = new ExchangeRateService({ dbClient: tx, fetchImpl });
+
+      const firstLookup = await service.getRate("USD", "CHF");
+      const secondLookup = await service.getRate("USD", "CHF");
+
+      expect(firstLookup.source).toBe("default_fallback");
+      expect(secondLookup.source).toBe("default_fallback");
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes a strict timeout signal to the remote fetch", async () => {
+    process.env.EXCHANGE_RATE_API_KEY = "test-key";
+    await db
+      .delete(exchangeRates)
+      .where(and(eq(exchangeRates.currency, "EUR"), eq(exchangeRates.baseCurrency, "CHF")));
+
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          conversion_rates: {
+            CHF: 0.95,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await withTenantContext(ORG_ID, async (tx) => {
+      const service = new ExchangeRateService({ dbClient: tx, fetchImpl });
+      await service.getRate("EUR", "CHF");
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/packages/api/src/modules/finance/exchange-rate-service.ts
+++ b/packages/api/src/modules/finance/exchange-rate-service.ts
@@ -1,197 +1,26 @@
-import { exchangeRates, tenants } from "@givernance/shared/schema";
-import { and, desc, eq } from "drizzle-orm";
+import { ExchangeRateService as SharedExchangeRateService } from "@givernance/shared";
 import pino from "pino";
 import { env } from "../../env.js";
 import { db } from "../../lib/db.js";
-
-type DbClient = Pick<typeof db, "select" | "insert">;
-
-interface ExchangeRateApiResponse {
-  conversion_rates?: Record<string, number>;
-}
-
-export interface ExchangeRateLookup {
-  rate: number;
-  source: "same_currency" | "local_exact" | "api" | "local_fallback" | "default_fallback";
-}
-
-interface ExchangeRateServiceOptions {
-  dbClient?: DbClient;
-  fetchImpl?: typeof fetch;
-  logger?: { warn: (...args: unknown[]) => void };
-}
 
 const exchangeRateLogger = pino({
   level: env.LOG_LEVEL,
   base: { service: "givernance-api", module: "exchange-rate-service" },
 });
 
-function normalizeCurrency(currency: string) {
-  return currency.trim().toUpperCase();
+interface ExchangeRateServiceOptions {
+  dbClient?: Pick<typeof db, "select" | "insert">;
+  fetchImpl?: typeof fetch;
+  logger?: { warn: (...args: unknown[]) => void };
 }
 
-function todayIsoDate() {
-  return new Date().toISOString().slice(0, 10);
-}
-
-function parseRate(value: string | number | null | undefined) {
-  const rate = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(rate) && rate > 0 ? rate : null;
-}
-
-function toStoredRate(rate: number) {
-  return rate.toFixed(8);
-}
-
-async function getBaseCurrency(dbClient: DbClient, orgId: string) {
-  const [tenant] = await dbClient
-    .select({ baseCurrency: tenants.baseCurrency })
-    .from(tenants)
-    .where(eq(tenants.id, orgId));
-
-  return normalizeCurrency(tenant?.baseCurrency ?? "EUR");
-}
-
-export class ExchangeRateService {
-  private readonly dbClient: DbClient;
-  private readonly fetchImpl: typeof fetch;
-  private readonly logger: { warn: (...args: unknown[]) => void };
-
+export class ExchangeRateService extends SharedExchangeRateService {
   constructor(options: ExchangeRateServiceOptions = {}) {
-    this.dbClient = options.dbClient ?? db;
-    this.fetchImpl = options.fetchImpl ?? fetch;
-    this.logger = options.logger ?? exchangeRateLogger;
-  }
-
-  async getOrgBaseCurrency(orgId: string) {
-    return getBaseCurrency(this.dbClient, orgId);
-  }
-
-  async getRate(sourceCurrency: string, targetCurrency: string): Promise<ExchangeRateLookup> {
-    const source = normalizeCurrency(sourceCurrency);
-    const target = normalizeCurrency(targetCurrency);
-
-    if (source === target) {
-      return { rate: 1, source: "same_currency" };
-    }
-
-    const date = todayIsoDate();
-    const [exactRate] = await this.dbClient
-      .select({ rate: exchangeRates.rate })
-      .from(exchangeRates)
-      .where(
-        and(
-          eq(exchangeRates.currency, source),
-          eq(exchangeRates.baseCurrency, target),
-          eq(exchangeRates.date, date),
-        ),
-      )
-      .limit(1);
-
-    const localRate = parseRate(exactRate?.rate);
-    if (localRate) {
-      return { rate: localRate, source: "local_exact" };
-    }
-
-    const apiRate = await this.fetchAndStoreRate(source, target, date);
-    if (apiRate) {
-      return { rate: apiRate, source: "api" };
-    }
-
-    const [latestKnownRate] = await this.dbClient
-      .select({ rate: exchangeRates.rate, date: exchangeRates.date })
-      .from(exchangeRates)
-      .where(and(eq(exchangeRates.currency, source), eq(exchangeRates.baseCurrency, target)))
-      .orderBy(desc(exchangeRates.date), desc(exchangeRates.updatedAt))
-      .limit(1);
-
-    const fallbackRate = parseRate(latestKnownRate?.rate);
-    if (fallbackRate) {
-      this.logger.warn(
-        {
-          sourceCurrency: source,
-          targetCurrency: target,
-          fallbackRate,
-          fallbackDate: latestKnownRate?.date ?? null,
-        },
-        "exchange_rate.api_failed_using_latest_local_rate",
-      );
-      return { rate: fallbackRate, source: "local_fallback" };
-    }
-
-    this.logger.warn(
-      { sourceCurrency: source, targetCurrency: target },
-      "exchange_rate.no_rate_available_defaulting_to_1",
-    );
-    return { rate: 1, source: "default_fallback" };
-  }
-
-  async convertAmountCents(amountCents: number, sourceCurrency: string, targetCurrency: string) {
-    const lookup = await this.getRate(sourceCurrency, targetCurrency);
-    return {
-      exchangeRate: lookup.rate,
-      amountBaseCents: Math.round(amountCents * lookup.rate),
-      source: lookup.source,
-    };
-  }
-
-  private async fetchAndStoreRate(source: string, target: string, date: string) {
-    const apiKey = process.env.EXCHANGE_RATE_API_KEY ?? env.EXCHANGE_RATE_API_KEY;
-    if (!apiKey) {
-      this.logger.warn(
-        { sourceCurrency: source, targetCurrency: target },
-        "exchange_rate.api_key_missing_skipping_remote_fetch",
-      );
-      return null;
-    }
-
-    try {
-      const response = await this.fetchImpl(
-        `https://v6.exchangerate-api.com/v6/${apiKey}/latest/${source}`,
-      );
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      const payload = (await response.json()) as ExchangeRateApiResponse;
-      const rate = parseRate(payload.conversion_rates?.[target]);
-
-      if (!rate) {
-        throw new Error(`Missing conversion rate for ${target}`);
-      }
-
-      await this.dbClient
-        .insert(exchangeRates)
-        .values({
-          currency: source,
-          baseCurrency: target,
-          rate: toStoredRate(rate),
-          date,
-        })
-        .onConflictDoUpdate({
-          target: [
-            exchangeRates.currency,
-            exchangeRates.baseCurrency,
-            exchangeRates.date,
-          ],
-          set: {
-            rate: toStoredRate(rate),
-            updatedAt: new Date(),
-          },
-        });
-
-      return rate;
-    } catch (error) {
-      this.logger.warn(
-        {
-          sourceCurrency: source,
-          targetCurrency: target,
-          err: error instanceof Error ? error.message : String(error),
-        },
-        "exchange_rate.remote_fetch_failed",
-      );
-      return null;
-    }
+    super({
+      apiKey: process.env.EXCHANGE_RATE_API_KEY ?? env.EXCHANGE_RATE_API_KEY,
+      dbClient: options.dbClient ?? db,
+      fetchImpl: options.fetchImpl,
+      logger: options.logger ?? exchangeRateLogger,
+    });
   }
 }

--- a/packages/api/src/modules/finance/exchange-rate-service.ts
+++ b/packages/api/src/modules/finance/exchange-rate-service.ts
@@ -1,0 +1,197 @@
+import { exchangeRates, tenants } from "@givernance/shared/schema";
+import { and, desc, eq } from "drizzle-orm";
+import pino from "pino";
+import { env } from "../../env.js";
+import { db } from "../../lib/db.js";
+
+type DbClient = Pick<typeof db, "select" | "insert">;
+
+interface ExchangeRateApiResponse {
+  conversion_rates?: Record<string, number>;
+}
+
+export interface ExchangeRateLookup {
+  rate: number;
+  source: "same_currency" | "local_exact" | "api" | "local_fallback" | "default_fallback";
+}
+
+interface ExchangeRateServiceOptions {
+  dbClient?: DbClient;
+  fetchImpl?: typeof fetch;
+  logger?: { warn: (...args: unknown[]) => void };
+}
+
+const exchangeRateLogger = pino({
+  level: env.LOG_LEVEL,
+  base: { service: "givernance-api", module: "exchange-rate-service" },
+});
+
+function normalizeCurrency(currency: string) {
+  return currency.trim().toUpperCase();
+}
+
+function todayIsoDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function parseRate(value: string | number | null | undefined) {
+  const rate = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(rate) && rate > 0 ? rate : null;
+}
+
+function toStoredRate(rate: number) {
+  return rate.toFixed(8);
+}
+
+async function getBaseCurrency(dbClient: DbClient, orgId: string) {
+  const [tenant] = await dbClient
+    .select({ baseCurrency: tenants.baseCurrency })
+    .from(tenants)
+    .where(eq(tenants.id, orgId));
+
+  return normalizeCurrency(tenant?.baseCurrency ?? "EUR");
+}
+
+export class ExchangeRateService {
+  private readonly dbClient: DbClient;
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger: { warn: (...args: unknown[]) => void };
+
+  constructor(options: ExchangeRateServiceOptions = {}) {
+    this.dbClient = options.dbClient ?? db;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.logger = options.logger ?? exchangeRateLogger;
+  }
+
+  async getOrgBaseCurrency(orgId: string) {
+    return getBaseCurrency(this.dbClient, orgId);
+  }
+
+  async getRate(sourceCurrency: string, targetCurrency: string): Promise<ExchangeRateLookup> {
+    const source = normalizeCurrency(sourceCurrency);
+    const target = normalizeCurrency(targetCurrency);
+
+    if (source === target) {
+      return { rate: 1, source: "same_currency" };
+    }
+
+    const date = todayIsoDate();
+    const [exactRate] = await this.dbClient
+      .select({ rate: exchangeRates.rate })
+      .from(exchangeRates)
+      .where(
+        and(
+          eq(exchangeRates.currency, source),
+          eq(exchangeRates.baseCurrency, target),
+          eq(exchangeRates.date, date),
+        ),
+      )
+      .limit(1);
+
+    const localRate = parseRate(exactRate?.rate);
+    if (localRate) {
+      return { rate: localRate, source: "local_exact" };
+    }
+
+    const apiRate = await this.fetchAndStoreRate(source, target, date);
+    if (apiRate) {
+      return { rate: apiRate, source: "api" };
+    }
+
+    const [latestKnownRate] = await this.dbClient
+      .select({ rate: exchangeRates.rate, date: exchangeRates.date })
+      .from(exchangeRates)
+      .where(and(eq(exchangeRates.currency, source), eq(exchangeRates.baseCurrency, target)))
+      .orderBy(desc(exchangeRates.date), desc(exchangeRates.updatedAt))
+      .limit(1);
+
+    const fallbackRate = parseRate(latestKnownRate?.rate);
+    if (fallbackRate) {
+      this.logger.warn(
+        {
+          sourceCurrency: source,
+          targetCurrency: target,
+          fallbackRate,
+          fallbackDate: latestKnownRate?.date ?? null,
+        },
+        "exchange_rate.api_failed_using_latest_local_rate",
+      );
+      return { rate: fallbackRate, source: "local_fallback" };
+    }
+
+    this.logger.warn(
+      { sourceCurrency: source, targetCurrency: target },
+      "exchange_rate.no_rate_available_defaulting_to_1",
+    );
+    return { rate: 1, source: "default_fallback" };
+  }
+
+  async convertAmountCents(amountCents: number, sourceCurrency: string, targetCurrency: string) {
+    const lookup = await this.getRate(sourceCurrency, targetCurrency);
+    return {
+      exchangeRate: lookup.rate,
+      amountBaseCents: Math.round(amountCents * lookup.rate),
+      source: lookup.source,
+    };
+  }
+
+  private async fetchAndStoreRate(source: string, target: string, date: string) {
+    const apiKey = process.env.EXCHANGE_RATE_API_KEY ?? env.EXCHANGE_RATE_API_KEY;
+    if (!apiKey) {
+      this.logger.warn(
+        { sourceCurrency: source, targetCurrency: target },
+        "exchange_rate.api_key_missing_skipping_remote_fetch",
+      );
+      return null;
+    }
+
+    try {
+      const response = await this.fetchImpl(
+        `https://v6.exchangerate-api.com/v6/${apiKey}/latest/${source}`,
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const payload = (await response.json()) as ExchangeRateApiResponse;
+      const rate = parseRate(payload.conversion_rates?.[target]);
+
+      if (!rate) {
+        throw new Error(`Missing conversion rate for ${target}`);
+      }
+
+      await this.dbClient
+        .insert(exchangeRates)
+        .values({
+          currency: source,
+          baseCurrency: target,
+          rate: toStoredRate(rate),
+          date,
+        })
+        .onConflictDoUpdate({
+          target: [
+            exchangeRates.currency,
+            exchangeRates.baseCurrency,
+            exchangeRates.date,
+          ],
+          set: {
+            rate: toStoredRate(rate),
+            updatedAt: new Date(),
+          },
+        });
+
+      return rate;
+    } catch (error) {
+      this.logger.warn(
+        {
+          sourceCurrency: source,
+          targetCurrency: target,
+          err: error instanceof Error ? error.message : String(error),
+        },
+        "exchange_rate.remote_fetch_failed",
+      );
+      return null;
+    }
+  }
+}

--- a/packages/api/src/modules/reports/service.ts
+++ b/packages/api/src/modules/reports/service.ts
@@ -45,7 +45,7 @@ export async function getLybuntReport(
         c.last_name  AS "lastName",
         c.email,
         MAX(d.donated_at)::text AS "lastDonationAt",
-        COALESCE(SUM(d.amount_cents), 0)::int AS "totalDonatedCents"
+        COALESCE(SUM(d.amount_base_cents), 0)::int AS "totalDonatedCents"
       FROM constituents c
       INNER JOIN donations d ON d.constituent_id = c.id AND d.org_id = c.org_id
       WHERE c.org_id = ${orgId}
@@ -105,7 +105,7 @@ export async function getSybuntReport(
         c.last_name  AS "lastName",
         c.email,
         MAX(d.donated_at)::text AS "lastDonationAt",
-        COALESCE(SUM(d.amount_cents), 0)::int AS "totalDonatedCents"
+        COALESCE(SUM(d.amount_base_cents), 0)::int AS "totalDonatedCents"
       FROM constituents c
       INNER JOIN donations d ON d.constituent_id = c.id AND d.org_id = c.org_id
       WHERE c.org_id = ${orgId}

--- a/packages/api/src/tests/integration/campaigns.test.ts
+++ b/packages/api/src/tests/integration/campaigns.test.ts
@@ -6,8 +6,10 @@ import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, ORG_A, signToken, signTokenB } from "../helpers/auth.js";
 
 let app: FastifyInstance;
+const CAMPAIGN_STATS_ORG = "00000000-0000-0000-0000-000000000127";
 
 let constituentIdA: string;
+let statsConstituentId: string;
 
 beforeAll(async () => {
   app = await createServer();
@@ -23,6 +25,21 @@ beforeAll(async () => {
     payload: { firstName: "Campaign", lastName: "Donor", type: "donor" },
   });
   constituentIdA = res.json<{ data: { id: string } }>().data.id;
+
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, base_currency)
+        VALUES (${CAMPAIGN_STATS_ORG}, 'Campaign Stats Org', 'campaign-stats-org', 'CHF')
+        ON CONFLICT (id) DO UPDATE SET base_currency = 'CHF'`,
+  );
+
+  const statsToken = signToken(app, { org_id: CAMPAIGN_STATS_ORG });
+  const statsConstituentRes = await app.inject({
+    method: "POST",
+    url: "/v1/constituents?force=true",
+    headers: authHeader(statsToken),
+    payload: { firstName: "Stats", lastName: "Donor", type: "donor" },
+  });
+  statsConstituentId = statsConstituentRes.json<{ data: { id: string } }>().data.id;
 });
 
 afterAll(async () => {
@@ -574,7 +591,7 @@ describe("Campaign Stats & ROI", () => {
   let statsCampaignId: string;
 
   beforeAll(async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: CAMPAIGN_STATS_ORG });
 
     // Create campaign with cost
     const campaignRes = await app.inject({
@@ -585,33 +602,25 @@ describe("Campaign Stats & ROI", () => {
     });
     statsCampaignId = campaignRes.json<{ data: { id: string } }>().data.id;
 
-    // Create donations linked to this campaign
-    await app.inject({
-      method: "POST",
-      url: "/v1/donations",
-      headers: authHeader(token),
-      payload: {
-        constituentId: constituentIdA,
-        amountCents: 5000,
-        currency: "EUR",
-        campaignId: statsCampaignId,
-      },
-    });
-    await app.inject({
-      method: "POST",
-      url: "/v1/donations",
-      headers: authHeader(token),
-      payload: {
-        constituentId: constituentIdA,
-        amountCents: 15000,
-        currency: "EUR",
-        campaignId: statsCampaignId,
-      },
-    });
+    await db.execute(sql`
+      INSERT INTO donations (
+        org_id,
+        constituent_id,
+        amount_cents,
+        currency,
+        exchange_rate,
+        amount_base_cents,
+        campaign_id,
+        donated_at
+      )
+      VALUES
+        (${CAMPAIGN_STATS_ORG}, ${statsConstituentId}, 5000, 'EUR', 0.95000000, 4750, ${statsCampaignId}, NOW()),
+        (${CAMPAIGN_STATS_ORG}, ${statsConstituentId}, 15000, 'EUR', 0.95000000, 14250, ${statsCampaignId}, NOW())
+    `);
   });
 
   it("GET /v1/campaigns/:id/stats returns campaign statistics", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: CAMPAIGN_STATS_ORG });
     const res = await app.inject({
       method: "GET",
       url: `/v1/campaigns/${statsCampaignId}/stats`,
@@ -628,13 +637,13 @@ describe("Campaign Stats & ROI", () => {
       };
     }>();
     expect(body.data.campaignId).toBe(statsCampaignId);
-    expect(body.data.totalRaisedCents).toBe(20000);
+    expect(body.data.totalRaisedCents).toBe(19000);
     expect(body.data.donationCount).toBe(2);
     expect(body.data.uniqueDonors).toBe(1);
   });
 
   it("GET /v1/campaigns/:id/stats returns 404 for non-existent campaign", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: CAMPAIGN_STATS_ORG });
     const res = await app.inject({
       method: "GET",
       url: "/v1/campaigns/00000000-0000-0000-0000-ffffffffffff/stats",
@@ -645,7 +654,7 @@ describe("Campaign Stats & ROI", () => {
   });
 
   it("GET /v1/campaigns/:id/roi returns campaign ROI", async () => {
-    const token = signToken(app);
+    const token = signToken(app, { org_id: CAMPAIGN_STATS_ORG });
     const res = await app.inject({
       method: "GET",
       url: `/v1/campaigns/${statsCampaignId}/roi`,
@@ -657,10 +666,9 @@ describe("Campaign Stats & ROI", () => {
       data: { campaignId: string; totalRaisedCents: number; costCents: number; roi: number };
     }>();
     expect(body.data.campaignId).toBe(statsCampaignId);
-    expect(body.data.totalRaisedCents).toBe(20000);
+    expect(body.data.totalRaisedCents).toBe(19000);
     expect(body.data.costCents).toBe(10000);
-    // ROI = (20000 - 10000) / 10000 = 1.0
-    expect(body.data.roi).toBe(1.0);
+    expect(body.data.roi).toBe(0.9);
   });
 
   it("GET /v1/campaigns/:id/roi returns null ROI and null costCents when no cost set", async () => {

--- a/packages/api/src/tests/integration/donations.test.ts
+++ b/packages/api/src/tests/integration/donations.test.ts
@@ -7,10 +7,12 @@ import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, ORG_A, signToken, signTokenB } from "../helpers/auth.js";
 
 let app: FastifyInstance;
+const MULTI_CURRENCY_ORG = "00000000-0000-0000-0000-000000000126";
 
 let constituentIdA: string;
 let constituentIdB: string;
 let fundIdA: string;
+let multiCurrencyConstituentId: string;
 
 beforeAll(async () => {
   app = await createServer();
@@ -46,6 +48,21 @@ beforeAll(async () => {
     // biome-ignore lint/style/noNonNullAssertion: test setup — insert always returns a row
     fundIdA = fund!.id;
   });
+
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, base_currency)
+        VALUES (${MULTI_CURRENCY_ORG}, 'Donations Multi Currency Org', 'donations-multi-currency-org', 'CHF')
+        ON CONFLICT (id) DO UPDATE SET base_currency = 'CHF'`,
+  );
+
+  const multiCurrencyToken = signToken(app, { org_id: MULTI_CURRENCY_ORG });
+  const multiCurrencyConstituentRes = await app.inject({
+    method: "POST",
+    url: "/v1/constituents?force=true",
+    headers: authHeader(multiCurrencyToken),
+    payload: { firstName: "Multi", lastName: "Currency", type: "donor" },
+  });
+  multiCurrencyConstituentId = multiCurrencyConstituentRes.json<{ data: { id: string } }>().data.id;
 });
 
 afterAll(async () => {
@@ -93,6 +110,42 @@ describe("Donations CRUD", () => {
     });
 
     expect(res.statusCode).toBe(201);
+  });
+
+  it("POST /v1/donations computes amountBaseCents from the organization base currency", async () => {
+    await db.execute(
+      sql`INSERT INTO exchange_rates (currency, base_currency, rate, date)
+          VALUES ('EUR', 'CHF', 0.95000000, CURRENT_DATE)
+          ON CONFLICT (currency, base_currency, date)
+          DO UPDATE SET rate = EXCLUDED.rate, updated_at = NOW()`,
+    );
+
+    const token = signToken(app, { org_id: MULTI_CURRENCY_ORG });
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(token),
+      payload: {
+        constituentId: multiCurrencyConstituentId,
+        amountCents: 10000,
+        currency: "EUR",
+        paymentMethod: "bank_transfer",
+        paymentRef: `XCH-${Date.now()}`,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const donationId = res.json<{ data: { id: string } }>().data.id;
+    const row = await db.execute(
+      sql`SELECT amount_base_cents, exchange_rate
+          FROM donations
+          WHERE id = ${donationId}`,
+    );
+
+    expect(row.rows[0]).toMatchObject({
+      amount_base_cents: 9500,
+      exchange_rate: "0.95000000",
+    });
   });
 
   it("GET /v1/donations lists donations", async () => {

--- a/packages/api/src/tests/integration/reports.test.ts
+++ b/packages/api/src/tests/integration/reports.test.ts
@@ -17,10 +17,13 @@ beforeAll(async () => {
   app = await createServer();
   await app.ready();
   await ensureTestTenants();
+  await db.execute(sql`DELETE FROM outbox_events WHERE tenant_id = ${REPORTS_ORG}`);
+  await db.execute(sql`DELETE FROM donations WHERE org_id = ${REPORTS_ORG}`);
+  await db.execute(sql`DELETE FROM constituents WHERE org_id = ${REPORTS_ORG}`);
   await db.execute(
-    sql`INSERT INTO tenants (id, name, slug)
-        VALUES (${REPORTS_ORG}, 'Reports Org', 'reports-org')
-        ON CONFLICT (id) DO NOTHING`,
+    sql`INSERT INTO tenants (id, name, slug, base_currency)
+        VALUES (${REPORTS_ORG}, 'Reports Org', 'reports-org', 'CHF')
+        ON CONFLICT (id) DO UPDATE SET base_currency = 'CHF'`,
   );
 
   const tokenA = signToken(app, { org_id: REPORTS_ORG });
@@ -81,18 +84,18 @@ beforeAll(async () => {
     )
     VALUES
       -- LYBUNT donor: donated last year only
-      (${REPORTS_ORG}, ${lybuntId}, 5000, 'EUR', 1, 5000, ${`${lastYear}-06-15`}::timestamptz),
+      (${REPORTS_ORG}, ${lybuntId}, 5000, 'EUR', 0.98000000, 4900, ${`${lastYear}-06-15`}::timestamptz),
       -- SYBUNT donor: donated two years ago only
-      (${REPORTS_ORG}, ${sybuntId}, 3000, 'EUR', 1, 3000, ${`${twoYearsAgo}-03-10`}::timestamptz),
+      (${REPORTS_ORG}, ${sybuntId}, 3000, 'EUR', 0.93333333, 2800, ${`${twoYearsAgo}-03-10`}::timestamptz),
       -- Active donor: donated this year (should NOT appear in either report)
-      (${REPORTS_ORG}, ${activeId}, 10000, 'EUR', 1, 10000, ${`${thisYear}-01-20`}::timestamptz),
+      (${REPORTS_ORG}, ${activeId}, 10000, 'EUR', 0.97000000, 9700, ${`${thisYear}-01-20`}::timestamptz),
       -- Active donor also donated last year
-      (${REPORTS_ORG}, ${activeId}, 8000, 'EUR', 1, 8000, ${`${lastYear}-11-05`}::timestamptz),
+      (${REPORTS_ORG}, ${activeId}, 8000, 'EUR', 0.97500000, 7800, ${`${lastYear}-11-05`}::timestamptz),
       -- MultiYear donor: donated last year + two years ago (LYBUNT, total = 12000)
-      (${REPORTS_ORG}, ${multiYearId}, 7000, 'EUR', 1, 7000, ${`${lastYear}-04-01`}::timestamptz),
-      (${REPORTS_ORG}, ${multiYearId}, 5000, 'EUR', 1, 5000, ${`${twoYearsAgo}-09-20`}::timestamptz),
+      (${REPORTS_ORG}, ${multiYearId}, 7000, 'EUR', 0.97142857, 6800, ${`${lastYear}-04-01`}::timestamptz),
+      (${REPORTS_ORG}, ${multiYearId}, 5000, 'EUR', 0.94000000, 4700, ${`${twoYearsAgo}-09-20`}::timestamptz),
       -- Ancient donor: donated 3 years ago only (SYBUNT boundary, total = 2500)
-      (${REPORTS_ORG}, ${ancientId}, 2500, 'EUR', 1, 2500, ${`${threeYearsAgo}-12-01`}::timestamptz)
+      (${REPORTS_ORG}, ${ancientId}, 2500, 'EUR', 0.96000000, 2400, ${`${threeYearsAgo}-12-01`}::timestamptz)
   `);
 });
 
@@ -131,8 +134,7 @@ describe("LYBUNT Report", () => {
     const body = res.json<{ data: { firstName: string; totalDonatedCents: number }[] }>();
     const multiYear = body.data.find((d) => d.firstName === "MultiYear");
     expect(multiYear).toBeDefined();
-    // LYBUNT only sums last-year donations: 7000
-    expect(multiYear?.totalDonatedCents).toBe(7000);
+    expect(multiYear?.totalDonatedCents).toBe(6800);
   });
 
   it("does not include ancient-only donor (no last year donations)", async () => {
@@ -160,7 +162,7 @@ describe("LYBUNT Report", () => {
     const body = res.json<{ data: { firstName: string; totalDonatedCents: number }[] }>();
     const lybunt = body.data.find((d) => d.firstName === "Lybunt");
     expect(lybunt).toBeDefined();
-    expect(lybunt?.totalDonatedCents).toBe(5000);
+    expect(lybunt?.totalDonatedCents).toBe(4900);
   });
 
   it("GET /v1/reports/lybunt accepts year query parameter", async () => {
@@ -219,7 +221,7 @@ describe("SYBUNT Report", () => {
     const body = res.json<{ data: { firstName: string; totalDonatedCents: number }[] }>();
     const ancient = body.data.find((d) => d.firstName === "Ancient");
     expect(ancient).toBeDefined();
-    expect(ancient?.totalDonatedCents).toBe(2500);
+    expect(ancient?.totalDonatedCents).toBe(2400);
   });
 
   it("multi-year donor totalDonatedCents aggregates all past donations", async () => {
@@ -234,8 +236,7 @@ describe("SYBUNT Report", () => {
     const body = res.json<{ data: { firstName: string; totalDonatedCents: number }[] }>();
     const multiYear = body.data.find((d) => d.firstName === "MultiYear");
     expect(multiYear).toBeDefined();
-    // SYBUNT sums all past donations: 7000 + 5000 = 12000
-    expect(multiYear?.totalDonatedCents).toBe(12000);
+    expect(multiYear?.totalDonatedCents).toBe(11500);
   });
 
   it("Sybunt donor totalDonatedCents is correct", async () => {
@@ -249,7 +250,7 @@ describe("SYBUNT Report", () => {
     const body = res.json<{ data: { firstName: string; totalDonatedCents: number }[] }>();
     const sybunt = body.data.find((d) => d.firstName === "Sybunt");
     expect(sybunt).toBeDefined();
-    expect(sybunt?.totalDonatedCents).toBe(3000);
+    expect(sybunt?.totalDonatedCents).toBe(2800);
   });
 
   it("GET /v1/reports/sybunt without auth returns 401", async () => {

--- a/packages/shared/src/finance/exchange-rate-service.ts
+++ b/packages/shared/src/finance/exchange-rate-service.ts
@@ -1,0 +1,252 @@
+import { and, desc, eq } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type * as schema from "../schema/index.js";
+import { exchangeRates, tenants } from "../schema/index.js";
+
+type DbClient = Pick<NodePgDatabase<typeof schema>, "select" | "insert">;
+
+interface ExchangeRateApiResponse {
+  conversion_rates?: Record<string, number>;
+}
+
+export interface ExchangeRateLookup {
+  rate: number;
+  source:
+    | "same_currency"
+    | "local_exact"
+    | "api"
+    | "api_cache"
+    | "local_fallback"
+    | "default_fallback";
+}
+
+interface ExchangeRateCacheEntry {
+  expiresAt: number;
+  rate: number | null;
+}
+
+export interface ExchangeRateServiceOptions {
+  apiKey?: string;
+  cacheTtlMs?: number;
+  dbClient: DbClient;
+  fetchImpl?: typeof fetch;
+  logger?: { warn: (...args: unknown[]) => void };
+  timeoutMs?: number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 2_000;
+const exchangeRateApiCache = new Map<string, ExchangeRateCacheEntry>();
+
+function normalizeCurrency(currency: string) {
+  return currency.trim().toUpperCase();
+}
+
+function todayIsoDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function parseRate(value: string | number | null | undefined) {
+  const rate = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(rate) && rate > 0 ? rate : null;
+}
+
+function toStoredRate(rate: number) {
+  return rate.toFixed(8);
+}
+
+function getCacheKey(source: string, target: string, date: string) {
+  return `${source}:${target}:${date}`;
+}
+
+function readCachedRate(source: string, target: string, date: string) {
+  const cacheKey = getCacheKey(source, target, date);
+  const cached = exchangeRateApiCache.get(cacheKey);
+
+  if (!cached) {
+    return null;
+  }
+
+  if (cached.expiresAt <= Date.now()) {
+    exchangeRateApiCache.delete(cacheKey);
+    return null;
+  }
+
+  return cached;
+}
+
+async function getBaseCurrency(dbClient: DbClient, orgId: string) {
+  const [tenant] = await dbClient
+    .select({ baseCurrency: tenants.baseCurrency })
+    .from(tenants)
+    .where(eq(tenants.id, orgId));
+
+  return normalizeCurrency(tenant?.baseCurrency ?? "EUR");
+}
+
+export function clearExchangeRateApiCache() {
+  exchangeRateApiCache.clear();
+}
+
+export class ExchangeRateService {
+  private readonly apiKey?: string;
+  private readonly cacheTtlMs: number;
+  private readonly dbClient: DbClient;
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger: { warn: (...args: unknown[]) => void };
+  private readonly timeoutMs: number;
+
+  constructor(options: ExchangeRateServiceOptions) {
+    this.apiKey = options.apiKey;
+    this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.dbClient = options.dbClient;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.logger = options.logger ?? console;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async getOrgBaseCurrency(orgId: string) {
+    return getBaseCurrency(this.dbClient, orgId);
+  }
+
+  async getRate(sourceCurrency: string, targetCurrency: string): Promise<ExchangeRateLookup> {
+    const source = normalizeCurrency(sourceCurrency);
+    const target = normalizeCurrency(targetCurrency);
+
+    if (source === target) {
+      return { rate: 1, source: "same_currency" };
+    }
+
+    const date = todayIsoDate();
+    const [exactRate] = await this.dbClient
+      .select({ rate: exchangeRates.rate })
+      .from(exchangeRates)
+      .where(
+        and(
+          eq(exchangeRates.currency, source),
+          eq(exchangeRates.baseCurrency, target),
+          eq(exchangeRates.date, date),
+        ),
+      )
+      .limit(1);
+
+    const localRate = parseRate(exactRate?.rate);
+    if (localRate) {
+      return { rate: localRate, source: "local_exact" };
+    }
+
+    const cachedRate = readCachedRate(source, target, date);
+    if (cachedRate?.rate) {
+      return { rate: cachedRate.rate, source: "api_cache" };
+    }
+
+    const apiRate = cachedRate ? null : await this.fetchAndStoreRate(source, target, date);
+    if (apiRate) {
+      return { rate: apiRate, source: "api" };
+    }
+
+    const [latestKnownRate] = await this.dbClient
+      .select({ rate: exchangeRates.rate, date: exchangeRates.date })
+      .from(exchangeRates)
+      .where(and(eq(exchangeRates.currency, source), eq(exchangeRates.baseCurrency, target)))
+      .orderBy(desc(exchangeRates.date), desc(exchangeRates.updatedAt))
+      .limit(1);
+
+    const fallbackRate = parseRate(latestKnownRate?.rate);
+    if (fallbackRate) {
+      this.logger.warn(
+        {
+          sourceCurrency: source,
+          targetCurrency: target,
+          fallbackRate,
+          fallbackDate: latestKnownRate?.date ?? null,
+        },
+        "exchange_rate.api_failed_using_latest_local_rate",
+      );
+      return { rate: fallbackRate, source: "local_fallback" };
+    }
+
+    this.logger.warn(
+      { sourceCurrency: source, targetCurrency: target },
+      "exchange_rate.no_rate_available_defaulting_to_1",
+    );
+    return { rate: 1, source: "default_fallback" };
+  }
+
+  async convertAmountCents(amountCents: number, sourceCurrency: string, targetCurrency: string) {
+    const lookup = await this.getRate(sourceCurrency, targetCurrency);
+    return {
+      exchangeRate: lookup.rate,
+      amountBaseCents: Math.round(amountCents * lookup.rate),
+      source: lookup.source,
+    };
+  }
+
+  private async fetchAndStoreRate(source: string, target: string, date: string) {
+    if (!this.apiKey) {
+      this.logger.warn(
+        { sourceCurrency: source, targetCurrency: target },
+        "exchange_rate.api_key_missing_skipping_remote_fetch",
+      );
+      return null;
+    }
+
+    try {
+      const response = await this.fetchImpl(
+        `https://v6.exchangerate-api.com/v6/${this.apiKey}/latest/${source}`,
+        {
+          signal: AbortSignal.timeout(this.timeoutMs),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const payload = (await response.json()) as ExchangeRateApiResponse;
+      const rate = parseRate(payload.conversion_rates?.[target]);
+
+      if (!rate) {
+        throw new Error(`Missing conversion rate for ${target}`);
+      }
+
+      await this.dbClient
+        .insert(exchangeRates)
+        .values({
+          currency: source,
+          baseCurrency: target,
+          rate: toStoredRate(rate),
+          date,
+        })
+        .onConflictDoUpdate({
+          target: [exchangeRates.currency, exchangeRates.baseCurrency, exchangeRates.date],
+          set: {
+            rate: toStoredRate(rate),
+            updatedAt: new Date(),
+          },
+        });
+
+      exchangeRateApiCache.set(getCacheKey(source, target, date), {
+        expiresAt: Date.now() + this.cacheTtlMs,
+        rate,
+      });
+
+      return rate;
+    } catch (error) {
+      exchangeRateApiCache.set(getCacheKey(source, target, date), {
+        expiresAt: Date.now() + this.cacheTtlMs,
+        rate: null,
+      });
+
+      this.logger.warn(
+        {
+          sourceCurrency: source,
+          targetCurrency: target,
+          err: error instanceof Error ? error.message : String(error),
+        },
+        "exchange_rate.remote_fetch_failed",
+      );
+      return null;
+    }
+  }
+}

--- a/packages/shared/src/finance/index.ts
+++ b/packages/shared/src/finance/index.ts
@@ -1,0 +1,1 @@
+export * from "./exchange-rate-service.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,6 +2,7 @@
 
 export * from "./constants/index.js";
 export * from "./events/index.js";
+export * from "./finance/index.js";
 export * from "./jobs/index.js";
 export * from "./schema/index.js";
 export * from "./types/index.js";

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -39,6 +39,8 @@ const EnvSchema = Type.Object({
   LOG_LEVEL: LogLevel,
   /** Stripe secret key (sk_test_... or sk_live_...) */
   STRIPE_SECRET_KEY: Type.Optional(Type.String({ minLength: 1 })),
+  /** ExchangeRate-API key used for currency conversion refreshes */
+  EXCHANGE_RATE_API_KEY: Type.Optional(Type.String({ minLength: 1 })),
 });
 
 export type WorkerEnv = Static<typeof EnvSchema>;

--- a/packages/worker/src/processors/stripe-webhook.ts
+++ b/packages/worker/src/processors/stripe-webhook.ts
@@ -1,5 +1,6 @@
 /** Job processor — handle Stripe webhook events asynchronously */
 
+import { ExchangeRateService } from "@givernance/shared";
 import type { ProcessStripeWebhookJob } from "@givernance/shared/jobs";
 import {
   constituents,
@@ -10,6 +11,7 @@ import {
 } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
 import { eq, sql } from "drizzle-orm";
+import { env } from "../env.js";
 import { db, withWorkerContext } from "../lib/db.js";
 import { jobLogger } from "../lib/logger.js";
 
@@ -100,6 +102,18 @@ async function handlePaymentIntentSucceeded(
   const campaignId = metadata.campaign_id || null;
 
   await withWorkerContext(orgId, async (tx) => {
+    const exchangeRateService = new ExchangeRateService({
+      apiKey: env.EXCHANGE_RATE_API_KEY,
+      dbClient: tx,
+      logger: log,
+    });
+    const baseCurrency = await exchangeRateService.getOrgBaseCurrency(orgId);
+    const convertedAmount = await exchangeRateService.convertAmountCents(
+      amountCents,
+      currency,
+      baseCurrency,
+    );
+
     // Find or create constituent
     let constituentId: string;
 
@@ -151,8 +165,8 @@ async function handlePaymentIntentSucceeded(
         constituentId,
         amountCents,
         currency,
-        exchangeRate: "1",
-        amountBaseCents: amountCents,
+        exchangeRate: convertedAmount.exchangeRate.toFixed(8),
+        amountBaseCents: convertedAmount.amountBaseCents,
         campaignId: campaignId || undefined,
         paymentMethod: "stripe",
         paymentRef: paymentIntentId,
@@ -185,7 +199,15 @@ async function handlePaymentIntentSucceeded(
     });
 
     log.info(
-      { donationId, constituentId, amountCents, currency },
+      {
+        amountBaseCents: convertedAmount.amountBaseCents,
+        baseCurrency,
+        constituentId,
+        currency,
+        donationId,
+        exchangeRate: convertedAmount.exchangeRate,
+        amountCents,
+      },
       "Donation created from Stripe payment_intent.succeeded",
     );
   });

--- a/packages/worker/src/tests/integration/stripe-webhook.test.ts
+++ b/packages/worker/src/tests/integration/stripe-webhook.test.ts
@@ -1,6 +1,13 @@
-import { constituents, donations, outboxEvents, webhookEvents } from "@givernance/shared/schema";
+import { clearExchangeRateApiCache } from "@givernance/shared";
+import {
+  constituents,
+  donations,
+  exchangeRates,
+  outboxEvents,
+  webhookEvents,
+} from "@givernance/shared/schema";
 import { and, eq, sql } from "drizzle-orm";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "../../lib/db.js";
 import { processStripeWebhook } from "../../processors/stripe-webhook.js";
 
@@ -8,6 +15,7 @@ const ORG_ID = "00000000-0000-0000-0000-00000000000b";
 const ORG_ID_OTHER = "00000000-0000-0000-0000-00000000000c";
 const STRIPE_ACCOUNT_ID = "acct_test_worker";
 const STRIPE_ACCOUNT_ID_OTHER = "acct_test_other";
+const TODAY = new Date().toISOString().slice(0, 10);
 
 function makeMockJob(data: Record<string, unknown>) {
   return {
@@ -42,12 +50,19 @@ beforeAll(async () => {
   });
 });
 
+beforeEach(() => {
+  clearExchangeRateApiCache();
+});
+
 afterAll(async () => {
   // Cleanup in reverse dependency order
   await db.execute(sql`DELETE FROM outbox_events WHERE tenant_id IN (${ORG_ID}, ${ORG_ID_OTHER})`);
   await db.execute(sql`DELETE FROM donations WHERE org_id IN (${ORG_ID}, ${ORG_ID_OTHER})`);
   await db.execute(sql`DELETE FROM constituents WHERE org_id IN (${ORG_ID}, ${ORG_ID_OTHER})`);
   await db.execute(sql`DELETE FROM webhook_events WHERE stripe_event_id LIKE 'evt_test_%'`);
+  await db.execute(
+    sql`DELETE FROM exchange_rates WHERE currency = 'EUR' AND base_currency = 'CHF' AND date = ${TODAY}`,
+  );
 });
 
 describe("processStripeWebhook", () => {
@@ -217,5 +232,59 @@ describe("processStripeWebhook", () => {
       .from(donations)
       .where(and(eq(donations.orgId, ORG_ID), eq(donations.paymentRef, "pi_test_worker_123")));
     expect(dupes).toHaveLength(1);
+  });
+
+  it("computes amountBaseCents and exchangeRate from the organization base currency", async () => {
+    await db.execute(sql`UPDATE tenants SET base_currency = 'CHF' WHERE id = ${ORG_ID}`);
+    await db
+      .insert(exchangeRates)
+      .values({
+        currency: "EUR",
+        baseCurrency: "CHF",
+        rate: "0.90000000",
+        date: TODAY,
+      })
+      .onConflictDoUpdate({
+        target: [exchangeRates.currency, exchangeRates.baseCurrency, exchangeRates.date],
+        set: { rate: "0.90000000", updatedAt: new Date() },
+      });
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000e5",
+      stripeEventId: "evt_test_foreign_currency",
+      eventType: "payment_intent.succeeded",
+      accountId: STRIPE_ACCOUNT_ID,
+      payload: {},
+      status: "pending",
+      livemode: false,
+    });
+
+    const job = makeMockJob({
+      webhookEventId: "00000000-0000-0000-0000-0000000000e5",
+      stripeEventId: "evt_test_foreign_currency",
+      eventType: "payment_intent.succeeded",
+      accountId: STRIPE_ACCOUNT_ID,
+      payload: {
+        id: "pi_test_foreign_currency",
+        amount: 2500,
+        currency: "eur",
+        metadata: {
+          constituent_email: "stripe-fx@example.org",
+        },
+      },
+    });
+
+    await processStripeWebhook(job);
+
+    const [donation] = await db
+      .select()
+      .from(donations)
+      .where(
+        and(eq(donations.orgId, ORG_ID), eq(donations.paymentRef, "pi_test_foreign_currency")),
+      );
+
+    expect(donation?.exchangeRate).toBe("0.90000000");
+    expect(donation?.amountBaseCents).toBe(2250);
+
+    await db.execute(sql`UPDATE tenants SET base_currency = 'EUR' WHERE id = ${ORG_ID}`);
   });
 });


### PR DESCRIPTION
## What changed
- added `ExchangeRateService` to resolve source/target conversion rates from local `exchange_rates` rows, refresh from ExchangeRate-API when needed, and persist the fetched rate
- updated donation creation to convert `amountCents` into the tenant base currency and store `exchangeRate` plus `amountBaseCents`
- switched campaign stats, campaign ROI, and lifecycle reports to aggregate on `amount_base_cents`
- added env wiring and test coverage for the exchange-rate flow, safe fallbacks, and base-currency analytics

## Why
Campaign and reporting totals need to reflect the organization base currency instead of the original donation currency. This keeps dashboards and ROI consistent when donations arrive in multiple currencies.

## Impact
- donations now store converted base amounts at write time
- dashboards and reports read base-currency totals
- if the external exchange-rate API is unavailable, the API falls back to the latest local rate or `1` and logs a warning

## Validation
- `pnpm typecheck`
- `DATABASE_URL=postgresql://givernance:givernance_dev@localhost:5432/givernance_test pnpm db:migrate`
- `pnpm test`
