### PR TITLE
fix(dev): disable Keycloak SSL requirement in local realm import

### DIFF
--- a/infra/keycloak/realm-givernance.json
+++ b/infra/keycloak/realm-givernance.json
@@ -1,6 +1,7 @@
 {
   "realm": "givernance",
   "enabled": true,
+  "sslRequired": "none",
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,


### PR DESCRIPTION
## Summary

- Adds `"sslRequired": "none"` to [infra/keycloak/realm-givernance.json](infra/keycloak/realm-givernance.json) so OIDC works out-of-the-box after a fresh realm import.
- Keycloak defaults `sslRequired` to `"external"`, which rejects the auth flow with **"HTTPS required"** the first time a developer boots the stack against a clean Postgres volume (e.g. `docker compose down -v && up -d`). Login silently breaks until someone knows to run `kcadm.sh update realms/givernance -s sslRequired=NONE`.
- This realm file is **only mounted by `docker-compose.yml`** for local dev. Prod Keycloak is provisioned separately on Scaleway VMs per [docs/15-infra-adr.md](docs/15-infra-adr.md) and keeps its own SSL policy, so this change cannot weaken the production posture.

## Why now

While testing the new `KEYCLOAK_ADMIN_CLIENT_ID` / `KEYCLOAK_ADMIN_CLIENT_SECRET` flow (ADR-016 / #107), a realm re-import was needed to pick up the `givernance-admin` client — which surfaced this long-standing dev-ergonomics bug.

## Test plan

- [ ] `docker compose down -v && docker compose up -d` (fresh Keycloak volume)
- [ ] Visit http://localhost:3000, get redirected to `/login` → Keycloak → back to `/dashboard` without any "HTTPS required" page
- [ ] Verify `sslRequired` is `NONE` in the realm settings via `kcadm.sh get realms/givernance | grep sslRequired`

## Notes for reviewers

- Safe because this JSON is strictly the local-dev Keycloak import. If the file ever gets repurposed for prod, revert to `"external"`.
- No code changes, no schema changes, no migration impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)