### PR TITLE
[codex] add funds management ui

### DIFF
--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -414,6 +414,70 @@
   "title": "Settings",
   "subtitle": "Manage organisation-level defaults and export tools.",
   "breadcrumbRoot": "Dashboard",
+  "funds": {
+    "settings": "Settings",
+    "title": "Funds",
+    "subtitleEmpty": "Create restricted and unrestricted funds that can be attached to campaigns and donations.",
+    "subtitleWithCount": "{count, plural, one {# fund configured} other {# funds configured}}",
+    "readOnly": "Only organisation admins can create funds.",
+    "descriptionEmpty": "No description",
+    "types": {
+      "restricted": "Restricted",
+      "unrestricted": "Unrestricted"
+    },
+    "columns": {
+      "name": "Fund",
+      "type": "Type",
+      "description": "Description",
+      "createdAt": "Created"
+    },
+    "actions": {
+      "new": "New fund"
+    },
+    "empty": {
+      "title": "No funds yet",
+      "description": "Add your first fund to control which designations can be used in campaigns and donations."
+    },
+    "form": {
+      "createTitle": "Create fund",
+      "createSubtitle": "Add a restricted or unrestricted fund for campaign and donation allocation.",
+      "breadcrumbNew": "New fund",
+      "sections": {
+        "identity": {
+          "title": "Identity",
+          "description": "Core information used to label and classify the fund."
+        },
+        "description": {
+          "title": "Description",
+          "description": "Optional context to explain when this fund should be used."
+        }
+      },
+      "fields": {
+        "name": "Fund name",
+        "namePlaceholder": "Major donors restricted fund",
+        "nameHint": "Use a precise label that fundraising staff will recognize.",
+        "type": "Fund type",
+        "typeHint": "Restricted funds are for designated giving. Unrestricted funds can support general operations.",
+        "description": "Description",
+        "descriptionPlaceholder": "Explain the designation or internal use of this fund.",
+        "descriptionHint": "This is optional, but helpful when several funds sound similar."
+      },
+      "actions": {
+        "cancel": "Cancel",
+        "submitCreate": "Create fund",
+        "submitting": "Saving…"
+      },
+      "errors": {
+        "nameRequired": "Fund name is required.",
+        "nameTooLong": "Fund name must be 255 characters or fewer.",
+        "descriptionTooLong": "Description must be 5000 characters or fewer.",
+        "generic": "Something went wrong while saving. Please try again."
+      },
+      "success": {
+        "created": "Fund created."
+      }
+    }
+  },
   "tenant": {
     "title": "Organisation settings",
     "description": "Choose the tenant base currency used for reporting and currency conversions.",
@@ -705,6 +769,10 @@
         "structure": {
           "title": "Structure",
           "description": "Parent campaign and operational cost used for rollup and ROI reporting."
+        },
+        "funds": {
+          "title": "Eligible funds",
+          "description": "Choose which fund designations can be associated with this campaign."
         }
       },
       "fields": {
@@ -719,7 +787,15 @@
         "parentLoading": "Loading available campaigns…",
         "operationalCost": "Operational cost",
         "operationalCostPlaceholder": "0.00",
-        "operationalCostHint": "Manual campaign spend. Platform fees are tracked separately from donations."
+        "operationalCostHint": "Manual campaign spend. Platform fees are tracked separately from donations.",
+        "funds": "Eligible funds",
+        "fundsHint": "Selected funds will be available when gifts are associated with this campaign.",
+        "fundsLoading": "Loading available funds…",
+        "fundsEmpty": "No funds are configured yet. Create one from settings first."
+      },
+      "fundTypeHint": {
+        "restricted": "Restricted fund",
+        "unrestricted": "Unrestricted fund"
       },
       "actions": {
         "cancel": "Cancel",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -805,6 +805,7 @@
       },
       "errors": {
         "validation": "Please correct the highlighted fields.",
+        "optionsLoad": "Unable to load the related campaigns or funds. Reload the page before saving to avoid overwriting existing funds.",
         "generic": "Something went wrong while saving. Please try again."
       },
       "success": {

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -805,6 +805,7 @@
       },
       "errors": {
         "validation": "Corrigez les champs en surbrillance.",
+        "optionsLoad": "Impossible de charger les campagnes ou fonds associés. Rechargez la page avant d’enregistrer pour éviter d’écraser les fonds existants.",
         "generic": "Une erreur est survenue lors de l'enregistrement. Réessayez."
       },
       "success": {

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -414,6 +414,70 @@
   "title": "Paramètres",
   "subtitle": "Gérez les paramètres de l'organisation et les outils d'export.",
   "breadcrumbRoot": "Tableau de bord",
+  "funds": {
+    "settings": "Paramètres",
+    "title": "Fonds",
+    "subtitleEmpty": "Créez des fonds restreints ou non restreints pouvant être rattachés aux campagnes et aux dons.",
+    "subtitleWithCount": "{count, plural, one {# fonds configuré} other {# fonds configurés}}",
+    "readOnly": "Seuls les administrateurs de l'organisation peuvent créer des fonds.",
+    "descriptionEmpty": "Aucune description",
+    "types": {
+      "restricted": "Restreint",
+      "unrestricted": "Non restreint"
+    },
+    "columns": {
+      "name": "Fonds",
+      "type": "Type",
+      "description": "Description",
+      "createdAt": "Créé le"
+    },
+    "actions": {
+      "new": "Nouveau fonds"
+    },
+    "empty": {
+      "title": "Aucun fonds",
+      "description": "Ajoutez un premier fonds pour contrôler les affectations disponibles dans les campagnes et les dons."
+    },
+    "form": {
+      "createTitle": "Créer un fonds",
+      "createSubtitle": "Ajoutez un fonds restreint ou non restreint pour l’affectation des campagnes et des dons.",
+      "breadcrumbNew": "Nouveau fonds",
+      "sections": {
+        "identity": {
+          "title": "Identité",
+          "description": "Informations principales utilisées pour nommer et classer le fonds."
+        },
+        "description": {
+          "title": "Description",
+          "description": "Contexte optionnel pour expliquer quand utiliser ce fonds."
+        }
+      },
+      "fields": {
+        "name": "Nom du fonds",
+        "namePlaceholder": "Fonds restreint grands donateurs",
+        "nameHint": "Utilisez un libellé précis reconnu par l’équipe fundraising.",
+        "type": "Type de fonds",
+        "typeHint": "Les fonds restreints servent aux dons fléchés. Les fonds non restreints peuvent financer les opérations générales.",
+        "description": "Description",
+        "descriptionPlaceholder": "Expliquez l’affectation ou l’usage interne de ce fonds.",
+        "descriptionHint": "Optionnel, mais utile quand plusieurs fonds se ressemblent."
+      },
+      "actions": {
+        "cancel": "Annuler",
+        "submitCreate": "Créer le fonds",
+        "submitting": "Enregistrement…"
+      },
+      "errors": {
+        "nameRequired": "Le nom du fonds est requis.",
+        "nameTooLong": "Le nom du fonds doit contenir au plus 255 caractères.",
+        "descriptionTooLong": "La description doit contenir au plus 5000 caractères.",
+        "generic": "Une erreur est survenue pendant l’enregistrement. Veuillez réessayer."
+      },
+      "success": {
+        "created": "Fonds créé."
+      }
+    }
+  },
   "tenant": {
     "title": "Paramètres de l'organisation",
     "description": "Choisissez la devise de base du tenant utilisée pour le reporting et les conversions.",
@@ -705,6 +769,10 @@
         "structure": {
           "title": "Structure",
           "description": "Campagne parente et coût opérationnel utilisés pour le regroupement et le reporting ROI."
+        },
+        "funds": {
+          "title": "Fonds éligibles",
+          "description": "Choisissez les affectations de fonds qui peuvent être associées à cette campagne."
         }
       },
       "fields": {
@@ -719,7 +787,15 @@
         "parentLoading": "Chargement des campagnes disponibles…",
         "operationalCost": "Coût opérationnel",
         "operationalCostPlaceholder": "0,00",
-        "operationalCostHint": "Dépense saisie par l'organisation. Les frais plateforme sont suivis séparément sur les dons."
+        "operationalCostHint": "Dépense saisie par l'organisation. Les frais plateforme sont suivis séparément sur les dons.",
+        "funds": "Fonds éligibles",
+        "fundsHint": "Les fonds sélectionnés seront disponibles lorsque des dons seront associés à cette campagne.",
+        "fundsLoading": "Chargement des fonds disponibles…",
+        "fundsEmpty": "Aucun fonds n’est configuré pour le moment. Créez-en un depuis les paramètres."
+      },
+      "fundTypeHint": {
+        "restricted": "Fonds restreint",
+        "unrestricted": "Fonds non restreint"
       },
       "actions": {
         "cancel": "Annuler",

--- a/packages/web/src/app/(app)/settings/funds/funds-table.tsx
+++ b/packages/web/src/app/(app)/settings/funds/funds-table.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { PiggyBank } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { useCallback, useMemo } from "react";
+
+import { EmptyState } from "@/components/shared/empty-state";
+import { Badge } from "@/components/ui/badge";
+import { DataTable, type DataTablePagination } from "@/components/ui/data-table";
+import { formatDate } from "@/lib/format";
+import type { Fund, FundType } from "@/models/fund";
+
+const FUND_TYPES = new Set<FundType>(["restricted", "unrestricted"]);
+
+const TYPE_VARIANTS: Record<FundType, "warning" | "info"> = {
+  restricted: "warning",
+  unrestricted: "info",
+};
+
+interface FundsTableProps {
+  funds: Fund[];
+  pagination: DataTablePagination;
+}
+
+function isFundType(value: string): value is FundType {
+  return FUND_TYPES.has(value as FundType);
+}
+
+export function FundsTable({ funds, pagination }: FundsTableProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const locale = useLocale();
+  const t = useTranslations("settings.funds");
+
+  const navigateToPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (page <= 1) {
+        params.delete("page");
+      } else {
+        params.set("page", String(page));
+      }
+      const query = params.toString();
+      router.push(query ? `${pathname}?${query}` : pathname);
+    },
+    [pathname, router, searchParams],
+  );
+
+  const columns = useMemo<ColumnDef<Fund>[]>(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: () => t("columns.name"),
+        enableSorting: true,
+        cell: ({ row }) => <span className="font-medium text-on-surface">{row.original.name}</span>,
+      },
+      {
+        id: "type",
+        accessorKey: "type",
+        header: () => t("columns.type"),
+        enableSorting: true,
+        cell: ({ row }) => {
+          const type = String(row.original.type);
+          if (!isFundType(type)) {
+            return <Badge variant="neutral">{type}</Badge>;
+          }
+          return <Badge variant={TYPE_VARIANTS[type]}>{t(`types.${type}`)}</Badge>;
+        },
+      },
+      {
+        id: "description",
+        accessorFn: (row) => row.description ?? "",
+        header: () => t("columns.description"),
+        enableSorting: false,
+        cell: ({ row }) => (
+          <span className="line-clamp-2 max-w-xl text-on-surface-variant">
+            {row.original.description?.trim() || t("descriptionEmpty")}
+          </span>
+        ),
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: () => t("columns.createdAt"),
+        enableSorting: true,
+        cell: ({ row }) => (
+          <span className="whitespace-nowrap text-on-surface-variant">
+            {formatDate(row.original.createdAt, locale, "short")}
+          </span>
+        ),
+      },
+    ],
+    [locale, t],
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      data={funds}
+      pagination={pagination}
+      onPageChange={navigateToPage}
+      emptyState={
+        <EmptyState
+          icon={PiggyBank}
+          title={t("empty.title")}
+          description={t("empty.description")}
+        />
+      }
+    />
+  );
+}

