### PR TITLE
[codex] Add super-admin tenant management UI

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -302,6 +302,112 @@
           }
         }
       }
+    },
+    "tenants": {
+      "list": {
+        "title": "Tenant management",
+        "subtitle": "Inspect every enterprise tenant and drill into lifecycle state, domains, users, and recent audit events.",
+        "columns": {
+          "name": "Tenant",
+          "status": "Status",
+          "plan": "Plan",
+          "primaryDomain": "Primary domain",
+          "createdVia": "Created via",
+          "updatedAt": "Last updated"
+        },
+        "statuses": {
+          "active": "Active",
+          "suspended": "Suspended",
+          "archived": "Archived"
+        },
+        "verification": {
+          "verified": "Verified",
+          "pending": "Pending"
+        },
+        "empty": {
+          "title": "No tenants found",
+          "description": "Tenant records created through the super-admin onboarding flow will appear here."
+        }
+      },
+      "detail": {
+        "backToList": "Back to tenants",
+        "statuses": {
+          "active": "Active",
+          "suspended": "Suspended",
+          "archived": "Archived"
+        },
+        "verification": {
+          "verified": "Verified",
+          "pending": "Pending"
+        },
+        "tabs": {
+          "overview": "Overview",
+          "domains": "Domains",
+          "users": "Users",
+          "audit": "Audit"
+        },
+        "overview": {
+          "fields": {
+            "slug": "Slug",
+            "plan": "Plan",
+            "createdVia": "Created via",
+            "primaryDomain": "Primary domain",
+            "keycloakOrgId": "Keycloak org ID",
+            "createdAt": "Created at",
+            "updatedAt": "Updated at",
+            "verifiedAt": "Verified at"
+          }
+        },
+        "domains": {
+          "columns": {
+            "domain": "Domain",
+            "state": "State",
+            "dnsTxtValue": "DNS TXT",
+            "verifiedAt": "Verified at"
+          },
+          "empty": "No managed domains are attached to this tenant yet."
+        },
+        "users": {
+          "columns": {
+            "name": "Name",
+            "email": "Email",
+            "role": "Role",
+            "flags": "Flags",
+            "lastVisitedAt": "Last visited"
+          },
+          "flags": {
+            "firstAdmin": "First admin",
+            "provisionalUntil": "Provisional until {date}"
+          },
+          "empty": "No tenant users have been provisioned yet."
+        },
+        "audit": {
+          "columns": {
+            "createdAt": "Created at",
+            "action": "Action",
+            "resource": "Resource",
+            "actor": "Actor",
+            "changes": "Changes"
+          },
+          "oldValues": "Old: {value}",
+          "newValues": "New: {value}",
+          "empty": "No recent audit events are available for this tenant."
+        },
+        "lifecycle": {
+          "title": "Lifecycle actions",
+          "description": "Suspend, archive, or reactivate the tenant from the super-admin back office.",
+          "reasonLabel": "Reason",
+          "reasonPlaceholder": "Optional note recorded alongside the lifecycle transition.",
+          "actions": {
+            "suspend": "Suspend",
+            "archive": "Archive",
+            "activate": "Reactivate"
+          },
+          "submitting": "Saving…",
+          "success": "Tenant lifecycle updated: {action}.",
+          "error": "Unable to update tenant lifecycle. Please retry."
+        }
+      }
     }
   },
   "settings": {

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -302,6 +302,112 @@
           }
         }
       }
