### PR TITLE
fix(api): avoid duplicate admin tenant detail route

### DIFF
--- a/packages/api/src/modules/tenant-admin/routes.ts
+++ b/packages/api/src/modules/tenant-admin/routes.ts
@@ -3,7 +3,7 @@
  *
  *  - `POST /v1/admin/tenants`                         — super-admin, create enterprise tenant.
  *  - `GET  /v1/admin/tenants`                         — super-admin, list + filter.
- *  - `GET  /v1/admin/tenants/:id`                     — super-admin, detail + tabs data.
+ *  - `GET  /v1/admin/tenants/:id/detail`              — super-admin, detail + tabs data.
  *  - `POST /v1/admin/tenants/:id/provision-idp`       — super-admin.
  *  - `PATCH /v1/admin/tenants/:id/idp`                — super-admin, rotate/patch config.
  *  - `DELETE /v1/admin/tenants/:id/idp`               — super-admin.
@@ -291,9 +291,9 @@ export async function tenantAdminRoutes(app: FastifyInstance) {
     },
   );
 
-  /** GET /v1/admin/tenants/:id — tenant detail + tabs payload (super-admin). */
+  /** GET /v1/admin/tenants/:id/detail — tenant detail + tabs payload (super-admin). */
   app.get(
-    "/admin/tenants/:id",
+    "/admin/tenants/:id/detail",
     {
       preHandler: requireSuperAdmin,
       schema: {


### PR DESCRIPTION
## Summary
- move the super-admin tenant detail endpoint from `/v1/admin/tenants/:id` to `/v1/admin/tenants/:id/detail`
- update the route comment to match the new path
- keep the owning-org-admin route `/v1/admin/tenants/:orgId` conflict-free for Fastify startup

## Validation
- `pnpm run build` ✅
- `pnpm test` ❌ fails in `packages/api/src/modules/health/routes.test.ts` on `POST /v1/tenants` returning `500` instead of `201` (reproduced independently of this route-path fix)