--- a/packages/web/src/app/(app)/settings/funds/new/page.tsx
+++ b/packages/web/src/app/(app)/settings/funds/new/page.tsx
@@ -1,0 +1,28 @@
+import { getTranslations } from "next-intl/server";
+
+import { FundForm } from "@/components/settings/fund-form";
+import { PageHeader } from "@/components/shared/page-header";
+import { requireAuth } from "@/lib/auth/guards";
+
+export default async function NewFundPage() {
+  const auth = await requireAuth();
+  const t = await getTranslations("settings.funds");
+  const tSettings = await getTranslations("settings");
+  const tForm = await getTranslations("settings.funds.form");
+
+  return (
+    <>
+      <PageHeader
+        title={tForm("createTitle")}
+        description={tForm("createSubtitle")}
+        breadcrumbs={[
+          { label: tSettings("breadcrumbRoot"), href: "/dashboard" },
+          { label: t("settings"), href: "/settings" },
+          { label: t("title"), href: "/settings/funds" },
+          { label: tForm("breadcrumbNew") },
+        ]}
+      />
+      <FundForm canManageFunds={auth.roles.includes("org_admin")} />
+    </>
+  );
+}

--- a/packages/web/src/app/(app)/settings/funds/page.tsx
+++ b/packages/web/src/app/(app)/settings/funds/page.tsx
@@ -5,10 +5,8 @@ import { getTranslations } from "next-intl/server";
 import { EmptyState } from "@/components/shared/empty-state";
 import { PageHeader } from "@/components/shared/page-header";
 import { Button } from "@/components/ui/button";