+    },
+    "tenants": {
+      "list": {
+        "title": "Gestion des tenants",
+        "subtitle": "Consultez l’ensemble des tenants enterprise et accédez à leur cycle de vie, domaines, utilisateurs et audit récent.",
+        "columns": {
+          "name": "Tenant",
+          "status": "Statut",
+          "plan": "Plan",
+          "primaryDomain": "Domaine principal",
+          "createdVia": "Créé via",
+          "updatedAt": "Dernière mise à jour"
+        },
+        "statuses": {
+          "active": "Actif",
+          "suspended": "Suspendu",
+          "archived": "Archivé"
+        },
+        "verification": {
+          "verified": "Vérifié",
+          "pending": "En attente"
+        },
+        "empty": {
+          "title": "Aucun tenant",
+          "description": "Les tenants créés via le parcours de super-admin apparaîtront ici."
+        }
+      },
+      "detail": {
+        "backToList": "Retour à la liste",
+        "statuses": {
+          "active": "Actif",
+          "suspended": "Suspendu",
+          "archived": "Archivé"
+        },
+        "verification": {
+          "verified": "Vérifié",
+          "pending": "En attente"
+        },
+        "tabs": {
+          "overview": "Vue d’ensemble",
+          "domains": "Domaines",
+          "users": "Utilisateurs",
+          "audit": "Audit"
+        },
+        "overview": {
+          "fields": {
+            "slug": "Slug",
+            "plan": "Plan",
+            "createdVia": "Créé via",
+            "primaryDomain": "Domaine principal",
+            "keycloakOrgId": "ID org Keycloak",
+            "createdAt": "Créé le",
+            "updatedAt": "Mis à jour le",
+            "verifiedAt": "Vérifié le"
+          }
+        },
+        "domains": {
+          "columns": {
+            "domain": "Domaine",
+            "state": "État",
+            "dnsTxtValue": "DNS TXT",
+            "verifiedAt": "Vérifié le"
+          },
+          "empty": "Aucun domaine géré n’est encore rattaché à ce tenant."
+        },
+        "users": {
+          "columns": {
+            "name": "Nom",
+            "email": "Email",
+            "role": "Rôle",
+            "flags": "Indicateurs",
+            "lastVisitedAt": "Dernière visite"
+          },
+          "flags": {
+            "firstAdmin": "Premier admin",
+            "provisionalUntil": "Provisoire jusqu’au {date}"
+          },
+          "empty": "Aucun utilisateur n’a encore été provisionné pour ce tenant."
+        },
+        "audit": {
+          "columns": {
+            "createdAt": "Créé le",
+            "action": "Action",
+            "resource": "Ressource",
+            "actor": "Acteur",
+            "changes": "Changements"
+          },
+          "oldValues": "Ancien : {value}",
+          "newValues": "Nouveau : {value}",
+          "empty": "Aucun événement d’audit récent n’est disponible pour ce tenant."
+        },
+        "lifecycle": {
+          "title": "Actions de cycle de vie",
+          "description": "Suspendre, archiver ou réactiver le tenant depuis le back-office super-admin.",
+          "reasonLabel": "Motif",
+          "reasonPlaceholder": "Note facultative enregistrée avec la transition de cycle de vie.",
+          "actions": {
+            "suspend": "Suspendre",
+            "archive": "Archiver",
+            "activate": "Réactiver"
+          },
+          "submitting": "Enregistrement…",
+          "success": "Cycle de vie du tenant mis à jour : {action}.",
+          "error": "Impossible de mettre à jour le cycle de vie du tenant. Réessayez."
+        }
+      }
     }
   },
   "settings": {

--- a/packages/web/src/app/(admin)/admin/disputes/[id]/page.tsx
+++ b/packages/web/src/app/(admin)/admin/disputes/[id]/page.tsx
@@ -21,6 +21,12 @@ export default async function DisputeDetailPage({ params }: { params: Promise<{ 
   }
   if (!row) notFound();
 
+  function resolutionLabel(resolution: string | null): string {
+    if (resolution === "replaced") return t("resolutions.replaced");
+    if (resolution === "escalated_to_support") return t("resolutions.escalated_to_support");
+    return t("resolutions.kept");
+  }
+
   return (
     <div className="max-w-2xl space-y-6">
       <header>
@@ -58,12 +64,8 @@ export default async function DisputeDetailPage({ params }: { params: Promise<{ 
         <section className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
           <h2 className="text-sm font-semibold text-text-secondary">{t("resolvedLabel")}</h2>
           <p className="mt-2 text-sm text-text">
-            {row.resolution === "replaced"
-              ? t("resolutions.replaced")
-              : row.resolution === "escalated_to_support"
-                ? t("resolutions.escalated_to_support")
-                : t("resolutions.kept")}{" "}
-            — {row.resolvedAt ? new Date(row.resolvedAt).toLocaleString() : ""}
+            {resolutionLabel(row.resolution)} —{" "}
+            {row.resolvedAt ? new Date(row.resolvedAt).toLocaleString() : ""}
           </p>
         </section>
       ) : (

--- a/packages/web/src/app/(admin)/admin/disputes/page.tsx
+++ b/packages/web/src/app/(admin)/admin/disputes/page.tsx
@@ -27,6 +27,12 @@ export default async function DisputeListPage() {
   const open = rows.filter((r) => r.resolution === null);
   const closed = rows.filter((r) => r.resolution !== null);
 
+  function resolutionLabel(resolution: string | null): string {
+    if (resolution === "replaced") return t("resolutions.replaced");
+    if (resolution === "escalated_to_support") return t("resolutions.escalated_to_support");
+    return t("resolutions.kept");
+  }
+
   return (
     <div className="space-y-8">
       <header>
@@ -102,11 +108,7 @@ export default async function DisputeListPage() {
                       </p>
                     </div>
                     <span className="rounded-full bg-surface-container-low px-2 py-0.5 text-xs font-medium text-text-secondary">
-                      {row.resolution === "replaced"
-                        ? t("resolutions.replaced")
-                        : row.resolution === "escalated_to_support"
-                          ? t("resolutions.escalated_to_support")
-                          : t("resolutions.kept")}
+                      {resolutionLabel(row.resolution)}
                     </span>
                   </div>
                 </Link>

--- a/packages/web/src/app/(admin)/admin/tenants/[id]/page.tsx
+++ b/packages/web/src/app/(admin)/admin/tenants/[id]/page.tsx
@@ -1,0 +1,228 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import {
+  formatAdminDate,
+  formatTenantUserName,
+  normalizeTenantToken,
+  renderJsonPreview,
+  TenantStatusBadge,
+  TenantVerificationBadge,
+} from "@/components/admin/tenant-admin-shared";
+import { TenantDetailTabs } from "@/components/admin/tenant-detail-tabs";
+import { TenantLifecycleActions } from "@/components/admin/tenant-lifecycle-actions";
+import { createServerApiClient } from "@/lib/api/client-server";
+import type { AdminTenantDetailResponse } from "@/services/TenantAdminService";
+
+export const dynamic = "force-dynamic";
+
+function DetailCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">{label}</p>
+      <p className="mt-2 text-sm text-text">{value}</p>
+    </div>
+  );
+}
+
+function tenantStatusLabel(
+  t: (key: "statuses.active" | "statuses.suspended" | "statuses.archived") => string,
+  status: string,
+): string {
+  const normalized = normalizeTenantToken(status);
+  if (normalized === "active") return t("statuses.active");
+  if (normalized === "suspended") return t("statuses.suspended");
+  if (normalized === "archived") return t("statuses.archived");
+  return status;
+}
+
+export default async function TenantDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const t = await getTranslations("admin.tenants.detail");
+  const api = await createServerApiClient();
+
+  let detail: AdminTenantDetailResponse["data"] | null = null;
+  try {
+    const res = await api.get<AdminTenantDetailResponse>(
+      `/v1/superadmin/tenants/${encodeURIComponent(id)}/detail`,
+    );
+    detail = res.data;
+  } catch {
+    notFound();
+  }
+
+  if (!detail) notFound();
+
+  const { tenant, domains, users, recentAudit } = detail;
+
+  const overview = (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <DetailCard label={t("overview.fields.slug")} value={tenant.slug} />
+      <DetailCard label={t("overview.fields.plan")} value={tenant.plan} />
+      <DetailCard label={t("overview.fields.createdVia")} value={tenant.createdVia} />
+      <DetailCard label={t("overview.fields.primaryDomain")} value={tenant.primaryDomain ?? "—"} />
+      <DetailCard label={t("overview.fields.keycloakOrgId")} value={tenant.keycloakOrgId ?? "—"} />
+      <DetailCard
+        label={t("overview.fields.createdAt")}
+        value={formatAdminDate(tenant.createdAt)}
+      />
+      <DetailCard
+        label={t("overview.fields.updatedAt")}
+        value={formatAdminDate(tenant.updatedAt)}
+      />
+      <DetailCard
+        label={t("overview.fields.verifiedAt")}
+        value={tenant.verifiedAt ? formatAdminDate(tenant.verifiedAt) : "—"}
+      />
+    </div>
+  );
+
+  const domainsTab = domains.length ? (
+    <div className="overflow-hidden rounded-lg border border-outline-variant bg-surface-container-lowest">
+      <table className="w-full border-separate border-spacing-0 text-left text-sm">
+        <thead className="bg-surface-container-low text-xs uppercase tracking-wide text-text-secondary">
+          <tr>
+            <th className="px-4 py-3">{t("domains.columns.domain")}</th>
+            <th className="px-4 py-3">{t("domains.columns.state")}</th>
+            <th className="px-4 py-3">{t("domains.columns.dnsTxtValue")}</th>
+            <th className="px-4 py-3">{t("domains.columns.verifiedAt")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {domains.map((domain) => (
+            <tr key={domain.id} className="border-t border-outline-variant">
+              <td className="px-4 py-3 text-text">{domain.domain}</td>
+              <td className="px-4 py-3 text-text">{domain.state}</td>
+              <td className="px-4 py-3 font-mono text-xs text-text-secondary">
+                {domain.dnsTxtValue}
+              </td>
+              <td className="px-4 py-3 text-text-secondary">
+                {formatAdminDate(domain.verifiedAt)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ) : (
+    <p className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4 text-sm text-text-secondary">
+      {t("domains.empty")}
+    </p>
+  );
+
+  const usersTab = users.length ? (
+    <div className="overflow-hidden rounded-lg border border-outline-variant bg-surface-container-lowest">
+      <table className="w-full border-separate border-spacing-0 text-left text-sm">
+        <thead className="bg-surface-container-low text-xs uppercase tracking-wide text-text-secondary">
+          <tr>
+            <th className="px-4 py-3">{t("users.columns.name")}</th>
+            <th className="px-4 py-3">{t("users.columns.email")}</th>
+            <th className="px-4 py-3">{t("users.columns.role")}</th>
+            <th className="px-4 py-3">{t("users.columns.flags")}</th>
+            <th className="px-4 py-3">{t("users.columns.lastVisitedAt")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((user) => (
+            <tr key={user.id} className="border-t border-outline-variant">
+              <td className="px-4 py-3 text-text">
+                {formatTenantUserName(user.firstName, user.lastName)}
+              </td>
+              <td className="px-4 py-3 text-text-secondary">{user.email}</td>
+              <td className="px-4 py-3 text-text">{user.role}</td>
+              <td className="px-4 py-3 text-text-secondary">
+                {user.firstAdmin
+                  ? t("users.flags.firstAdmin")
+                  : user.provisionalUntil
+                    ? t("users.flags.provisionalUntil", {
+                        date: formatAdminDate(user.provisionalUntil),
+                      })
+                    : "—"}
+              </td>
+              <td className="px-4 py-3 text-text-secondary">
+                {formatAdminDate(user.lastVisitedAt)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ) : (
+    <p className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4 text-sm text-text-secondary">
+      {t("users.empty")}
+    </p>
+  );
+
+  const auditTab = recentAudit.length ? (
+    <div className="overflow-hidden rounded-lg border border-outline-variant bg-surface-container-lowest">
+      <table className="w-full border-separate border-spacing-0 text-left text-sm">
+        <thead className="bg-surface-container-low text-xs uppercase tracking-wide text-text-secondary">
+          <tr>
+            <th className="px-4 py-3">{t("audit.columns.createdAt")}</th>
+            <th className="px-4 py-3">{t("audit.columns.action")}</th>
+            <th className="px-4 py-3">{t("audit.columns.resource")}</th>
+            <th className="px-4 py-3">{t("audit.columns.actor")}</th>
+            <th className="px-4 py-3">{t("audit.columns.changes")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {recentAudit.map((entry) => (
+            <tr key={entry.id} className="border-t border-outline-variant align-top">
+              <td className="px-4 py-3 text-text-secondary">{formatAdminDate(entry.createdAt)}</td>
+              <td className="px-4 py-3 text-text">{entry.action}</td>
+              <td className="px-4 py-3 text-text-secondary">
+                {[entry.resourceType, entry.resourceId].filter(Boolean).join(" · ") || "—"}
+              </td>
+              <td className="px-4 py-3 font-mono text-xs text-text-secondary">
+                {entry.userId ?? "—"}
+              </td>
+              <td className="px-4 py-3 text-xs text-text-secondary">
+                <p>{t("audit.oldValues", { value: renderJsonPreview(entry.oldValues) })}</p>
+                <p className="mt-1">
+                  {t("audit.newValues", { value: renderJsonPreview(entry.newValues) })}
+                </p>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ) : (
+    <p className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4 text-sm text-text-secondary">
+      {t("audit.empty")}
+    </p>
+  );
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-3">
+        <Link href="/admin/tenants" className="text-xs text-primary hover:underline">
+          ← {t("backToList")}
+        </Link>
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h1 className="font-heading text-2xl text-text">{tenant.name}</h1>
+            <p className="mt-1 text-sm text-text-secondary">{tenant.slug}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <TenantStatusBadge status={tenant.status} label={tenantStatusLabel(t, tenant.status)} />
+            <TenantVerificationBadge
+              verifiedAt={tenant.verifiedAt}
+              verifiedLabel={t("verification.verified")}
+              pendingLabel={t("verification.pending")}
+            />
+          </div>
+        </div>
+      </header>
+
+      <TenantLifecycleActions tenantId={tenant.id} currentStatus={tenant.status} />
+
+      <TenantDetailTabs
+        overview={overview}
+        domains={domainsTab}
+        users={usersTab}
+        audit={auditTab}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/(admin)/admin/tenants/page.tsx
+++ b/packages/web/src/app/(admin)/admin/tenants/page.tsx
@@ -1,0 +1,31 @@
+import { getTranslations } from "next-intl/server";
+
+import { TenantsTable } from "@/components/admin/tenants-table";
+import { createServerApiClient } from "@/lib/api/client-server";
+import type { AdminTenantListResponse, AdminTenantSummary } from "@/services/TenantAdminService";
+
+export const dynamic = "force-dynamic";
+
+export default async function TenantListPage() {
+  const t = await getTranslations("admin.tenants.list");
+  const api = await createServerApiClient();
+
+  let tenants: AdminTenantSummary[] = [];
+  try {
+    const res = await api.get<AdminTenantListResponse>("/v1/superadmin/tenants");
+    tenants = res.data;
+  } catch {
+    tenants = [];
+  }
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="font-heading text-2xl text-text">{t("title")}</h1>
+        <p className="mt-1 text-sm text-text-secondary">{t("subtitle")}</p>
+      </header>
+
+      <TenantsTable tenants={tenants} />
+    </div>
+  );
+}

--- a/packages/web/src/components/admin/dispute-resolve-form.tsx
+++ b/packages/web/src/components/admin/dispute-resolve-form.tsx
@@ -20,6 +20,19 @@ export function DisputeResolveForm({ disputeId }: { disputeId: string }) {
   const [choice, setChoice] = useState<DisputeResolution>("kept");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const options: Array<{
+    value: DisputeResolution;
+    label: "options.kept.label" | "options.replaced.label" | "options.escalated_to_support.label";
+    hint: "options.kept.hint" | "options.replaced.hint" | "options.escalated_to_support.hint";
+  }> = [
+    { value: "kept", label: "options.kept.label", hint: "options.kept.hint" },
+    { value: "replaced", label: "options.replaced.label", hint: "options.replaced.hint" },
+    {
+      value: "escalated_to_support",
+      label: "options.escalated_to_support.label",
+      hint: "options.escalated_to_support.hint",
+    },
+  ];
 
   const onSubmit = useCallback(
     async (e: FormEvent<HTMLFormElement>) => {
@@ -48,28 +61,28 @@ export function DisputeResolveForm({ disputeId }: { disputeId: string }) {
         <legend id={`${groupId}-label`} className="sr-only">
           {t("title")}
         </legend>
-        {(["kept", "replaced", "escalated_to_support"] as const).map((opt) => (
+        {options.map((opt) => (
           <label
-            key={opt}
-            htmlFor={`${groupId}-${opt}`}
+            key={opt.value}
+            htmlFor={`${groupId}-${opt.value}`}
             className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 text-sm transition-colors duration-normal ease-out focus-within:ring-2 focus-within:ring-primary ${
-              choice === opt
+              choice === opt.value
                 ? "border-primary bg-primary-50"
                 : "border-outline-variant hover:border-primary"
             }`}
           >
             <input
-              id={`${groupId}-${opt}`}
+              id={`${groupId}-${opt.value}`}
               type="radio"
               name={groupId}
-              value={opt}
-              checked={choice === opt}
-              onChange={() => setChoice(opt)}
+              value={opt.value}
+              checked={choice === opt.value}
+              onChange={() => setChoice(opt.value)}
               className="sr-only"
             />
             <div>
-              <p className="font-medium text-text">{t(`options.${opt}.label`)}</p>
-              <p className="mt-0.5 text-xs text-text-muted">{t(`options.${opt}.hint`)}</p>
+              <p className="font-medium text-text">{t(opt.label)}</p>
+              <p className="mt-0.5 text-xs text-text-muted">{t(opt.hint)}</p>
             </div>
           </label>
         ))}

--- a/packages/web/src/components/admin/tenant-admin-shared.tsx
+++ b/packages/web/src/components/admin/tenant-admin-shared.tsx
@@ -1,0 +1,69 @@
+import { Badge } from "@/components/ui/badge";
+
+type BadgeVariant = "success" | "warning" | "error" | "info" | "neutral";
+
+function normalizeToken(value: string | null | undefined): string {
+  return (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[\s-]+/g, "_");
+}
+
+export function formatAdminDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export function formatTenantUserName(firstName: string, lastName: string): string {
+  const fullName = `${firstName} ${lastName}`.trim();
+  return fullName || "—";
+}
+
+export function renderJsonPreview(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function normalizeTenantToken(value: string | null | undefined): string {
+  return normalizeToken(value);
+}
+
+export function TenantStatusBadge({ status, label }: { status: string; label: string }) {
+  const normalized = normalizeToken(status);
+  const variant: BadgeVariant =
+    normalized === "active"
+      ? "success"
+      : normalized === "suspended"
+        ? "warning"
+        : normalized === "archived"
+          ? "error"
+          : "neutral";
+
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+export function TenantVerificationBadge({
+  verifiedAt,
+  verifiedLabel,
+  pendingLabel,
+}: {
+  verifiedAt: string | null;
+  verifiedLabel: string;
+  pendingLabel: string;
+}) {
+  return verifiedAt ? (
+    <Badge variant="success">{verifiedLabel}</Badge>
+  ) : (
+    <Badge variant="warning">{pendingLabel}</Badge>
+  );
+}

--- a/packages/web/src/components/admin/tenant-detail-tabs.test.tsx
+++ b/packages/web/src/components/admin/tenant-detail-tabs.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { TenantDetailTabs } from "./tenant-detail-tabs";
+
+describe("TenantDetailTabs", () => {
+  it("switches between overview and domains panels", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TenantDetailTabs
+        overview={<div>Overview content</div>}
+        domains={<div>Domains content</div>}
+        users={<div>Users content</div>}
+        audit={<div>Audit content</div>}
+      />,
+    );
+
+    expect(screen.getByText("Overview content")).toBeVisible();
+
+    await user.click(screen.getByRole("tab", { name: "Domains" }));
+
+    expect(screen.getByText("Domains content")).toBeVisible();
+  });
+});

--- a/packages/web/src/components/admin/tenant-detail-tabs.tsx
+++ b/packages/web/src/components/admin/tenant-detail-tabs.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+interface TenantDetailTabsProps {
+  overview: ReactNode;
+  domains: ReactNode;
+  users: ReactNode;
+  audit: ReactNode;
+}
+
+export function TenantDetailTabs({ overview, domains, users, audit }: TenantDetailTabsProps) {
+  const t = useTranslations("admin.tenants.detail.tabs");
+
+  return (
+    <Tabs defaultValue="overview" className="w-full">
+      <TabsList>
+        <TabsTrigger value="overview">{t("overview")}</TabsTrigger>
+        <TabsTrigger value="domains">{t("domains")}</TabsTrigger>
+        <TabsTrigger value="users">{t("users")}</TabsTrigger>
+        <TabsTrigger value="audit">{t("audit")}</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview">{overview}</TabsContent>
+      <TabsContent value="domains">{domains}</TabsContent>
+      <TabsContent value="users">{users}</TabsContent>
+      <TabsContent value="audit">{audit}</TabsContent>
+    </Tabs>
+  );
+}

--- a/packages/web/src/components/admin/tenant-lifecycle-actions.test.tsx
+++ b/packages/web/src/components/admin/tenant-lifecycle-actions.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { mockApiClient, mockRouter, mockToast } from "@/tests/mocks";
+
+import { TenantLifecycleActions } from "./tenant-lifecycle-actions";
+
+describe("TenantLifecycleActions", () => {
+  it("posts the selected lifecycle action, shows feedback, and refreshes the route", async () => {
+    const user = userEvent.setup();
+    mockApiClient.post.mockResolvedValue({ status: "suspended" });
+
+    render(<TenantLifecycleActions tenantId="tenant-1" currentStatus="active" />);
+
+    await user.type(screen.getByLabelText("Reason"), "Payment default");
+    await user.click(screen.getByRole("button", { name: "Suspend" }));
+
+    await waitFor(() => {
+      expect(mockApiClient.post).toHaveBeenCalledWith("/v1/superadmin/tenants/tenant-1/lifecycle", {
+        action: "suspend",
+        reason: "Payment default",
+      });
+    });
+    expect(mockToast.success).toHaveBeenCalledWith("Tenant lifecycle updated: suspend.");
+    expect(mockRouter.refresh).toHaveBeenCalled();
+  });
+
+  it("disables suspend when the tenant is already suspended", () => {
+    render(<TenantLifecycleActions tenantId="tenant-2" currentStatus="suspended" />);
+
+    expect(screen.getByRole("button", { name: "Suspend" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Archive" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Reactivate" })).toBeEnabled();
+  });
+});

--- a/packages/web/src/components/admin/tenant-lifecycle-actions.tsx
+++ b/packages/web/src/components/admin/tenant-lifecycle-actions.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import { type TenantLifecycleAction, triggerTenantLifecycle } from "@/services/TenantAdminService";
+
+interface TenantLifecycleActionsProps {
+  tenantId: string;
+  currentStatus: string;
+}
+
+function normalizeStatus(status: string): string {
+  return status.trim().toLowerCase();
+}
+
+export function TenantLifecycleActions({ tenantId, currentStatus }: TenantLifecycleActionsProps) {
+  const router = useRouter();
+  const t = useTranslations("admin.tenants.detail.lifecycle");
+  const [reason, setReason] = useState("");
+  const [pendingAction, setPendingAction] = useState<TenantLifecycleAction | null>(null);
+
+  const allowedActions = useMemo(() => {
+    const normalized = normalizeStatus(currentStatus);
+    return {
+      suspend: normalized !== "suspended" && normalized !== "archived",
+      archive: normalized !== "archived",
+      activate: normalized !== "active",
+    };
+  }, [currentStatus]);
+
+  async function onAction(action: TenantLifecycleAction) {
+    setPendingAction(action);
+    try {
+      await triggerTenantLifecycle(tenantId, action, reason);
+      toast.success(t("success", { action }));
+      setReason("");
+      router.refresh();
+    } catch {
+      toast.error(t("error"));
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold text-text-secondary">{t("title")}</h2>
+        <p className="text-sm text-text-muted">{t("description")}</p>
+      </div>
+
+      <div className="mt-4 space-y-4">
+        <div className="space-y-2">
+          <label htmlFor="tenant-lifecycle-reason" className="text-sm font-medium text-text">
+            {t("reasonLabel")}
+          </label>
+          <textarea
+            id="tenant-lifecycle-reason"
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+            placeholder={t("reasonPlaceholder")}
+            rows={3}
+            className="w-full rounded-md border border-outline-variant bg-surface px-3 py-2 text-sm text-text outline-none transition-colors duration-normal ease-out placeholder:text-text-muted focus:border-primary"
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <Button
+            variant="secondary"
+            disabled={!allowedActions.suspend || pendingAction !== null}
+            onClick={() => void onAction("suspend")}
+          >
+            {pendingAction === "suspend" ? t("submitting") : t("actions.suspend")}
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={!allowedActions.archive || pendingAction !== null}
+            onClick={() => void onAction("archive")}
+          >
+            {pendingAction === "archive" ? t("submitting") : t("actions.archive")}
+          </Button>
+          <Button
+            disabled={!allowedActions.activate || pendingAction !== null}
+            onClick={() => void onAction("activate")}
+          >
+            {pendingAction === "activate" ? t("submitting") : t("actions.activate")}
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/admin/tenants-table.test.tsx
+++ b/packages/web/src/components/admin/tenants-table.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { mockRouter } from "@/tests/mocks";
+
+import { TenantsTable } from "./tenants-table";
+
+describe("TenantsTable", () => {
+  it("renders tenant rows and navigates to the detail page on row click", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TenantsTable
+        tenants={[
+          {
+            id: "tenant-1",
+            name: "Acme Foundation",
+            slug: "acme-foundation",
+            plan: "enterprise",
+            status: "active",
+            createdVia: "sales-led",
+            verifiedAt: "2026-04-20T10:00:00.000Z",
+            primaryDomain: "acme.org",
+            keycloakOrgId: "kc-acme",
+            createdAt: "2026-04-10T10:00:00.000Z",
+            updatedAt: "2026-04-21T10:00:00.000Z",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Acme Foundation")).toBeInTheDocument();
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Acme Foundation"));
+
+    expect(mockRouter.push).toHaveBeenCalledWith("/admin/tenants/tenant-1");
+  });
+});

--- a/packages/web/src/components/admin/tenants-table.tsx
+++ b/packages/web/src/components/admin/tenants-table.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { Building2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useMemo } from "react";
+
+import { EmptyState } from "@/components/shared/empty-state";
+import { DataTable } from "@/components/ui/data-table";
+import type { AdminTenantSummary } from "@/services/TenantAdminService";
+
+import {
+  formatAdminDate,
+  normalizeTenantToken,
+  TenantStatusBadge,
+  TenantVerificationBadge,
+} from "./tenant-admin-shared";
+
+function tenantStatusLabel(
+  t: (key: "statuses.active" | "statuses.suspended" | "statuses.archived") => string,
+  status: string,
+): string {
+  const normalized = normalizeTenantToken(status);
+  if (normalized === "active") return t("statuses.active");
+  if (normalized === "suspended") return t("statuses.suspended");
+  if (normalized === "archived") return t("statuses.archived");
+  return status;
+}
+
+interface TenantsTableProps {
+  tenants: AdminTenantSummary[];
+}
+
+export function TenantsTable({ tenants }: TenantsTableProps) {
+  const router = useRouter();
+  const t = useTranslations("admin.tenants.list");
+
+  const columns = useMemo<ColumnDef<AdminTenantSummary>[]>(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: () => t("columns.name"),
+        cell: ({ row }) => (
+          <div>
+            <p className="font-medium text-on-surface">{row.original.name}</p>
+            <p className="text-xs text-on-surface-variant">{row.original.slug}</p>
+          </div>
+        ),
+      },
+      {
+        id: "status",
+        accessorKey: "status",
+        header: () => t("columns.status"),
+        cell: ({ row }) => (
+          <TenantStatusBadge
+            status={row.original.status}
+            label={tenantStatusLabel(t, row.original.status)}
+          />
+        ),
+      },
+      {
+        id: "plan",
+        accessorKey: "plan",
+        header: () => t("columns.plan"),
+      },
+      {
+        id: "domain",
+        accessorKey: "primaryDomain",
+        header: () => t("columns.primaryDomain"),
+        cell: ({ row }) => (
+          <div className="space-y-1">
+            <p className="text-on-surface">{row.original.primaryDomain ?? "—"}</p>
+            <TenantVerificationBadge
+              verifiedAt={row.original.verifiedAt}
+              verifiedLabel={t("verification.verified")}
+              pendingLabel={t("verification.pending")}
+            />
+          </div>
+        ),
+      },
+      {
+        id: "createdVia",
+        accessorKey: "createdVia",
+        header: () => t("columns.createdVia"),
+      },
+      {
+        id: "updatedAt",
+        accessorKey: "updatedAt",
+        header: () => t("columns.updatedAt"),
+        cell: ({ row }) => formatAdminDate(row.original.updatedAt),
+      },
+    ],
+    [t],
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      data={tenants}
+      pagination={{
+        page: 1,
+        perPage: tenants.length || 1,
+        total: tenants.length,
+        totalPages: 1,
+      }}
+      onPageChange={() => {}}
+      onRowClick={(row) => router.push(`/admin/tenants/${row.original.id}`)}
+      emptyState={
+        <EmptyState
+          icon={Building2}
+          title={t("empty.title")}
+          description={t("empty.description")}
+        />
+      }
+    />
+  );
+}

--- a/packages/web/src/services/TenantAdminService.ts
+++ b/packages/web/src/services/TenantAdminService.ts
@@ -1,0 +1,78 @@
+import { createClientApiClient } from "@/lib/api/client-browser";
+
+export interface AdminTenantSummary {
+  id: string;
+  name: string;
+  slug: string;
+  plan: string;
+  status: string;
+  createdVia: string;
+  verifiedAt: string | null;
+  primaryDomain: string | null;
+  keycloakOrgId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AdminTenantDomain {
+  id: string;
+  domain: string;
+  state: string;
+  dnsTxtValue: string;
+  verifiedAt: string | null;
+  createdAt: string;
+}
+
+export interface AdminTenantUser {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+  firstAdmin: boolean;
+  provisionalUntil: string | null;
+  lastVisitedAt: string | null;
+}
+
+export interface AdminTenantAuditEntry {
+  id: string;
+  action: string;
+  resourceType: string | null;
+  resourceId: string | null;
+  userId: string | null;
+  newValues: unknown;
+  oldValues: unknown;
+  createdAt: string;
+}
+
+export interface AdminTenantDetail {
+  tenant: AdminTenantSummary;
+  domains: AdminTenantDomain[];
+  users: AdminTenantUser[];
+  recentAudit: AdminTenantAuditEntry[];
+}
+
+export interface AdminTenantListResponse {
+  data: AdminTenantSummary[];
+}
+
+export interface AdminTenantDetailResponse {
+  data: AdminTenantDetail;
+}
+
+export type TenantLifecycleAction = "suspend" | "archive" | "activate";
+
+export async function triggerTenantLifecycle(
+  tenantId: string,
+  action: TenantLifecycleAction,
+  reason?: string,
+): Promise<{ status: string }> {
+  const api = createClientApiClient();
+  return api.post<{ status: string }>(
+    `/v1/superadmin/tenants/${encodeURIComponent(tenantId)}/lifecycle`,
+    {
+      action,
+      reason: reason?.trim() ? reason.trim() : undefined,
+    },
+  );
+}


### PR DESCRIPTION
## What changed
- add the global back-office tenant list at `/admin/tenants` using the existing admin layout and a clickable `DataTable`
- add the tenant detail page at `/admin/tenants/[id]` with overview, domains, users, and audit tabs based on `TenantDetailResponse`
- add client-side lifecycle controls to suspend, archive, or reactivate a tenant through `/v1/superadmin/tenants/:id/lifecycle`
- add frontend integration tests for the tenant table, detail tabs, and lifecycle actions

## Why
Issue #111 requires the Phase 2 super-admin tenant management UI on top of the tenant-admin API routes that were already introduced under `/v1/superadmin/tenants`.

## Impact
Super-admins can now inspect tenants from the global back-office, drill into tenant state, and trigger lifecycle transitions without leaving the web admin surface.

## Notes
- the PR also folds the tenant admin translations into the existing `admin` i18n namespace and replaces a few dispute-page dynamic translation lookups with typed mappings so `next-intl` typecheck passes cleanly
- `packages/api/test-api.ts` was left untouched and is not included in this PR

## Validation
- `pnpm --filter @givernance/web test`
- `pnpm lint`
- `pnpm typecheck`
