### PR TITLE
feat: complete multi-currency UI rollout

### DIFF
--- a/packages/api/src/modules/campaigns/routes.ts
+++ b/packages/api/src/modules/campaigns/routes.ts
@@ -1,6 +1,7 @@
 /** Campaign routes — full CRUD, stats, ROI, and document generation */
 
 import { CAMPAIGN_STATUS_VALUES, CAMPAIGN_TYPE_VALUES } from "@givernance/shared/schema";
+import { MULTI_CURRENCY_VALUES } from "@givernance/shared/validators";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { requireAuth, requireOrgAdmin } from "../../lib/guards.js";
@@ -31,6 +32,9 @@ const CampaignTypeSchema = Type.Union(CAMPAIGN_TYPE_VALUES.map((v) => Type.Liter
 
 /** Shared campaign status TypeBox union built from the canonical CAMPAIGN_STATUS_VALUES */
 const CampaignStatusSchema = Type.Union(CAMPAIGN_STATUS_VALUES.map((v) => Type.Literal(v)));
+const CampaignDefaultCurrencySchema = Type.Union(
+  MULTI_CURRENCY_VALUES.map((value) => Type.Literal(value)),
+);
 
 /** Idempotency-Key header schema — accepted on POST routes for future dedup enforcement */
 const IdempotencyKeyHeader = Type.Object({
@@ -46,6 +50,7 @@ const IdempotencyKeyHeader = Type.Object({
 const CampaignCreateBody = Type.Object({
   name: Type.String({ minLength: 1, maxLength: 255 }),
   type: CampaignTypeSchema,
+  defaultCurrency: Type.Optional(CampaignDefaultCurrencySchema),
   parentId: Type.Optional(Type.Union([UuidSchema, Type.Null()])),
   costCents: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
 });
@@ -54,6 +59,7 @@ const CampaignUpdateBody = Type.Object(
   {
     name: Type.Optional(Type.String({ minLength: 1, maxLength: 255 })),
     type: Type.Optional(CampaignTypeSchema),
+    defaultCurrency: Type.Optional(CampaignDefaultCurrencySchema),
     status: Type.Optional(
       Type.Union([Type.Literal("draft"), Type.Literal("active"), Type.Literal("closed")]),
     ),
@@ -73,6 +79,7 @@ const CampaignResponse = Type.Object({
   name: Type.String(),
   type: CampaignTypeSchema,
   status: CampaignStatusSchema,
+  defaultCurrency: CampaignDefaultCurrencySchema,
   parentId: Type.Union([UuidSchema, Type.Null()]),
   costCents: Type.Union([Type.Integer(), Type.Null()]),
   createdAt: Type.String(),
@@ -152,6 +159,7 @@ export async function campaignRoutes(app: FastifyInstance) {
       const body = request.body as {
         name: string;
         type: "nominative_postal" | "door_drop" | "digital";
+        defaultCurrency?: "EUR" | "GBP" | "CHF";
         parentId?: string | null;
         costCents?: number | null;
       };
@@ -222,6 +230,7 @@ export async function campaignRoutes(app: FastifyInstance) {
       const body = request.body as {
         name?: string;
         type?: "nominative_postal" | "door_drop" | "digital";
+        defaultCurrency?: "EUR" | "GBP" | "CHF";
         status?: "draft" | "active" | "closed";
         parentId?: string | null;
         costCents?: number | null;

--- a/packages/api/src/modules/campaigns/service.ts
+++ b/packages/api/src/modules/campaigns/service.ts
@@ -8,6 +8,7 @@ import { withTenantContext } from "../../lib/db.js";
 export interface CreateCampaignInput {
   name: string;
   type: "nominative_postal" | "door_drop" | "digital";
+  defaultCurrency?: "EUR" | "GBP" | "CHF";
   parentId?: string | null;
   costCents?: number | null;
 }
@@ -15,6 +16,7 @@ export interface CreateCampaignInput {
 export interface UpdateCampaignInput {
   name?: string;
   type?: "nominative_postal" | "door_drop" | "digital";
+  defaultCurrency?: "EUR" | "GBP" | "CHF";
   status?: "draft" | "active" | "closed";
   parentId?: string | null;
   costCents?: number | null;
@@ -84,6 +86,7 @@ export async function createCampaign(orgId: string, input: CreateCampaignInput, 
         orgId,
         name: input.name,
         type: input.type,
+        defaultCurrency: input.defaultCurrency ?? "EUR",
         parentId: input.parentId ?? null,
         costCents: input.costCents ?? null,
       })

--- a/packages/api/src/modules/public/routes.ts
+++ b/packages/api/src/modules/public/routes.ts
@@ -21,11 +21,12 @@ const PublicPageResponse = Type.Object({
   description: Type.Union([Type.String(), Type.Null()]),
   colorPrimary: Type.Union([Type.String(), Type.Null()]),
   goalAmountCents: Type.Union([Type.Integer(), Type.Null()]),
+  defaultCurrency: Type.Union([Type.Literal("EUR"), Type.Literal("GBP"), Type.Literal("CHF")]),
 });
 
 const DonateBody = Type.Object({
   amountCents: Type.Integer({ minimum: 100, maximum: 1000000 }),
-  currency: Type.Union([Type.Literal("EUR"), Type.Literal("CHF")]),
+  currency: Type.Union([Type.Literal("EUR"), Type.Literal("GBP"), Type.Literal("CHF")]),
   email: Type.String({ format: "email" }),
   firstName: Type.String({ minLength: 1, maxLength: 255 }),
   lastName: Type.String({ minLength: 1, maxLength: 255 }),
@@ -140,7 +141,7 @@ export async function publicDonationRoutes(app: FastifyInstance) {
       const { id } = request.params as { id: string };
       const body = request.body as {
         amountCents: number;
-        currency: "EUR" | "CHF";
+        currency: "EUR" | "GBP" | "CHF";
         email: string;
         firstName: string;
         lastName: string;

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -22,8 +22,10 @@ export async function getPublicPage(campaignId: string) {
       description: campaignPublicPages.description,
       colorPrimary: campaignPublicPages.colorPrimary,
       goalAmountCents: campaignPublicPages.goalAmountCents,
+      defaultCurrency: campaigns.defaultCurrency,
     })
     .from(campaignPublicPages)
+    .innerJoin(campaigns, eq(campaigns.id, campaignPublicPages.campaignId))
     .where(
       and(
         eq(campaignPublicPages.campaignId, campaignId),
@@ -82,7 +84,11 @@ export async function createDonationIntent(
 
   // Look up the campaign to find the org
   const [campaign] = await db
-    .select({ id: campaigns.id, orgId: campaigns.orgId })
+    .select({
+      id: campaigns.id,
+      orgId: campaigns.orgId,
+      defaultCurrency: campaigns.defaultCurrency,
+    })
     .from(campaigns)
     .where(eq(campaigns.id, campaignId));
 
@@ -112,6 +118,7 @@ export async function createDonationIntent(
     metadata: {
       campaign_id: campaignId,
       org_id: campaign.orgId,
+      campaign_default_currency: campaign.defaultCurrency,
       constituent_first_name: body.firstName,
       constituent_last_name: body.lastName,
     },

--- a/packages/api/src/modules/tenants/routes.ts
+++ b/packages/api/src/modules/tenants/routes.ts
@@ -24,11 +24,25 @@ const CreateTenantBody = Type.Object({
   ),
 });
 
+const TenantBaseCurrencySchema = Type.Union([
+  Type.Literal("EUR"),
+  Type.Literal("GBP"),
+  Type.Literal("CHF"),
+]);
+
+const UpdateTenantBody = Type.Object(
+  {
+    baseCurrency: Type.Optional(TenantBaseCurrencySchema),
+  },
+  { minProperties: 1 },
+);
+
 const TenantResponse = Type.Object({
   id: UuidSchema,
   name: Type.String(),
   slug: Type.String(),
   plan: Type.String(),
+  baseCurrency: TenantBaseCurrencySchema,
   createdAt: Type.String(),
   updatedAt: Type.String(),
 });
@@ -87,6 +101,73 @@ const TenantSnapshotResponse = Type.Object({
 });
 
 export async function tenantRoutes(app: FastifyInstance) {
+  /** GET /v1/admin/tenants/:orgId — fetch tenant settings for the owning org admin */
+  app.get(
+    "/admin/tenants/:orgId",
+    {
+      preHandler: requireSuperAdminOrOwnOrgAdmin,
+      schema: {
+        tags: ["Admin"],
+        params: OrgIdParams,
+        response: { 200: DataResponse(TenantResponse), ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const { orgId } = request.params as { orgId: string };
+      const [tenant] = await db.select().from(tenants).where(eq(tenants.id, orgId));
+
+      if (!tenant) {
+        const t = resolveTranslations(request);
+        return reply.status(404).send({
+          type: "https://httpproblems.com/http-status/404",
+          title: "Not Found",
+          status: 404,
+          detail: t("errors.notFound", { resource: t("resources.tenant") }),
+        });
+      }
+
+      return reply.send({ data: tenant });
+    },
+  );
+
+  /** PUT /v1/admin/tenants/:orgId — update tenant settings for the owning org admin */
+  app.put(
+    "/admin/tenants/:orgId",
+    {
+      preHandler: requireSuperAdminOrOwnOrgAdmin,
+      schema: {
+        tags: ["Admin"],
+        params: OrgIdParams,
+        body: UpdateTenantBody,
+        response: { 200: DataResponse(TenantResponse), ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const { orgId } = request.params as { orgId: string };
+      const body = request.body as { baseCurrency?: "EUR" | "GBP" | "CHF" };
+      const [updated] = await db
+        .update(tenants)
+        .set({
+          ...(body.baseCurrency ? { baseCurrency: body.baseCurrency } : {}),
+          updatedAt: new Date(),
+        })
+        .where(eq(tenants.id, orgId))
+        .returning();
+
+      if (!updated) {
+        const t = resolveTranslations(request);
+        return reply.status(404).send({
+          type: "https://httpproblems.com/http-status/404",
+          title: "Not Found",
+          status: 404,
+          detail: t("errors.notFound", { resource: t("resources.tenant") }),
+        });
+      }
+
+      return reply.send({ data: updated });
+    },
+  );
+
   /** GET /v1/admin/tenants/:orgId/snapshot — export tenant data as JSON */
   app.get(
     "/admin/tenants/:orgId/snapshot",

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -76,6 +76,12 @@ export const DonationAllocationSchema = Type.Object({
   amountCents: Type.Integer({ exclusiveMinimum: 0 }),
 });
 
+export const MULTI_CURRENCY_VALUES = ["EUR", "GBP", "CHF"] as const;
+export const MultiCurrencySchema = Type.Union(
+  MULTI_CURRENCY_VALUES.map((currency) => Type.Literal(currency)),
+  { default: "EUR" },
+);
+
 /** Schema for creating a new donation */
 export const DonationCreateSchema = Type.Object({
   constituentId: Type.String({ format: "uuid" }),
@@ -109,6 +115,7 @@ export const CampaignCreateSchema = Type.Object({
     Type.Literal("door_drop"),
     Type.Literal("digital"),
   ]),
+  defaultCurrency: Type.Optional(MultiCurrencySchema),
   parentId: Type.Optional(Type.Union([Type.String({ format: "uuid" }), Type.Null()])),
   costCents: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
 });

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -122,10 +122,32 @@
     }
   },
   "settings": {
-    "title": "Settings",
-    "subtitle": "Minimal organisation settings surface for the MVP demo.",
-    "breadcrumbRoot": "Dashboard",
-    "snapshot": {
+  "title": "Settings",
+  "subtitle": "Manage organisation-level defaults and export tools.",
+  "breadcrumbRoot": "Dashboard",
+  "tenant": {
+    "title": "Organisation settings",
+    "description": "Choose the tenant base currency used for reporting and currency conversions.",
+    "readOnly": "Only organisation admins can update tenant settings.",
+    "fields": {
+      "baseCurrency": "Base currency",
+      "baseCurrencyPlaceholder": "Select a base currency",
+      "baseCurrencyHint": "This currency is used as the organisation reporting currency.",
+      "baseCurrencyHintWithName": "{name} will use this currency for converted totals and reports."
+    },
+    "actions": {
+      "save": "Save settings",
+      "saving": "Saving…"
+    },
+    "errors": {
+      "load": "Unable to load organisation settings right now.",
+      "save": "Unable to save organisation settings right now."
+    },
+    "success": {
+      "updated": "Organisation settings updated."
+    }
+  },
+  "snapshot": {
       "badge": "ADM-001 MVP",
       "title": "Data export (GDPR / GL)",
       "description": "Download a JSON snapshot of the organisation data for portability, archival, or general-ledger handoff needs.",
@@ -396,12 +418,14 @@
           "description": "Parent campaign and target amount used for rollup and reporting."
         }
       },
-      "fields": {
-        "name": "Campaign name",
-        "namePlaceholder": "Spring appeal 2026",
-        "type": "Campaign type",
-        "parent": "Parent campaign",
-        "parentPlaceholder": "No parent campaign",
+    "fields": {
+      "name": "Campaign name",
+      "namePlaceholder": "Spring appeal 2026",
+      "type": "Campaign type",
+      "defaultCurrency": "Default currency",
+      "defaultCurrencyHint": "Preselected when donations are created from this campaign.",
+      "parent": "Parent campaign",
+      "parentPlaceholder": "No parent campaign",
         "parentHint": "Use a parent campaign to group related outreach.",
         "parentLoading": "Loading available campaigns…",
         "goal": "Goal amount",
@@ -579,9 +603,11 @@
         "lastNamePlaceholder": "Doe",
         "email": "Email",
         "emailPlaceholder": "jane.doe@example.org",
-        "amount": "Amount",
-        "amountPlaceholder": "50"
-      },
+    "amount": "Amount",
+    "amountPlaceholder": "50"
+    ,
+    "currency": "Currency"
+  },
       "actions": {
         "submit": "Continue to payment",
         "submitting": "Preparing…"
@@ -592,9 +618,9 @@
         "emailRequired": "Enter your email address.",
         "emailInvalid": "Enter a valid email address.",
         "amountRequired": "Enter a donation amount.",
-        "amountInvalid": "Amount must be at least €1.",
-        "generic": "Something went wrong while preparing payment. Please try again."
-      },
+    "amountInvalid": "Amount must be at least 1.",
+    "generic": "Something went wrong while preparing payment. Please try again."
+  },
       "success": {
         "intentCreated": "Your donation is ready. The Stripe payment step is the next integration.",
         "nextStepTitle": "Next step",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -122,10 +122,32 @@
     }
   },
   "settings": {
-    "title": "Paramètres",
-    "subtitle": "Configuration minimale de l'organisation pour la démo MVP.",
-    "breadcrumbRoot": "Tableau de bord",
-    "snapshot": {
+  "title": "Paramètres",
+  "subtitle": "Gérez les paramètres de l'organisation et les outils d'export.",
+  "breadcrumbRoot": "Tableau de bord",
+  "tenant": {
+    "title": "Paramètres de l'organisation",
+    "description": "Choisissez la devise de base du tenant utilisée pour le reporting et les conversions.",
+    "readOnly": "Seuls les administrateurs de l'organisation peuvent modifier ces paramètres.",
+    "fields": {
+      "baseCurrency": "Devise de base",
+      "baseCurrencyPlaceholder": "Choisissez une devise de base",
+      "baseCurrencyHint": "Cette devise est utilisée comme devise de reporting de l'organisation.",
+      "baseCurrencyHintWithName": "{name} utilisera cette devise pour les montants convertis et les rapports."
+    },
+    "actions": {
+      "save": "Enregistrer les paramètres",
+      "saving": "Enregistrement…"
+    },
+    "errors": {
+      "load": "Impossible de charger les paramètres de l'organisation pour le moment.",
+      "save": "Impossible d'enregistrer les paramètres de l'organisation pour le moment."
+    },
+    "success": {
+      "updated": "Paramètres de l'organisation mis à jour."
+    }
+  },
+  "snapshot": {
       "badge": "ADM-001 MVP",
       "title": "Export des données (RGPD / GL)",
       "description": "Téléchargez un snapshot JSON des données de l'organisation pour les besoins de portabilité, d'archivage ou de handoff comptable.",
@@ -396,12 +418,14 @@
           "description": "Campagne parente et montant cible utilisés pour le regroupement et le reporting."
         }
       },
-      "fields": {
-        "name": "Nom de la campagne",
-        "namePlaceholder": "Campagne de printemps 2026",
-        "type": "Type de campagne",
-        "parent": "Campagne parente",
-        "parentPlaceholder": "Aucune campagne parente",
+    "fields": {
+      "name": "Nom de la campagne",
+      "namePlaceholder": "Campagne de printemps 2026",
+      "type": "Type de campagne",
+      "defaultCurrency": "Devise par défaut",
+      "defaultCurrencyHint": "Préremplie lorsque des dons sont créés depuis cette campagne.",
+      "parent": "Campagne parente",
+      "parentPlaceholder": "Aucune campagne parente",
         "parentHint": "Utilisez une campagne parente pour regrouper des actions liées.",
         "parentLoading": "Chargement des campagnes disponibles…",
         "goal": "Montant cible",
@@ -579,9 +603,11 @@
         "lastNamePlaceholder": "Dupont",
         "email": "Email",
         "emailPlaceholder": "marie.dupont@exemple.org",
-        "amount": "Montant",
-        "amountPlaceholder": "50"
-      },
+    "amount": "Montant",
+    "amountPlaceholder": "50"
+    ,
+    "currency": "Devise"
+  },
       "actions": {
         "submit": "Continuer vers le paiement",
         "submitting": "Préparation…"
@@ -592,9 +618,9 @@
         "emailRequired": "Saisissez votre adresse e-mail.",
         "emailInvalid": "Saisissez une adresse e-mail valide.",
         "amountRequired": "Saisissez un montant de don.",
-        "amountInvalid": "Le montant doit être d'au moins 1 €.",
-        "generic": "Une erreur est survenue lors de la préparation du paiement. Réessayez."
-      },
+    "amountInvalid": "Le montant doit être d'au moins 1.",
+    "generic": "Une erreur est survenue lors de la préparation du paiement. Réessayez."
+  },
       "success": {
         "intentCreated": "Votre don est prêt. L'étape de paiement Stripe est la prochaine intégration.",
         "nextStepTitle": "Étape suivante",

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from "next-intl/server";
 import { SettingsSnapshotPanel } from "@/components/settings/settings-snapshot-panel";
+import { TenantSettingsForm } from "@/components/settings/tenant-settings-form";
 import { PageHeader } from "@/components/shared/page-header";
 import { requireAuth } from "@/lib/auth/guards";
 
@@ -19,6 +20,7 @@ export default async function SettingsPage() {
         description={t("subtitle")}
         breadcrumbs={[{ label: t("breadcrumbRoot"), href: "/dashboard" }, { label: t("title") }]}
       />
+      <TenantSettingsForm orgId={auth.orgId} canManageTenant={auth.roles.includes("org_admin")} />
       <SettingsSnapshotPanel orgId={auth.orgId} canExport={auth.roles.includes("org_admin")} />
     </div>
   );

--- a/packages/web/src/app/(public)/p/[id]/page.tsx
+++ b/packages/web/src/app/(public)/p/[id]/page.tsx
@@ -87,6 +87,7 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
               colorPrimary={colorPrimary}
               locale={locale}
               goalAmountCents={page.goalAmountCents}
+              defaultCurrency={page.defaultCurrency}
             />
           </div>
         </div>

--- a/packages/web/src/components/campaigns/campaign-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.test.tsx
@@ -10,6 +10,7 @@ const parentCampaign: Campaign = {
   name: "Regional Appeal",
   type: "digital",
   status: "active",
+  defaultCurrency: "EUR",
   parentId: null,
   costCents: 35000,
   createdAt: "2026-04-21T10:00:00.000Z",

--- a/packages/web/src/components/campaigns/campaign-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.tsx
@@ -38,7 +38,7 @@ import {
 import { toast } from "@/components/ui/toast";
 import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
-import type { Campaign, CampaignType } from "@/models/campaign";
+import type { Campaign, CampaignCurrency, CampaignType } from "@/models/campaign";
 import { CampaignService } from "@/services/CampaignService";
 
 const CAMPAIGN_TYPES: readonly CampaignType[] = [
@@ -46,10 +46,12 @@ const CAMPAIGN_TYPES: readonly CampaignType[] = [
   "door_drop",
   "digital",
 ] as const;
+const CAMPAIGN_CURRENCIES: readonly CampaignCurrency[] = ["EUR", "GBP", "CHF"] as const;
 
 interface CampaignFormValues {
   name: string;
   type: CampaignType;
+  defaultCurrency: CampaignCurrency;
   parentId: string;
   costCents: number | null;
 }
@@ -70,6 +72,7 @@ export function CampaignForm(props: CampaignFormProps) {
   const defaultValues: DefaultValues<CampaignFormValues> = {
     name: props.campaign?.name ?? "",
     type: props.campaign?.type ?? "digital",
+    defaultCurrency: props.campaign?.defaultCurrency ?? "EUR",
     parentId: props.campaign?.parentId ?? "",
     costCents: props.campaign?.costCents ?? null,
   };
@@ -200,6 +203,33 @@ export function CampaignForm(props: CampaignFormProps) {
                 </FormItem>
               )}
             />
+            <FormField
+              control={form.control}
+              name="defaultCurrency"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.defaultCurrency")}</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger aria-invalid={Boolean(form.formState.errors.defaultCurrency)}>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {CAMPAIGN_CURRENCIES.map((currency) => (
+                        <SelectItem key={currency} value={currency}>
+                          {currency}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-on-surface-variant">
+                    {t("fields.defaultCurrencyHint")}
+                  </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </div>
         </FormSection>
 
@@ -286,6 +316,7 @@ function toApiPayload(values: CampaignFormValues) {
   return {
     name: values.name?.trim() ?? "",
     type: values.type,
+    defaultCurrency: values.defaultCurrency,
     parentId: values.parentId?.trim() || null,
     costCents: values.costCents,
   };
@@ -302,6 +333,7 @@ function buildResolver(): Resolver<CampaignFormValues> {
     const cleaned: Record<string, unknown> = {
       name: values.name?.trim() ?? "",
       type: values.type,
+      defaultCurrency: values.defaultCurrency,
     };
 
     if (values.parentId?.trim() !== "") {

--- a/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
@@ -29,6 +29,7 @@ describe("CampaignPublicPageForm", () => {
           name: "Spring Appeal",
           type: "digital",
           status: "active",
+          defaultCurrency: "EUR",
           parentId: null,
           costCents: null,
           createdAt: "2026-01-01T00:00:00.000Z",

--- a/packages/web/src/components/campaigns/public-donation-form.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.tsx
@@ -6,10 +6,18 @@ import { type FormEvent, type ReactNode, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { toast } from "@/components/ui/toast";
 import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import { formatCurrency } from "@/lib/format";
+import type { PublicDonationCurrency } from "@/models/public-page";
 import { CampaignPublicPageService } from "@/services/CampaignPublicPageService";
 
 interface PublicDonationFormProps {
@@ -17,6 +25,7 @@ interface PublicDonationFormProps {
   colorPrimary: string;
   locale: string;
   goalAmountCents: number | null;
+  defaultCurrency?: PublicDonationCurrency;
 }
 
 interface PublicDonationFormValues {
@@ -24,6 +33,7 @@ interface PublicDonationFormValues {
   lastName: string;
   email: string;
   amount: string;
+  currency: PublicDonationCurrency;
 }
 
 interface FormErrors {
@@ -40,16 +50,22 @@ const DEFAULT_VALUES: PublicDonationFormValues = {
   lastName: "",
   email: "",
   amount: "",
+  currency: "EUR",
 };
+const PUBLIC_DONATION_CURRENCIES: PublicDonationCurrency[] = ["EUR", "GBP", "CHF"];
 
 export function PublicDonationForm({
   campaignId,
   colorPrimary,
   locale,
   goalAmountCents,
+  defaultCurrency = "EUR",
 }: PublicDonationFormProps) {
   const t = useTranslations("publicDonationPage.form");
-  const [values, setValues] = useState<PublicDonationFormValues>(DEFAULT_VALUES);
+  const [values, setValues] = useState<PublicDonationFormValues>({
+    ...DEFAULT_VALUES,
+    currency: defaultCurrency,
+  });
   const [errors, setErrors] = useState<FormErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [clientSecret, setClientSecret] = useState<string | null>(null);
@@ -69,7 +85,7 @@ export function PublicDonationForm({
         campaignId,
         {
           amountCents: parseAmountToCents(values.amount),
-          currency: "EUR",
+          currency: values.currency,
           email: values.email.trim(),
           firstName: values.firstName.trim(),
           lastName: values.lastName.trim(),
@@ -128,7 +144,7 @@ export function PublicDonationForm({
             <span className="block text-center text-lg font-semibold sm:text-xl">
               {new Intl.NumberFormat(locale, {
                 style: "currency",
-                currency: "EUR",
+                currency: values.currency,
                 maximumFractionDigits: 0,
               }).format(amount)}
             </span>
@@ -138,7 +154,7 @@ export function PublicDonationForm({
 
       {goalAmountCents !== null ? (
         <p className="mt-4 text-sm text-on-surface-variant">
-          {t("goal", { amount: formatCurrency(goalAmountCents, locale) })}
+          {t("goal", { amount: formatCurrency(goalAmountCents, locale, defaultCurrency) })}
         </p>
       ) : null}
 
@@ -213,7 +229,7 @@ export function PublicDonationForm({
           input={
             <div className="relative">
               <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-on-surface-variant">
-                €
+                {getCurrencySymbol(values.currency)}
               </span>
               <Input
                 id="public-donation-amount"
@@ -231,6 +247,33 @@ export function PublicDonationForm({
                 inputMode="decimal"
               />
             </div>
+          }
+        />
+
+        <Field
+          inputId="public-donation-currency"
+          label={t("fields.currency")}
+          input={
+            <Select
+              value={values.currency}
+              onValueChange={(currency) =>
+                setValues((current) => ({
+                  ...current,
+                  currency: currency as PublicDonationCurrency,
+                }))
+              }
+            >
+              <SelectTrigger id="public-donation-currency">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PUBLIC_DONATION_CURRENCIES.map((currency) => (
+                  <SelectItem key={currency} value={currency}>
+                    {currency}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           }
         />
 
@@ -263,6 +306,17 @@ export function PublicDonationForm({
       </form>
     </section>
   );
+}
+
+function getCurrencySymbol(currency: PublicDonationCurrency): string {
+  switch (currency) {
+    case "GBP":
+      return "£";
+    case "CHF":
+      return "CHF";
+    default:
+      return "€";
+  }
 }
 
 function Field({

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -57,14 +57,14 @@ import { toast } from "@/components/ui/toast";
 import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import { cn } from "@/lib/utils";
-import type { Campaign } from "@/models/campaign";
+import type { Campaign, CampaignCurrency } from "@/models/campaign";
 import { type Constituent, fullName } from "@/models/constituent";
 import type { DonationAllocationInput, DonationCreateInput } from "@/models/donation";
 import { CampaignService } from "@/services/CampaignService";
 import { ConstituentService } from "@/services/ConstituentService";
 import { DonationService } from "@/services/DonationService";
 
-const CURRENCIES = ["EUR", "GBP", "CHF", "SEK", "NOK", "DKK", "PLN", "CZK"] as const;
+const CURRENCIES: readonly CampaignCurrency[] = ["EUR", "GBP", "CHF"] as const;
 const PAYMENT_METHODS = ["wire", "cheque", "card", "sepa", "cash", "other"] as const;
 
 interface AllocationFormValue {
@@ -75,7 +75,7 @@ interface AllocationFormValue {
 interface DonationFormValues {
   constituentId: string;
   amountCents: number | null;
-  currency: (typeof CURRENCIES)[number];
+  currency: CampaignCurrency;
   campaignId: string;
   paymentMethod: (typeof PAYMENT_METHODS)[number] | "";
   paymentRef: string;
@@ -146,6 +146,24 @@ export function DonationForm() {
       active = false;
     };
   }, []);
+
+  useEffect(() => {
+    const subscription = form.watch((values, info) => {
+      if (info.name !== "campaignId") return;
+
+      const selectedCampaign = campaignOptions.find(
+        (campaign) => campaign.id === values.campaignId,
+      );
+      if (!selectedCampaign) return;
+
+      form.setValue("currency", selectedCampaign.defaultCurrency, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    });
+
+    return () => subscription.unsubscribe();
+  }, [campaignOptions, form]);
 
   async function onSubmit(values: DonationFormValues) {
     form.clearErrors("root");

--- a/packages/web/src/components/settings/tenant-settings-form.tsx
+++ b/packages/web/src/components/settings/tenant-settings-form.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Lock } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { TenantCurrency } from "@/models/tenant";
+import { TenantService } from "@/services/TenantService";
+
+const TENANT_CURRENCIES: TenantCurrency[] = ["EUR", "GBP", "CHF"];
+
+interface TenantSettingsFormProps {
+  orgId?: string;
+  canManageTenant: boolean;
+}
+
+export function TenantSettingsForm({ orgId, canManageTenant }: TenantSettingsFormProps) {
+  const t = useTranslations("settings.tenant");
+  const tenantOrgId = orgId;
+  const [baseCurrency, setBaseCurrency] = useState<TenantCurrency>("EUR");
+  const [initialCurrency, setInitialCurrency] = useState<TenantCurrency>("EUR");
+  const [tenantName, setTenantName] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!tenantOrgId || !canManageTenant) {
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+
+    async function loadTenant(nextOrgId: string) {
+      try {
+        const tenant = await TenantService.getTenant(createClientApiClient(), nextOrgId);
+        if (!active) return;
+        setTenantName(tenant.name);
+        setBaseCurrency(tenant.baseCurrency);
+        setInitialCurrency(tenant.baseCurrency);
+      } catch (error) {
+        if (!active) return;
+        const message =
+          error instanceof ApiProblem
+            ? (error.detail ?? error.title ?? t("errors.load"))
+            : t("errors.load");
+        setErrorMessage(message);
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    void loadTenant(tenantOrgId);
+
+    return () => {
+      active = false;
+    };
+  }, [canManageTenant, t, tenantOrgId]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!tenantOrgId || !canManageTenant || saving) return;
+
+    setSaving(true);
+    setErrorMessage(null);
+
+    try {
+      const tenant = await TenantService.updateTenant(createClientApiClient(), tenantOrgId, {
+        baseCurrency,
+      });
+      setTenantName(tenant.name);
+      setBaseCurrency(tenant.baseCurrency);
+      setInitialCurrency(tenant.baseCurrency);
+      toast.success(t("success.updated"));
+    } catch (error) {
+      const message =
+        error instanceof ApiProblem
+          ? (error.detail ?? error.title ?? t("errors.save"))
+          : t("errors.save");
+      setErrorMessage(message);
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const isDirty = baseCurrency !== initialCurrency;
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+      <div className="max-w-3xl">
+        <h2 className="font-heading text-2xl leading-tight text-on-surface">{t("title")}</h2>
+        <p className="mt-2 text-sm leading-6 text-on-surface-variant">{t("description")}</p>
+      </div>
+
+      {canManageTenant && tenantOrgId ? (
+        <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+          <div className="grid gap-5 md:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="tenant-base-currency" className="text-sm font-medium text-on-surface">
+                {t("fields.baseCurrency")}
+              </label>
+              <Select
+                value={baseCurrency}
+                onValueChange={(value) => setBaseCurrency(value as TenantCurrency)}
+                disabled={loading || saving}
+              >
+                <SelectTrigger id="tenant-base-currency" aria-label={t("fields.baseCurrency")}>
+                  <SelectValue placeholder={t("fields.baseCurrencyPlaceholder")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {TENANT_CURRENCIES.map((currency) => (
+                    <SelectItem key={currency} value={currency}>
+                      {currency}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-on-surface-variant">
+                {tenantName
+                  ? t("fields.baseCurrencyHintWithName", { name: tenantName })
+                  : t("fields.baseCurrencyHint")}
+              </p>
+            </div>
+          </div>
+
+          {errorMessage ? <p className="text-sm text-error">{errorMessage}</p> : null}
+
+          <div className="flex items-center justify-end gap-3">
+            <Button type="submit" disabled={loading || saving || !isDirty}>
+              {saving ? t("actions.saving") : t("actions.save")}
+            </Button>
+          </div>
+        </form>
+      ) : (
+        <div className="mt-6 inline-flex items-center gap-2 rounded-xl bg-surface-container px-4 py-3 text-sm text-on-surface-variant">
+          <Lock size={16} aria-hidden="true" />
+          <span>{t("readOnly")}</span>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/models/campaign.ts
+++ b/packages/web/src/models/campaign.ts
@@ -2,6 +2,7 @@ import type { Pagination } from "@/models/constituent";
 
 export type CampaignType = "nominative_postal" | "door_drop" | "digital";
 export type CampaignStatus = "draft" | "active" | "closed";
+export type CampaignCurrency = "EUR" | "GBP" | "CHF";
 
 export interface Campaign {
   id: string;
@@ -9,6 +10,7 @@ export interface Campaign {
   name: string;
   type: CampaignType;
   status: CampaignStatus;
+  defaultCurrency: CampaignCurrency;
   parentId: string | null;
   costCents: number | null;
   createdAt: string;
@@ -44,6 +46,7 @@ export interface CampaignDetailResponse {
 export interface CampaignCreateInput {
   name: string;
   type: CampaignType;
+  defaultCurrency?: CampaignCurrency;
   parentId?: string | null;
   costCents?: number | null;
 }

--- a/packages/web/src/models/public-page.ts
+++ b/packages/web/src/models/public-page.ts
@@ -1,7 +1,7 @@
 import type { CampaignPublicPageColor } from "@givernance/shared/validators";
 
 export type PublicPageStatus = "draft" | "published";
-export type PublicDonationCurrency = "EUR" | "CHF";
+export type PublicDonationCurrency = "EUR" | "GBP" | "CHF";
 
 export interface CampaignPublicPage {
   id: string;
@@ -27,6 +27,7 @@ export interface PublishedCampaignPublicPage {
   description: string | null;
   colorPrimary: CampaignPublicPageColor | null;
   goalAmountCents: number | null;
+  defaultCurrency: PublicDonationCurrency;
 }
 
 export interface PublishedCampaignPublicPageResponse {

--- a/packages/web/src/models/tenant.ts
+++ b/packages/web/src/models/tenant.ts
@@ -1,0 +1,19 @@
+export type TenantCurrency = "EUR" | "GBP" | "CHF";
+
+export interface Tenant {
+  id: string;
+  name: string;
+  slug: string;
+  plan: string;
+  baseCurrency: TenantCurrency;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TenantResponse {
+  data: Tenant;
+}
+
+export interface TenantUpdateInput {
+  baseCurrency: TenantCurrency;
+}

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -107,6 +107,7 @@ function mapCampaign(raw: Campaign): Campaign {
     name: raw.name,
     type: raw.type,
     status: raw.status,
+    defaultCurrency: raw.defaultCurrency,
     parentId: raw.parentId,
     costCents: raw.costCents,
     createdAt: raw.createdAt,
@@ -120,6 +121,7 @@ function toRequestBody(input: CampaignCreateInput | CampaignUpdateInput): Record
 
   if (input.name !== undefined) body.name = input.name;
   if (input.type !== undefined) body.type = input.type;
+  if (input.defaultCurrency !== undefined) body.defaultCurrency = input.defaultCurrency;
   if (maybeStatus.status !== undefined) body.status = maybeStatus.status;
   if (input.parentId !== undefined) body.parentId = input.parentId;
   if (input.costCents !== undefined) body.costCents = input.costCents;

--- a/packages/web/src/services/TenantService.ts
+++ b/packages/web/src/services/TenantService.ts
@@ -1,0 +1,19 @@
+import type { ApiClient } from "@/lib/api";
+import type { Tenant, TenantResponse, TenantUpdateInput } from "@/models/tenant";
+
+export const TenantService = {
+  async getTenant(client: ApiClient, orgId: string): Promise<Tenant> {
+    const response = await client.get<TenantResponse>(
+      `/v1/admin/tenants/${encodeURIComponent(orgId)}`,
+    );
+    return response.data;
+  },
+
+  async updateTenant(client: ApiClient, orgId: string, input: TenantUpdateInput): Promise<Tenant> {
+    const response = await client.put<TenantResponse>(
+      `/v1/admin/tenants/${encodeURIComponent(orgId)}`,
+      input,
+    );
+    return response.data;
+  },
+};


### PR DESCRIPTION
## What changed
- added tenant settings management in the app settings page with a new authenticated admin API to read and update `baseCurrency`
- exposed `defaultCurrency` on campaigns end to end and added the select to the campaign form
- added donation currency selection in the internal donation form and public donation page, with public page defaults now sourced from the campaign default currency
- updated shared/frontend models and translations for the new currency fields

## Why
The multi-currency backend and exchange-rate service were already in place, but the frontend still could not configure tenant/campaign currencies or send donation currency choices through to the API.

## Impact
- org admins can configure tenant reporting currency from Settings
- campaigns can define their default donation currency
- donation creation now sends EUR/GBP/CHF explicitly to the API
- public donation pages default to the selected campaign currency instead of assuming EUR

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test -- packages/web/src/components/campaigns/campaign-form.test.tsx packages/web/src/components/donations/donation-form.test.tsx packages/web/src/components/campaigns/public-donation-form.test.tsx packages/web/src/components/campaigns/campaign-public-page-form.test.tsx`

## Notes
- `pnpm lint` still reports pre-existing cognitive-complexity warnings in `packages/api/src/lib/keycloak-admin.ts` and a warning in the new tenant settings form, but the command exits successfully.
- no dedicated API integration tests were added in this pass.