-import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
-import type { FundListResponse } from "@/models/fund";
 import { FundService } from "@/services/FundService";
 
 import { FundsTable } from "./funds-table";
@@ -38,20 +36,7 @@ export default async function FundsPage({ searchParams }: FundsPageProps) {
   const canManageFunds = auth.roles.includes("org_admin");
 
   const client = await createServerApiClient();
-
-  let result: FundListResponse;
-  try {
-    result = await FundService.listFunds(client, { page, perPage });
-  } catch (error) {
-    if (error instanceof ApiProblem && (error.status === 401 || error.status === 403)) {
-      result = {
-        data: [],
-        pagination: { page, perPage, total: 0, totalPages: 0 },
-      };
-    } else {
-      throw error;
-    }
-  }
+  const result = await FundService.listFunds(client, { page, perPage });
 
   const hasAny = result.pagination.total > 0;
 

--- a/packages/web/src/app/(app)/settings/funds/page.tsx
+++ b/packages/web/src/app/(app)/settings/funds/page.tsx
@@ -1,0 +1,95 @@
+import { PiggyBank, Plus } from "lucide-react";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+
+import { EmptyState } from "@/components/shared/empty-state";
+import { PageHeader } from "@/components/shared/page-header";
+import { Button } from "@/components/ui/button";
+import { ApiProblem } from "@/lib/api";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import type { FundListResponse } from "@/models/fund";
+import { FundService } from "@/services/FundService";
+
+import { FundsTable } from "./funds-table";
+
+const DEFAULT_PER_PAGE = 20;
+const MAX_PER_PAGE = 100;
+
+interface FundsPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function parsePositiveInt(value: string | string[] | undefined, fallback: number, max?: number) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return max ? Math.min(parsed, max) : parsed;
+}
+
+export default async function FundsPage({ searchParams }: FundsPageProps) {
+  const auth = await requireAuth();
+  const params = await searchParams;
+  const t = await getTranslations("settings.funds");
+  const tSettings = await getTranslations("settings");
+
+  const page = parsePositiveInt(params.page, 1);
+  const perPage = parsePositiveInt(params.perPage, DEFAULT_PER_PAGE, MAX_PER_PAGE);
+  const canManageFunds = auth.roles.includes("org_admin");
+
+  const client = await createServerApiClient();
+
+  let result: FundListResponse;
+  try {
+    result = await FundService.listFunds(client, { page, perPage });
+  } catch (error) {
+    if (error instanceof ApiProblem && (error.status === 401 || error.status === 403)) {
+      result = {
+        data: [],
+        pagination: { page, perPage, total: 0, totalPages: 0 },
+      };
+    } else {
+      throw error;
+    }
+  }
+
+  const hasAny = result.pagination.total > 0;
+
+  return (
+    <>
+      <PageHeader
+        title={t("title")}
+        description={
+          hasAny ? t("subtitleWithCount", { count: result.pagination.total }) : t("subtitleEmpty")
+        }
+        breadcrumbs={[
+          { label: tSettings("breadcrumbRoot"), href: "/dashboard" },
+          { label: t("settings"), href: "/settings" },
+          { label: t("title") },
+        ]}
+        actions={
+          canManageFunds ? (
+            <Button asChild variant="primary" size="sm">
+              <Link href="/settings/funds/new">
+                <Plus size={16} aria-hidden="true" />
+                {t("actions.new")}
+              </Link>
+            </Button>
+          ) : null
+        }
+      />
+
+      {hasAny ? (
+        <FundsTable funds={result.data} pagination={result.pagination} />
+      ) : (
+        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+          <EmptyState
+            icon={PiggyBank}
+            title={t("empty.title")}
+            description={t("empty.description")}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/web/src/components/campaigns/campaign-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.test.tsx
@@ -60,7 +60,9 @@ describe("CampaignForm", () => {
 
     await user.type(screen.getByPlaceholderText("Spring appeal 2026"), "  Spring Appeal 2026  ");
     await user.type(screen.getByPlaceholderText("0.00"), "12.50");
-    await user.click(screen.getByRole("checkbox", { name: "Restricted Fund" }));
+    const fundCheckbox = await screen.findByRole("checkbox", { name: "Restricted Fund" });
+    await user.click(fundCheckbox);
+    await waitFor(() => expect(fundCheckbox).toHaveAttribute("data-state", "checked"));
     await user.click(screen.getByRole("button", { name: "Create campaign" }));
 
     await waitFor(() =>
@@ -102,5 +104,34 @@ describe("CampaignForm", () => {
     await user.click(screen.getByRole("button", { name: "Create campaign" }));
 
     expect(await screen.findByText("Campaign name is already used.")).toBeInTheDocument();
+  });
+
+  it("exposes the eligible funds as an accessible group", async () => {
+    render(<CampaignForm mode="create" />);
+
+    await waitFor(() => expect(FundService.listFunds).toHaveBeenCalled());
+
+    expect(screen.getByRole("group", { name: "Eligible funds" })).toBeInTheDocument();
+  });
+
+  it("blocks editing when campaign fund options fail to load", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(FundService, "listCampaignFunds").mockRejectedValueOnce(new Error("boom"));
+    const updateCampaign = vi
+      .spyOn(CampaignService, "updateCampaign")
+      .mockResolvedValue(parentCampaign);
+
+    render(<CampaignForm mode="edit" campaign={parentCampaign} />);
+
+    expect(
+      await screen.findByText(/Unable to load the related campaigns or funds/i),
+    ).toBeInTheDocument();
+
+    const submitButton = screen.getByRole("button", { name: "Save changes" });
+    expect(submitButton).toBeDisabled();
+
+    await user.click(submitButton);
+
+    expect(updateCampaign).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/campaigns/campaign-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.test.tsx
@@ -2,6 +2,7 @@ import { CampaignForm } from "@/components/campaigns/campaign-form";
 import { ApiProblem } from "@/lib/api";
 import type { Campaign } from "@/models/campaign";
 import { CampaignService } from "@/services/CampaignService";
+import { FundService } from "@/services/FundService";
 import { mockRouter, mockToast, render, screen, userEvent, waitFor } from "../../tests/test-utils";
 
 const parentCampaign: Campaign = {
@@ -25,6 +26,21 @@ describe("CampaignForm", () => {
       data: [parentCampaign],
       pagination: { page: 1, perPage: 100, total: 1, totalPages: 1 },
     });
+    vi.spyOn(FundService, "listFunds").mockResolvedValue({
+      data: [
+        {
+          id: "33333333-3333-4333-8333-333333333333",
+          orgId: parentCampaign.orgId,
+          name: "Restricted Fund",
+          description: "Restricted",
+          type: "restricted",
+          createdAt: parentCampaign.createdAt,
+          updatedAt: parentCampaign.updatedAt,
+        },
+      ],
+      pagination: { page: 1, perPage: 100, total: 1, totalPages: 1 },
+    });
+    vi.spyOn(FundService, "listCampaignFunds").mockResolvedValue([]);
   });
 
   it("submits trimmed values in create mode", async () => {
@@ -40,9 +56,11 @@ describe("CampaignForm", () => {
     render(<CampaignForm mode="create" />);
 
     await waitFor(() => expect(CampaignService.listCampaigns).toHaveBeenCalled());
+    await waitFor(() => expect(FundService.listFunds).toHaveBeenCalled());
 
     await user.type(screen.getByPlaceholderText("Spring appeal 2026"), "  Spring Appeal 2026  ");
     await user.type(screen.getByPlaceholderText("0.00"), "12.50");
+    await user.click(screen.getByRole("checkbox", { name: "Restricted Fund" }));
     await user.click(screen.getByRole("button", { name: "Create campaign" }));
 
     await waitFor(() =>
@@ -53,6 +71,7 @@ describe("CampaignForm", () => {
           type: "digital",
           parentId: null,
           operationalCostCents: 1250,
+          fundIds: ["33333333-3333-4333-8333-333333333333"],
         }),
       ),
     );
@@ -77,6 +96,7 @@ describe("CampaignForm", () => {
     render(<CampaignForm mode="create" />);
 
     await waitFor(() => expect(CampaignService.listCampaigns).toHaveBeenCalled());
+    await waitFor(() => expect(FundService.listFunds).toHaveBeenCalled());
 
     await user.type(screen.getByPlaceholderText("Spring appeal 2026"), "Existing campaign");
     await user.click(screen.getByRole("button", { name: "Create campaign" }));

--- a/packages/web/src/components/campaigns/campaign-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.tsx
@@ -20,6 +20,7 @@ import { AmountInput } from "@/components/shared/amount-input";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -27,6 +28,7 @@ import {
 } from "@/components/shared/form-field";
 import { FormSection } from "@/components/shared/form-section";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -39,7 +41,9 @@ import { toast } from "@/components/ui/toast";
 import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import type { Campaign, CampaignCurrency, CampaignType } from "@/models/campaign";
+import type { Fund } from "@/models/fund";
 import { CampaignService } from "@/services/CampaignService";
+import { FundService } from "@/services/FundService";
 
 const CAMPAIGN_TYPES: readonly CampaignType[] = [
   "nominative_postal",
@@ -54,6 +58,7 @@ interface CampaignFormValues {
   defaultCurrency: CampaignCurrency;
   parentId: string;
   operationalCostCents: number | null;
+  fundIds: string[];
 }
 
 type CreateMode = { mode: "create"; campaign?: undefined };
@@ -62,6 +67,7 @@ type EditMode = { mode: "edit"; campaign: Campaign };
 export type CampaignFormProps = CreateMode | EditMode;
 
 const EMPTY_PARENT = "__none__";
+const CAMPAIGN_OPTION_PAGE_SIZE = 100;
 
 export function CampaignForm(props: CampaignFormProps) {
   const { mode } = props;
@@ -75,6 +81,7 @@ export function CampaignForm(props: CampaignFormProps) {
     defaultCurrency: props.campaign?.defaultCurrency ?? "EUR",
     parentId: props.campaign?.parentId ?? "",
     operationalCostCents: props.campaign?.operationalCostCents ?? null,
+    fundIds: [],
   };
 
   const form = useForm<CampaignFormValues>({
@@ -84,27 +91,36 @@ export function CampaignForm(props: CampaignFormProps) {
   });
 
   const [parentOptions, setParentOptions] = useState<Campaign[]>([]);
+  const [fundOptions, setFundOptions] = useState<Fund[]>([]);
   const [optionsLoading, setOptionsLoading] = useState(true);
+  const [fundsLoading, setFundsLoading] = useState(true);
 
   useEffect(() => {
     let active = true;
 
     async function loadOptions() {
       try {
-        const result = await CampaignService.listCampaigns(createClientApiClient(), {
-          perPage: 100,
-        });
+        const { campaigns, funds, selectedFundIds } = await loadCampaignFormOptions(
+          mode,
+          props.campaign?.id,
+        );
         if (!active) return;
         setParentOptions(
-          result.data.filter((campaign) =>
+          campaigns.filter((campaign) =>
             mode === "edit" ? campaign.id !== props.campaign.id : true,
           ),
         );
+        setFundOptions(funds);
+        form.setValue("fundIds", selectedFundIds, { shouldDirty: false });
       } catch {
         if (!active) return;
         setParentOptions([]);
+        setFundOptions([]);
       } finally {
-        if (active) setOptionsLoading(false);
+        if (active) {
+          setOptionsLoading(false);
+          setFundsLoading(false);
+        }
       }
     }
 
@@ -113,7 +129,7 @@ export function CampaignForm(props: CampaignFormProps) {
     return () => {
       active = false;
     };
-  }, [mode, props.campaign?.id]);
+  }, [form, mode, props.campaign?.id]);
 
   async function onSubmit(values: CampaignFormValues) {
     form.clearErrors("root");
@@ -292,6 +308,70 @@ export function CampaignForm(props: CampaignFormProps) {
           </div>
         </FormSection>
 
+        <FormSection
+          title={t("sections.funds.title")}
+          description={t("sections.funds.description")}
+        >
+          <FormField
+            control={form.control}
+            name="fundIds"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("fields.funds")}</FormLabel>
+                {fundsLoading ? (
+                  <FormDescription>{t("fields.fundsLoading")}</FormDescription>
+                ) : fundOptions.length > 0 ? (
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {fundOptions.map((fund) => {
+                      const checked = field.value.includes(fund.id);
+                      const checkboxId = `campaign-fund-${fund.id}`;
+                      const descriptionId = `${checkboxId}-description`;
+                      return (
+                        <div
+                          key={fund.id}
+                          className="flex items-start gap-3 rounded-xl border border-outline-variant bg-surface-container-lowest px-4 py-3"
+                        >
+                          <Checkbox
+                            id={checkboxId}
+                            checked={checked}
+                            onCheckedChange={(nextChecked) => {
+                              const current = field.value;
+                              if (nextChecked === true) {
+                                field.onChange([...current, fund.id]);
+                                return;
+                              }
+                              field.onChange(current.filter((value) => value !== fund.id));
+                            }}
+                            aria-describedby={descriptionId}
+                          />
+                          <div className="min-w-0">
+                            <label
+                              htmlFor={checkboxId}
+                              className="block font-medium text-on-surface"
+                            >
+                              {fund.name}
+                            </label>
+                            <span
+                              id={descriptionId}
+                              className="block text-xs text-on-surface-variant"
+                            >
+                              {t(`fundTypeHint.${fund.type}`)}
+                            </span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <FormDescription>{t("fields.fundsEmpty")}</FormDescription>
+                )}
+                <FormDescription>{t("fields.fundsHint")}</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
         <div className="flex flex-col gap-3 py-8 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-h-5 text-sm text-error">{rootError}</div>
           <div className="flex flex-wrap items-center gap-3">
@@ -321,6 +401,7 @@ function toApiPayload(values: CampaignFormValues) {
     defaultCurrency: values.defaultCurrency,
     parentId: values.parentId?.trim() || null,
     operationalCostCents: values.operationalCostCents,
+    fundIds: values.fundIds.map((value) => value.trim()).filter((value) => value !== ""),
   };
 }
 
@@ -344,6 +425,7 @@ function buildResolver(): Resolver<CampaignFormValues> {
     if (values.operationalCostCents !== null) {
       cleaned.operationalCostCents = values.operationalCostCents;
     }
+    cleaned.fundIds = values.fundIds.map((value) => value.trim()).filter((value) => value !== "");
 
     const result = await innerResolver(
       cleaned,
@@ -379,4 +461,23 @@ function handleApiError(
   }
 
   form.setError("root", { type: "server", message: messages.generic });
+}
+
+async function loadCampaignFormOptions(mode: CampaignFormProps["mode"], campaignId?: string) {
+  const client = createClientApiClient();
+  const [campaignsResult, fundsResult, selectedFunds] = await Promise.all([
+    CampaignService.listCampaigns(client, {
+      perPage: CAMPAIGN_OPTION_PAGE_SIZE,
+    }),
+    FundService.listFunds(client, { perPage: CAMPAIGN_OPTION_PAGE_SIZE }),
+    mode === "edit" && campaignId
+      ? FundService.listCampaignFunds(client, campaignId)
+      : Promise.resolve([]),
+  ]);
+
+  return {
+    campaigns: campaignsResult.data,
+    funds: fundsResult.data,
+    selectedFundIds: selectedFunds.map((fund) => fund.id),
+  };
 }

--- a/packages/web/src/components/campaigns/campaign-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.tsx
@@ -14,7 +14,13 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
-import { type DefaultValues, type Resolver, type UseFormReturn, useForm } from "react-hook-form";
+import {
+  type ControllerRenderProps,
+  type DefaultValues,
+  type Resolver,
+  type UseFormReturn,
+  useForm,
+} from "react-hook-form";
 
 import { AmountInput } from "@/components/shared/amount-input";
 import {
@@ -25,6 +31,7 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
+  useFormField,
 } from "@/components/shared/form-field";
 import { FormSection } from "@/components/shared/form-section";
 import { Button } from "@/components/ui/button";
@@ -74,6 +81,7 @@ export function CampaignForm(props: CampaignFormProps) {
   const router = useRouter();
   const t = useTranslations("campaigns.form");
   const tCampaigns = useTranslations("campaigns");
+  const optionsLoadErrorMessage = t("errors.optionsLoad");
 
   const defaultValues: DefaultValues<CampaignFormValues> = {
     name: props.campaign?.name ?? "",
@@ -94,6 +102,7 @@ export function CampaignForm(props: CampaignFormProps) {
   const [fundOptions, setFundOptions] = useState<Fund[]>([]);
   const [optionsLoading, setOptionsLoading] = useState(true);
   const [fundsLoading, setFundsLoading] = useState(true);
+  const [optionsError, setOptionsError] = useState<string | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -105,17 +114,26 @@ export function CampaignForm(props: CampaignFormProps) {
           props.campaign?.id,
         );
         if (!active) return;
-        setParentOptions(
-          campaigns.filter((campaign) =>
-            mode === "edit" ? campaign.id !== props.campaign.id : true,
-          ),
-        );
-        setFundOptions(funds);
-        form.setValue("fundIds", selectedFundIds, { shouldDirty: false });
+        applyCampaignFormOptions({
+          campaigns,
+          funds,
+          selectedFundIds,
+          mode,
+          campaignId: props.campaign?.id,
+          form,
+          setOptionsError,
+          setParentOptions,
+          setFundOptions,
+        });
       } catch {
         if (!active) return;
-        setParentOptions([]);
-        setFundOptions([]);
+        resetCampaignFormOptions({
+          mode,
+          optionsLoadError: optionsLoadErrorMessage,
+          setOptionsError,
+          setParentOptions,
+          setFundOptions,
+        });
       } finally {
         if (active) {
           setOptionsLoading(false);
@@ -129,10 +147,15 @@ export function CampaignForm(props: CampaignFormProps) {
     return () => {
       active = false;
     };
-  }, [form, mode, props.campaign?.id]);
+  }, [form, mode, optionsLoadErrorMessage, props.campaign?.id]);
 
   async function onSubmit(values: CampaignFormValues) {
     form.clearErrors("root");
+
+    if (mode === "edit" && optionsError) {
+      toast.error(optionsError);
+      return;
+    }
 
     try {
       if (mode === "create") {
@@ -317,56 +340,13 @@ export function CampaignForm(props: CampaignFormProps) {
             name="fundIds"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>{t("fields.funds")}</FormLabel>
-                {fundsLoading ? (
-                  <FormDescription>{t("fields.fundsLoading")}</FormDescription>
-                ) : fundOptions.length > 0 ? (
-                  <div className="grid gap-3 md:grid-cols-2">
-                    {fundOptions.map((fund) => {
-                      const checked = field.value.includes(fund.id);
-                      const checkboxId = `campaign-fund-${fund.id}`;
-                      const descriptionId = `${checkboxId}-description`;
-                      return (
-                        <div
-                          key={fund.id}
-                          className="flex items-start gap-3 rounded-xl border border-outline-variant bg-surface-container-lowest px-4 py-3"
-                        >
-                          <Checkbox
-                            id={checkboxId}
-                            checked={checked}
-                            onCheckedChange={(nextChecked) => {
-                              const current = field.value;
-                              if (nextChecked === true) {
-                                field.onChange([...current, fund.id]);
-                                return;
-                              }
-                              field.onChange(current.filter((value) => value !== fund.id));
-                            }}
-                            aria-describedby={descriptionId}
-                          />
-                          <div className="min-w-0">
-                            <label
-                              htmlFor={checkboxId}
-                              className="block font-medium text-on-surface"
-                            >
-                              {fund.name}
-                            </label>
-                            <span
-                              id={descriptionId}
-                              className="block text-xs text-on-surface-variant"
-                            >
-                              {t(`fundTypeHint.${fund.type}`)}
-                            </span>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <FormDescription>{t("fields.fundsEmpty")}</FormDescription>
-                )}
-                <FormDescription>{t("fields.fundsHint")}</FormDescription>
-                <FormMessage />
+                <CampaignFundIdsField
+                  field={field}
+                  fundOptions={fundOptions}
+                  fundsLoading={fundsLoading}
+                  optionsError={optionsError}
+                  t={t}
+                />
               </FormItem>
             )}
           />
@@ -380,7 +360,10 @@ export function CampaignForm(props: CampaignFormProps) {
                 {t("actions.cancel")}
               </Link>
             </Button>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button
+              type="submit"
+              disabled={isSubmitting || (mode === "edit" && Boolean(optionsError))}
+            >
               {isSubmitting
                 ? t("actions.submitting")
                 : mode === "create"
@@ -436,6 +419,131 @@ function buildResolver(): Resolver<CampaignFormValues> {
   };
 
   return adapted;
+}
+
+function applyCampaignFormOptions({
+  campaigns,
+  funds,
+  selectedFundIds,
+  mode,
+  campaignId,
+  form,
+  setOptionsError,
+  setParentOptions,
+  setFundOptions,
+}: {
+  campaigns: Campaign[];
+  funds: Fund[];
+  selectedFundIds: string[];
+  mode: CampaignFormProps["mode"];
+  campaignId?: string;
+  form: UseFormReturn<CampaignFormValues>;
+  setOptionsError: (value: string | null) => void;
+  setParentOptions: (value: Campaign[]) => void;
+  setFundOptions: (value: Fund[]) => void;
+}) {
+  setOptionsError(null);
+  setParentOptions(
+    campaigns.filter((campaign) => (mode === "edit" ? campaign.id !== campaignId : true)),
+  );
+  setFundOptions(funds);
+  form.setValue("fundIds", selectedFundIds, { shouldDirty: false });
+}
+
+function resetCampaignFormOptions({
+  mode,
+  optionsLoadError,
+  setOptionsError,
+  setParentOptions,
+  setFundOptions,
+}: {
+  mode: CampaignFormProps["mode"];
+  optionsLoadError: string;
+  setOptionsError: (value: string | null) => void;
+  setParentOptions: (value: Campaign[]) => void;
+  setFundOptions: (value: Fund[]) => void;
+}) {
+  setParentOptions([]);
+  setFundOptions([]);
+  setOptionsError(mode === "edit" ? optionsLoadError : null);
+}
+
+function CampaignFundIdsField({
+  field,
+  fundOptions,
+  fundsLoading,
+  optionsError,
+  t,
+}: {
+  field: ControllerRenderProps<CampaignFormValues, "fundIds">;
+  fundOptions: Fund[];
+  fundsLoading: boolean;
+  optionsError: string | null;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const { formItemId, formDescriptionId, formMessageId, error } = useFormField();
+  const isInvalid = Boolean(error || optionsError);
+  const describedBy = isInvalid ? `${formDescriptionId} ${formMessageId}` : formDescriptionId;
+
+  return (
+    <>
+      <fieldset aria-describedby={describedBy} aria-invalid={isInvalid} className="space-y-3">
+        <legend
+          id={formItemId}
+          className={
+            isInvalid ? "text-sm font-medium text-error" : "text-sm font-medium text-on-surface"
+          }
+        >
+          {t("fields.funds")}
+        </legend>
+        {fundsLoading ? (
+          <p className="text-xs text-on-surface-variant">{t("fields.fundsLoading")}</p>
+        ) : fundOptions.length > 0 ? (
+          <div className="grid gap-3 md:grid-cols-2">
+            {fundOptions.map((fund) => {
+              const checked = field.value.includes(fund.id);
+              const checkboxId = `campaign-fund-${fund.id}`;
+              const descriptionId = `${checkboxId}-description`;
+              return (
+                <div
+                  key={fund.id}
+                  className="flex items-start gap-3 rounded-xl border border-outline-variant bg-surface-container-lowest px-4 py-3"
+                >
+                  <Checkbox
+                    id={checkboxId}
+                    checked={checked}
+                    onCheckedChange={(nextChecked) => {
+                      const current = field.value;
+                      if (nextChecked === true) {
+                        field.onChange([...current, fund.id]);
+                        return;
+                      }
+                      field.onChange(current.filter((value) => value !== fund.id));
+                    }}
+                    aria-describedby={`${formDescriptionId} ${descriptionId}`}
+                    aria-invalid={isInvalid}
+                    disabled={Boolean(optionsError)}
+                  />
+                  <div className="min-w-0">
+                    <label htmlFor={checkboxId} className="block font-medium text-on-surface">
+                      {fund.name}
+                    </label>
+                    <span id={descriptionId} className="block text-xs text-on-surface-variant">
+                      {t(`fundTypeHint.${fund.type}`)}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-xs text-on-surface-variant">{t("fields.fundsEmpty")}</p>
+        )}
+      </fieldset>
+      <FormDescription>{t("fields.fundsHint")}</FormDescription>
+      <FormMessage>{optionsError}</FormMessage>
+    </>
+  );
 }
 
 interface ErrorMessages {

--- a/packages/web/src/components/settings/fund-form.tsx
+++ b/packages/web/src/components/settings/fund-form.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { Lock } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/shared/form-field";
+import { FormSection } from "@/components/shared/form-section";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { FundType } from "@/models/fund";
+import { FundService } from "@/services/FundService";
+
+interface FundFormValues {
+  name: string;
+  description: string;
+  type: FundType;
+}
+
+interface FundFormProps {
+  canManageFunds: boolean;
+}
+
+const FUND_TYPES: readonly FundType[] = ["unrestricted", "restricted"];
+
+export function FundForm({ canManageFunds }: FundFormProps) {
+  const router = useRouter();
+  const t = useTranslations("settings.funds.form");
+  const tFunds = useTranslations("settings.funds");
+
+  const form = useForm<FundFormValues>({
+    mode: "onBlur",
+    defaultValues: {
+      name: "",
+      description: "",
+      type: "unrestricted",
+    },
+  });
+
+  async function onSubmit(values: FundFormValues) {
+    if (!canManageFunds) return;
+
+    form.clearErrors("root");
+
+    try {
+      await FundService.createFund(createClientApiClient(), {
+        name: values.name.trim(),
+        description: values.description.trim() || null,
+        type: values.type,
+      });
+      toast.success(t("success.created"));
+      router.push("/settings/funds");
+      router.refresh();
+    } catch (error) {
+      form.setError("root", {
+        type: "server",
+        message: resolveApiErrorMessage(error, t("errors.generic")),
+      });
+    }
+  }
+
+  const isSubmitting = form.formState.isSubmitting;
+  const rootError = form.formState.errors.root?.message;
+
+  if (!canManageFunds) {
+    return (
+      <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+        <div className="inline-flex items-center gap-2 rounded-xl bg-surface-container px-4 py-3 text-sm text-on-surface-variant">
+          <Lock size={16} aria-hidden="true" />
+          <span>{tFunds("readOnly")}</span>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
+        noValidate
+      >
+        <FormSection
+          title={t("sections.identity.title")}
+          description={t("sections.identity.description")}
+        >
+          <div className="grid gap-5 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="name"
+              rules={{
+                required: t("errors.nameRequired"),
+                validate: (value) => (value.trim().length > 0 ? true : t("errors.nameRequired")),
+                maxLength: {
+                  value: 255,
+                  message: t("errors.nameTooLong"),
+                },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.name")}</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder={t("fields.namePlaceholder")} maxLength={255} />
+                  </FormControl>
+                  <FormDescription>{t("fields.nameHint")}</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.type")}</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={(value) => field.onChange(value as FundType)}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {FUND_TYPES.map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {tFunds(`types.${type}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>{t("fields.typeHint")}</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        <FormSection
+          title={t("sections.description.title")}
+          description={t("sections.description.description")}
+        >
+          <FormField
+            control={form.control}
+            name="description"
+            rules={{
+              maxLength: {
+                value: 5000,
+                message: t("errors.descriptionTooLong"),
+              },
+            }}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("fields.description")}</FormLabel>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    rows={5}
+                    placeholder={t("fields.descriptionPlaceholder")}
+                    maxLength={5000}
+                  />
+                </FormControl>
+                <FormDescription>{t("fields.descriptionHint")}</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormSection>
+
+        <div className="flex flex-col gap-3 py-8 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-h-5 text-sm text-error">{rootError}</div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button asChild variant="ghost">
+              <Link href="/settings/funds">{t("actions.cancel")}</Link>
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? t("actions.submitting") : t("actions.submitCreate")}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+function resolveApiErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiProblem) {
+    return error.detail ?? error.title ?? fallback;
+  }
+
+  return fallback;
+}

--- a/packages/web/src/components/settings/fund-form.tsx
+++ b/packages/web/src/components/settings/fund-form.tsx
@@ -73,10 +73,7 @@ export function FundForm({ canManageFunds }: FundFormProps) {
       router.push("/settings/funds");
       router.refresh();
     } catch (error) {
-      form.setError("root", {
-        type: "server",
-        message: resolveApiErrorMessage(error, t("errors.generic")),
-      });
+      handleApiError(error, form, t("errors.generic"));
     }
   }
 
@@ -204,6 +201,19 @@ export function FundForm({ canManageFunds }: FundFormProps) {
       </form>
     </Form>
   );
+}
+
+function handleApiError(
+  error: unknown,
+  form: ReturnType<typeof useForm<FundFormValues>>,
+  fallback: string,
+) {
+  const message = resolveApiErrorMessage(error, fallback);
+  form.setError("root", {
+    type: "server",
+    message,
+  });
+  toast.error(message);
 }
 
 function resolveApiErrorMessage(error: unknown, fallback: string): string {

--- a/packages/web/src/models/campaign.ts
+++ b/packages/web/src/models/campaign.ts
@@ -65,6 +65,7 @@ export interface CampaignCreateInput {
   defaultCurrency?: CampaignCurrency;
   parentId?: string | null;
   operationalCostCents?: number | null;
+  fundIds?: string[];
 }
 
 export type CampaignUpdateInput = Partial<CampaignCreateInput> & {

--- a/packages/web/src/models/fund.ts
+++ b/packages/web/src/models/fund.ts
@@ -1,0 +1,37 @@
+import type { Pagination } from "@/models/constituent";
+
+export type FundType = "restricted" | "unrestricted";
+
+export interface Fund {
+  id: string;
+  orgId: string;
+  name: string;
+  description: string | null;
+  type: FundType;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FundListQuery {
+  page?: number;
+  perPage?: number;
+}
+
+export interface FundListResponse {
+  data: Fund[];
+  pagination: Pagination;
+}
+
+export interface FundDetailResponse {
+  data: Fund;
+}
+
+export interface FundCreateInput {
+  name: string;
+  description?: string | null;
+  type?: FundType;
+}
+
+export interface FundCampaignListResponse {
+  data: Fund[];
+}

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -130,6 +130,7 @@ function toRequestBody(input: CampaignCreateInput | CampaignUpdateInput): Record
   if (input.operationalCostCents !== undefined) {
     body.operationalCostCents = input.operationalCostCents;
   }
+  if (input.fundIds !== undefined) body.fundIds = input.fundIds;
 
   return body;
 }

--- a/packages/web/src/services/FundService.ts
+++ b/packages/web/src/services/FundService.ts
@@ -1,0 +1,57 @@
+import type { ApiClient } from "@/lib/api";
+import type {
+  Fund,
+  FundCampaignListResponse,
+  FundCreateInput,
+  FundDetailResponse,
+  FundListQuery,
+  FundListResponse,
+} from "@/models/fund";
+
+export const FundService = {
+  async listFunds(client: ApiClient, query: FundListQuery = {}): Promise<FundListResponse> {
+    const response = await client.get<FundListResponse>("/v1/funds", {
+      params: {
+        page: query.page ?? 1,
+        perPage: query.perPage ?? 20,
+      },
+    });
+
+    return {
+      data: response.data.map(mapFund),
+      pagination: response.pagination,
+    };
+  },
+
+  async createFund(client: ApiClient, input: FundCreateInput): Promise<Fund> {
+    const response = await client.post<FundDetailResponse>("/v1/funds", toRequestBody(input));
+    return mapFund(response.data);
+  },
+
+  async listCampaignFunds(client: ApiClient, campaignId: string): Promise<Fund[]> {
+    const response = await client.get<FundCampaignListResponse>(
+      `/v1/campaigns/${encodeURIComponent(campaignId)}/funds`,
+    );
+    return response.data.map(mapFund);
+  },
+};
+
+function mapFund(raw: Fund): Fund {
+  return {
+    id: raw.id,
+    orgId: raw.orgId,
+    name: raw.name,
+    description: raw.description,
+    type: raw.type,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function toRequestBody(input: FundCreateInput): Record<string, unknown> {
+  return {
+    name: input.name,
+    description: input.description ?? null,
+    type: input.type ?? "unrestricted",
+  };
+}


### PR DESCRIPTION
## What changed
- add a new `/settings/funds` management surface with a paginated `DataTable`
- add `/settings/funds/new` and a `FundForm` wired to the funds service
- extend the campaign form to load eligible funds, let users select them with checkboxes, and submit `fundIds`
- add web fund models/service and update messages in English and French
- cover campaign fund selection in the existing form test

## Why
The API already supports tenant funds and campaign fund eligibility. The web app was missing the UI needed to manage funds and assign them to campaigns.

## Impact
Organisation admins can now create funds from settings and attach eligible funds to campaigns without manual API calls.

## Validation
- `pnpm lint`
- `pnpm typecheck`
