### PR TITLE
feat(web): filter available funds by selected campaign in donation forms

### DIFF
--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -60,6 +60,7 @@ import { cn } from "@/lib/utils";
 import type { Campaign, CampaignCurrency } from "@/models/campaign";
 import { type Constituent, fullName } from "@/models/constituent";
 import type { DonationAllocationInput, DonationCreateInput } from "@/models/donation";
+import type { Fund } from "@/models/fund";
 import { CampaignService } from "@/services/CampaignService";
 import { ConstituentService } from "@/services/ConstituentService";
 import { DonationService } from "@/services/DonationService";
@@ -122,6 +123,9 @@ export function DonationForm() {
   const [campaignOptions, setCampaignOptions] = useState<Campaign[]>([]);
   const [campaignsLoading, setCampaignsLoading] = useState(true);
 
+  const [fundOptions, setFundOptions] = useState<Fund[]>([]);
+  const [fundsLoading, setFundsLoading] = useState(true);
+
   useEffect(() => {
     let active = true;
     async function loadCampaigns() {
@@ -164,6 +168,39 @@ export function DonationForm() {
 
     return () => subscription.unsubscribe();
   }, [campaignOptions, form]);
+
+  const watchedCampaignId = form.watch("campaignId");
+
+  useEffect(() => {
+    let active = true;
+    setFundsLoading(true);
+
+    async function loadFunds() {
+      try {
+        const client = createClientApiClient();
+        if (watchedCampaignId) {
+          const campaignFunds = await CampaignService.getCampaignFunds(client, watchedCampaignId);
+          if (active) setFundOptions(campaignFunds);
+        } else {
+          // If no campaign selected, we could either clear the funds or fetch all funds.
+          // Let's clear them for strict linkage or you can fetch all if preferred.
+          const allFundsResult = await client.get<{ data: Fund[], pagination: unknown }>("/v1/funds", {
+            params: { page: 1, perPage: 100 },
+          });
+          if (active) setFundOptions(allFundsResult.data);
+        }
+      } catch {
+        if (active) setFundOptions([]);
+      } finally {
+        if (active) setFundsLoading(false);
+      }
+    }
+
+    loadFunds();
+    return () => {
+      active = false;
+    };
+  }, [watchedCampaignId]);
 
   async function onSubmit(values: DonationFormValues) {
     form.clearErrors("root");
@@ -403,13 +440,26 @@ export function DonationForm() {
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel>{t("fields.allocationFund")}</FormLabel>
-                          <Input
-                            {...field}
-                            placeholder={t("fields.allocationFundPlaceholder")}
-                            aria-invalid={Boolean(
-                              form.formState.errors.allocations?.[index]?.fundId,
-                            )}
-                          />
+                          <Select
+                            value={field.value || "__none__"}
+                            onValueChange={(value) => field.onChange(value === "__none__" ? "" : value)}
+                          >
+                            <SelectTrigger
+                              aria-invalid={Boolean(form.formState.errors.allocations?.[index]?.fundId)}
+                            >
+                              <SelectValue placeholder={t("fields.allocationFundPlaceholder")} />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="__none__">
+                                {t("fields.allocationFundPlaceholder")}
+                              </SelectItem>
+                              {fundOptions.map((fund) => (
+                                <SelectItem key={fund.id} value={fund.id}>
+                                  {fund.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
                           <FormMessage />
                         </FormItem>
                       )}

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -11,6 +11,7 @@ import type {
   CampaignStatsResponse,
   CampaignUpdateInput,
 } from "@/models/campaign";
+import type { Fund } from "@/models/fund";
 
 /**
  * CampaignService — ADR-011 Layer 2 (services).
@@ -70,6 +71,13 @@ export const CampaignService = {
       `/v1/campaigns/${encodeURIComponent(id)}`,
     );
     return mapCampaign(response.data);
+  },
+
+  async getCampaignFunds(client: ApiClient, id: string): Promise<Fund[]> {
+    const response = await client.get<{ data: Fund[] }>(
+      `/v1/campaigns/${encodeURIComponent(id)}/funds`,
+    );
+    return response.data;
   },
 
   async createCampaign(client: ApiClient, input: CampaignCreateInput): Promise<Campaign> {


### PR DESCRIPTION
Resolves step 3 of Issue #102. Dynamically loads eligible funds via the campaign association endpoint during donation data entry.