### PR TITLE
feat(invitations): wire team invitations through end-to-end (#145)

### DIFF
--- a/packages/api/src/lib/guards.ts
+++ b/packages/api/src/lib/guards.ts
@@ -15,6 +15,32 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply) 
   }
 }
 
+/**
+ * Guard: require write access — accepts `org_admin` and `user`, blocks
+ * `viewer`. Use on operational write endpoints (create / update of
+ * fundraising data) where viewers should stay read-only but staff in the
+ * `user` role need parity with admins. For destructive admin actions
+ * (delete, status transitions, settings) use `requireOrgAdmin` instead.
+ */
+export async function requireWrite(request: FastifyRequest, reply: FastifyReply) {
+  if (!request.auth?.userId) {
+    return reply.status(401).send({
+      type: "https://httpproblems.com/http-status/401",
+      title: "Unauthorized",
+      status: 401,
+      detail: "Authentication required",
+    });
+  }
+  if (request.auth.role !== "org_admin" && request.auth.role !== "user") {
+    return reply.status(403).send({
+      type: "https://httpproblems.com/http-status/403",
+      title: "Forbidden",
+      status: 403,
+      detail: "write access required",
+    });
+  }
+}
+
 /** Guard: require org_admin role */
 export async function requireOrgAdmin(request: FastifyRequest, reply: FastifyReply) {
   if (!request.auth?.userId) {

--- a/packages/api/src/modules/campaigns/routes.ts
+++ b/packages/api/src/modules/campaigns/routes.ts
@@ -8,7 +8,7 @@ import {
 import { MULTI_CURRENCY_VALUES } from "@givernance/shared/validators";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
-import { requireAuth, requireOrgAdmin } from "../../lib/guards.js";
+import { requireAuth, requireOrgAdmin, requireWrite } from "../../lib/guards.js";
 import {
   DataArrayResponse,
   DataArrayResponseNoPagination,
@@ -174,7 +174,7 @@ export async function campaignRoutes(app: FastifyInstance) {
     "/campaigns",
     {
       config: { idempotency: { routeKey: "POST:/v1/campaigns" } },
-      preHandler: requireAuth,
+      preHandler: requireWrite,
       schema: {
         tags: ["Campaigns"],
         body: CampaignCreateBody,
@@ -247,11 +247,23 @@ export async function campaignRoutes(app: FastifyInstance) {
     },
   );
 
-  /** Update a campaign (partial update) */
+  /**
+   * Update a campaign (partial update).
+   *
+   * Operational fields (`name`, `type`, `defaultCurrency`, `parentId`,
+   * `operationalCostCents`, `fundIds`) are write-tier — `org_admin` AND
+   * `user` can edit them, mirroring the create endpoint's gate.
+   *
+   * `status` transitions stay admin-only (the StatusActions buttons in
+   * the web detail card are already hidden for non-admins). We enforce
+   * that here at the field level: if the body contains `status` and the
+   * caller isn't `org_admin`, return 403 — anyone bypassing the UI to
+   * call PATCH directly hits the same wall as the dedicated close endpoint.
+   */
   app.patch(
     "/campaigns/:id",
     {
-      preHandler: requireOrgAdmin,
+      preHandler: requireWrite,
       schema: {
         tags: ["Campaigns"],
         params: IdParams,
@@ -280,6 +292,14 @@ export async function campaignRoutes(app: FastifyInstance) {
         operationalCostCents?: number | null;
         fundIds?: string[];
       };
+
+      if (body.status !== undefined && request.auth?.role !== "org_admin") {
+        return reply
+          .status(403)
+          .send(
+            problemDetail(403, "Forbidden", "Only an org admin can change a campaign's status."),
+          );
+      }
 
       try {
         const updated = await updateCampaign(orgId, id, body, userId);

--- a/packages/api/src/modules/constituents/routes.ts
+++ b/packages/api/src/modules/constituents/routes.ts
@@ -322,11 +322,18 @@ export async function constituentRoutes(app: FastifyInstance) {
     },
   );
 
-  /** Soft-delete a constituent */
+  /**
+   * Soft-delete a constituent.
+   *
+   * Admin-only: deletion (even soft) is destructive enough that a non-admin
+   * staff member shouldn't be able to scrub a record everyone else relies on
+   * for fundraising history and GDPR audit. Operational write actions
+   * (create / update) stay open to the `user` role.
+   */
   app.delete(
     "/constituents/:id",
     {
-      preHandler: requireAuth,
+      preHandler: requireOrgAdmin,
       schema: {
         tags: ["Constituents"],
         params: IdParams,

--- a/packages/api/src/modules/invitations/routes.ts
+++ b/packages/api/src/modules/invitations/routes.ts
@@ -1,59 +1,137 @@
-/** Invitation routes — invite users by email, accept via token */
+/**
+ * Team invitation routes (issue #145).
+ *
+ * - `POST   /v1/invitations`              — org_admin creates an invite
+ * - `GET    /v1/invitations`              — org_admin lists pending/accepted
+ * - `POST   /v1/invitations/:id/resend`   — rotate token, re-emit email
+ * - `DELETE /v1/invitations/:id`          — revoke a pending invite
+ * - `POST   /v1/invitations/:token/accept` — public, token = credential
+ *
+ * The accept endpoint mirrors the structural twin in `signup/routes.ts`:
+ * all failure modes collapse to a single 410 generic to remove the
+ * status-code enumeration oracle. The service-side `log.warn` already
+ * emits a structured `event` discriminator (`team_invite.kc_user_exists`,
+ * etc.) that SRE can grep.
+ */
 
-import { invitations, users } from "@givernance/shared/schema";
+import { createHash } from "node:crypto";
 import { Type } from "@sinclair/typebox";
-import { and, eq, isNull } from "drizzle-orm";
-import type { FastifyInstance } from "fastify";
-import { db, withTenantContext } from "../../lib/db.js";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import { requireOrgAdmin } from "../../lib/guards.js";
 import {
+  DataArrayResponse,
   DataResponse,
   ErrorResponses,
+  IdParams,
+  PaginationQuery,
   ProblemDetailSchema,
   problemDetail,
   UuidSchema,
 } from "../../lib/schemas.js";
+import {
+  acceptTeamInvitation,
+  createTeamInvitation,
+  listTeamInvitations,
+  resendTeamInvitation,
+  revokeTeamInvitation,
+} from "./service.js";
+
+// ─── Schemas ────────────────────────────────────────────────────────────────
+
+const RoleSchema = Type.Union([
+  Type.Literal("org_admin"),
+  Type.Literal("user"),
+  Type.Literal("viewer"),
+]);
 
 const CreateInvitationBody = Type.Object({
-  email: Type.String({ format: "email" }),
-  role: Type.Optional(
-    Type.Union([Type.Literal("org_admin"), Type.Literal("user"), Type.Literal("viewer")]),
-  ),
+  email: Type.String({ format: "email", maxLength: 255 }),
+  role: Type.Optional(RoleSchema),
 });
 
 const AcceptInvitationBody = Type.Object({
   firstName: Type.String({ minLength: 1, maxLength: 255 }),
   lastName: Type.String({ minLength: 1, maxLength: 255 }),
+  /**
+   * Cleartext password the invitee picks. Min 12 to comply with the
+   * realm's brute-force protection without leaking exact policy back to
+   * the frontend (matches the signup verify endpoint).
+   */
+  password: Type.String({ minLength: 12, maxLength: 128 }),
 });
+
+const TokenParams = Type.Object({ token: UuidSchema });
 
 const InvitationResponse = Type.Object({
   id: UuidSchema,
   orgId: UuidSchema,
   email: Type.String(),
-  role: Type.String(),
-  token: Type.String(),
-  invitedById: Type.Union([UuidSchema, Type.Null()]),
-  acceptedAt: Type.Union([Type.String(), Type.Null()]),
+  role: RoleSchema,
+  invitedById: Type.Union([Type.Null(), UuidSchema]),
+  acceptedAt: Type.Union([Type.Null(), Type.String()]),
   expiresAt: Type.String(),
   createdAt: Type.String(),
 });
 
-const AcceptedUserResponse = Type.Object({
+const InvitationListItem = Type.Object({
   id: UuidSchema,
   orgId: UuidSchema,
   email: Type.String(),
-  firstName: Type.String(),
-  lastName: Type.String(),
-  role: Type.String(),
+  role: RoleSchema,
+  invitedById: Type.Union([Type.Null(), UuidSchema]),
+  acceptedAt: Type.Union([Type.Null(), Type.String()]),
+  expiresAt: Type.String(),
   createdAt: Type.String(),
-  updatedAt: Type.String(),
+  status: Type.Union([Type.Literal("pending"), Type.Literal("accepted"), Type.Literal("expired")]),
 });
 
+const AcceptResponse = Type.Object({
+  /** Tenant slug — drives the post-accept Keycloak login `?hint=` param. */
+  slug: Type.String(),
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function hashIp(ip: string | undefined): string | undefined {
+  if (!ip) return undefined;
+  return createHash("sha256").update(ip).digest("hex").slice(0, 32);
+}
+
+function clientIp(request: FastifyRequest): string | undefined {
+  return request.ip ?? undefined;
+}
+
+function userAgent(request: FastifyRequest): string | undefined {
+  const ua = request.headers["user-agent"];
+  return typeof ua === "string" ? ua.slice(0, 512) : undefined;
+}
+
+function serializeInvitation(row: {
+  id: string;
+  orgId: string;
+  email: string;
+  role: string;
+  invitedById: string | null;
+  acceptedAt: Date | null;
+  expiresAt: Date;
+  createdAt: Date;
+}) {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    email: row.email,
+    role: row.role,
+    invitedById: row.invitedById,
+    acceptedAt: row.acceptedAt ? row.acceptedAt.toISOString() : null,
+    expiresAt: row.expiresAt.toISOString(),
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+// ─── Routes ─────────────────────────────────────────────────────────────────
+
 export async function invitationRoutes(app: FastifyInstance) {
-  /**
-   * POST /v1/invitations — invite a user by email (org_admin only)
-   * Email delivery is Phase 2 — returns the token for now.
-   */
+  /** POST /v1/invitations — invite a teammate (org_admin only). */
   app.post(
     "/invitations",
     {
@@ -61,58 +139,184 @@ export async function invitationRoutes(app: FastifyInstance) {
       schema: {
         tags: ["Invitations"],
         body: CreateInvitationBody,
-        response: { 201: DataResponse(InvitationResponse), ...ErrorResponses },
+        response: {
+          201: DataResponse(InvitationResponse),
+          409: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
       },
     },
     async (request, reply) => {
       const userId = request.auth?.userId as string;
       const orgId = request.auth?.orgId as string;
-      const body = request.body as { email: string; role?: string };
+      const body = request.body as { email: string; role?: "org_admin" | "user" | "viewer" };
 
-      const invitation = await withTenantContext(orgId, async (tx) => {
-        const [inviter] = await tx
-          .select({ id: users.id })
-          .from(users)
-          .where(and(eq(users.keycloakId, userId), eq(users.orgId, orgId)));
-
-        const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
-
-        const [row] = await tx
-          .insert(invitations)
-          .values({
-            orgId,
-            email: body.email,
-            role: (body.role as "org_admin" | "user" | "viewer") ?? "user",
-            invitedById: inviter?.id ?? null,
-            purpose: "team_invite",
-            expiresAt,
-          })
-          .returning();
-
-        return row;
+      const result = await createTeamInvitation({
+        orgId,
+        email: body.email,
+        role: body.role,
+        inviterKeycloakId: userId,
+        ipHash: hashIp(clientIp(request)),
+        userAgent: userAgent(request),
       });
 
-      return reply.status(201).send({ data: invitation });
+      if (!result.ok) {
+        const detail =
+          result.error.kind === "already_member"
+            ? "This email already belongs to a member of your organisation."
+            : "An invitation for this email is already pending. Resend it instead.";
+        return reply.status(409).send(problemDetail(409, "Conflict", detail));
+      }
+
+      return reply.status(201).send({ data: serializeInvitation(result.data) });
+    },
+  );
+
+  /** GET /v1/invitations — list invitations for the current tenant (org_admin only). */
+  app.get(
+    "/invitations",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Invitations"],
+        querystring: PaginationQuery,
+        response: {
+          200: DataArrayResponse(InvitationListItem),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId as string;
+      const query = request.query as { page?: number; perPage?: number };
+      const result = await listTeamInvitations({
+        orgId,
+        page: query.page,
+        perPage: query.perPage,
+      });
+
+      return reply.status(200).send({
+        data: result.data.map((row) => ({
+          ...serializeInvitation(row),
+          status: row.status,
+        })),
+        pagination: result.pagination,
+      });
     },
   );
 
   /**
-   * POST /v1/invitations/:token/accept — accept an invitation (no auth required)
-   * The token itself is the credential. Creates a user record in the tenant.
+   * POST /v1/invitations/:id/resend — rotate token and re-emit email.
    *
-   * Invitation lookup uses `db` directly (no tenant context) because this endpoint
-   * is unauthenticated and the orgId isn't known until the invitation is found.
-   * FORCE RLS is intentionally omitted on invitations for this reason.
-   * Writes to users/invitations then use withTenantContext for RLS compliance.
+   * Per-invitation rate limiting protects against an admin accidentally
+   * spamming a single invitee — the service rotates the token on every
+   * call, so a tight loop here would invalidate just-delivered links.
+   */
+  app.post(
+    "/invitations/:id/resend",
+    {
+      preHandler: requireOrgAdmin,
+      config: { rateLimit: { max: 5, timeWindow: "15 minutes" } },
+      schema: {
+        tags: ["Invitations"],
+        params: IdParams,
+        response: {
+          204: Type.Null(),
+          409: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const userId = request.auth?.userId as string;
+      const orgId = request.auth?.orgId as string;
+      const { id } = request.params as { id: string };
+
+      const result = await resendTeamInvitation({
+        orgId,
+        invitationId: id,
+        actorKeycloakId: userId,
+        ipHash: hashIp(clientIp(request)),
+        userAgent: userAgent(request),
+      });
+
+      if (!result.ok) {
+        if (result.error === "not_found") {
+          return reply.status(404).send(problemDetail(404, "Not Found", "Invitation not found."));
+        }
+        return reply
+          .status(409)
+          .send(problemDetail(409, "Conflict", "This invitation has already been accepted."));
+      }
+
+      return reply.status(204).send();
+    },
+  );
+
+  /** DELETE /v1/invitations/:id — revoke a pending invitation (org_admin only). */
+  app.delete(
+    "/invitations/:id",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Invitations"],
+        params: IdParams,
+        response: {
+          204: Type.Null(),
+          409: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const userId = request.auth?.userId as string;
+      const orgId = request.auth?.orgId as string;
+      const { id } = request.params as { id: string };
+
+      const result = await revokeTeamInvitation({
+        orgId,
+        invitationId: id,
+        actorKeycloakId: userId,
+        ipHash: hashIp(clientIp(request)),
+        userAgent: userAgent(request),
+      });
+
+      if (!result.ok) {
+        if (result.error === "not_found") {
+          return reply.status(404).send(problemDetail(404, "Not Found", "Invitation not found."));
+        }
+        return reply
+          .status(409)
+          .send(
+            problemDetail(
+              409,
+              "Conflict",
+              "This invitation has already been accepted and cannot be revoked.",
+            ),
+          );
+      }
+
+      return reply.status(204).send();
+    },
+  );
+
+  /**
+   * POST /v1/invitations/:token/accept — public accept endpoint.
+   *
+   * The token IS the security boundary. All failure modes collapse to a
+   * generic 410 (no enumeration oracle); SRE breadcrumbs come from the
+   * service-side warn log.
    */
   app.post(
     "/invitations/:token/accept",
     {
       schema: {
         tags: ["Invitations"],
+        params: TokenParams,
         body: AcceptInvitationBody,
         response: {
-          201: DataResponse(AcceptedUserResponse),
+          201: DataResponse(AcceptResponse),
+          400: ProblemDetailSchema,
           410: ProblemDetailSchema,
           ...ErrorResponses,
         },
@@ -121,54 +325,35 @@ export async function invitationRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const { token } = request.params as { token: string };
-      const body = request.body as { firstName: string; lastName: string };
+      const body = request.body as {
+        firstName: string;
+        lastName: string;
+        password: string;
+      };
 
-      // Step 1: Look up invitation without tenant context (no FORCE RLS on invitations).
-      // Filter to purpose='team_invite' so self-serve signup-verification tokens
-      // cannot be consumed here (SEC-1 / DATA-3, review of PR #117).
-      const [invitation] = await db
-        .select()
-        .from(invitations)
-        .where(
-          and(
-            eq(invitations.token, token),
-            eq(invitations.purpose, "team_invite"),
-            isNull(invitations.acceptedAt),
-          ),
-        );
-
-      if (!invitation) {
-        return reply
-          .status(404)
-          .send(problemDetail(404, "Not Found", "Invalid or already used invitation token"));
-      }
-
-      if (invitation.expiresAt < new Date()) {
-        return reply.status(410).send(problemDetail(410, "Gone", "Invitation has expired"));
-      }
-
-      // Step 2: Create user and mark invitation accepted within tenant context
-      const user = await withTenantContext(invitation.orgId, async (tx) => {
-        const [newUser] = await tx
-          .insert(users)
-          .values({
-            orgId: invitation.orgId,
-            email: invitation.email,
-            firstName: body.firstName,
-            lastName: body.lastName,
-            role: invitation.role,
-          })
-          .returning();
-
-        await tx
-          .update(invitations)
-          .set({ acceptedAt: new Date() })
-          .where(eq(invitations.id, invitation.id));
-
-        return newUser;
+      const result = await acceptTeamInvitation({
+        token,
+        firstName: body.firstName,
+        lastName: body.lastName,
+        password: body.password,
+        ipHash: hashIp(clientIp(request)),
+        userAgent: userAgent(request),
       });
 
-      return reply.status(201).send({ data: user });
+      if (!result.ok) {
+        request.log.info({ event: "team_invite.accept_rejected" }, "accept rejected");
+        return reply
+          .status(410)
+          .send(
+            problemDetail(
+              410,
+              "Invitation expired",
+              "This invitation link is invalid or has already been used. Ask the person who invited you to send a new one.",
+            ),
+          );
+      }
+
+      return reply.status(201).send({ data: { slug: result.slug } });
     },
   );
 }

--- a/packages/api/src/modules/invitations/service.ts
+++ b/packages/api/src/modules/invitations/service.ts
@@ -40,6 +40,13 @@
  *    `tenants_keycloak_org_id_uuid_chk` CHECK constraint).
  *  - SEC-7: outbox payloads never carry the raw token; the email worker
  *    looks it up by invitation id inside its own trust boundary.
+ *
+ * Known caveat (shared with signup/service.ts, tracked there as the
+ * compensating-delete follow-up): if KC operations succeed but the DB tx
+ * rolls back, the resulting KC artefacts orphan with no compensating
+ * delete. The recovery half-states above are designed to absorb the next
+ * accept attempt; a long-running orphan is best resolved by a periodic
+ * KC-vs-DB reconciliation job.
  */
 
 import { randomUUID } from "node:crypto";
@@ -67,6 +74,42 @@ const INVITATION_TTL_DAYS = 7;
 const RESEND_TTL_DAYS = INVITATION_TTL_DAYS;
 
 export type InviteRole = "org_admin" | "user" | "viewer";
+
+/**
+ * Recover the tenant's country from the original
+ * `tenant.signup_verification_requested` outbox event so the worker picks the
+ * right EN/FR template for invitation emails. There is no `tenants.country`
+ * column today (issue #145 review F1 / QA-F1) — until one lands, this is the
+ * single durable source of truth. Mirror of `signup/service.ts`'s
+ * recovery-path lookup. Returns undefined for enterprise tenants seeded via
+ * super-admin (no signup event) and for self-serve tenants that predate
+ * country tracking; the worker falls back to its EN default.
+ */
+async function lookupTenantCountry(
+  tx: Parameters<Parameters<typeof withTenantContext>[1]>[0],
+  tenantId: string,
+): Promise<string | undefined> {
+  const [originalEvent] = await tx
+    .select({ payload: outboxEvents.payload })
+    .from(outboxEvents)
+    .where(
+      and(
+        eq(outboxEvents.tenantId, tenantId),
+        eq(outboxEvents.type, "tenant.signup_verification_requested"),
+      ),
+    )
+    .orderBy(sql`${outboxEvents.createdAt} ASC`)
+    .limit(1);
+  if (
+    typeof originalEvent?.payload === "object" &&
+    originalEvent.payload !== null &&
+    "country" in originalEvent.payload &&
+    typeof originalEvent.payload.country === "string"
+  ) {
+    return originalEvent.payload.country;
+  }
+  return undefined;
+}
 
 // ─── Create ─────────────────────────────────────────────────────────────────
 
@@ -117,6 +160,13 @@ export async function createTeamInvitation(
 
   // Pre-flight: is this email already a member of the tenant? `users` is
   // FORCE RLS so this lookup must run inside the tenant context.
+  //
+  // This pre-flight runs in a DIFFERENT tx from the actual insert below.
+  // A concurrent admin inserting a `users` row for the same `(org_id, email)`
+  // between the two txs could slip past this check — but the worst case is
+  // a redundant invitation row, since the accept-path upsert is idempotent
+  // on `(users.org_id, users.email)`. Treating this as a UX hint, not an
+  // authorisation gate (data review F-A).
   const existingUser = await withTenantContext(input.orgId, async (tx) => {
     const [row] = await tx
       .select({ id: users.id })
@@ -186,7 +236,10 @@ export async function createTeamInvitation(
     const invite = row!;
 
     // SEC-7: never put the raw token in the outbox; the worker looks it up
-    // by invitation id inside its own trust boundary.
+    // by invitation id inside its own trust boundary. `country` is recovered
+    // from the original signup event so the worker picks the right EN/FR
+    // template (QA-F1).
+    const country = await lookupTenantCountry(tx, input.orgId);
     await tx.insert(outboxEvents).values({
       tenantId: input.orgId,
       type: "invitation.created",
@@ -197,6 +250,7 @@ export async function createTeamInvitation(
         role: invite.role,
         inviterUserId: inviter?.id ?? null,
         expiresAt: invite.expiresAt.toISOString(),
+        ...(country ? { country } : {}),
       },
     });
 
@@ -442,6 +496,7 @@ export async function resendTeamInvitation(
       .where(and(eq(users.keycloakId, input.actorKeycloakId), eq(users.orgId, input.orgId)))
       .limit(1);
 
+    const country = await lookupTenantCountry(tx, input.orgId);
     await tx.insert(outboxEvents).values({
       tenantId: input.orgId,
       type: "invitation.resent",
@@ -452,6 +507,7 @@ export async function resendTeamInvitation(
         role: row.role,
         inviterUserId: actor?.id ?? null,
         expiresAt: expiresAt.toISOString(),
+        ...(country ? { country } : {}),
       },
     });
 
@@ -527,9 +583,12 @@ export async function acceptTeamInvitation(
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: mirrors verifySignup — pending-accept + two recovery half-states + outbox dedup must stay inside one tx for atomicity. Splitting is tracked as the same overnight follow-up.
     return await systemDb.transaction(async (tx) => {
       // FOR UPDATE so concurrent accepts serialise on the invitation row.
-      // The token IS the security boundary on this unauthenticated route;
-      // anything that doesn't match here returns a generic 410 (no
-      // status-code enumeration oracle).
+      // Under READ COMMITTED, a second waiter's SELECT FOR UPDATE re-reads
+      // the row after the first commits, so the JS-side `acceptedAt` check
+      // below correctly observes the post-commit state. The token IS the
+      // security boundary on this unauthenticated route; anything that
+      // doesn't match here returns a generic 410 (no status-code
+      // enumeration oracle). (Data review F-C.)
       const [row] = await tx
         .select({
           invitationId: invitations.id,
@@ -599,11 +658,17 @@ export async function acceptTeamInvitation(
       }
 
       // Hijack discriminator — see header comment. Read DB state before
-      // any KC call.
+      // any KC call. Email match uses lower(...) on both sides as
+      // defence-in-depth: `invitations.email` is normalised lowercase at
+      // INSERT (createTeamInvitation, signup()), but `users.email` has no
+      // schema-level case-folding constraint, so a historical mixed-case
+      // import or manual support write could otherwise miss the match
+      // and fall through to the createUser path → 409 → spurious 410.
+      // (Data review F-E.)
       const [existingUserRow] = await tx
         .select({ keycloakId: users.keycloakId })
         .from(users)
-        .where(and(eq(users.orgId, row.orgId), eq(users.email, row.email)))
+        .where(and(eq(users.orgId, row.orgId), sql`lower(${users.email}) = lower(${row.email})`))
         .limit(1);
       const existingKcId = existingUserRow?.keycloakId ?? null;
 

--- a/packages/api/src/modules/invitations/service.ts
+++ b/packages/api/src/modules/invitations/service.ts
@@ -1,0 +1,785 @@
+/**
+ * Team invitation service (issue #145).
+ *
+ * Structural twin of `modules/signup/service.ts` — the same recovery-state
+ * matrix and hijack-vs-takeover discriminator apply, with two scoping
+ * differences:
+ *
+ *  - The tenant is already `active`; we never flip status here.
+ *  - The inviter is an org_admin (or the seeded super_admin via
+ *    `inviteFirstEnterpriseUser`), not the operator themselves.
+ *
+ * Recovery half-states the accept endpoint must handle (each one came up
+ * during the PR #143 signup work and has the same shape here):
+ *
+ *   1. **First accept** — invitation `acceptedAt IS NULL`, no `users` row,
+ *      no KC artefact for this email. Straight first-time path.
+ *   2. **No KC credential** — `users` row exists with `keycloak_id IS NULL`
+ *      (e.g. an operator created the row by hand, or a prior accept tx
+ *      rolled back after the user INSERT). Recovery: createUser + attach +
+ *      patch `keycloak_id` onto the existing row.
+ *   3. **No KC Organization yet** — `users.keycloak_id` set, but
+ *      `tenant.keycloak_org_id IS NULL` (the seed-via-super-admin path on
+ *      enterprise tenants ran before issue #114 shipped). Recovery: get-or-
+ *      create the Org, reset the bound user's password, patch attributes,
+ *      attach.
+ *
+ * The discriminator between "legitimate recovery" and "hijack attempt" is
+ * `users.keycloak_id` — read in the accept tx before any KC call. If it's
+ * set, we own that KC user and may safely re-bind. If it's null and KC
+ * reports the email exists (409 on createUser), we throw
+ * `KeycloakUserExistsError` and the route surfaces a generic 410 (no
+ * enumeration oracle), with a `team_invite.kc_user_exists` warn log.
+ *
+ * Patterns inherited verbatim from signup/service.ts:
+ *  - Owner-role DB on the unauthenticated path (token IS the boundary).
+ *  - `FOR UPDATE` on the invitation row to serialise concurrent accepts.
+ *  - Outbox dedup via `RETURNING (xmax = 0)` on user upsert.
+ *  - KC org adoption only when `attributes.org_id` matches THIS tenant.
+ *  - UUID-shape preflight on KC org id before binding to `tenants` (the
+ *    `tenants_keycloak_org_id_uuid_chk` CHECK constraint).
+ *  - SEC-7: outbox payloads never carry the raw token; the email worker
+ *    looks it up by invitation id inside its own trust boundary.
+ */
+
+import { randomUUID } from "node:crypto";
+import { PINO_REDACT_PATHS } from "@givernance/shared/constants";
+import { auditLogs, invitations, outboxEvents, tenants, users } from "@givernance/shared/schema";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import pino from "pino";
+import { systemDb, withTenantContext } from "../../lib/db.js";
+import {
+  type KeycloakAdminClient,
+  KeycloakAdminError,
+  KeycloakUserExistsError,
+  keycloakAdmin,
+} from "../../lib/keycloak-admin.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const log = pino({
+  name: "invitations-service",
+  redact: { paths: [...PINO_REDACT_PATHS], censor: "[REDACTED]" },
+});
+
+const INVITATION_TTL_DAYS = 7;
+/** Resend rotates the token; this is the same TTL the create path uses. */
+const RESEND_TTL_DAYS = INVITATION_TTL_DAYS;
+
+export type InviteRole = "org_admin" | "user" | "viewer";
+
+// ─── Create ─────────────────────────────────────────────────────────────────
+
+export interface CreateInvitationInput {
+  orgId: string;
+  email: string;
+  role?: InviteRole;
+  /** Keycloak `sub` of the inviting org_admin (resolved to a `users.id`). */
+  inviterKeycloakId: string;
+  ipHash?: string;
+  userAgent?: string;
+}
+
+export interface CreateInvitationResult {
+  id: string;
+  orgId: string;
+  email: string;
+  role: InviteRole;
+  invitedById: string | null;
+  acceptedAt: Date | null;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+export type CreateInvitationError = { kind: "already_member" } | { kind: "already_invited" };
+
+/**
+ * Insert a `team_invite` invitation, emit `invitation.created`, and audit.
+ *
+ * Returns `already_member` if a `users` row with the same email already
+ * exists in this tenant — the operator's intent (loop them in) is already
+ * satisfied. Returns `already_invited` if a non-expired pending invitation
+ * is already on file — let the operator resend instead of fanning out
+ * duplicate links to the same inbox.
+ *
+ * Both error cases are surfaced as 409 by the route. We deliberately do NOT
+ * collapse them with the underlying DB unique-violation: the operator is
+ * already authenticated, so anti-enumeration concerns from the public
+ * signup flow don't apply here.
+ */
+export async function createTeamInvitation(
+  input: CreateInvitationInput,
+): Promise<
+  { ok: true; data: CreateInvitationResult } | { ok: false; error: CreateInvitationError }
+> {
+  const normalisedEmail = input.email.trim().toLowerCase();
+  const role: InviteRole = input.role ?? "user";
+
+  // Pre-flight: is this email already a member of the tenant? `users` is
+  // FORCE RLS so this lookup must run inside the tenant context.
+  const existingUser = await withTenantContext(input.orgId, async (tx) => {
+    const [row] = await tx
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.orgId, input.orgId), sql`lower(${users.email}) = ${normalisedEmail}`))
+      .limit(1);
+    return row;
+  });
+  if (existingUser) {
+    return { ok: false, error: { kind: "already_member" } };
+  }
+
+  const expiresAt = new Date(Date.now() + INVITATION_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+  const result = await withTenantContext(input.orgId, async (tx) => {
+    // Resolve inviter's `users.id` — `invitedById` references the
+    // application user, not the KC subject. The first super_admin seeding
+    // path (`inviteFirstEnterpriseUser`) leaves `invitedById = null`, so
+    // missing rows are tolerated.
+    const [inviter] = await tx
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.keycloakId, input.inviterKeycloakId), eq(users.orgId, input.orgId)))
+      .limit(1);
+
+    // Reuse a still-pending invitation rather than fan out a duplicate. We
+    // surface this as a 409 from the route so the operator gets a clear
+    // signal that they already invited this person; the dedicated
+    // resend endpoint is the right way to retry.
+    const [pending] = await tx
+      .select({ id: invitations.id, expiresAt: invitations.expiresAt })
+      .from(invitations)
+      .where(
+        and(
+          eq(invitations.orgId, input.orgId),
+          sql`lower(${invitations.email}) = ${normalisedEmail}`,
+          eq(invitations.purpose, "team_invite"),
+          isNull(invitations.acceptedAt),
+        ),
+      )
+      .limit(1);
+    if (pending && pending.expiresAt > new Date()) {
+      return { ok: false as const, error: { kind: "already_invited" as const } };
+    }
+
+    const [row] = await tx
+      .insert(invitations)
+      .values({
+        orgId: input.orgId,
+        email: normalisedEmail,
+        role,
+        invitedById: inviter?.id ?? null,
+        purpose: "team_invite",
+        expiresAt,
+      })
+      .returning({
+        id: invitations.id,
+        orgId: invitations.orgId,
+        email: invitations.email,
+        role: invitations.role,
+        invitedById: invitations.invitedById,
+        acceptedAt: invitations.acceptedAt,
+        expiresAt: invitations.expiresAt,
+        createdAt: invitations.createdAt,
+      });
+    // biome-ignore lint/style/noNonNullAssertion: returning() always yields one row
+    const invite = row!;
+
+    // SEC-7: never put the raw token in the outbox; the worker looks it up
+    // by invitation id inside its own trust boundary.
+    await tx.insert(outboxEvents).values({
+      tenantId: input.orgId,
+      type: "invitation.created",
+      payload: {
+        tenantId: input.orgId,
+        invitationId: invite.id,
+        email: invite.email,
+        role: invite.role,
+        inviterUserId: inviter?.id ?? null,
+        expiresAt: invite.expiresAt.toISOString(),
+      },
+    });
+
+    await tx.insert(auditLogs).values({
+      orgId: input.orgId,
+      userId: inviter?.id ?? null,
+      action: "invitation.created",
+      resourceType: "invitation",
+      resourceId: invite.id,
+      // No raw email in audit — the redact list masks it but we also
+      // omit it here so a missing redact rule can't leak PII via audit
+      // export. The invitation id is enough to reconstruct the row.
+      newValues: { role: invite.role, purpose: "team_invite" },
+      ipHash: input.ipHash,
+      userAgent: input.userAgent,
+    });
+
+    return { ok: true as const, data: invite };
+  });
+
+  return result;
+}
+
+// ─── List ───────────────────────────────────────────────────────────────────
+
+export interface ListInvitationsInput {
+  orgId: string;
+  page?: number;
+  perPage?: number;
+}
+
+export interface InvitationSummary {
+  id: string;
+  orgId: string;
+  email: string;
+  role: InviteRole;
+  invitedById: string | null;
+  acceptedAt: Date | null;
+  expiresAt: Date;
+  createdAt: Date;
+  /** Derived: pending | accepted | expired. */
+  status: "pending" | "accepted" | "expired";
+}
+
+export interface ListInvitationsResult {
+  data: InvitationSummary[];
+  pagination: { page: number; perPage: number; total: number; totalPages: number };
+}
+
+/**
+ * Paginated list of `team_invite` invitations for the current tenant.
+ *
+ * The route filters by purpose so the members page never surfaces self-
+ * serve `signup_verification` rows; those belong to the signup flow and
+ * leak the raw email of the original signup admin, who may have intended
+ * the inbox shared with someone other than the team-invite UI shows.
+ */
+export async function listTeamInvitations(
+  input: ListInvitationsInput,
+): Promise<ListInvitationsResult> {
+  const page = input.page ?? 1;
+  const perPage = input.perPage ?? 20;
+  const offset = (page - 1) * perPage;
+
+  const now = new Date();
+  return withTenantContext(input.orgId, async (tx) => {
+    const rows = await tx
+      .select({
+        id: invitations.id,
+        orgId: invitations.orgId,
+        email: invitations.email,
+        role: invitations.role,
+        invitedById: invitations.invitedById,
+        acceptedAt: invitations.acceptedAt,
+        expiresAt: invitations.expiresAt,
+        createdAt: invitations.createdAt,
+      })
+      .from(invitations)
+      .where(and(eq(invitations.orgId, input.orgId), eq(invitations.purpose, "team_invite")))
+      .orderBy(desc(invitations.createdAt))
+      .limit(perPage)
+      .offset(offset);
+
+    const totalRows = await tx
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invitations)
+      .where(and(eq(invitations.orgId, input.orgId), eq(invitations.purpose, "team_invite")));
+    const total = Number(totalRows[0]?.total ?? 0);
+
+    const data: InvitationSummary[] = rows.map((r) => ({
+      ...r,
+      role: r.role as InviteRole,
+      status: r.acceptedAt
+        ? ("accepted" as const)
+        : r.expiresAt < now
+          ? ("expired" as const)
+          : ("pending" as const),
+    }));
+
+    return {
+      data,
+      pagination: {
+        page,
+        perPage,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / perPage)),
+      },
+    };
+  });
+}
+
+// ─── Revoke ─────────────────────────────────────────────────────────────────
+
+export interface RevokeInvitationInput {
+  orgId: string;
+  invitationId: string;
+  actorKeycloakId: string;
+  ipHash?: string;
+  userAgent?: string;
+}
+
+export type RevokeInvitationResult =
+  | { ok: true }
+  | { ok: false; error: "not_found" | "already_accepted" };
+
+/**
+ * Revoke a pending team invitation.
+ *
+ * Implemented as a hard DELETE — there is no "revoked" lifecycle state on
+ * the row. This prevents an invitee clicking an old link from getting any
+ * row back at all (the accept route 404s, which the route maps to a
+ * generic 410). Soft-delete (a `revokedAt` column) was rejected: the
+ * accept lookup already filters on `acceptedAt IS NULL`, so a soft-deleted
+ * row would still match unless we added another column to the WHERE; a
+ * second filter is one more thing to forget on an audit query.
+ */
+export async function revokeTeamInvitation(
+  input: RevokeInvitationInput,
+): Promise<RevokeInvitationResult> {
+  return withTenantContext(input.orgId, async (tx) => {
+    const [row] = await tx
+      .select({ id: invitations.id, acceptedAt: invitations.acceptedAt, email: invitations.email })
+      .from(invitations)
+      .where(
+        and(
+          eq(invitations.id, input.invitationId),
+          eq(invitations.orgId, input.orgId),
+          eq(invitations.purpose, "team_invite"),
+        ),
+      )
+      .limit(1);
+
+    if (!row) return { ok: false as const, error: "not_found" as const };
+    if (row.acceptedAt) {
+      return { ok: false as const, error: "already_accepted" as const };
+    }
+
+    const [actor] = await tx
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.keycloakId, input.actorKeycloakId), eq(users.orgId, input.orgId)))
+      .limit(1);
+
+    await tx.delete(invitations).where(eq(invitations.id, input.invitationId));
+
+    await tx.insert(auditLogs).values({
+      orgId: input.orgId,
+      userId: actor?.id ?? null,
+      action: "invitation.revoked",
+      resourceType: "invitation",
+      resourceId: input.invitationId,
+      newValues: { revoked: true },
+      ipHash: input.ipHash,
+      userAgent: input.userAgent,
+    });
+
+    return { ok: true as const };
+  });
+}
+
+// ─── Resend ─────────────────────────────────────────────────────────────────
+
+export interface ResendInvitationInput {
+  orgId: string;
+  invitationId: string;
+  actorKeycloakId: string;
+  ipHash?: string;
+  userAgent?: string;
+}
+
+export type ResendInvitationResult =
+  | { ok: true; data: { id: string; expiresAt: Date } }
+  | { ok: false; error: "not_found" | "already_accepted" };
+
+/**
+ * Rotate the token + expiry on a pending invitation and re-emit the
+ * delivery event. The previous token is invalidated by virtue of the
+ * `invitations.token` column being a UNIQUE constraint we overwrite.
+ *
+ * Always rotates the token (even if the existing one hasn't expired)
+ * because the most common reason for a resend is "the original email
+ * never arrived" — if the invitee only just received the original and
+ * the operator clicks resend in parallel, we want only the most recent
+ * link to be live to keep audit trails unambiguous.
+ */
+export async function resendTeamInvitation(
+  input: ResendInvitationInput,
+): Promise<ResendInvitationResult> {
+  return withTenantContext(input.orgId, async (tx) => {
+    const [row] = await tx
+      .select({
+        id: invitations.id,
+        acceptedAt: invitations.acceptedAt,
+        email: invitations.email,
+        role: invitations.role,
+      })
+      .from(invitations)
+      .where(
+        and(
+          eq(invitations.id, input.invitationId),
+          eq(invitations.orgId, input.orgId),
+          eq(invitations.purpose, "team_invite"),
+        ),
+      )
+      .limit(1);
+
+    if (!row) return { ok: false as const, error: "not_found" as const };
+    if (row.acceptedAt) {
+      return { ok: false as const, error: "already_accepted" as const };
+    }
+
+    const newToken = randomUUID();
+    const expiresAt = new Date(Date.now() + RESEND_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+    await tx
+      .update(invitations)
+      .set({ token: newToken, expiresAt })
+      .where(eq(invitations.id, input.invitationId));
+
+    const [actor] = await tx
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.keycloakId, input.actorKeycloakId), eq(users.orgId, input.orgId)))
+      .limit(1);
+
+    await tx.insert(outboxEvents).values({
+      tenantId: input.orgId,
+      type: "invitation.resent",
+      payload: {
+        tenantId: input.orgId,
+        invitationId: row.id,
+        email: row.email,
+        role: row.role,
+        inviterUserId: actor?.id ?? null,
+        expiresAt: expiresAt.toISOString(),
+      },
+    });
+
+    await tx.insert(auditLogs).values({
+      orgId: input.orgId,
+      userId: actor?.id ?? null,
+      action: "invitation.resent",
+      resourceType: "invitation",
+      resourceId: input.invitationId,
+      newValues: { rotated: true },
+      ipHash: input.ipHash,
+      userAgent: input.userAgent,
+    });
+
+    return { ok: true as const, data: { id: row.id, expiresAt } };
+  });
+}
+
+// ─── Accept ─────────────────────────────────────────────────────────────────
+
+export interface AcceptInvitationInput {
+  token: string;
+  firstName: string;
+  lastName: string;
+  /**
+   * Cleartext password the invitee picks on the accept form. Sent over TLS
+   * to Keycloak as a non-temporary credential. Validated for length at the
+   * route boundary; never logged.
+   */
+  password: string;
+  ipHash?: string;
+  userAgent?: string;
+}
+
+export interface AcceptInvitationDeps {
+  /** Override the Keycloak admin client — used by integration tests. */
+  keycloakAdmin?: KeycloakAdminClient;
+}
+
+export type AcceptInvitationResult =
+  | {
+      ok: true;
+      tenantId: string;
+      userId: string;
+      slug: string;
+    }
+  | { ok: false };
+
+/**
+ * Accept a team invitation: provision (or recover) the Keycloak user,
+ * attach to the Organization, and bind `users.keycloak_id`.
+ *
+ * Mirrors `verifySignup` exactly — same FOR UPDATE serialisation, same
+ * hijack-vs-recovery discriminator, same UUID preflight on the KC org id,
+ * same outbox-dedup gating on the user upsert. The one Phase-1 difference
+ * is that we don't flip a tenant's `status` here: the tenant is already
+ * `active` (either via super-admin seeding or via a prior signup verify).
+ */
+export async function acceptTeamInvitation(
+  input: AcceptInvitationInput,
+  deps: AcceptInvitationDeps = {},
+): Promise<AcceptInvitationResult> {
+  const firstName = input.firstName.trim();
+  const lastName = input.lastName.trim();
+  // Lazily resolve the KC admin client AFTER the invitation lookup so a
+  // bogus / expired token doesn't 500 in environments where the KC admin
+  // client isn't configured (e.g. unit tests of the route's RBAC plumbing
+  // that never reach the KC step). The singleton throws if
+  // KEYCLOAK_ADMIN_CLIENT_SECRET is unset.
+  const resolveKcAdmin = (): KeycloakAdminClient => deps.keycloakAdmin ?? keycloakAdmin();
+
+  try {
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: mirrors verifySignup — pending-accept + two recovery half-states + outbox dedup must stay inside one tx for atomicity. Splitting is tracked as the same overnight follow-up.
+    return await systemDb.transaction(async (tx) => {
+      // FOR UPDATE so concurrent accepts serialise on the invitation row.
+      // The token IS the security boundary on this unauthenticated route;
+      // anything that doesn't match here returns a generic 410 (no
+      // status-code enumeration oracle).
+      const [row] = await tx
+        .select({
+          invitationId: invitations.id,
+          orgId: invitations.orgId,
+          email: invitations.email,
+          role: invitations.role,
+          expiresAt: invitations.expiresAt,
+          acceptedAt: invitations.acceptedAt,
+          tenantName: tenants.name,
+          tenantSlug: tenants.slug,
+          keycloakOrgId: tenants.keycloakOrgId,
+        })
+        .from(invitations)
+        .innerJoin(tenants, eq(invitations.orgId, tenants.id))
+        .where(and(eq(invitations.token, input.token), eq(invitations.purpose, "team_invite")))
+        .for("update")
+        .limit(1);
+
+      if (!row || row.acceptedAt || row.expiresAt < new Date()) {
+        return { ok: false } as const;
+      }
+
+      // Resolve the KC admin client now that we know the row is valid —
+      // the singleton throws if KEYCLOAK_ADMIN_CLIENT_SECRET is unset, so
+      // doing this earlier would 500 the no-match path on an unstubbed
+      // test env.
+      const kcAdmin = resolveKcAdmin();
+
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${row.orgId}, true)`);
+
+      // Get-or-create the tenant's Keycloak Organization. Enterprise
+      // tenants seeded via the super-admin path before issue #114 don't
+      // have a `keycloak_org_id` yet — same idempotent shape as
+      // verifySignup uses to recover from a half-failed signup.
+      let kcOrgId = row.keycloakOrgId;
+      if (!kcOrgId) {
+        try {
+          const created = await kcAdmin.createOrganization({
+            name: row.tenantName,
+            alias: row.tenantSlug,
+            attributes: { org_id: [row.orgId] },
+          });
+          kcOrgId = created.id;
+        } catch (err) {
+          if (err instanceof KeycloakAdminError && err.status === 409) {
+            // Recovery: a prior call created the Org but the DB tx rolled
+            // back. Adopt only if its `org_id` attribute proves it belongs
+            // to THIS tenant — slugs are globally unique in our DB, so the
+            // only legit alias collision is our own prior crash.
+            const existing = await kcAdmin.getOrganizationByAlias(row.tenantSlug);
+            const existingOrgId = existing?.attributes?.org_id?.[0];
+            if (!existing || existingOrgId !== row.orgId) {
+              throw err;
+            }
+            kcOrgId = existing.id;
+          } else {
+            throw err;
+          }
+        }
+        if (!UUID_RE.test(kcOrgId)) {
+          throw new Error(`Keycloak organization id is not a UUID: ${kcOrgId}`);
+        }
+        await tx
+          .update(tenants)
+          .set({ keycloakOrgId: kcOrgId, updatedAt: new Date() })
+          .where(eq(tenants.id, row.orgId));
+      }
+
+      // Hijack discriminator — see header comment. Read DB state before
+      // any KC call.
+      const [existingUserRow] = await tx
+        .select({ keycloakId: users.keycloakId })
+        .from(users)
+        .where(and(eq(users.orgId, row.orgId), eq(users.email, row.email)))
+        .limit(1);
+      const existingKcId = existingUserRow?.keycloakId ?? null;
+
+      let kcUserId: string;
+      if (existingKcId) {
+        // Legitimate recovery — we own this KC user. Reset password to
+        // whatever the invitee just typed (forgot-password semantics, with
+        // the invitation token as the proof of inbox control), patch
+        // attributes idempotently. Role attribute is sourced from the
+        // invitation row, NOT from the existing users row, so an admin
+        // updating a stale invitation's role before the invitee accepts
+        // produces the right JWT claims downstream.
+        await kcAdmin.resetUserPassword(existingKcId, input.password);
+        await kcAdmin.setUserAttributes(existingKcId, {
+          org_id: [row.orgId],
+          role: [row.role],
+        });
+        kcUserId = existingKcId;
+      } else {
+        // First binding for this email under this tenant. 409 here means
+        // the email belongs to a realm user we do NOT own — surface as a
+        // generic 410 with a `team_invite.kc_user_exists` warn for SRE.
+        const created = await kcAdmin.createUser({
+          email: row.email,
+          firstName,
+          lastName,
+          password: input.password,
+          // Token possession proves inbox control — flag as verified so KC
+          // doesn't ask the invitee for another round.
+          emailVerified: true,
+          attributes: { org_id: [row.orgId], role: [row.role] },
+        });
+        kcUserId = created.id;
+      }
+
+      try {
+        await kcAdmin.attachUserToOrg(kcOrgId, kcUserId);
+      } catch (err) {
+        if (!(err instanceof KeycloakAdminError && err.status === 409)) {
+          throw err;
+        }
+        // 409 = already a member (recovery path). Treat as success.
+      }
+
+      // Upsert the users row. `RETURNING (xmax = 0) AS inserted` lets us
+      // gate the `user.invited_accepted` outbox event so a recovery re-run
+      // doesn't re-fire the welcome consumer.
+      const upsertResult = await tx
+        .insert(users)
+        .values({
+          orgId: row.orgId,
+          email: row.email,
+          firstName,
+          lastName,
+          role: row.role,
+          keycloakId: kcUserId,
+        })
+        .onConflictDoUpdate({
+          target: [users.orgId, users.email],
+          set: {
+            firstName,
+            lastName,
+            keycloakId: kcUserId,
+            // Don't downgrade an existing user's role on recovery — the
+            // invitation may carry a stale role from before an admin
+            // promoted them through another path.
+            role: row.role,
+            updatedAt: new Date(),
+          },
+        })
+        .returning({ id: users.id, inserted: sql<boolean>`(xmax = 0)` });
+      // biome-ignore lint/style/noNonNullAssertion: insert/upsert returning() yields one row
+      const u = upsertResult[0]!;
+      const userWasInserted = u.inserted === true;
+
+      // Mark accepted and gate outbox emission on the actual flip — a
+      // recovery re-run lands here with `acceptedAt` already set above
+      // (no, the FOR UPDATE filter rejected it) so this UPDATE always
+      // moves a row, but the user-side dedup is still important.
+      await tx
+        .update(invitations)
+        .set({ acceptedAt: new Date() })
+        .where(eq(invitations.id, row.invitationId));
+
+      const eventsToEmit: Array<{
+        tenantId: string;
+        type: string;
+        payload: Record<string, unknown>;
+      }> = [
+        {
+          tenantId: row.orgId,
+          type: "invitation.accepted",
+          payload: {
+            tenantId: row.orgId,
+            invitationId: row.invitationId,
+            userId: u.id,
+            role: row.role,
+          },
+        },
+      ];
+      if (userWasInserted) {
+        eventsToEmit.push({
+          tenantId: row.orgId,
+          type: "user.invited_accepted",
+          payload: {
+            tenantId: row.orgId,
+            userId: u.id,
+            role: row.role,
+            firstAdmin: false,
+          },
+        });
+      }
+      await tx.insert(outboxEvents).values(eventsToEmit);
+
+      await tx.insert(auditLogs).values({
+        orgId: row.orgId,
+        userId: u.id,
+        action: "invitation.accepted",
+        resourceType: "invitation",
+        resourceId: row.invitationId,
+        newValues: { role: row.role, userId: u.id },
+        ipHash: input.ipHash,
+        userAgent: input.userAgent,
+      });
+
+      return {
+        ok: true as const,
+        tenantId: row.orgId,
+        userId: u.id,
+        slug: row.tenantSlug,
+      };
+    });
+  } catch (err) {
+    if (err instanceof KeycloakUserExistsError) {
+      log.warn({ event: "team_invite.kc_user_exists" }, "accept rejected — KC user already exists");
+      return { ok: false };
+    }
+    throw err;
+  }
+}
+
+// ─── Pre-flight visibility for the route ────────────────────────────────────
+
+/**
+ * Look up an invitation by id without tenant context — used by the route
+ * to assert the row exists in the same tenant as the authenticated
+ * org_admin before touching anything. Returns null when the row doesn't
+ * exist or doesn't belong to the caller's tenant.
+ */
+export async function getTeamInvitationForOrg(
+  orgId: string,
+  invitationId: string,
+): Promise<{ id: string; email: string; role: InviteRole; acceptedAt: Date | null } | null> {
+  return withTenantContext(orgId, async (tx) => {
+    const [row] = await tx
+      .select({
+        id: invitations.id,
+        email: invitations.email,
+        role: invitations.role,
+        acceptedAt: invitations.acceptedAt,
+      })
+      .from(invitations)
+      .where(
+        and(
+          eq(invitations.id, invitationId),
+          eq(invitations.orgId, orgId),
+          eq(invitations.purpose, "team_invite"),
+        ),
+      )
+      .limit(1);
+    if (!row) return null;
+    return {
+      id: row.id,
+      email: row.email,
+      role: row.role as InviteRole,
+      acceptedAt: row.acceptedAt,
+    };
+  });
+}

--- a/packages/api/src/tests/integration/auth-rbac.test.ts
+++ b/packages/api/src/tests/integration/auth-rbac.test.ts
@@ -255,13 +255,15 @@ describe("Invitation routes", () => {
     expect(res.statusCode).toBe(403);
   });
 
-  it("POST /v1/invitations/:token/accept returns 404 for invalid token", async () => {
+  it("POST /v1/invitations/:token/accept returns 410 generic for unknown token", async () => {
+    // SEC-6: every accept failure mode (unknown / expired / already used /
+    // hijack) collapses to a single 410 to remove the enumeration oracle.
     const res = await app.inject({
       method: "POST",
       url: "/v1/invitations/00000000-0000-0000-0000-000000000000/accept",
-      payload: { firstName: "Jane", lastName: "Doe" },
+      payload: { firstName: "Jane", lastName: "Doe", password: "long-enough-password-1" },
     });
-    expect(res.statusCode).toBe(404);
+    expect(res.statusCode).toBe(410);
   });
 });
 

--- a/packages/api/src/tests/integration/campaigns.test.ts
+++ b/packages/api/src/tests/integration/campaigns.test.ts
@@ -965,4 +965,66 @@ describe("Campaigns RBAC — non-admin forbidden", () => {
     });
     expect(res.statusCode).toBe(403);
   });
+
+  it("POST /v1/campaigns with viewer role returns 403", async () => {
+    const token = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(token),
+      payload: { name: "Viewer attempt", type: "digital" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("user role can create + update operational fields on a campaign", async () => {
+    // Symmetric with create: if a user can POST, they can PATCH. The
+    // earlier asymmetry (PATCH was admin-only while POST was not) had
+    // them dead-ended once the campaign existed. (Reported on PR #148.)
+    const token = signToken(app, { role: "user" });
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(token),
+      payload: { name: "User-created campaign", type: "digital" },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const created = createRes.json<{ data: { id: string } }>().data;
+
+    const patchRes = await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${created.id}`,
+      headers: authHeader(token),
+      payload: { name: "User-edited campaign", operationalCostCents: 15000 },
+    });
+    expect(patchRes.statusCode).toBe(200);
+    const updated = patchRes.json<{ data: { name: string; operationalCostCents: number } }>().data;
+    expect(updated.name).toBe("User-edited campaign");
+    expect(updated.operationalCostCents).toBe(15000);
+  });
+
+  it("user role attempting to change status returns 403 (status stays admin-only)", async () => {
+    // Field-level gate: even though `user` can PATCH operational fields,
+    // status transitions still go through the org_admin-only path. The
+    // StatusActions buttons are already hidden for non-admins on the web,
+    // but a direct API caller hits the same wall.
+    const adminToken = signToken(app);
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(adminToken),
+      payload: { name: "Admin-created campaign for status guard", type: "digital" },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const created = createRes.json<{ data: { id: string } }>().data;
+
+    const userToken = signToken(app, { role: "user" });
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${created.id}`,
+      headers: authHeader(userToken),
+      payload: { status: "active" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
 });

--- a/packages/api/src/tests/integration/constituents.test.ts
+++ b/packages/api/src/tests/integration/constituents.test.ts
@@ -423,6 +423,16 @@ describe("Constituents unauthenticated access", () => {
     });
     expect(res.statusCode).toBe(401);
   });
+
+  it("DELETE /v1/constituents/:id requires org_admin (returns 403 for user role)", async () => {
+    const userToken = signToken(app, { role: "user" });
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/v1/constituents/00000000-0000-0000-0000-000000000001",
+      headers: authHeader(userToken),
+    });
+    expect(res.statusCode).toBe(403);
+  });
 });
 
 // ─── Duplicate Detection ──────────────────────────────────────────────────────

--- a/packages/api/src/tests/integration/team-invitations.test.ts
+++ b/packages/api/src/tests/integration/team-invitations.test.ts
@@ -779,4 +779,206 @@ describe("POST /v1/invitations/:token/accept", () => {
     });
     expect(res.statusCode).toBe(400);
   });
+
+  it("happy path with role=org_admin promotes the invitee to second org_admin (AC #9)", async () => {
+    const f = await makeFixture();
+    const email = `secondadmin+${f.slug}@example.org`;
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email, role: "org_admin" },
+    });
+    expect(create.statusCode).toBe(201);
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    const accept = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: {
+        firstName: "Second",
+        lastName: "Admin",
+        password: "long-enough-password-1",
+      },
+    });
+    expect(accept.statusCode).toBe(201);
+
+    const [user] = await db
+      .select({ role: users.role, keycloakId: users.keycloakId })
+      .from(users)
+      .where(and(eq(users.orgId, f.orgId), eq(users.email, email.toLowerCase())));
+    expect(user?.role).toBe("org_admin");
+    expect(user?.keycloakId).toBeTruthy();
+
+    // KC attribute payload must reflect the invitation's role, not the
+    // inviter's — otherwise the realm mapper would emit the wrong JWT
+    // claim and the invitee would land without admin access.
+    const createUserCall = kcCreateUser.mock.calls[0]?.[0];
+    expect(createUserCall?.attributes?.role).toEqual(["org_admin"]);
+    expect(kcAttachUserToOrg).toHaveBeenCalledTimes(1);
+  });
+
+  it("after resend, the OLD token returns 410 (token rotation kills the old link) (AC #7)", async () => {
+    const f = await makeFixture();
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email: `rotation+${f.slug}@example.org` },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const before = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const oldToken = before[0]?.token ?? "";
+
+    const resend = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${created.id}/resend`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(resend.statusCode).toBe(204);
+
+    // The old token must now be dead.
+    const oldAccept = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${oldToken}/accept`,
+      payload: { firstName: "X", lastName: "Y", password: "long-enough-password-1" },
+    });
+    expect(oldAccept.statusCode).toBe(410);
+
+    // The new token must still be live.
+    const after = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const newToken = after[0]?.token ?? "";
+    expect(newToken).not.toBe(oldToken);
+
+    const newAccept = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${newToken}/accept`,
+      payload: { firstName: "X", lastName: "Y", password: "long-enough-password-1" },
+    });
+    expect(newAccept.statusCode).toBe(201);
+  });
+
+  it("after revoke, accept with the deleted token returns generic 410 (AC #6)", async () => {
+    const f = await makeFixture();
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email: `revoke-then-accept+${f.slug}@example.org` },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    const revoke = await app.inject({
+      method: "DELETE",
+      url: `/v1/invitations/${created.id}`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(revoke.statusCode).toBe(204);
+
+    const accept = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "X", lastName: "Y", password: "long-enough-password-1" },
+    });
+    expect(accept.statusCode).toBe(410);
+    // No KC user was created for the dead-token attempt.
+    expect(kcCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("emits country in invitation.created when the tenant has a recorded signup country (QA-F1)", async () => {
+    const f = await makeFixture();
+
+    // Seed an original signup_verification_requested event the way self-
+    // serve signup() would have. The team-invite create path looks this up
+    // to drive EN/FR template selection.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx.insert(outboxEvents).values({
+        tenantId: f.orgId,
+        type: "tenant.signup_verification_requested",
+        payload: { tenantId: f.orgId, country: "FR" },
+      });
+    });
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email: `fr+${f.slug}@example.org` },
+    });
+    expect(create.statusCode).toBe(201);
+
+    const { rows } = await db.execute<{ payload: { country?: string } }>(
+      sql`SELECT payload FROM outbox_events WHERE tenant_id = ${f.orgId} AND type = 'invitation.created' LIMIT 1`,
+    );
+    expect(rows[0]?.payload?.country).toBe("FR");
+  });
+
+  // ─── Cross-tenant isolation ───────────────────────────────────────────
+
+  it("org_admin in tenant A cannot revoke / resend / read an invitation from tenant B (SEC-F2)", async () => {
+    const fA = await makeFixture();
+    const fB = await makeFixture();
+
+    // Create an invitation in tenant B.
+    const createB = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(fB.inviterToken),
+      payload: { email: `bb+${fB.slug}@example.org` },
+    });
+    expect(createB.statusCode).toBe(201);
+    const inviteB = createB.json<{ data: { id: string } }>().data;
+
+    // Tenant A admin cannot revoke B's invitation by id.
+    const revoke = await app.inject({
+      method: "DELETE",
+      url: `/v1/invitations/${inviteB.id}`,
+      headers: authHeader(fA.inviterToken),
+    });
+    expect(revoke.statusCode).toBe(404);
+
+    // Tenant A admin cannot resend B's invitation by id.
+    const resend = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${inviteB.id}/resend`,
+      headers: authHeader(fA.inviterToken),
+    });
+    expect(resend.statusCode).toBe(404);
+
+    // Tenant A admin's list does not include B's invitation.
+    const list = await app.inject({
+      method: "GET",
+      url: "/v1/invitations",
+      headers: authHeader(fA.inviterToken),
+    });
+    expect(list.statusCode).toBe(200);
+    const listBody = list.json<{ data: Array<{ id: string }> }>();
+    expect(listBody.data.find((row) => row.id === inviteB.id)).toBeUndefined();
+
+    // Tenant B's invitation row is untouched.
+    const [stillThere] = await db
+      .select({ id: invitations.id, acceptedAt: invitations.acceptedAt })
+      .from(invitations)
+      .where(eq(invitations.id, inviteB.id));
+    expect(stillThere).toBeDefined();
+    expect(stillThere?.acceptedAt).toBeNull();
+  });
 });

--- a/packages/api/src/tests/integration/team-invitations.test.ts
+++ b/packages/api/src/tests/integration/team-invitations.test.ts
@@ -1,0 +1,782 @@
+/**
+ * Integration coverage for the team-invitation flow (issue #145).
+ *
+ * Mirrors the structural twin in `signup.test.ts` — same KC stub shape,
+ * same Redis rate-limit hygiene, same per-test tenant teardown. Asserts
+ * the contract at the route boundary: status codes, outbox events, KC
+ * call counts, and the recovery / hijack discriminators.
+ */
+
+import { randomUUID } from "node:crypto";
+import { auditLogs, invitations, outboxEvents, tenants, users } from "@givernance/shared/schema";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "../../lib/db.js";
+import {
+  _resetKeycloakAdminSingleton,
+  _setKeycloakAdminSingleton,
+  type KeycloakAdminClient,
+  KeycloakAdminError,
+  KeycloakUserExistsError,
+} from "../../lib/keycloak-admin.js";
+import { redis } from "../../lib/redis.js";
+import { createServer } from "../../server.js";
+import { authHeader, signToken } from "../helpers/auth.js";
+
+let app: FastifyInstance;
+
+// ─── KC stub ────────────────────────────────────────────────────────────────
+
+const kcCreateUser = vi.fn<KeycloakAdminClient["createUser"]>(async (input) => ({
+  id: `kc-${input.email}-${randomUUID().slice(0, 8)}`,
+}));
+const kcCreateOrganization = vi.fn<KeycloakAdminClient["createOrganization"]>(
+  async ({ name, alias, attributes }) => ({
+    id: randomUUID(),
+    name,
+    alias,
+    attributes,
+  }),
+);
+const kcAttachUserToOrg = vi.fn<KeycloakAdminClient["attachUserToOrg"]>(async () => {});
+const kcGetOrganizationByAlias = vi.fn<KeycloakAdminClient["getOrganizationByAlias"]>(
+  async () => null,
+);
+const kcResetUserPassword = vi.fn<KeycloakAdminClient["resetUserPassword"]>(async () => {});
+const kcSetUserAttributes = vi.fn<KeycloakAdminClient["setUserAttributes"]>(async () => {});
+
+const fakeKeycloakAdmin: KeycloakAdminClient = {
+  createOrganization: kcCreateOrganization,
+  getOrganization: vi.fn(async () => null),
+  getOrganizationByAlias: kcGetOrganizationByAlias,
+  deleteOrganization: vi.fn(async () => {}),
+  addOrgDomain: vi.fn(async () => {}),
+  attachUserToOrg: kcAttachUserToOrg,
+  sendInvitation: vi.fn(async () => {}),
+  bindIdpToOrganization: vi.fn(async () => {}),
+  createUser: kcCreateUser,
+  getUserByEmail: vi.fn(async () => null),
+  resetUserPassword: kcResetUserPassword,
+  setUserAttributes: kcSetUserAttributes,
+  createIdentityProvider: vi.fn(async () => {}),
+  deleteIdentityProvider: vi.fn(async () => {}),
+  _circuitState: () => "closed",
+};
+
+// ─── Per-test tenant fixture ────────────────────────────────────────────────
+
+interface Fixture {
+  orgId: string;
+  slug: string;
+  keycloakOrgId: string;
+  inviterUserId: string;
+  inviterKeycloakId: string;
+  inviterToken: string;
+}
+
+const fixtureSlugs = new Set<string>();
+
+async function makeFixture(opts: { withKcOrgId?: boolean } = {}): Promise<Fixture> {
+  const { withKcOrgId = true } = opts;
+  const orgId = randomUUID();
+  const inviterUserId = randomUUID();
+  const inviterKeycloakId = `kc-inviter-${randomUUID().slice(0, 8)}`;
+  const slug = `team-invite-${randomUUID().slice(0, 8)}`;
+  const keycloakOrgId = randomUUID();
+  fixtureSlugs.add(slug);
+
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, status, created_via, keycloak_org_id)
+        VALUES (${orgId}, ${`Team Invite Test ${slug}`}, ${slug}, 'active', 'enterprise', ${withKcOrgId ? keycloakOrgId : null})`,
+  );
+
+  // Inviter user — required for the create endpoint to resolve `invitedById`
+  // and for the `users.email` uniqueness checks during accept.
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${orgId}, true)`);
+    await tx.insert(users).values({
+      id: inviterUserId,
+      orgId,
+      email: `inviter-${slug}@example.org`,
+      firstName: "Inviter",
+      lastName: "Admin",
+      role: "org_admin",
+      keycloakId: inviterKeycloakId,
+    });
+  });
+
+  const inviterToken = signToken(app, {
+    sub: inviterKeycloakId,
+    org_id: orgId,
+    email: `inviter-${slug}@example.org`,
+    role: "org_admin",
+  });
+
+  return { orgId, slug, keycloakOrgId, inviterUserId, inviterKeycloakId, inviterToken };
+}
+
+// ─── Lifecycle ──────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  _setKeycloakAdminSingleton(fakeKeycloakAdmin);
+  app = await createServer();
+  await app.ready();
+});
+
+beforeEach(async () => {
+  kcCreateUser.mockClear();
+  kcCreateOrganization.mockClear();
+  kcAttachUserToOrg.mockClear();
+  kcGetOrganizationByAlias.mockClear();
+  kcResetUserPassword.mockClear();
+  kcSetUserAttributes.mockClear();
+  // Reset stub default behaviour each test — resetting the singleton wipes
+  // mockImplementationOnce queues that earlier tests installed.
+  kcCreateUser.mockImplementation(async (input) => ({
+    id: `kc-${input.email}-${randomUUID().slice(0, 8)}`,
+  }));
+  kcCreateOrganization.mockImplementation(async ({ name, alias, attributes }) => ({
+    id: randomUUID(),
+    name,
+    alias,
+    attributes,
+  }));
+
+  const keys = await redis.keys("*rate-limit*");
+  if (keys.length > 0) await redis.del(...keys);
+});
+
+afterAll(async () => {
+  await app.close();
+  _resetKeycloakAdminSingleton();
+});
+
+afterEach(async () => {
+  if (fixtureSlugs.size === 0) return;
+  const slugList = [...fixtureSlugs];
+  const rows = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(inArray(tenants.slug, slugList));
+  const ids = rows.map((r) => r.id);
+  if (ids.length > 0) {
+    await db.transaction(async (tx) => {
+      // audit_logs has an immutability trigger; replica role bypasses it
+      // for the test cleanup (matches signup.test.ts).
+      await tx.execute(sql`SET LOCAL session_replication_role = 'replica'`);
+      await tx.delete(auditLogs).where(inArray(auditLogs.orgId, ids));
+      await tx.delete(outboxEvents).where(inArray(outboxEvents.tenantId, ids));
+      await tx.delete(invitations).where(inArray(invitations.orgId, ids));
+      await tx.delete(users).where(inArray(users.orgId, ids));
+      await tx.delete(tenants).where(inArray(tenants.id, ids));
+    });
+  }
+  fixtureSlugs.clear();
+});
+
+// ─── Create ─────────────────────────────────────────────────────────────────
+
+describe("POST /v1/invitations", () => {
+  it("creates a team-invite row, emits invitation.created, and audits", async () => {
+    const f = await makeFixture();
+    const email = `newbie+${f.slug}@example.org`;
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email, role: "user" },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { id: string; email: string; role: string } }>();
+    expect(body.data.email).toBe(email.toLowerCase());
+    expect(body.data.role).toBe("user");
+
+    const { rows: events } = await db.execute<{ type: string }>(
+      sql`SELECT type FROM outbox_events WHERE tenant_id = ${f.orgId} ORDER BY created_at ASC`,
+    );
+    expect(events.map((e) => e.type)).toContain("invitation.created");
+
+    const [audit] = await db
+      .select({ action: auditLogs.action })
+      .from(auditLogs)
+      .where(and(eq(auditLogs.orgId, f.orgId), eq(auditLogs.action, "invitation.created")));
+    expect(audit).toBeDefined();
+  });
+
+  it("returns 409 when the email is already a member of the tenant", async () => {
+    const f = await makeFixture();
+
+    // Pre-existing member
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx.insert(users).values({
+        orgId: f.orgId,
+        email: `existing-${f.slug}@example.org`,
+        firstName: "Existing",
+        lastName: "Member",
+        role: "user",
+        keycloakId: `kc-existing-${f.slug}`,
+      });
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email: `existing-${f.slug}@example.org` },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("returns 409 when a pending invitation for the same email already exists", async () => {
+    const f = await makeFixture();
+    const email = `dup+${f.slug}@example.org`;
+
+    const first = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    expect(first.statusCode).toBe(201);
+
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    expect(second.statusCode).toBe(409);
+  });
+});
+
+// ─── List ───────────────────────────────────────────────────────────────────
+
+describe("GET /v1/invitations", () => {
+  it("returns only team_invite rows for the current tenant", async () => {
+    const f = await makeFixture();
+
+    // Seed one team invite + one signup-verification row that must be
+    // hidden from the members page.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx.insert(invitations).values([
+        {
+          orgId: f.orgId,
+          email: `team-${f.slug}@example.org`,
+          role: "user",
+          purpose: "team_invite",
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        },
+        {
+          orgId: f.orgId,
+          email: `signup-${f.slug}@example.org`,
+          role: "org_admin",
+          purpose: "signup_verification",
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        },
+      ]);
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: Array<{ email: string; status: string }>;
+      pagination: { total: number };
+    }>();
+    expect(body.data.every((row) => row.email.startsWith("team-"))).toBe(true);
+    expect(body.pagination.total).toBe(1);
+  });
+
+  it("requires org_admin", async () => {
+    const f = await makeFixture();
+    const userToken = signToken(app, {
+      sub: `kc-user-${f.slug}`,
+      org_id: f.orgId,
+      role: "user",
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/invitations",
+      headers: authHeader(userToken),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ─── Resend ─────────────────────────────────────────────────────────────────
+
+describe("POST /v1/invitations/:id/resend", () => {
+  it("rotates the token and emits invitation.resent", async () => {
+    const f = await makeFixture();
+    const email = `resend+${f.slug}@example.org`;
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+
+    const [before] = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${created.id}/resend`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(res.statusCode).toBe(204);
+
+    const [after] = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    expect(after?.token).not.toBe(before?.token);
+
+    const { rows: events } = await db.execute<{ type: string }>(
+      sql`SELECT type FROM outbox_events WHERE tenant_id = ${f.orgId} AND type = 'invitation.resent'`,
+    );
+    expect(events).toHaveLength(1);
+  });
+
+  it("returns 404 for an unknown id and 409 for an accepted invitation", async () => {
+    const f = await makeFixture();
+    const email = `accepted+${f.slug}@example.org`;
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+
+    // Mark accepted directly so the resend hits the "already_accepted" path.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx
+        .update(invitations)
+        .set({ acceptedAt: new Date() })
+        .where(eq(invitations.id, created.id));
+    });
+
+    const conflict = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${created.id}/resend`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(conflict.statusCode).toBe(409);
+
+    const missing = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${randomUUID()}/resend`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+});
+
+// ─── Revoke ─────────────────────────────────────────────────────────────────
+
+describe("DELETE /v1/invitations/:id", () => {
+  it("hard-deletes the invitation row", async () => {
+    const f = await makeFixture();
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email: `revoke+${f.slug}@example.org` },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/invitations/${created.id}`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(res.statusCode).toBe(204);
+
+    const [after] = await db
+      .select({ id: invitations.id })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    expect(after).toBeUndefined();
+  });
+
+  it("rejects revoke on an accepted invitation with 409", async () => {
+    const f = await makeFixture();
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email: `revoke-accepted+${f.slug}@example.org` },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx
+        .update(invitations)
+        .set({ acceptedAt: new Date() })
+        .where(eq(invitations.id, created.id));
+    });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/invitations/${created.id}`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+// ─── Accept ─────────────────────────────────────────────────────────────────
+
+describe("POST /v1/invitations/:token/accept", () => {
+  it("provisions the KC user, attaches to the org, and returns slug", async () => {
+    const f = await makeFixture();
+    const email = `happy+${f.slug}@example.org`;
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email, role: "user" },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    const accept = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: {
+        firstName: "Newbie",
+        lastName: "Member",
+        password: "long-enough-password-1",
+      },
+    });
+    expect(accept.statusCode).toBe(201);
+    const body = accept.json<{ data: { slug: string } }>();
+    expect(body.data.slug).toBe(f.slug);
+
+    expect(kcCreateUser).toHaveBeenCalledTimes(1);
+    expect(kcAttachUserToOrg).toHaveBeenCalledTimes(1);
+    expect(kcResetUserPassword).not.toHaveBeenCalled();
+
+    const [user] = await db
+      .select({ id: users.id, role: users.role, keycloakId: users.keycloakId })
+      .from(users)
+      .where(and(eq(users.orgId, f.orgId), eq(users.email, email.toLowerCase())));
+    expect(user?.role).toBe("user");
+    expect(user?.keycloakId).toBeTruthy();
+
+    const { rows: events } = await db.execute<{ type: string }>(
+      sql`SELECT type FROM outbox_events WHERE tenant_id = ${f.orgId} ORDER BY created_at ASC`,
+    );
+    const types = events.map((e) => e.type);
+    expect(types).toContain("invitation.accepted");
+    expect(types).toContain("user.invited_accepted");
+  });
+
+  it("rejects a signup_verification token (purpose discriminator)", async () => {
+    const f = await makeFixture();
+    const token = randomUUID();
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx.insert(invitations).values({
+        orgId: f.orgId,
+        email: `signup-only+${f.slug}@example.org`,
+        role: "org_admin",
+        token,
+        purpose: "signup_verification",
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      });
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "X", lastName: "Y", password: "long-enough-password-1" },
+    });
+    expect(res.statusCode).toBe(410);
+    expect(kcCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("collapses hijack attempt (KC user exists, no prior binding) to a generic 410", async () => {
+    const f = await makeFixture();
+    const email = `hijack+${f.slug}@example.org`;
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    kcCreateUser.mockRejectedValueOnce(new KeycloakUserExistsError(email));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "X", lastName: "Y", password: "long-enough-password-1" },
+    });
+    expect(res.statusCode).toBe(410);
+
+    // Critical: no users row was created, no password was reset.
+    expect(kcResetUserPassword).not.toHaveBeenCalled();
+    const [user] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.orgId, f.orgId), eq(users.email, email.toLowerCase())));
+    expect(user).toBeUndefined();
+  });
+
+  it("recovers (no KC credential): existing users row with null keycloak_id triggers create", async () => {
+    const f = await makeFixture();
+    const email = `recovery-a+${f.slug}@example.org`;
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    // Pre-insert a half-provisioned users row (no keycloak_id) — mirrors a
+    // prior accept tx that rolled back after the user INSERT.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx.insert(users).values({
+        orgId: f.orgId,
+        email: email.toLowerCase(),
+        firstName: "Half",
+        lastName: "Provisioned",
+        role: "user",
+      });
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "Recovered", lastName: "Member", password: "long-enough-password-1" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(kcCreateUser).toHaveBeenCalledTimes(1);
+    expect(kcResetUserPassword).not.toHaveBeenCalled();
+  });
+
+  it("recovers (already bound): existing users.keycloak_id triggers password reset, not createUser", async () => {
+    const f = await makeFixture();
+    const email = `recovery-b+${f.slug}@example.org`;
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    // Pre-bind the users row to a KC id — simulates an enterprise tenant
+    // user provisioned before the team-invite path landed.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx.insert(users).values({
+        orgId: f.orgId,
+        email: email.toLowerCase(),
+        firstName: "Already",
+        lastName: "Bound",
+        role: "user",
+        keycloakId: `kc-prebound-${f.slug}`,
+      });
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "Reset", lastName: "Pwd", password: "long-enough-password-1" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(kcCreateUser).not.toHaveBeenCalled();
+    expect(kcResetUserPassword).toHaveBeenCalledTimes(1);
+    expect(kcSetUserAttributes).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates the KC organization when tenant.keycloak_org_id is null", async () => {
+    const f = await makeFixture({ withKcOrgId: false });
+    const email = `noorg+${f.slug}@example.org`;
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "X", lastName: "Y", password: "long-enough-password-1" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(kcCreateOrganization).toHaveBeenCalledTimes(1);
+
+    const [tenant] = await db
+      .select({ kcOrgId: tenants.keycloakOrgId })
+      .from(tenants)
+      .where(eq(tenants.id, f.orgId));
+    expect(tenant?.kcOrgId).toBeTruthy();
+  });
+
+  it("rejects org adoption when KC alias collision returns a foreign org_id (no silent takeover)", async () => {
+    const f = await makeFixture({ withKcOrgId: false });
+    const email = `foreign+${f.slug}@example.org`;
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    // First call: KC reports the alias is taken. Second call (lookup by
+    // alias): returns an Org belonging to a *different* tenant.
+    kcCreateOrganization.mockRejectedValueOnce(
+      new KeycloakAdminError("alias taken", 409, "/organizations"),
+    );
+    kcGetOrganizationByAlias.mockResolvedValueOnce({
+      id: randomUUID(),
+      name: "Foreign",
+      alias: f.slug,
+      attributes: { org_id: [randomUUID()] },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "X", lastName: "Y", password: "long-enough-password-1" },
+    });
+    // Service throws — Fastify maps to 500 by default. This is the intended
+    // "fail loud" behaviour: an alias-collision with a foreign org_id is
+    // tampering or misconfiguration, not a path the user can recover from.
+    expect(res.statusCode).toBeGreaterThanOrEqual(500);
+  });
+
+  it("rejects accept on an expired invitation", async () => {
+    const f = await makeFixture();
+    const token = randomUUID();
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx.insert(invitations).values({
+        orgId: f.orgId,
+        email: `expired+${f.slug}@example.org`,
+        role: "user",
+        token,
+        purpose: "team_invite",
+        expiresAt: new Date(Date.now() - 60 * 1000),
+      });
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "X", lastName: "Y", password: "long-enough-password-1" },
+    });
+    expect(res.statusCode).toBe(410);
+  });
+
+  it("rejects accept on an already-accepted invitation", async () => {
+    const f = await makeFixture();
+    const email = `twice+${f.slug}@example.org`;
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "First", lastName: "Try", password: "long-enough-password-1" },
+    });
+    expect(first.statusCode).toBe(201);
+
+    const second = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "Second", lastName: "Try", password: "long-enough-password-1" },
+    });
+    expect(second.statusCode).toBe(410);
+  });
+
+  it("rejects an underlength password with 400 (not 410)", async () => {
+    const f = await makeFixture();
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email: `pw+${f.slug}@example.org` },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+    const tokenRows = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    const token = tokenRows[0]?.token ?? "";
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${token}/accept`,
+      payload: { firstName: "X", lastName: "Y", password: "short" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -179,6 +179,32 @@
         "sent": "If the email matches an account, we've sent a fresh verification link. Please check your inbox."
       }
     },
+    "inviteAccept": {
+      "title": "Accept your invitation",
+      "subtitle": "Confirm your name and choose a password to join the workspace.",
+      "submit": "Join workspace & sign in",
+      "successTitle": "You're in",
+      "successBody": "Redirecting you to sign in…",
+      "errorTitle": "Invitation problem",
+      "backToLogin": "Back to sign in",
+      "fields": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "password": "Choose a password",
+        "passwordHint": "At least {min} characters. You'll use this to sign in on the next screen.",
+        "passwordConfirm": "Confirm password"
+      },
+      "errors": {
+        "invalid": "This invitation link is invalid.",
+        "expired": "This invitation link is invalid or has already been used. Ask the person who invited you to send a new one.",
+        "missingToken": "No invitation token supplied.",
+        "namesRequired": "Please provide your first and last name.",
+        "passwordTooShort": "Use a password of at least {min} characters.",
+        "passwordMismatch": "The two passwords don't match.",
+        "rateLimited": "Too many attempts. Please try again in a few minutes.",
+        "generic": "We couldn't accept this invitation. Please retry or ask the inviter to resend."
+      }
+    },
     "selectOrganization": {
       "title": "Which workspace would you like to enter?",
       "subtitle": "Your account belongs to multiple organisations.",
@@ -476,7 +502,80 @@
   "navigation": {
     "label": "Organisation settings navigation",
     "organization": "Organisation",
+    "members": "Members",
     "funds": "Funds"
+  },
+  "members": {
+    "title": "Members",
+    "subtitleEmpty": "Invite teammates to join your workspace.",
+    "subtitleWithCount": "{count, plural, one {# invitation on file} other {# invitations on file}}",
+    "columns": {
+      "email": "Email",
+      "role": "Role",
+      "status": "Status",
+      "createdAt": "Invited",
+      "actions": "Actions"
+    },
+    "roles": {
+      "org_admin": "Admin",
+      "user": "Member",
+      "viewer": "Viewer"
+    },
+    "statuses": {
+      "pending": "Pending",
+      "accepted": "Accepted",
+      "expired": "Expired"
+    },
+    "actions": {
+      "invite": "Invite teammate",
+      "menu": "Open actions for {email}",
+      "resend": "Resend invitation",
+      "revoke": "Revoke invitation"
+    },
+    "empty": {
+      "title": "No invitations yet",
+      "description": "Invite a teammate to give them access to this workspace."
+    },
+    "invite": {
+      "title": "Invite a teammate",
+      "description": "They'll receive an email with a link to join your workspace and choose their password.",
+      "fields": {
+        "email": "Email address",
+        "emailPlaceholder": "teammate@example.org",
+        "role": "Role"
+      },
+      "roleHints": {
+        "org_admin": "Full access — can invite others, manage settings, and access all data.",
+        "user": "Can read and update operational data (constituents, donations, campaigns).",
+        "viewer": "Read-only access to operational data."
+      },
+      "actions": {
+        "cancel": "Cancel",
+        "submit": "Send invitation",
+        "submitting": "Sending…"
+      },
+      "errors": {
+        "emailRequired": "Email address is required.",
+        "generic": "Couldn't send the invitation. Please try again."
+      }
+    },
+    "revokeDialog": {
+      "title": "Revoke invitation",
+      "description": "Revoke the invitation for {email}? The link will stop working immediately.",
+      "descriptionFallback": "Revoke this invitation? The link will stop working immediately.",
+      "cancel": "Cancel",
+      "confirm": "Revoke invitation",
+      "revoking": "Revoking…"
+    },
+    "success": {
+      "invited": "Invitation sent to {email}.",
+      "resent": "Invitation re-sent.",
+      "revoked": "Invitation revoked."
+    },
+    "errors": {
+      "resendGeneric": "Couldn't resend the invitation. Please try again.",
+      "revokeGeneric": "Couldn't revoke the invitation. Please try again."
+    }
   },
   "funds": {
     "settings": "Settings",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1128,10 +1128,12 @@
         "chartSummary": "Raised {raised} against a cost of {cost}. ROI: {roi}.",
         "chartSummaryUnavailable": "Raised {raised} against a cost of {cost}. ROI unavailable."
       },
+      "statusCard": {
+        "readOnlyTitle": "Campaign status"
+      },
       "actions": {
         "title": "Status actions",
         "description": "Move this campaign between draft, active, and closed states.",
-        "descriptionReadOnly": "Current campaign status — only an organisation admin can change it.",
         "readOnly": "Only an organisation admin can change a campaign's status.",
         "back": "Back to campaigns",
         "edit": "Edit",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1131,6 +1131,8 @@
       "actions": {
         "title": "Status actions",
         "description": "Move this campaign between draft, active, and closed states.",
+        "descriptionReadOnly": "Current campaign status — only an organisation admin can change it.",
+        "readOnly": "Only an organisation admin can change a campaign's status.",
         "back": "Back to campaigns",
         "edit": "Edit",
         "publicPage": "Public page",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -895,6 +895,7 @@
       "actions": {
         "back": "Back to donations",
         "edit": "Edit",
+        "delete": "Delete",
         "previewReceipt": "Receipt preview",
         "generatingReceipt": "Generating receipt…"
       },

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -894,6 +894,7 @@
       },
       "actions": {
         "back": "Back to donations",
+        "edit": "Edit",
         "previewReceipt": "Receipt preview",
         "generatingReceipt": "Generating receipt…"
       },
@@ -918,7 +919,8 @@
       "name": "Name",
       "type": "Type",
       "email": "Email",
-      "lastDonation": "Last donation"
+      "lastDonation": "Last donation",
+      "actions": "Actions"
     },
     "types": {
       "donor": "Donor",
@@ -928,7 +930,24 @@
       "partner": "Partner"
     },
     "actions": {
-      "new": "New constituent"
+      "new": "New constituent",
+      "menu": "Open actions for {name}",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "deleteDialog": {
+      "title": "Delete constituent",
+      "description": "Delete {name}? They will be removed from lists and reports. Past donations are kept for audit.",
+      "descriptionFallback": "Delete this constituent? They will be removed from lists and reports. Past donations are kept for audit.",
+      "cancel": "Cancel",
+      "confirm": "Delete constituent",
+      "deleting": "Deleting…"
+    },
+    "success": {
+      "deleted": "Constituent deleted."
+    },
+    "errors": {
+      "deleteGeneric": "Could not delete this constituent. Please try again."
     }
   },
   "campaigns": {
@@ -946,7 +965,8 @@
       "type": "Type",
       "status": "Status",
       "progress": "Progress",
-      "date": "Date"
+      "date": "Date",
+      "actions": "Actions"
     },
     "status": {
       "draft": "Draft",
@@ -959,7 +979,24 @@
       "digital": "Digital"
     },
     "actions": {
-      "new": "New Campaign"
+      "new": "New Campaign",
+      "menu": "Open actions for {name}",
+      "edit": "Edit",
+      "close": "Close campaign"
+    },
+    "closeDialog": {
+      "title": "Close campaign",
+      "description": "Close {name}? Donations linked to it stay accessible but no new ones can be recorded.",
+      "descriptionFallback": "Close this campaign? Donations linked to it stay accessible but no new ones can be recorded.",
+      "cancel": "Cancel",
+      "confirm": "Close campaign",
+      "closing": "Closing…"
+    },
+    "success": {
+      "closed": "Campaign closed."
+    },
+    "errors": {
+      "closeGeneric": "Could not close this campaign. Please try again."
     },
     "noGoal": "No goal",
     "progressAria": "{raised} raised of {goal}",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -895,6 +895,7 @@
       "actions": {
         "back": "Retour aux dons",
         "edit": "Modifier",
+        "delete": "Supprimer",
         "previewReceipt": "Aperçu du reçu",
         "generatingReceipt": "Génération du reçu…"
       },

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -894,6 +894,7 @@
       },
       "actions": {
         "back": "Retour aux dons",
+        "edit": "Modifier",
         "previewReceipt": "Aperçu du reçu",
         "generatingReceipt": "Génération du reçu…"
       },
@@ -918,7 +919,8 @@
       "name": "Nom",
       "type": "Type",
       "email": "Email",
-      "lastDonation": "Dernier don"
+      "lastDonation": "Dernier don",
+      "actions": "Actions"
     },
     "types": {
       "donor": "Donateur",
@@ -928,7 +930,24 @@
       "partner": "Partenaire"
     },
     "actions": {
-      "new": "Nouveau constituant"
+      "new": "Nouveau constituant",
+      "menu": "Ouvrir les actions pour {name}",
+      "edit": "Modifier",
+      "delete": "Supprimer"
+    },
+    "deleteDialog": {
+      "title": "Supprimer le constituant",
+      "description": "Supprimer {name} ? Il/elle ne figurera plus dans les listes ni les rapports. Les dons passés sont conservés pour l'audit.",
+      "descriptionFallback": "Supprimer ce constituant ? Il/elle ne figurera plus dans les listes ni les rapports. Les dons passés sont conservés pour l'audit.",
+      "cancel": "Annuler",
+      "confirm": "Supprimer le constituant",
+      "deleting": "Suppression…"
+    },
+    "success": {
+      "deleted": "Constituant supprimé."
+    },
+    "errors": {
+      "deleteGeneric": "Impossible de supprimer ce constituant. Veuillez réessayer."
     }
   },
   "campaigns": {
@@ -946,7 +965,8 @@
       "type": "Type",
       "status": "Statut",
       "progress": "Progression",
-      "date": "Date"
+      "date": "Date",
+      "actions": "Actions"
     },
     "status": {
       "draft": "Brouillon",
@@ -959,7 +979,24 @@
       "digital": "Digital"
     },
     "actions": {
-      "new": "Nouvelle campagne"
+      "new": "Nouvelle campagne",
+      "menu": "Ouvrir les actions pour {name}",
+      "edit": "Modifier",
+      "close": "Clôturer la campagne"
+    },
+    "closeDialog": {
+      "title": "Clôturer la campagne",
+      "description": "Clôturer {name} ? Les dons rattachés restent accessibles, mais aucun nouveau don ne pourra être enregistré.",
+      "descriptionFallback": "Clôturer cette campagne ? Les dons rattachés restent accessibles, mais aucun nouveau don ne pourra être enregistré.",
+      "cancel": "Annuler",
+      "confirm": "Clôturer la campagne",
+      "closing": "Clôture…"
+    },
+    "success": {
+      "closed": "Campagne clôturée."
+    },
+    "errors": {
+      "closeGeneric": "Impossible de clôturer cette campagne. Veuillez réessayer."
     },
     "noGoal": "Aucun objectif",
     "progressAria": "{raised} collectés sur {goal}",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -1128,10 +1128,12 @@
         "chartSummary": "Montant collecté : {raised}, pour un coût de {cost}. ROI : {roi}.",
         "chartSummaryUnavailable": "Montant collecté : {raised}, pour un coût de {cost}. ROI indisponible."
       },
+      "statusCard": {
+        "readOnlyTitle": "Statut de la campagne"
+      },
       "actions": {
         "title": "Actions de statut",
         "description": "Faites passer cette campagne entre les états brouillon, active et clôturée.",
-        "descriptionReadOnly": "Statut actuel de la campagne — seul·e un·e administrateur·trice peut le modifier.",
         "readOnly": "Seul·e un·e administrateur·trice de l'organisation peut modifier le statut d'une campagne.",
         "back": "Retour aux campagnes",
         "edit": "Modifier",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -179,6 +179,32 @@
         "sent": "Si l'adresse correspond à un compte, nous avons envoyé un nouveau lien. Pensez à vérifier votre boîte de réception."
       }
     },
+    "inviteAccept": {
+      "title": "Accepter votre invitation",
+      "subtitle": "Confirmez votre nom et choisissez un mot de passe pour rejoindre l'espace.",
+      "submit": "Rejoindre l'espace et se connecter",
+      "successTitle": "Bienvenue",
+      "successBody": "Redirection vers la connexion…",
+      "errorTitle": "Problème d'invitation",
+      "backToLogin": "Retour à la connexion",
+      "fields": {
+        "firstName": "Prénom",
+        "lastName": "Nom",
+        "password": "Choisissez un mot de passe",
+        "passwordHint": "Au moins {min} caractères. Vous l'utiliserez à l'écran suivant pour vous connecter.",
+        "passwordConfirm": "Confirmez le mot de passe"
+      },
+      "errors": {
+        "invalid": "Ce lien d'invitation n'est pas valide.",
+        "expired": "Ce lien d'invitation n'est pas valide ou a déjà été utilisé. Demandez à la personne qui vous a invité·e d'en envoyer un nouveau.",
+        "missingToken": "Aucun token d'invitation fourni.",
+        "namesRequired": "Veuillez saisir votre prénom et votre nom.",
+        "passwordTooShort": "Utilisez un mot de passe d'au moins {min} caractères.",
+        "passwordMismatch": "Les deux mots de passe ne correspondent pas.",
+        "rateLimited": "Trop de tentatives. Réessayez dans quelques minutes.",
+        "generic": "Nous n'avons pas pu accepter cette invitation. Réessayez ou demandez un nouvel envoi."
+      }
+    },
     "selectOrganization": {
       "title": "Quel espace souhaitez-vous ouvrir ?",
       "subtitle": "Votre compte est associé à plusieurs associations.",
@@ -476,7 +502,80 @@
   "navigation": {
     "label": "Navigation des paramètres de l'organisation",
     "organization": "Organisation",
+    "members": "Membres",
     "funds": "Fonds"
+  },
+  "members": {
+    "title": "Membres",
+    "subtitleEmpty": "Invitez vos collègues à rejoindre votre espace.",
+    "subtitleWithCount": "{count, plural, one {# invitation enregistrée} other {# invitations enregistrées}}",
+    "columns": {
+      "email": "Email",
+      "role": "Rôle",
+      "status": "Statut",
+      "createdAt": "Invité·e le",
+      "actions": "Actions"
+    },
+    "roles": {
+      "org_admin": "Administrateur·trice",
+      "user": "Membre",
+      "viewer": "Lecteur·trice"
+    },
+    "statuses": {
+      "pending": "En attente",
+      "accepted": "Accepté·e",
+      "expired": "Expirée"
+    },
+    "actions": {
+      "invite": "Inviter un·e collègue",
+      "menu": "Ouvrir les actions pour {email}",
+      "resend": "Renvoyer l'invitation",
+      "revoke": "Révoquer l'invitation"
+    },
+    "empty": {
+      "title": "Aucune invitation",
+      "description": "Invitez un·e collègue pour lui donner accès à cet espace."
+    },
+    "invite": {
+      "title": "Inviter un·e collègue",
+      "description": "Ils·elles recevront un email avec un lien pour rejoindre l'espace et choisir leur mot de passe.",
+      "fields": {
+        "email": "Adresse email",
+        "emailPlaceholder": "collegue@exemple.org",
+        "role": "Rôle"
+      },
+      "roleHints": {
+        "org_admin": "Accès complet — peut inviter d'autres personnes, gérer les paramètres et accéder à toutes les données.",
+        "user": "Peut consulter et modifier les données opérationnelles (constituants, dons, campagnes).",
+        "viewer": "Accès en lecture seule aux données opérationnelles."
+      },
+      "actions": {
+        "cancel": "Annuler",
+        "submit": "Envoyer l'invitation",
+        "submitting": "Envoi…"
+      },
+      "errors": {
+        "emailRequired": "L'adresse email est requise.",
+        "generic": "Impossible d'envoyer l'invitation. Veuillez réessayer."
+      }
+    },
+    "revokeDialog": {
+      "title": "Révoquer l'invitation",
+      "description": "Révoquer l'invitation de {email} ? Le lien cessera immédiatement de fonctionner.",
+      "descriptionFallback": "Révoquer cette invitation ? Le lien cessera immédiatement de fonctionner.",
+      "cancel": "Annuler",
+      "confirm": "Révoquer l'invitation",
+      "revoking": "Révocation…"
+    },
+    "success": {
+      "invited": "Invitation envoyée à {email}.",
+      "resent": "Invitation renvoyée.",
+      "revoked": "Invitation révoquée."
+    },
+    "errors": {
+      "resendGeneric": "Impossible de renvoyer l'invitation. Veuillez réessayer.",
+      "revokeGeneric": "Impossible de révoquer l'invitation. Veuillez réessayer."
+    }
   },
   "funds": {
     "settings": "Paramètres",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -1131,6 +1131,8 @@
       "actions": {
         "title": "Actions de statut",
         "description": "Faites passer cette campagne entre les états brouillon, active et clôturée.",
+        "descriptionReadOnly": "Statut actuel de la campagne — seul·e un·e administrateur·trice peut le modifier.",
+        "readOnly": "Seul·e un·e administrateur·trice de l'organisation peut modifier le statut d'une campagne.",
         "back": "Retour aux campagnes",
         "edit": "Modifier",
         "publicPage": "Page publique",

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -152,7 +152,7 @@ export default async function CampaignDetailPage({
       <div className="grid gap-6 lg:grid-cols-[minmax(280px,340px)_minmax(0,1fr)]">
         <aside className="space-y-6">
           <StatsCard campaign={campaign} stats={stats} roiMetrics={roiMetrics} locale={locale} />
-          <StatusCard campaign={campaign} />
+          <StatusCard campaign={campaign} canManage={auth.roles.includes("org_admin")} />
         </aside>
         <div className="space-y-6">
           <CampaignRoiChart
@@ -297,16 +297,22 @@ async function CostBreakdownCard({
   );
 }
 
-async function StatusCard({ campaign }: { campaign: Campaign }) {
+async function StatusCard({ campaign, canManage }: { campaign: Campaign; canManage: boolean }) {
   const t = await getTranslations("campaigns.detail");
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>{t("actions.title")}</CardTitle>
-        <CardDescription>{t("actions.description")}</CardDescription>
+        <CardDescription>
+          {canManage ? t("actions.description") : t("actions.descriptionReadOnly")}
+        </CardDescription>
       </CardHeader>
-      <CampaignStatusActions campaignId={campaign.id} status={campaign.status} />
+      <CampaignStatusActions
+        campaignId={campaign.id}
+        status={campaign.status}
+        canManage={canManage}
+      />
     </Card>
   );
 }

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -300,13 +300,29 @@ async function CostBreakdownCard({
 async function StatusCard({ campaign, canManage }: { campaign: Campaign; canManage: boolean }) {
   const t = await getTranslations("campaigns.detail");
 
+  // For non-admins the card is informational, not actionable — show the
+  // current status badge with a single read-only note so we don't end up
+  // with a redundant "Status actions" title + duplicate description copy
+  // around buttons that aren't there.
+  if (!canManage) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("statusCard.readOnlyTitle")}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <StatusBadge status={campaign.status} />
+          <p className="text-sm text-on-surface-variant">{t("actions.readOnly")}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>{t("actions.title")}</CardTitle>
-        <CardDescription>
-          {canManage ? t("actions.description") : t("actions.descriptionReadOnly")}
-        </CardDescription>
+        <CardDescription>{t("actions.description")}</CardDescription>
       </CardHeader>
       <CampaignStatusActions
         campaignId={campaign.id}

--- a/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
+++ b/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
@@ -1,17 +1,37 @@
 "use client";
 
 import type { ColumnDef } from "@tanstack/react-table";
-import { Megaphone } from "lucide-react";
+import { Megaphone, MoreHorizontal, Pencil, XCircle } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { EmptyState } from "@/components/shared/empty-state";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { DataTable, type DataTablePagination } from "@/components/ui/data-table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
 import { formatCurrency, formatDate } from "@/lib/format";
 import type { Campaign, CampaignStats, CampaignStatus, CampaignType } from "@/models/campaign";
+import { CampaignService } from "@/services/CampaignService";
 
 type BadgeVariant = "success" | "warning" | "error" | "info" | "neutral";
 
@@ -38,6 +58,12 @@ const CAMPAIGN_STATUSES = new Set<CampaignStatus>(["draft", "active", "closed"])
 interface CampaignsTableProps {
   campaigns: CampaignWithStats[];
   pagination: DataTablePagination;
+  /**
+   * `Close` is `requireOrgAdmin` server-side; when `false`, the row's
+   * dropdown only shows Edit. Mirrors the donations + members + constituents
+   * shortcut pattern.
+   */
+  canManageAdminActions: boolean;
 }
 
 function isCampaignType(value: string): value is CampaignType {
@@ -48,12 +74,18 @@ function isCampaignStatus(value: string): value is CampaignStatus {
   return CAMPAIGN_STATUSES.has(value as CampaignStatus);
 }
 
-export function CampaignsTable({ campaigns, pagination }: CampaignsTableProps) {
+export function CampaignsTable({
+  campaigns,
+  pagination,
+  canManageAdminActions,
+}: CampaignsTableProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const locale = useLocale();
   const t = useTranslations("campaigns");
+  const [closeTarget, setCloseTarget] = useState<Campaign | null>(null);
+  const [isClosing, setIsClosing] = useState(false);
 
   const navigateToPage = useCallback(
     (page: number) => {
@@ -68,6 +100,26 @@ export function CampaignsTable({ campaigns, pagination }: CampaignsTableProps) {
     },
     [pathname, router, searchParams],
   );
+
+  const confirmClose = useCallback(async () => {
+    if (!closeTarget) return;
+    setIsClosing(true);
+    try {
+      await CampaignService.closeCampaign(createClientApiClient(), closeTarget.id);
+      toast.success(t("success.closed"));
+      setCloseTarget(null);
+      router.refresh();
+    } catch (err) {
+      if (!(err instanceof ApiProblem)) console.error("campaigns.close failed", err);
+      const message =
+        err instanceof ApiProblem
+          ? (err.detail ?? err.title ?? t("errors.closeGeneric"))
+          : t("errors.closeGeneric");
+      toast.error(message);
+    } finally {
+      setIsClosing(false);
+    }
+  }, [closeTarget, router, t]);
 
   const columns = useMemo<ColumnDef<CampaignWithStats>[]>(
     () => [
@@ -163,26 +215,133 @@ export function CampaignsTable({ campaigns, pagination }: CampaignsTableProps) {
           </span>
         ),
       },
+      {
+        id: "actions",
+        header: () => <span className="sr-only">{t("columns.actions")}</span>,
+        enableSorting: false,
+        cell: ({ row }) => {
+          const campaign = row.original.campaign;
+          const canClose =
+            canManageAdminActions && (campaign.status === "draft" || campaign.status === "active");
+          return (
+            <CampaignRowActions
+              campaign={campaign}
+              canClose={canClose}
+              onClose={() => setCloseTarget(campaign)}
+              menuLabel={t("actions.menu", { name: campaign.name })}
+              editLabel={t("actions.edit")}
+              closeLabel={t("actions.close")}
+            />
+          );
+        },
+      },
     ],
-    [t, locale],
+    [canManageAdminActions, t, locale],
   );
 
   return (
-    <div className="transition-opacity duration-normal">
-      <DataTable
-        columns={columns}
-        data={campaigns}
-        pagination={pagination}
-        onPageChange={navigateToPage}
-        onRowClick={(row) => router.push(`/campaigns/${row.original.campaign.id}`)}
-        emptyState={
-          <EmptyState
-            icon={Megaphone}
-            title={t("empty.title")}
-            description={t("empty.description")}
-          />
-        }
-      />
-    </div>
+    <>
+      <div className="transition-opacity duration-normal">
+        <DataTable
+          columns={columns}
+          data={campaigns}
+          pagination={pagination}
+          onPageChange={navigateToPage}
+          onRowClick={(row) => router.push(`/campaigns/${row.original.campaign.id}`)}
+          emptyState={
+            <EmptyState
+              icon={Megaphone}
+              title={t("empty.title")}
+              description={t("empty.description")}
+            />
+          }
+        />
+      </div>
+
+      <AlertDialog
+        open={closeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setCloseTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("closeDialog.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {closeTarget
+                ? t("closeDialog.description", { name: closeTarget.name })
+                : t("closeDialog.descriptionFallback")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel asChild>
+              <Button variant="ghost" disabled={isClosing}>
+                {t("closeDialog.cancel")}
+              </Button>
+            </AlertDialogCancel>
+            <Button variant="destructive" disabled={isClosing} onClick={() => void confirmClose()}>
+              {isClosing ? t("closeDialog.closing") : t("closeDialog.confirm")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+interface CampaignRowActionsProps {
+  campaign: Campaign;
+  canClose: boolean;
+  onClose: () => void;
+  menuLabel: string;
+  editLabel: string;
+  closeLabel: string;
+}
+
+function CampaignRowActions({
+  campaign,
+  canClose,
+  onClose,
+  menuLabel,
+  editLabel,
+  closeLabel,
+}: CampaignRowActionsProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label={menuLabel}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <MoreHorizontal size={16} aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
+        <DropdownMenuItem asChild>
+          <Link
+            href={`/campaigns/${campaign.id}/edit`}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Pencil size={16} aria-hidden="true" />
+            {editLabel}
+          </Link>
+        </DropdownMenuItem>
+        {canClose ? (
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onClose();
+            }}
+            className="text-error focus:text-error"
+          >
+            <XCircle size={16} aria-hidden="true" />
+            {closeLabel}
+          </DropdownMenuItem>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/packages/web/src/app/(app)/campaigns/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/page.tsx
@@ -28,7 +28,8 @@ function parsePositiveInt(value: string | string[] | undefined, fallback: number
 }
 
 export default async function CampaignsPage({ searchParams }: CampaignsPageProps) {
-  await requireAuth();
+  const auth = await requireAuth();
+  const canManageAdminActions = auth.roles.includes("org_admin");
   const params = await searchParams;
   const t = await getTranslations("campaigns");
 
@@ -78,7 +79,11 @@ export default async function CampaignsPage({ searchParams }: CampaignsPageProps
       />
 
       {hasAny ? (
-        <CampaignsTable campaigns={campaignsWithStats} pagination={result.pagination} />
+        <CampaignsTable
+          campaigns={campaignsWithStats}
+          pagination={result.pagination}
+          canManageAdminActions={canManageAdminActions}
+        />
       ) : (
         <div className="rounded-2xl bg-surface-container-lowest shadow-card">
           <EmptyState icon={Megaphone} title={t("empty.title")} description={t("empty.seedHint")} />

--- a/packages/web/src/app/(app)/constituents/[id]/page.tsx
+++ b/packages/web/src/app/(app)/constituents/[id]/page.tsx
@@ -81,7 +81,8 @@ async function fetchDonationsOrEmpty(
 }
 
 export default async function ConstituentDetailPage({ params, searchParams }: DetailPageProps) {
-  await requireAuth();
+  const auth = await requireAuth();
+  const canManageAdminActions = auth.roles.includes("org_admin");
   const { id } = await params;
   const sp = await searchParams;
 
@@ -124,6 +125,7 @@ export default async function ConstituentDetailPage({ params, searchParams }: De
         })}
         typeLabel={resolveTypeLabel(constituent.type, tType)}
         typeVariant={TYPE_VARIANTS[String(constituent.type)] ?? "neutral"}
+        canManageAdminActions={canManageAdminActions}
         labels={{
           ariaLabel: t("profile.ariaLabel"),
           email: t("profile.email"),
@@ -240,6 +242,7 @@ function ProfileCard({
   memberSinceLabel,
   typeLabel,
   typeVariant,
+  canManageAdminActions,
   labels,
 }: {
   constituent: Constituent;
@@ -247,6 +250,7 @@ function ProfileCard({
   memberSinceLabel: string;
   typeLabel: string;
   typeVariant: BadgeVariant;
+  canManageAdminActions: boolean;
   labels: ProfileLabels;
 }) {
   return (
@@ -288,7 +292,11 @@ function ProfileCard({
         </dl>
       </div>
 
-      <ProfileActions constituentId={constituent.id} labels={labels} />
+      <ProfileActions
+        constituentId={constituent.id}
+        canManageAdminActions={canManageAdminActions}
+        labels={labels}
+      />
     </section>
   );
 }
@@ -321,9 +329,18 @@ function ContactLink({ href, children }: { href: string; children: string }) {
 
 function ProfileActions({
   constituentId,
+  canManageAdminActions,
   labels,
 }: {
   constituentId: string;
+  /**
+   * Merge (`POST /v1/constituents/:id/merge`) and Delete
+   * (`DELETE /v1/constituents/:id`) both require `org_admin` server-side.
+   * Hide the affordances for non-admins so they don't see buttons that
+   * would 403 once wired up. Edit / Export GDPR stay visible — they're
+   * either operational writes (Edit) or open to all roles (export stub).
+   */
+  canManageAdminActions: boolean;
   labels: ProfileLabels;
 }) {
   return (
@@ -334,18 +351,22 @@ function ProfileActions({
           {labels.edit}
         </Link>
       </Button>
-      <Button variant="secondary" size="sm" disabled>
-        <GitMerge size={16} aria-hidden="true" />
-        {labels.merge}
-      </Button>
+      {canManageAdminActions ? (
+        <Button variant="secondary" size="sm" disabled>
+          <GitMerge size={16} aria-hidden="true" />
+          {labels.merge}
+        </Button>
+      ) : null}
       <Button variant="secondary" size="sm" disabled>
         <Download size={16} aria-hidden="true" />
         {labels.exportGdpr}
       </Button>
-      <Button variant="destructive" size="sm" disabled>
-        <Trash2 size={16} aria-hidden="true" />
-        {labels.delete}
-      </Button>
+      {canManageAdminActions ? (
+        <Button variant="destructive" size="sm" disabled>
+          <Trash2 size={16} aria-hidden="true" />
+          {labels.delete}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/app/(app)/constituents/constituents-table.tsx
+++ b/packages/web/src/app/(app)/constituents/constituents-table.tsx
@@ -1,15 +1,36 @@
 "use client";
 
 import type { ColumnDef } from "@tanstack/react-table";
-import { Users } from "lucide-react";
+import { MoreHorizontal, Pencil, Trash2, Users } from "lucide-react";
+import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { EmptyState } from "@/components/shared/empty-state";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
 import { type Constituent, fullName, initials } from "@/models/constituent";
+import { ConstituentService } from "@/services/ConstituentService";
 
 type BadgeVariant = "success" | "warning" | "error" | "info" | "neutral";
 
@@ -36,14 +57,26 @@ function translateType(
 interface ConstituentsTableProps {
   constituents: Constituent[];
   pagination: { page: number; perPage: number; total: number; totalPages: number };
+  /**
+   * Delete is `requireOrgAdmin` server-side; when `false`, the row's
+   * dropdown only shows Edit. Mirrors the donations + members table
+   * shortcut pattern.
+   */
+  canManageAdminActions: boolean;
 }
 
-export function ConstituentsTable({ constituents, pagination }: ConstituentsTableProps) {
+export function ConstituentsTable({
+  constituents,
+  pagination,
+  canManageAdminActions,
+}: ConstituentsTableProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const t = useTranslations("constituents");
   const tType = useTranslations("constituents.types");
+  const [deleteTarget, setDeleteTarget] = useState<Constituent | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const navigateToPage = useCallback(
     (page: number) => {
@@ -58,6 +91,26 @@ export function ConstituentsTable({ constituents, pagination }: ConstituentsTabl
     },
     [pathname, router, searchParams],
   );
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await ConstituentService.deleteConstituent(createClientApiClient(), deleteTarget.id);
+      toast.success(t("success.deleted"));
+      setDeleteTarget(null);
+      router.refresh();
+    } catch (err) {
+      if (!(err instanceof ApiProblem)) console.error("constituents.delete failed", err);
+      const message =
+        err instanceof ApiProblem
+          ? (err.detail ?? err.title ?? t("errors.deleteGeneric"))
+          : t("errors.deleteGeneric");
+      toast.error(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [deleteTarget, router, t]);
 
   const columns = useMemo<ColumnDef<Constituent>[]>(
     () => [
@@ -108,22 +161,132 @@ export function ConstituentsTable({ constituents, pagination }: ConstituentsTabl
         enableSorting: false,
         cell: () => <span className="text-on-surface-variant">—</span>,
       },
+      {
+        id: "actions",
+        header: () => <span className="sr-only">{t("columns.actions")}</span>,
+        enableSorting: false,
+        cell: ({ row }) => (
+          <ConstituentRowActions
+            constituent={row.original}
+            canDelete={canManageAdminActions}
+            onDelete={() => setDeleteTarget(row.original)}
+            menuLabel={t("actions.menu", { name: fullName(row.original) })}
+            editLabel={t("actions.edit")}
+            deleteLabel={t("actions.delete")}
+          />
+        ),
+      },
     ],
-    [t, tType],
+    [canManageAdminActions, t, tType],
   );
 
   return (
-    <div className="transition-opacity duration-normal">
-      <DataTable
-        columns={columns}
-        data={constituents}
-        pagination={pagination}
-        onPageChange={navigateToPage}
-        onRowClick={(row) => router.push(`/constituents/${row.original.id}`)}
-        emptyState={
-          <EmptyState icon={Users} title={t("empty.title")} description={t("empty.description")} />
-        }
-      />
-    </div>
+    <>
+      <div className="transition-opacity duration-normal">
+        <DataTable
+          columns={columns}
+          data={constituents}
+          pagination={pagination}
+          onPageChange={navigateToPage}
+          onRowClick={(row) => router.push(`/constituents/${row.original.id}`)}
+          emptyState={
+            <EmptyState
+              icon={Users}
+              title={t("empty.title")}
+              description={t("empty.description")}
+            />
+          }
+        />
+      </div>
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("deleteDialog.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteTarget
+                ? t("deleteDialog.description", { name: fullName(deleteTarget) })
+                : t("deleteDialog.descriptionFallback")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel asChild>
+              <Button variant="ghost" disabled={isDeleting}>
+                {t("deleteDialog.cancel")}
+              </Button>
+            </AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={isDeleting}
+              onClick={() => void confirmDelete()}
+            >
+              {isDeleting ? t("deleteDialog.deleting") : t("deleteDialog.confirm")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+interface ConstituentRowActionsProps {
+  constituent: Constituent;
+  canDelete: boolean;
+  onDelete: () => void;
+  menuLabel: string;
+  editLabel: string;
+  deleteLabel: string;
+}
+
+function ConstituentRowActions({
+  constituent,
+  canDelete,
+  onDelete,
+  menuLabel,
+  editLabel,
+  deleteLabel,
+}: ConstituentRowActionsProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label={menuLabel}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <MoreHorizontal size={16} aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
+        <DropdownMenuItem asChild>
+          <Link
+            href={`/constituents/${constituent.id}/edit`}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Pencil size={16} aria-hidden="true" />
+            {editLabel}
+          </Link>
+        </DropdownMenuItem>
+        {canDelete ? (
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onDelete();
+            }}
+            className="text-error focus:text-error"
+          >
+            <Trash2 size={16} aria-hidden="true" />
+            {deleteLabel}
+          </DropdownMenuItem>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/packages/web/src/app/(app)/constituents/page.tsx
+++ b/packages/web/src/app/(app)/constituents/page.tsx
@@ -29,7 +29,8 @@ function parsePositiveInt(value: string | string[] | undefined, fallback: number
 }
 
 export default async function ConstituentsPage({ searchParams }: ConstituentsPageProps) {
-  await requireAuth();
+  const auth = await requireAuth();
+  const canManageAdminActions = auth.roles.includes("org_admin");
   const params = await searchParams;
   const t = await getTranslations("constituents");
 
@@ -78,7 +79,11 @@ export default async function ConstituentsPage({ searchParams }: ConstituentsPag
       />
 
       {hasAny ? (
-        <ConstituentsTable constituents={result.data} pagination={result.pagination} />
+        <ConstituentsTable
+          constituents={result.data}
+          pagination={result.pagination}
+          canManageAdminActions={canManageAdminActions}
+        />
       ) : (
         <div className="rounded-2xl bg-surface-container-lowest shadow-card">
           <EmptyState icon={Users} title={t("empty.title")} description={t("empty.seedHint")} />

--- a/packages/web/src/app/(app)/donations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/donations/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Pencil } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
@@ -69,6 +69,12 @@ export default async function DonationDetailPage({ params }: DonationDetailPageP
               <Link href="/donations">
                 <ArrowLeft size={16} aria-hidden="true" />
                 {t("actions.back")}
+              </Link>
+            </Button>
+            <Button asChild size="sm">
+              <Link href={`/donations/${donation.id}/edit`}>
+                <Pencil size={16} aria-hidden="true" />
+                {t("actions.edit")}
               </Link>
             </Button>
             <ReceiptPreviewButton donationId={donation.id} />

--- a/packages/web/src/app/(app)/donations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/donations/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
+import { DeleteDonationButton } from "@/components/donations/delete-donation-button";
 import { ReceiptPreviewButton } from "@/components/donations/receipt-preview-button";
 import { PageHeader } from "@/components/shared/page-header";
 import { Button } from "@/components/ui/button";
@@ -78,6 +79,10 @@ export default async function DonationDetailPage({ params }: DonationDetailPageP
               </Link>
             </Button>
             <ReceiptPreviewButton donationId={donation.id} />
+            <DeleteDonationButton
+              donationId={donation.id}
+              donorName={donationDetailDonorName(donation) || null}
+            />
           </>
         }
       />

--- a/packages/web/src/app/(app)/settings/layout.tsx
+++ b/packages/web/src/app/(app)/settings/layout.tsx
@@ -1,0 +1,25 @@
+import { notFound } from "next/navigation";
+import { requireAuth } from "@/lib/auth/guards";
+
+/**
+ * Settings layout — guarded by the application `org_admin` role.
+ *
+ * The whole `/settings/*` surface (organisation defaults, members,
+ * funds, snapshot export) is admin-only: every page issues a request
+ * to an `org_admin`-gated endpoint, and a non-admin landing on any of
+ * them would crash the SSR render with a 403 from the API. Blocking
+ * here is the right architectural layer.
+ *
+ * Non-admin users get a 404 (not a 403) so the surface is not
+ * discoverable via authorisation-error probing — same rationale as
+ * `(admin)/layout.tsx`. The sidebar / topbar entries that link here
+ * are hidden client-side via `hasAppRole("org_admin")` to avoid
+ * dead-end clicks; this guard is the durable enforcement.
+ */
+export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
+  const auth = await requireAuth();
+  if (!auth.roles.includes("org_admin")) {
+    notFound();
+  }
+  return <>{children}</>;
+}

--- a/packages/web/src/app/(app)/settings/members/invite-action.tsx
+++ b/packages/web/src/app/(app)/settings/members/invite-action.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { UserPlus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { type FormEvent, useCallback, useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { InvitationRole } from "@/models/invitation";
+import { InvitationService } from "@/services/InvitationService";
+
+const ROLE_VALUES: readonly InvitationRole[] = ["user", "org_admin", "viewer"];
+
+/**
+ * "Invite teammate" page-header action. Holds its own dialog state so the
+ * invitation flow is reachable both from the populated members table AND
+ * from the empty-state card — the funds page convention is to put the
+ * primary CTA in the header so the body content can render clean.
+ */
+export function InviteAction() {
+  const router = useRouter();
+  const t = useTranslations("settings.members");
+  const emailId = useId();
+  const roleId = useId();
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<InvitationRole>("user");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setEmail("");
+    setRole("user");
+    setError(null);
+  }, []);
+
+  const handleClose = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (!next) reset();
+    },
+    [reset],
+  );
+
+  const onSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const trimmed = email.trim();
+      if (trimmed.length === 0) {
+        setError(t("invite.errors.emailRequired"));
+        return;
+      }
+      setSubmitting(true);
+      setError(null);
+      try {
+        await InvitationService.createInvitation(createClientApiClient(), {
+          email: trimmed,
+          role,
+        });
+        toast.success(t("success.invited", { email: trimmed }));
+        handleClose(false);
+        router.refresh();
+      } catch (err) {
+        if (!(err instanceof ApiProblem)) console.error("members.invite failed", err);
+        if (err instanceof ApiProblem && err.detail) {
+          setError(err.detail);
+        } else {
+          setError(t("invite.errors.generic"));
+        }
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [email, handleClose, role, router, t],
+  );
+
+  return (
+    <>
+      <Button variant="primary" size="sm" onClick={() => setOpen(true)}>
+        <UserPlus size={16} aria-hidden="true" />
+        {t("actions.invite")}
+      </Button>
+
+      <Dialog open={open} onOpenChange={handleClose}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("invite.title")}</DialogTitle>
+            <DialogDescription>{t("invite.description")}</DialogDescription>
+          </DialogHeader>
+          <form onSubmit={onSubmit} className="space-y-4" noValidate>
+            {error ? (
+              <div
+                role="alert"
+                aria-live="polite"
+                className="rounded-lg border border-error-border bg-error-container p-3 text-sm text-on-error-container"
+              >
+                {error}
+              </div>
+            ) : null}
+
+            <div className="space-y-2">
+              <Label htmlFor={emailId} required>
+                {t("invite.fields.email")}
+              </Label>
+              <Input
+                id={emailId}
+                type="email"
+                autoComplete="email"
+                required
+                maxLength={255}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder={t("invite.fields.emailPlaceholder")}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={roleId} required>
+                {t("invite.fields.role")}
+              </Label>
+              <Select value={role} onValueChange={(v) => setRole(v as InvitationRole)}>
+                <SelectTrigger id={roleId}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ROLE_VALUES.map((r) => (
+                    <SelectItem key={r} value={r}>
+                      {t(`roles.${r}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-text-muted">{t(`invite.roleHints.${role}`)}</p>
+            </div>
+
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => handleClose(false)} disabled={submitting}>
+                {t("invite.actions.cancel")}
+              </Button>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? t("invite.actions.submitting") : t("invite.actions.submit")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/web/src/app/(app)/settings/members/members-table.tsx
+++ b/packages/web/src/app/(app)/settings/members/members-table.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { MoreHorizontal, RefreshCw, Trash2, UserPlus, Users } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { type FormEvent, useCallback, useId, useMemo, useState } from "react";
+
+import { EmptyState } from "@/components/shared/empty-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DataTable, type DataTablePagination } from "@/components/ui/data-table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { formatDate } from "@/lib/format";
+import type { Invitation, InvitationRole, InvitationStatus } from "@/models/invitation";
+import { InvitationService } from "@/services/InvitationService";
+
+interface MembersTableProps {
+  invitations: Invitation[];
+  pagination: DataTablePagination;
+  canManageMembers: boolean;
+}
+
+const ROLE_VALUES: readonly InvitationRole[] = ["user", "org_admin", "viewer"];
+
+const STATUS_VARIANT: Record<InvitationStatus, "success" | "info" | "warning"> = {
+  accepted: "success",
+  pending: "info",
+  expired: "warning",
+};
+
+export function MembersTable({ invitations, pagination, canManageMembers }: MembersTableProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const locale = useLocale();
+  const t = useTranslations("settings.members");
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [revokeTarget, setRevokeTarget] = useState<Invitation | null>(null);
+  const [isMutating, setIsMutating] = useState(false);
+
+  const navigateToPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (page <= 1) params.delete("page");
+      else params.set("page", String(page));
+      const query = params.toString();
+      router.push(query ? `${pathname}?${query}` : pathname);
+    },
+    [pathname, router, searchParams],
+  );
+
+  const onResend = useCallback(
+    async (invitation: Invitation) => {
+      setIsMutating(true);
+      try {
+        await InvitationService.resendInvitation(createClientApiClient(), invitation.id);
+        toast.success(t("success.resent"));
+        router.refresh();
+      } catch (err) {
+        if (!(err instanceof ApiProblem)) console.error("members.resend failed", err);
+        const message =
+          err instanceof ApiProblem
+            ? (err.detail ?? err.title ?? t("errors.resendGeneric"))
+            : t("errors.resendGeneric");
+        toast.error(message);
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [router, t],
+  );
+
+  const confirmRevoke = useCallback(async () => {
+    if (!revokeTarget) return;
+    setIsMutating(true);
+    try {
+      await InvitationService.revokeInvitation(createClientApiClient(), revokeTarget.id);
+      toast.success(t("success.revoked"));
+      setRevokeTarget(null);
+      router.refresh();
+    } catch (err) {
+      if (!(err instanceof ApiProblem)) console.error("members.revoke failed", err);
+      const message =
+        err instanceof ApiProblem
+          ? (err.detail ?? err.title ?? t("errors.revokeGeneric"))
+          : t("errors.revokeGeneric");
+      toast.error(message);
+    } finally {
+      setIsMutating(false);
+    }
+  }, [revokeTarget, router, t]);
+
+  const columns = useMemo<ColumnDef<Invitation>[]>(
+    () => [
+      {
+        id: "email",
+        accessorKey: "email",
+        header: () => t("columns.email"),
+        enableSorting: false,
+        cell: ({ row }) => (
+          <span className="font-medium text-on-surface">{row.original.email}</span>
+        ),
+      },
+      {
+        id: "role",
+        accessorKey: "role",
+        header: () => t("columns.role"),
+        enableSorting: false,
+        cell: ({ row }) => <Badge variant="neutral">{t(`roles.${row.original.role}`)}</Badge>,
+      },
+      {
+        id: "status",
+        accessorKey: "status",
+        header: () => t("columns.status"),
+        enableSorting: false,
+        cell: ({ row }) => (
+          <Badge variant={STATUS_VARIANT[row.original.status]}>
+            {t(`statuses.${row.original.status}`)}
+          </Badge>
+        ),
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: () => t("columns.createdAt"),
+        enableSorting: false,
+        cell: ({ row }) => (
+          <span className="whitespace-nowrap text-on-surface-variant">
+            {formatDate(row.original.createdAt, locale, "short")}
+          </span>
+        ),
+      },
+      ...(canManageMembers
+        ? [
+            {
+              id: "actions",
+              header: () => <span className="sr-only">{t("columns.actions")}</span>,
+              enableSorting: false,
+              cell: ({ row }: { row: { original: Invitation } }) => {
+                const canResend = row.original.status !== "accepted";
+                const canRevoke = row.original.status !== "accepted";
+                if (!canResend && !canRevoke) return null;
+                return (
+                  <RowActions
+                    invitation={row.original}
+                    onResend={canResend ? () => void onResend(row.original) : undefined}
+                    onRevoke={canRevoke ? () => setRevokeTarget(row.original) : undefined}
+                    disabled={isMutating}
+                    resendLabel={t("actions.resend")}
+                    revokeLabel={t("actions.revoke")}
+                    menuLabel={t("actions.menu", { email: row.original.email })}
+                  />
+                );
+              },
+            } satisfies ColumnDef<Invitation>,
+          ]
+        : []),
+    ],
+    [canManageMembers, isMutating, locale, onResend, t],
+  );
+
+  return (
+    <>
+      {canManageMembers ? (
+        <div className="flex justify-end">
+          <Button variant="primary" size="sm" onClick={() => setInviteOpen(true)}>
+            <UserPlus size={16} aria-hidden="true" />
+            {t("actions.invite")}
+          </Button>
+        </div>
+      ) : null}
+
+      <DataTable
+        columns={columns}
+        data={invitations}
+        pagination={pagination}
+        onPageChange={navigateToPage}
+        emptyState={
+          <EmptyState icon={Users} title={t("empty.title")} description={t("empty.description")} />
+        }
+      />
+
+      <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} />
+
+      <Dialog open={revokeTarget !== null} onOpenChange={(open) => !open && setRevokeTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("revokeDialog.title")}</DialogTitle>
+            <DialogDescription>
+              {revokeTarget
+                ? t("revokeDialog.description", { email: revokeTarget.email })
+                : t("revokeDialog.descriptionFallback")}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRevokeTarget(null)} disabled={isMutating}>
+              {t("revokeDialog.cancel")}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => void confirmRevoke()}
+              disabled={isMutating}
+            >
+              {isMutating ? t("revokeDialog.revoking") : t("revokeDialog.confirm")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+interface RowActionsProps {
+  invitation: Invitation;
+  onResend: (() => void) | undefined;
+  onRevoke: (() => void) | undefined;
+  disabled: boolean;
+  resendLabel: string;
+  revokeLabel: string;
+  menuLabel: string;
+}
+
+function RowActions({
+  invitation: _invitation,
+  onResend,
+  onRevoke,
+  disabled,
+  resendLabel,
+  revokeLabel,
+  menuLabel,
+}: RowActionsProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label={menuLabel}
+          className="justify-center"
+          disabled={disabled}
+        >
+          <MoreHorizontal size={16} aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {onResend ? (
+          <DropdownMenuItem onSelect={onResend}>
+            <RefreshCw size={16} aria-hidden="true" />
+            {resendLabel}
+          </DropdownMenuItem>
+        ) : null}
+        {onRevoke ? (
+          <DropdownMenuItem onSelect={onRevoke} className="text-error focus:text-error">
+            <Trash2 size={16} aria-hidden="true" />
+            {revokeLabel}
+          </DropdownMenuItem>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// ─── Invite dialog ──────────────────────────────────────────────────────────
+
+interface InviteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function InviteDialog({ open, onOpenChange }: InviteDialogProps) {
+  const router = useRouter();
+  const t = useTranslations("settings.members");
+  const emailId = useId();
+  const roleId = useId();
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<InvitationRole>("user");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setEmail("");
+    setRole("user");
+    setError(null);
+  }, []);
+
+  const handleClose = useCallback(
+    (next: boolean) => {
+      onOpenChange(next);
+      if (!next) reset();
+    },
+    [onOpenChange, reset],
+  );
+
+  const onSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const trimmed = email.trim();
+      if (trimmed.length === 0) {
+        setError(t("invite.errors.emailRequired"));
+        return;
+      }
+      setSubmitting(true);
+      setError(null);
+      try {
+        await InvitationService.createInvitation(createClientApiClient(), {
+          email: trimmed,
+          role,
+        });
+        toast.success(t("success.invited", { email: trimmed }));
+        handleClose(false);
+        router.refresh();
+      } catch (err) {
+        if (!(err instanceof ApiProblem)) console.error("members.invite failed", err);
+        if (err instanceof ApiProblem && err.detail) {
+          setError(err.detail);
+        } else {
+          setError(t("invite.errors.generic"));
+        }
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [email, handleClose, role, router, t],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("invite.title")}</DialogTitle>
+          <DialogDescription>{t("invite.description")}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="space-y-4" noValidate>
+          {error ? (
+            <div
+              role="alert"
+              aria-live="polite"
+              className="rounded-lg border border-error-border bg-error-container p-3 text-sm text-on-error-container"
+            >
+              {error}
+            </div>
+          ) : null}
+
+          <div className="space-y-2">
+            <Label htmlFor={emailId} required>
+              {t("invite.fields.email")}
+            </Label>
+            <Input
+              id={emailId}
+              type="email"
+              autoComplete="email"
+              required
+              maxLength={255}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={t("invite.fields.emailPlaceholder")}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor={roleId} required>
+              {t("invite.fields.role")}
+            </Label>
+            <Select value={role} onValueChange={(v) => setRole(v as InvitationRole)}>
+              <SelectTrigger id={roleId}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ROLE_VALUES.map((r) => (
+                  <SelectItem key={r} value={r}>
+                    {t(`roles.${r}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-text-muted">{t(`invite.roleHints.${role}`)}</p>
+          </div>
+
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => handleClose(false)} disabled={submitting}>
+              {t("invite.actions.cancel")}
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? t("invite.actions.submitting") : t("invite.actions.submit")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/app/(app)/settings/members/members-table.tsx
+++ b/packages/web/src/app/(app)/settings/members/members-table.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type { ColumnDef } from "@tanstack/react-table";
-import { MoreHorizontal, RefreshCw, Trash2, UserPlus, Users } from "lucide-react";
+import { MoreHorizontal, RefreshCw, Trash2, Users } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
-import { type FormEvent, useCallback, useId, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { EmptyState } from "@/components/shared/empty-state";
 import { Badge } from "@/components/ui/badge";
@@ -24,20 +24,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { toast } from "@/components/ui/toast";
 import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import { formatDate } from "@/lib/format";
-import type { Invitation, InvitationRole, InvitationStatus } from "@/models/invitation";
+import type { Invitation, InvitationStatus } from "@/models/invitation";
 import { InvitationService } from "@/services/InvitationService";
 
 interface MembersTableProps {
@@ -45,8 +36,6 @@ interface MembersTableProps {
   pagination: DataTablePagination;
   canManageMembers: boolean;
 }
-
-const ROLE_VALUES: readonly InvitationRole[] = ["user", "org_admin", "viewer"];
 
 const STATUS_VARIANT: Record<InvitationStatus, "success" | "info" | "warning"> = {
   accepted: "success",
@@ -60,7 +49,6 @@ export function MembersTable({ invitations, pagination, canManageMembers }: Memb
   const searchParams = useSearchParams();
   const locale = useLocale();
   const t = useTranslations("settings.members");
-  const [inviteOpen, setInviteOpen] = useState(false);
   const [revokeTarget, setRevokeTarget] = useState<Invitation | null>(null);
   const [isMutating, setIsMutating] = useState(false);
 
@@ -168,7 +156,6 @@ export function MembersTable({ invitations, pagination, canManageMembers }: Memb
                 if (!canResend && !canRevoke) return null;
                 return (
                   <RowActions
-                    invitation={row.original}
                     onResend={canResend ? () => void onResend(row.original) : undefined}
                     onRevoke={canRevoke ? () => setRevokeTarget(row.original) : undefined}
                     disabled={isMutating}
@@ -187,15 +174,6 @@ export function MembersTable({ invitations, pagination, canManageMembers }: Memb
 
   return (
     <>
-      {canManageMembers ? (
-        <div className="flex justify-end">
-          <Button variant="primary" size="sm" onClick={() => setInviteOpen(true)}>
-            <UserPlus size={16} aria-hidden="true" />
-            {t("actions.invite")}
-          </Button>
-        </div>
-      ) : null}
-
       <DataTable
         columns={columns}
         data={invitations}
@@ -205,8 +183,6 @@ export function MembersTable({ invitations, pagination, canManageMembers }: Memb
           <EmptyState icon={Users} title={t("empty.title")} description={t("empty.description")} />
         }
       />
-
-      <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} />
 
       <Dialog open={revokeTarget !== null} onOpenChange={(open) => !open && setRevokeTarget(null)}>
         <DialogContent>
@@ -237,7 +213,6 @@ export function MembersTable({ invitations, pagination, canManageMembers }: Memb
 }
 
 interface RowActionsProps {
-  invitation: Invitation;
   onResend: (() => void) | undefined;
   onRevoke: (() => void) | undefined;
   disabled: boolean;
@@ -247,7 +222,6 @@ interface RowActionsProps {
 }
 
 function RowActions({
-  invitation: _invitation,
   onResend,
   onRevoke,
   disabled,
@@ -283,135 +257,5 @@ function RowActions({
         ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
-  );
-}
-
-// ─── Invite dialog ──────────────────────────────────────────────────────────
-
-interface InviteDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}
-
-function InviteDialog({ open, onOpenChange }: InviteDialogProps) {
-  const router = useRouter();
-  const t = useTranslations("settings.members");
-  const emailId = useId();
-  const roleId = useId();
-  const [email, setEmail] = useState("");
-  const [role, setRole] = useState<InvitationRole>("user");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const reset = useCallback(() => {
-    setEmail("");
-    setRole("user");
-    setError(null);
-  }, []);
-
-  const handleClose = useCallback(
-    (next: boolean) => {
-      onOpenChange(next);
-      if (!next) reset();
-    },
-    [onOpenChange, reset],
-  );
-
-  const onSubmit = useCallback(
-    async (e: FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      const trimmed = email.trim();
-      if (trimmed.length === 0) {
-        setError(t("invite.errors.emailRequired"));
-        return;
-      }
-      setSubmitting(true);
-      setError(null);
-      try {
-        await InvitationService.createInvitation(createClientApiClient(), {
-          email: trimmed,
-          role,
-        });
-        toast.success(t("success.invited", { email: trimmed }));
-        handleClose(false);
-        router.refresh();
-      } catch (err) {
-        if (!(err instanceof ApiProblem)) console.error("members.invite failed", err);
-        if (err instanceof ApiProblem && err.detail) {
-          setError(err.detail);
-        } else {
-          setError(t("invite.errors.generic"));
-        }
-      } finally {
-        setSubmitting(false);
-      }
-    },
-    [email, handleClose, role, router, t],
-  );
-
-  return (
-    <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t("invite.title")}</DialogTitle>
-          <DialogDescription>{t("invite.description")}</DialogDescription>
-        </DialogHeader>
-        <form onSubmit={onSubmit} className="space-y-4" noValidate>
-          {error ? (
-            <div
-              role="alert"
-              aria-live="polite"
-              className="rounded-lg border border-error-border bg-error-container p-3 text-sm text-on-error-container"
-            >
-              {error}
-            </div>
-          ) : null}
-
-          <div className="space-y-2">
-            <Label htmlFor={emailId} required>
-              {t("invite.fields.email")}
-            </Label>
-            <Input
-              id={emailId}
-              type="email"
-              autoComplete="email"
-              required
-              maxLength={255}
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder={t("invite.fields.emailPlaceholder")}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor={roleId} required>
-              {t("invite.fields.role")}
-            </Label>
-            <Select value={role} onValueChange={(v) => setRole(v as InvitationRole)}>
-              <SelectTrigger id={roleId}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {ROLE_VALUES.map((r) => (
-                  <SelectItem key={r} value={r}>
-                    {t(`roles.${r}`)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-text-muted">{t(`invite.roleHints.${role}`)}</p>
-          </div>
-
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => handleClose(false)} disabled={submitting}>
-              {t("invite.actions.cancel")}
-            </Button>
-            <Button type="submit" disabled={submitting}>
-              {submitting ? t("invite.actions.submitting") : t("invite.actions.submit")}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/packages/web/src/app/(app)/settings/members/page.tsx
+++ b/packages/web/src/app/(app)/settings/members/page.tsx
@@ -1,10 +1,13 @@
+import { Users } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { SettingsNavigation } from "@/components/settings/settings-navigation";
+import { EmptyState } from "@/components/shared/empty-state";
 import { PageHeader } from "@/components/shared/page-header";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
 import { InvitationService } from "@/services/InvitationService";
 
+import { InviteAction } from "./invite-action";
 import { MembersTable } from "./members-table";
 
 const DEFAULT_PER_PAGE = 20;
@@ -27,7 +30,9 @@ function parsePositiveInt(value: string | string[] | undefined, fallback: number
  * Lists every team invitation (pending / accepted / expired) for the
  * current tenant and lets org_admins invite new teammates, resend pending
  * invitations, or revoke them. Non-admins see the data without the action
- * affordances.
+ * affordances. The "Invite teammate" CTA lives in the page header (mirrors
+ * the funds page convention) so the empty-state card can render clean
+ * without table chrome.
  */
 export default async function MembersPage({ searchParams }: MembersPageProps) {
   const auth = await requireAuth();
@@ -43,24 +48,33 @@ export default async function MembersPage({ searchParams }: MembersPageProps) {
   const result = await InvitationService.listInvitations(client, { page, perPage });
 
   const total = result.pagination.total;
+  const hasAny = total > 0;
 
   return (
     <>
       <PageHeader
         title={t("title")}
-        description={total > 0 ? t("subtitleWithCount", { count: total }) : t("subtitleEmpty")}
+        description={hasAny ? t("subtitleWithCount", { count: total }) : t("subtitleEmpty")}
         breadcrumbs={[
           { label: tSettings("breadcrumbRoot"), href: "/dashboard" },
           { label: tSettings("title"), href: "/settings" },
           { label: t("title") },
         ]}
+        actions={canManageMembers ? <InviteAction /> : null}
       />
       <SettingsNavigation />
-      <MembersTable
-        invitations={result.data}
-        pagination={result.pagination}
-        canManageMembers={canManageMembers}
-      />
+
+      {hasAny ? (
+        <MembersTable
+          invitations={result.data}
+          pagination={result.pagination}
+          canManageMembers={canManageMembers}
+        />
+      ) : (
+        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+          <EmptyState icon={Users} title={t("empty.title")} description={t("empty.description")} />
+        </div>
+      )}
     </>
   );
 }

--- a/packages/web/src/app/(app)/settings/members/page.tsx
+++ b/packages/web/src/app/(app)/settings/members/page.tsx
@@ -1,0 +1,66 @@
+import { getTranslations } from "next-intl/server";
+import { SettingsNavigation } from "@/components/settings/settings-navigation";
+import { PageHeader } from "@/components/shared/page-header";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import { InvitationService } from "@/services/InvitationService";
+
+import { MembersTable } from "./members-table";
+
+const DEFAULT_PER_PAGE = 20;
+const MAX_PER_PAGE = 100;
+
+interface MembersPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function parsePositiveInt(value: string | string[] | undefined, fallback: number, max?: number) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return max ? Math.min(parsed, max) : parsed;
+}
+
+/**
+ * /settings/members — Members & invitations management.
+ *
+ * Lists every team invitation (pending / accepted / expired) for the
+ * current tenant and lets org_admins invite new teammates, resend pending
+ * invitations, or revoke them. Non-admins see the data without the action
+ * affordances.
+ */
+export default async function MembersPage({ searchParams }: MembersPageProps) {
+  const auth = await requireAuth();
+  const params = await searchParams;
+  const t = await getTranslations("settings.members");
+  const tSettings = await getTranslations("settings");
+
+  const page = parsePositiveInt(params.page, 1);
+  const perPage = parsePositiveInt(params.perPage, DEFAULT_PER_PAGE, MAX_PER_PAGE);
+  const canManageMembers = auth.roles.includes("org_admin");
+
+  const client = await createServerApiClient();
+  const result = await InvitationService.listInvitations(client, { page, perPage });
+
+  const total = result.pagination.total;
+
+  return (
+    <>
+      <PageHeader
+        title={t("title")}
+        description={total > 0 ? t("subtitleWithCount", { count: total }) : t("subtitleEmpty")}
+        breadcrumbs={[
+          { label: tSettings("breadcrumbRoot"), href: "/dashboard" },
+          { label: tSettings("title"), href: "/settings" },
+          { label: t("title") },
+        ]}
+      />
+      <SettingsNavigation />
+      <MembersTable
+        invitations={result.data}
+        pagination={result.pagination}
+        canManageMembers={canManageMembers}
+      />
+    </>
+  );
+}

--- a/packages/web/src/app/(auth)/invite/accept/page.tsx
+++ b/packages/web/src/app/(auth)/invite/accept/page.tsx
@@ -88,6 +88,13 @@ function AcceptContent() {
         // an Organization member and stamped the `org_id` user attribute
         // that the realm's mapper turns into the JWT claim the callback
         // requires.
+        //
+        // NOTE: `?hint=<slug>` is currently a no-op — the `/api/auth/login`
+        // route handler doesn't read query params, so the slug round-trip
+        // doesn't actually drive `kc_idp_hint`/`login_hint`. Kept for
+        // structural parity with `/signup/verify` (same dead query string)
+        // until both can be wired or removed together. Tracked as a
+        // follow-up to issue #145 (review F1).
         window.location.href = `/api/auth/login?hint=${encodeURIComponent(res.data.slug)}`;
         return;
       }

--- a/packages/web/src/app/(auth)/invite/accept/page.tsx
+++ b/packages/web/src/app/(auth)/invite/accept/page.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { CheckCircle2, LogIn, TriangleAlert } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { type FormEvent, Suspense, useCallback, useId, useState } from "react";
+import { AuthCard } from "@/components/auth/auth-card";
+import { AuthLogo } from "@/components/auth/auth-logo";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { acceptInvitation } from "@/services/InvitationService";
+
+const PASSWORD_MIN_LENGTH = 12;
+
+type ValidationKey = "invalid" | "namesRequired" | "passwordTooShort" | "passwordMismatch";
+
+interface AcceptFormFields {
+  token: string;
+  firstName: string;
+  lastName: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+function validateAcceptForm(f: AcceptFormFields): ValidationKey | null {
+  if (!f.token) return "invalid";
+  if (f.firstName.trim().length < 1 || f.lastName.trim().length < 1) return "namesRequired";
+  if (f.password.length < PASSWORD_MIN_LENGTH) return "passwordTooShort";
+  if (f.password !== f.passwordConfirm) return "passwordMismatch";
+  return null;
+}
+
+/**
+ * Team-invite accept landing (issue #145).
+ *
+ * Mirrors `/signup/verify` — collects firstName, lastName, and password
+ * for the invitee, then redirects through Keycloak login. The API has
+ * already provisioned the realm user + Organization membership + the
+ * `org_id` / `role` user attributes that the realm's mapper turns into
+ * the JWT claims the auth callback requires.
+ *
+ * Failure modes are intentionally collapsed to a single 410 by the API
+ * (no enumeration oracle). The UI shows a static "ask the inviter to
+ * resend" copy for that case rather than a self-serve resend form: the
+ * resend endpoint is org_admin-only in the team-invite flow, unlike the
+ * signup-verification resend which is public-with-rate-limit.
+ */
+function AcceptContent() {
+  const t = useTranslations("auth.inviteAccept");
+  const params = useSearchParams();
+  const token = params.get("token") ?? "";
+
+  const ids = {
+    firstName: useId(),
+    lastName: useId(),
+    password: useId(),
+    passwordConfirm: useId(),
+  };
+
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "done">("idle");
+  const [error, setError] = useState<string | undefined>();
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const validation = validateAcceptForm({
+        token,
+        firstName,
+        lastName,
+        password,
+        passwordConfirm,
+      });
+      if (validation) {
+        setError(t(`errors.${validation}`, { min: PASSWORD_MIN_LENGTH }));
+        return;
+      }
+      setStatus("submitting");
+      setError(undefined);
+      const res = await acceptInvitation(token, firstName.trim(), lastName.trim(), password);
+      if (res.ok) {
+        setStatus("done");
+        // Redirect to Keycloak login. The API has already attached us as
+        // an Organization member and stamped the `org_id` user attribute
+        // that the realm's mapper turns into the JWT claim the callback
+        // requires.
+        window.location.href = `/api/auth/login?hint=${encodeURIComponent(res.data.slug)}`;
+        return;
+      }
+      setStatus("idle");
+      const errorKey =
+        res.status === 410 ? "expired" : res.status === 429 ? "rateLimited" : "generic";
+      setError(t(`errors.${errorKey}`));
+    },
+    [token, firstName, lastName, password, passwordConfirm, t],
+  );
+
+  if (!token) {
+    return (
+      <AuthCard>
+        <AuthLogo />
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-error-container text-on-error-container">
+          <TriangleAlert className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <h1 className="mb-2 text-center font-heading text-xl text-text">{t("errorTitle")}</h1>
+        <p className="mb-6 text-center text-sm text-text-secondary">{t("errors.missingToken")}</p>
+        <Link
+          href="/login"
+          className="inline-flex h-[var(--btn-height-md)] w-full items-center justify-center rounded-button bg-primary px-6 text-sm font-medium text-on-primary"
+        >
+          {t("backToLogin")}
+        </Link>
+      </AuthCard>
+    );
+  }
+
+  if (status === "done") {
+    return (
+      <AuthCard>
+        <AuthLogo />
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary-50 text-primary">
+          <CheckCircle2 className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <h1 className="mb-2 text-center font-heading text-xl text-text">{t("successTitle")}</h1>
+        <p className="mb-6 text-center text-sm text-text-secondary">{t("successBody")}</p>
+        <div className="flex items-center justify-center text-xs text-text-muted">
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard>
+      <AuthLogo />
+      <h1 className="mb-2 text-center font-heading text-xl text-text">{t("title")}</h1>
+      <p className="mb-6 text-center text-sm text-text-secondary">{t("subtitle")}</p>
+
+      {error && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="mb-4 rounded-lg border border-error-border bg-error-container p-3 text-sm text-on-error-container"
+        >
+          <div className="flex items-start gap-3">
+            <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <span className="flex-1">{error}</span>
+          </div>
+        </div>
+      )}
+
+      <form noValidate onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <Label htmlFor={ids.firstName} required>
+              {t("fields.firstName")}
+            </Label>
+            <Input
+              id={ids.firstName}
+              name="firstName"
+              autoComplete="given-name"
+              required
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              maxLength={255}
+            />
+          </div>
+          <div>
+            <Label htmlFor={ids.lastName} required>
+              {t("fields.lastName")}
+            </Label>
+            <Input
+              id={ids.lastName}
+              name="lastName"
+              autoComplete="family-name"
+              required
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              maxLength={255}
+            />
+          </div>
+        </div>
+
+        <div>
+          <Label htmlFor={ids.password} required>
+            {t("fields.password")}
+          </Label>
+          <Input
+            id={ids.password}
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            required
+            minLength={PASSWORD_MIN_LENGTH}
+            maxLength={128}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            aria-describedby={`${ids.password}-hint`}
+          />
+          <p id={`${ids.password}-hint`} className="mt-1 text-xs text-text-muted">
+            {t("fields.passwordHint", { min: PASSWORD_MIN_LENGTH })}
+          </p>
+        </div>
+
+        <div>
+          <Label htmlFor={ids.passwordConfirm} required>
+            {t("fields.passwordConfirm")}
+          </Label>
+          <Input
+            id={ids.passwordConfirm}
+            name="passwordConfirm"
+            type="password"
+            autoComplete="new-password"
+            required
+            minLength={PASSWORD_MIN_LENGTH}
+            maxLength={128}
+            value={passwordConfirm}
+            onChange={(e) => setPasswordConfirm(e.target.value)}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={status === "submitting"}
+          className="inline-flex h-[var(--btn-height-lg)] w-full items-center justify-center gap-2 rounded-button bg-primary px-8 font-body text-base font-medium text-on-primary transition-opacity duration-normal ease-out hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {status === "submitting" ? (
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-on-primary border-t-transparent" />
+          ) : (
+            <LogIn className="h-4 w-4" aria-hidden="true" />
+          )}
+          {t("submit")}
+        </button>
+      </form>
+    </AuthCard>
+  );
+}
+
+export default function InviteAcceptPage() {
+  return (
+    <Suspense
+      fallback={
+        <AuthCard>
+          <span role="status">Loading…</span>
+        </AuthCard>
+      }
+    >
+      <AcceptContent />
+    </Suspense>
+  );
+}

--- a/packages/web/src/components/campaigns/campaign-status-actions.tsx
+++ b/packages/web/src/components/campaigns/campaign-status-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Play, RotateCcw, XCircle } from "lucide-react";
+import { Lock, Play, RotateCcw, XCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -15,14 +15,38 @@ import { CampaignService } from "@/services/CampaignService";
 interface CampaignStatusActionsProps {
   campaignId: string;
   status: CampaignStatus;
+  /**
+   * Status transitions (`PATCH /v1/campaigns/:id` and
+   * `POST /v1/campaigns/:id/close`) require `org_admin`. Pass `false` for
+   * non-admins so we render a read-only hint instead of buttons that would
+   * 403 on click — the StatusCard itself stays visible because the
+   * current status is still useful information for everyone.
+   */
+  canManage: boolean;
 }
 
-export function CampaignStatusActions({ campaignId, status }: CampaignStatusActionsProps) {
+export function CampaignStatusActions({
+  campaignId,
+  status,
+  canManage,
+}: CampaignStatusActionsProps) {
   const router = useRouter();
   const t = useTranslations("campaigns.detail.actions");
   const [pendingAction, setPendingAction] = useState<"activate" | "backToDraft" | "close" | null>(
     null,
   );
+
+  if (!canManage) {
+    return (
+      <p
+        className="flex items-start gap-2 rounded-lg bg-surface-container px-3 py-2 text-sm text-on-surface-variant"
+        role="note"
+      >
+        <Lock size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+        <span>{t("readOnly")}</span>
+      </p>
+    );
+  }
 
   async function runAction(action: "activate" | "backToDraft" | "close") {
     setPendingAction(action);

--- a/packages/web/src/components/donations/delete-donation-button.tsx
+++ b/packages/web/src/components/donations/delete-donation-button.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { DonationService } from "@/services/DonationService";
+
+interface DeleteDonationButtonProps {
+  donationId: string;
+  /**
+   * Donor display name interpolated into the confirm dialog. Falls back
+   * to the generic copy when null (e.g. anonymous donations).
+   */
+  donorName: string | null;
+}
+
+/**
+ * Detail-page Delete affordance — mirrors the row-level Delete in
+ * `donations-table.tsx` (same `DonationService.deleteDonation` call,
+ * same AlertDialog confirmation copy from the `donations.*` namespace).
+ *
+ * On success we navigate back to `/donations` rather than `router.refresh()`
+ * because the entity the current route resolves no longer exists; staying
+ * on `/donations/[id]` would re-fetch and 404.
+ */
+export function DeleteDonationButton({ donationId, donorName }: DeleteDonationButtonProps) {
+  const router = useRouter();
+  const t = useTranslations("donations");
+  const tDetail = useTranslations("donations.detail.actions");
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function confirmDelete() {
+    setIsDeleting(true);
+    try {
+      await DonationService.deleteDonation(createClientApiClient(), donationId);
+      toast.success(t("success.deleted"));
+      // Replace (not push) so the back button doesn't return to the now-gone
+      // detail page.
+      router.replace("/donations");
+      router.refresh();
+    } catch (err) {
+      if (!(err instanceof ApiProblem)) console.error("donation.delete failed", err);
+      const message =
+        err instanceof ApiProblem
+          ? (err.detail ?? err.title ?? t("errors.deleteGeneric"))
+          : t("errors.deleteGeneric");
+      toast.error(message);
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <Button variant="destructive" size="sm" onClick={() => setOpen(true)}>
+        <Trash2 size={16} aria-hidden="true" />
+        {tDetail("delete")}
+      </Button>
+
+      <AlertDialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!isDeleting) setOpen(next);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("deleteDialog.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {donorName
+                ? t("deleteDialog.description", { name: donorName })
+                : t("deleteDialog.descriptionFallback")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel asChild>
+              <Button variant="ghost" disabled={isDeleting}>
+                {t("deleteDialog.cancel")}
+              </Button>
+            </AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={isDeleting}
+              onClick={() => void confirmDelete()}
+            >
+              {isDeleting ? t("deleteDialog.deleting") : t("deleteDialog.confirm")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -90,13 +90,17 @@ export function Sidebar({
   isSuperAdmin: isSuperAdminProp,
 }: SidebarProps) {
   const pathname = usePathname();
-  const { user, hasRole, logout } = useAuth();
+  const { user, hasRole, hasAppRole, logout } = useAuth();
   const t = useTranslations("appShell.sidebar");
   const tAdmin = useTranslations("appShell.sidebar.admin");
   // Prefer the SSR-resolved flag; fall back to client-side role check so
   // callers that haven't threaded the prop still get the correct behaviour
   // (just with a brief post-hydration pop-in).
   const isSuperAdmin = isSuperAdminProp ?? hasRole("super_admin");
+  // `/settings/*` is org_admin-only at the route level (see settings layout
+  // guard). Hide the dropdown link for everyone else so they don't dead-end
+  // on a 404.
+  const canManageOrgSettings = hasAppRole("org_admin");
   const canSwitchOrganization = typeof membershipCount !== "number" || membershipCount > 1;
 
   const initials = user
@@ -249,11 +253,13 @@ export function Sidebar({
                   </Link>
                 </DropdownMenuItem>
               ) : null}
-              <DropdownMenuItem asChild>
-                <Link href="/settings" onClick={handleMobileClose}>
-                  {t("workspaceSettings")}
-                </Link>
-              </DropdownMenuItem>
+              {canManageOrgSettings ? (
+                <DropdownMenuItem asChild>
+                  <Link href="/settings" onClick={handleMobileClose}>
+                    {t("workspaceSettings")}
+                  </Link>
+                </DropdownMenuItem>
+              ) : null}
               <DropdownMenuSeparator />
               <DropdownMenuLabel>{user?.email ?? t("userPlaceholder")}</DropdownMenuLabel>
               <DropdownMenuItem onSelect={logout}>

--- a/packages/web/src/components/layout/topbar.tsx
+++ b/packages/web/src/components/layout/topbar.tsx
@@ -19,7 +19,7 @@ interface TopbarProps {
  * Matches dashboard.html mockup: breadcrumb left, search center, actions right.
  */
 export function Topbar({ title, onMenuToggle, sidebarOpen, hamburgerRef }: TopbarProps) {
-  const { user } = useAuth();
+  const { user, hasAppRole } = useAuth();
   const t = useTranslations("appShell.topbar");
 
   const initials = user
@@ -27,6 +27,12 @@ export function Topbar({ title, onMenuToggle, sidebarOpen, hamburgerRef }: Topba
     : "?";
 
   const displayName = user ? `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() : "";
+  // The avatar links to `/settings`, which is org_admin-only. For non-admins
+  // render an informational (non-clickable) badge instead so they don't
+  // dead-end on a 404. A dedicated profile page is out of scope here.
+  const canManageOrgSettings = hasAppRole("org_admin");
+  const avatarClasses =
+    "flex h-9 w-9 items-center justify-center rounded-full bg-primary text-xs font-semibold text-on-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2";
 
   return (
     <header className="sticky top-0 z-[var(--z-sticky)] flex h-[var(--topbar-height)] items-center gap-4 border-b border-[var(--topbar-border)] bg-[var(--topbar-bg)] px-[var(--content-padding)] backdrop-blur-xl">
@@ -76,14 +82,25 @@ export function Topbar({ title, onMenuToggle, sidebarOpen, hamburgerRef }: Topba
           />
         </button>
 
-        <Link
-          href="/settings"
-          className="flex h-9 w-9 items-center justify-center rounded-full bg-primary text-xs font-semibold text-on-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-          title={displayName}
-          aria-label={t("profileOf", { name: displayName })}
-        >
-          {initials}
-        </Link>
+        {canManageOrgSettings ? (
+          <Link
+            href="/settings"
+            className={avatarClasses}
+            title={displayName}
+            aria-label={t("profileOf", { name: displayName })}
+          >
+            {initials}
+          </Link>
+        ) : (
+          <span
+            role="img"
+            className={avatarClasses}
+            title={displayName}
+            aria-label={t("profileOf", { name: displayName })}
+          >
+            {initials}
+          </span>
+        )}
       </div>
     </header>
   );

--- a/packages/web/src/components/settings/settings-navigation.tsx
+++ b/packages/web/src/components/settings/settings-navigation.tsx
@@ -13,6 +13,11 @@ const SETTINGS_NAV_ITEMS = [
     match: (pathname: string) => pathname === "/settings",
   },
   {
+    href: "/settings/members",
+    key: "members",
+    match: (pathname: string) => pathname.startsWith("/settings/members"),
+  },
+  {
     href: "/settings/funds",
     key: "funds",
     match: (pathname: string) => pathname.startsWith("/settings/funds"),

--- a/packages/web/src/models/invitation.ts
+++ b/packages/web/src/models/invitation.ts
@@ -1,0 +1,35 @@
+import type { Pagination } from "@/models/constituent";
+
+export type InvitationRole = "org_admin" | "user" | "viewer";
+export type InvitationStatus = "pending" | "accepted" | "expired";
+
+export interface Invitation {
+  id: string;
+  orgId: string;
+  email: string;
+  role: InvitationRole;
+  invitedById: string | null;
+  acceptedAt: string | null;
+  expiresAt: string;
+  createdAt: string;
+  status: InvitationStatus;
+}
+
+export interface InvitationListQuery {
+  page?: number;
+  perPage?: number;
+}
+
+export interface InvitationListResponse {
+  data: Invitation[];
+  pagination: Pagination;
+}
+
+export interface InvitationCreateInput {
+  email: string;
+  role?: InvitationRole;
+}
+
+export interface InvitationCreateResponse {
+  data: Omit<Invitation, "status">;
+}

--- a/packages/web/src/services/ConstituentService.ts
+++ b/packages/web/src/services/ConstituentService.ts
@@ -95,6 +95,18 @@ export const ConstituentService = {
     );
     return mapConstituent(response.data);
   },
+
+  /**
+   * Soft-delete a constituent. The API returns the soft-deleted row
+   * (with `deletedAt` populated). org_admin-only — surfaces 403 to non-
+   * admins via `ApiProblem`.
+   */
+  async deleteConstituent(client: ApiClient, id: string): Promise<Constituent> {
+    const response = await client.delete<ConstituentDetailResponse>(
+      `/v1/constituents/${encodeURIComponent(id)}`,
+    );
+    return mapConstituent(response.data);
+  },
 };
 
 function mapConstituent(raw: Constituent): Constituent {

--- a/packages/web/src/services/InvitationService.ts
+++ b/packages/web/src/services/InvitationService.ts
@@ -1,0 +1,96 @@
+import type { ApiClient } from "@/lib/api";
+import type {
+  Invitation,
+  InvitationCreateInput,
+  InvitationCreateResponse,
+  InvitationListQuery,
+  InvitationListResponse,
+} from "@/models/invitation";
+
+/**
+ * InvitationService — ADR-011 Layer 2 (services).
+ *
+ * Wraps the authenticated team-invitation API for the org_admin "Members"
+ * settings page. The public accept endpoint (`/v1/invitations/:token/accept`)
+ * is unauthenticated and ships in a separate browser-side service —
+ * `acceptInvitation` below — so we don't have to mix cookie-bearing and
+ * cookieless requests on the same client instance.
+ */
+export const InvitationService = {
+  async listInvitations(
+    client: ApiClient,
+    query: InvitationListQuery = {},
+  ): Promise<InvitationListResponse> {
+    const params: Record<string, string | number | boolean | undefined> = {
+      page: query.page,
+      perPage: query.perPage,
+    };
+    return client.get<InvitationListResponse>("/v1/invitations", { params });
+  },
+
+  async createInvitation(client: ApiClient, input: InvitationCreateInput): Promise<Invitation> {
+    const body: Record<string, unknown> = { email: input.email };
+    if (input.role) body.role = input.role;
+    const response = await client.post<InvitationCreateResponse>("/v1/invitations", body);
+    // The create endpoint returns the row without a derived status; treat
+    // it as pending — `acceptedAt` is null and `expiresAt` is in the future
+    // by construction.
+    return { ...response.data, status: "pending" };
+  },
+
+  async resendInvitation(client: ApiClient, id: string): Promise<void> {
+    await client.post<void>(`/v1/invitations/${encodeURIComponent(id)}/resend`);
+  },
+
+  async revokeInvitation(client: ApiClient, id: string): Promise<void> {
+    await client.delete<void>(`/v1/invitations/${encodeURIComponent(id)}`);
+  },
+};
+
+// ─── Public accept endpoint — token = credential, no cookies ────────────────
+
+const PUBLIC_API_URL = process.env.NEXT_PUBLIC_API_URL ?? "/api";
+
+export interface AcceptInvitationSuccess {
+  /** Tenant slug — drives the post-accept Keycloak login `?hint=` param. */
+  slug: string;
+}
+
+export type AcceptInvitationResult =
+  | { ok: true; data: AcceptInvitationSuccess }
+  | { ok: false; status: number; detail?: string };
+
+export async function acceptInvitation(
+  token: string,
+  firstName: string,
+  lastName: string,
+  password: string,
+): Promise<AcceptInvitationResult> {
+  let res: Response;
+  try {
+    // No `credentials: "include"` — accept is unauthenticated; the token
+    // itself is the credential.
+    res = await fetch(`${PUBLIC_API_URL}/v1/invitations/${encodeURIComponent(token)}/accept`, {
+      method: "POST",
+      credentials: "omit",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ firstName, lastName, password }),
+    });
+  } catch {
+    return { ok: false, status: 0 };
+  }
+
+  if (res.status === 201) {
+    const json = (await res.json()) as { data: AcceptInvitationSuccess };
+    return { ok: true, data: json.data };
+  }
+
+  let detail: string | undefined;
+  try {
+    const problem = (await res.json()) as { detail?: string };
+    detail = problem.detail;
+  } catch {
+    // no body
+  }
+  return { ok: false, status: res.status, detail };
+}

--- a/packages/worker/src/lib/email-templates.ts
+++ b/packages/worker/src/lib/email-templates.ts
@@ -1,5 +1,5 @@
 /**
- * Email templates for signup verification.
+ * Email templates for signup verification + team invitations.
  *
  * Bilingual (EN/FR) — Givernance's initial markets. Picks FR when the
  * tenant's country is France, defaults to English otherwise. Keep the
@@ -10,6 +10,17 @@
 export interface SignupVerifyTemplateInput {
   tenantName: string;
   verifyUrl: string;
+  expiresAt: Date;
+  country?: string | null;
+}
+
+export interface TeamInviteTemplateInput {
+  tenantName: string;
+  /** Inviter's display name — falls back to "your colleague" when null. */
+  inviterName: string | null;
+  /** `org_admin` | `user` | `viewer` — surfaced to the invitee for transparency. */
+  role: string;
+  acceptUrl: string;
   expiresAt: Date;
   country?: string | null;
 }
@@ -31,6 +42,23 @@ function escapeHtml(value: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+const ROLE_LABELS: Record<"en" | "fr", Record<string, string>> = {
+  en: {
+    org_admin: "organisation admin",
+    user: "team member",
+    viewer: "viewer",
+  },
+  fr: {
+    org_admin: "administrateur·trice",
+    user: "membre de l'équipe",
+    viewer: "lecteur·trice",
+  },
+};
+
+function roleLabel(locale: "en" | "fr", role: string): string {
+  return ROLE_LABELS[locale][role] ?? role;
 }
 
 export function renderSignupVerifyEmail(input: SignupVerifyTemplateInput): RenderedEmail {
@@ -84,6 +112,72 @@ export function renderSignupVerifyEmail(input: SignupVerifyTemplateInput): Rende
 <p style="font-size:13px;color:#555">Or copy this link into your browser:<br><span style="word-break:break-all">${safeUrl}</span></p>
 <p style="font-size:13px;color:#555">This link expires on ${expires}.</p>
 <p style="font-size:12px;color:#888;margin-top:32px;border-top:1px solid #eee;padding-top:16px">If you didn't request this workspace, ignore this message — nothing has been activated.</p>
+</body></html>`,
+  };
+}
+
+/**
+ * Render the "X invited you to Y" email for team invitations.
+ *
+ * The inviter's display name is interpolated when known so the recipient
+ * sees a personal name rather than a generic "Someone invited you".
+ */
+export function renderTeamInviteEmail(input: TeamInviteTemplateInput): RenderedEmail {
+  const locale = pickLocale(input.country);
+  const expires = input.expiresAt.toUTCString();
+  const safeName = escapeHtml(input.tenantName);
+  const safeUrl = escapeHtml(input.acceptUrl);
+  const safeRole = escapeHtml(roleLabel(locale, input.role));
+
+  if (locale === "fr") {
+    const inviter = input.inviterName ? escapeHtml(input.inviterName) : "Un·e collègue";
+    const subjectInviter = input.inviterName ?? "Un·e collègue";
+    return {
+      subject: `${subjectInviter} vous invite à rejoindre ${input.tenantName} sur Givernance`,
+      text: [
+        `${subjectInviter} vous invite à rejoindre l'espace "${input.tenantName}" sur Givernance avec le rôle ${roleLabel(locale, input.role)}.`,
+        ``,
+        `Acceptez l'invitation en cliquant sur ce lien et en choisissant votre mot de passe :`,
+        ``,
+        input.acceptUrl,
+        ``,
+        `Ce lien expire le ${expires}.`,
+        ``,
+        `Si vous n'attendiez pas cette invitation, ignorez ce message — aucune action n'a été effectuée.`,
+      ].join("\n"),
+      html: `<!doctype html><html lang="fr"><body style="font-family:-apple-system,system-ui,sans-serif;line-height:1.6;color:#111;max-width:560px;margin:32px auto;padding:0 16px">
+<h1 style="font-size:20px;margin:0 0 16px">Vous êtes invité·e à rejoindre ${safeName}</h1>
+<p>${inviter} vous invite à rejoindre l'espace <strong>${safeName}</strong> sur Givernance avec le rôle <strong>${safeRole}</strong>.</p>
+<p style="margin:24px 0"><a href="${safeUrl}" style="display:inline-block;padding:12px 20px;background:#1a56db;color:#fff;border-radius:6px;text-decoration:none;font-weight:500">Accepter l'invitation</a></p>
+<p style="font-size:13px;color:#555">Ou copiez ce lien dans votre navigateur :<br><span style="word-break:break-all">${safeUrl}</span></p>
+<p style="font-size:13px;color:#555">Ce lien expire le ${expires}.</p>
+<p style="font-size:12px;color:#888;margin-top:32px;border-top:1px solid #eee;padding-top:16px">Si vous n'attendiez pas cette invitation, ignorez ce message — aucune action n'a été effectuée.</p>
+</body></html>`,
+    };
+  }
+
+  const inviter = input.inviterName ? escapeHtml(input.inviterName) : "A colleague";
+  const subjectInviter = input.inviterName ?? "A colleague";
+  return {
+    subject: `${subjectInviter} invited you to join ${input.tenantName} on Givernance`,
+    text: [
+      `${subjectInviter} invited you to join the workspace "${input.tenantName}" on Givernance as a ${roleLabel(locale, input.role)}.`,
+      ``,
+      `Accept the invitation by clicking this link and choosing your password:`,
+      ``,
+      input.acceptUrl,
+      ``,
+      `This link expires on ${expires}.`,
+      ``,
+      `If you weren't expecting this invitation, ignore this message — nothing has been activated.`,
+    ].join("\n"),
+    html: `<!doctype html><html lang="en"><body style="font-family:-apple-system,system-ui,sans-serif;line-height:1.6;color:#111;max-width:560px;margin:32px auto;padding:0 16px">
+<h1 style="font-size:20px;margin:0 0 16px">You're invited to join ${safeName}</h1>
+<p>${inviter} invited you to join the workspace <strong>${safeName}</strong> on Givernance as a <strong>${safeRole}</strong>.</p>
+<p style="margin:24px 0"><a href="${safeUrl}" style="display:inline-block;padding:12px 20px;background:#1a56db;color:#fff;border-radius:6px;text-decoration:none;font-weight:500">Accept the invitation</a></p>
+<p style="font-size:13px;color:#555">Or copy this link into your browser:<br><span style="word-break:break-all">${safeUrl}</span></p>
+<p style="font-size:13px;color:#555">This link expires on ${expires}.</p>
+<p style="font-size:12px;color:#888;margin-top:32px;border-top:1px solid #eee;padding-top:16px">If you weren't expecting this invitation, ignore this message — nothing has been activated.</p>
 </body></html>`,
   };
 }

--- a/packages/worker/src/lib/email-templates.ts
+++ b/packages/worker/src/lib/email-templates.ts
@@ -44,6 +44,18 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;");
 }
 
+/**
+ * Strip CR/LF from values that flow into the SMTP `Subject` header. Nodemailer
+ * folds CR/LF in headers by default, so this is defence-in-depth — a future
+ * MTA swap (raw `sendmail`, a managed transport that doesn't sanitise) would
+ * otherwise let an operator-controlled `tenants.name` or `users.first_name`
+ * inject a `\nBcc:` line and silently fork every email. (Security review of
+ * PR #148, finding F1.)
+ */
+function sanitiseSubjectField(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").slice(0, 200);
+}
+
 const ROLE_LABELS: Record<"en" | "fr", Record<string, string>> = {
   en: {
     org_admin: "organisation admin",
@@ -66,10 +78,11 @@ export function renderSignupVerifyEmail(input: SignupVerifyTemplateInput): Rende
   const expires = input.expiresAt.toUTCString();
   const safeName = escapeHtml(input.tenantName);
   const safeUrl = escapeHtml(input.verifyUrl);
+  const subjectTenantName = sanitiseSubjectField(input.tenantName);
 
   if (locale === "fr") {
     return {
-      subject: `Confirmez votre espace ${input.tenantName} sur Givernance`,
+      subject: `Confirmez votre espace ${subjectTenantName} sur Givernance`,
       text: [
         `Bienvenue sur Givernance !`,
         ``,
@@ -93,7 +106,7 @@ export function renderSignupVerifyEmail(input: SignupVerifyTemplateInput): Rende
   }
 
   return {
-    subject: `Confirm your Givernance workspace "${input.tenantName}"`,
+    subject: `Confirm your Givernance workspace "${subjectTenantName}"`,
     text: [
       `Welcome to Givernance!`,
       ``,
@@ -128,12 +141,15 @@ export function renderTeamInviteEmail(input: TeamInviteTemplateInput): RenderedE
   const safeName = escapeHtml(input.tenantName);
   const safeUrl = escapeHtml(input.acceptUrl);
   const safeRole = escapeHtml(roleLabel(locale, input.role));
+  // Subject is interpolated raw, so strip CR/LF defensively — see
+  // sanitiseSubjectField docblock for rationale.
+  const subjectTenantName = sanitiseSubjectField(input.tenantName);
 
   if (locale === "fr") {
     const inviter = input.inviterName ? escapeHtml(input.inviterName) : "Un·e collègue";
-    const subjectInviter = input.inviterName ?? "Un·e collègue";
+    const subjectInviter = sanitiseSubjectField(input.inviterName ?? "Un·e collègue");
     return {
-      subject: `${subjectInviter} vous invite à rejoindre ${input.tenantName} sur Givernance`,
+      subject: `${subjectInviter} vous invite à rejoindre ${subjectTenantName} sur Givernance`,
       text: [
         `${subjectInviter} vous invite à rejoindre l'espace "${input.tenantName}" sur Givernance avec le rôle ${roleLabel(locale, input.role)}.`,
         ``,
@@ -157,9 +173,9 @@ export function renderTeamInviteEmail(input: TeamInviteTemplateInput): RenderedE
   }
 
   const inviter = input.inviterName ? escapeHtml(input.inviterName) : "A colleague";
-  const subjectInviter = input.inviterName ?? "A colleague";
+  const subjectInviter = sanitiseSubjectField(input.inviterName ?? "A colleague");
   return {
-    subject: `${subjectInviter} invited you to join ${input.tenantName} on Givernance`,
+    subject: `${subjectInviter} invited you to join ${subjectTenantName} on Givernance`,
     text: [
       `${subjectInviter} invited you to join the workspace "${input.tenantName}" on Givernance as a ${roleLabel(locale, input.role)}.`,
       ``,

--- a/packages/worker/src/processors/team-invite-email.ts
+++ b/packages/worker/src/processors/team-invite-email.ts
@@ -1,0 +1,100 @@
+/**
+ * Team-invite email processor (issue #145).
+ *
+ * Handles three outbox event types:
+ *  - `invitation.created` — first delivery after an org_admin clicks "Invite".
+ *  - `invitation.resent`  — token was rotated; old link is now dead.
+ *  - `tenant.first_admin_invited` — super-admin seeding path; same template,
+ *     different copy because the inviter row may not exist yet.
+ *
+ * Pattern is identical to `processSignupVerificationEmail`: the raw token
+ * is intentionally NOT in the outbox payload (SEC-7 in the API service) —
+ * we look it up here by invitation id, inside the same trust boundary as
+ * the SMTP relay. Unknown / already-accepted invitations are terminal
+ * no-ops so a stale event after a token rotation doesn't retry forever.
+ */
+
+import { invitations, tenants, users } from "@givernance/shared/schema";
+import { and, eq } from "drizzle-orm";
+import { env } from "../env.js";
+import { db } from "../lib/db.js";
+import { defaultEmailSender, type EmailSender } from "../lib/email.js";
+import { renderTeamInviteEmail } from "../lib/email-templates.js";
+
+export interface TeamInviteEmailJobPayload {
+  tenantId: string;
+  invitationId: string;
+  /** UUID of the inviting `users` row, or null when seeded by super-admin. */
+  inviterUserId?: string | null;
+  /** ISO-3166-1 alpha-2 — drives EN/FR template selection. Optional. */
+  country?: string;
+}
+
+export interface TeamInviteEmailDeps {
+  sender?: EmailSender;
+}
+
+export async function processTeamInviteEmail(
+  payload: TeamInviteEmailJobPayload,
+  deps: TeamInviteEmailDeps = {},
+): Promise<{ sent: boolean; reason?: "not_found" | "already_accepted" }> {
+  const sender = deps.sender ?? defaultEmailSender;
+
+  const [row] = await db
+    .select({
+      invitationId: invitations.id,
+      email: invitations.email,
+      role: invitations.role,
+      token: invitations.token,
+      acceptedAt: invitations.acceptedAt,
+      expiresAt: invitations.expiresAt,
+      tenantName: tenants.name,
+    })
+    .from(invitations)
+    .innerJoin(tenants, eq(invitations.orgId, tenants.id))
+    .where(
+      and(
+        eq(invitations.id, payload.invitationId),
+        eq(invitations.orgId, payload.tenantId),
+        eq(invitations.purpose, "team_invite"),
+      ),
+    )
+    .limit(1);
+
+  if (!row) return { sent: false, reason: "not_found" };
+  if (row.acceptedAt) return { sent: false, reason: "already_accepted" };
+
+  // Resolve the inviter's display name — purely for personalisation. We
+  // run this without tenant context because the worker has no JWT and the
+  // events queue is itself the tenant boundary; `users` is FORCE RLS but
+  // the worker process uses the system role. A null result is fine —
+  // `renderTeamInviteEmail` falls back to "A colleague".
+  let inviterName: string | null = null;
+  if (payload.inviterUserId) {
+    const [u] = await db
+      .select({ firstName: users.firstName, lastName: users.lastName })
+      .from(users)
+      .where(eq(users.id, payload.inviterUserId))
+      .limit(1);
+    if (u) inviterName = `${u.firstName} ${u.lastName}`.trim() || null;
+  }
+
+  const acceptUrl = `${env.APP_URL}/invite/accept?token=${encodeURIComponent(row.token)}`;
+  const rendered = renderTeamInviteEmail({
+    tenantName: row.tenantName,
+    inviterName,
+    role: row.role,
+    acceptUrl,
+    expiresAt: row.expiresAt,
+    country: payload.country,
+  });
+
+  await sender.send({
+    to: row.email,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
+  });
+
+  return { sent: true };
+}

--- a/packages/worker/src/tests/integration/team-invite-email.test.ts
+++ b/packages/worker/src/tests/integration/team-invite-email.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Team-invite email processor — integration test (issue #145).
+ *
+ * Mirrors the signup-email integration test: real DB lookup, mocked
+ * EmailSender. Verifies the worker:
+ *   - Looks up the invitation by id + tenant + purpose='team_invite'.
+ *   - Renders the right (EN/FR) template and personalises with the inviter.
+ *   - No-ops on already-accepted / not-found events (terminal, no retry).
+ */
+
+import { randomUUID } from "node:crypto";
+import { invitations, tenants, users } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { db } from "../../lib/db.js";
+import {
+  processTeamInviteEmail,
+  type TeamInviteEmailJobPayload,
+} from "../../processors/team-invite-email.js";
+
+const ORG_ID = "00000000-0000-0000-0000-0000000001a1";
+const INVITER_USER_ID = "00000000-0000-0000-0000-0000000001a2";
+const INVITATION_ID = "00000000-0000-0000-0000-0000000001a3";
+const INVITATION_TOKEN = "00000000-0000-0000-0000-0000000001a4";
+
+const ORG_ID_FR = "00000000-0000-0000-0000-0000000001b1";
+const INVITATION_ID_FR = "00000000-0000-0000-0000-0000000001b3";
+const INVITATION_TOKEN_FR = "00000000-0000-0000-0000-0000000001b4";
+
+const ORG_ID_ACCEPTED = "00000000-0000-0000-0000-0000000001c1";
+const INVITATION_ID_ACCEPTED = "00000000-0000-0000-0000-0000000001c3";
+
+beforeAll(async () => {
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, status, created_via)
+        VALUES (${ORG_ID}, 'Acme Charity', ${`team-invite-${randomUUID().slice(0, 8)}`}, 'active', 'enterprise')
+        ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name`,
+  );
+  await db.execute(
+    sql`INSERT INTO users (id, org_id, email, first_name, last_name, role, keycloak_id)
+        VALUES (${INVITER_USER_ID}, ${ORG_ID}, 'inviter@acme.org', 'Alice', 'Inviter', 'org_admin', 'kc-inviter-acme')
+        ON CONFLICT (id) DO UPDATE SET first_name = EXCLUDED.first_name`,
+  );
+  await db
+    .insert(invitations)
+    .values({
+      id: INVITATION_ID,
+      orgId: ORG_ID,
+      email: "newbie@acme.org",
+      role: "user",
+      token: INVITATION_TOKEN,
+      invitedById: INVITER_USER_ID,
+      purpose: "team_invite",
+      expiresAt,
+    })
+    .onConflictDoNothing();
+
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, status, created_via)
+        VALUES (${ORG_ID_FR}, 'Assoc Demo', ${`team-invite-fr-${randomUUID().slice(0, 8)}`}, 'active', 'enterprise')
+        ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name`,
+  );
+  await db
+    .insert(invitations)
+    .values({
+      id: INVITATION_ID_FR,
+      orgId: ORG_ID_FR,
+      email: "newbie@assoc.fr",
+      role: "org_admin",
+      token: INVITATION_TOKEN_FR,
+      purpose: "team_invite",
+      expiresAt,
+    })
+    .onConflictDoNothing();
+
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, status, created_via)
+        VALUES (${ORG_ID_ACCEPTED}, 'Done Corp', ${`team-invite-done-${randomUUID().slice(0, 8)}`}, 'active', 'enterprise')
+        ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name`,
+  );
+  await db
+    .insert(invitations)
+    .values({
+      id: INVITATION_ID_ACCEPTED,
+      orgId: ORG_ID_ACCEPTED,
+      email: "done@example.org",
+      role: "user",
+      token: randomUUID(),
+      purpose: "team_invite",
+      expiresAt,
+      acceptedAt: new Date(),
+    })
+    .onConflictDoNothing();
+});
+
+afterAll(async () => {
+  await db.delete(invitations).where(eq(invitations.id, INVITATION_ID));
+  await db.delete(invitations).where(eq(invitations.id, INVITATION_ID_FR));
+  await db.delete(invitations).where(eq(invitations.id, INVITATION_ID_ACCEPTED));
+  await db.delete(users).where(eq(users.id, INVITER_USER_ID));
+  await db.delete(tenants).where(eq(tenants.id, ORG_ID));
+  await db.delete(tenants).where(eq(tenants.id, ORG_ID_FR));
+  await db.delete(tenants).where(eq(tenants.id, ORG_ID_ACCEPTED));
+});
+
+function makeSender() {
+  return { send: vi.fn().mockResolvedValue(undefined) };
+}
+
+describe("processTeamInviteEmail", () => {
+  it("sends a personalised English email with the accept URL", async () => {
+    const sender = makeSender();
+    const payload: TeamInviteEmailJobPayload = {
+      tenantId: ORG_ID,
+      invitationId: INVITATION_ID,
+      inviterUserId: INVITER_USER_ID,
+    };
+
+    const result = await processTeamInviteEmail(payload, { sender });
+    expect(result).toEqual({ sent: true });
+    expect(sender.send).toHaveBeenCalledTimes(1);
+    const call = sender.send.mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    if (!call) return;
+    expect(call.to).toBe("newbie@acme.org");
+    expect(call.subject).toContain("Acme Charity");
+    expect(call.subject).toContain("Alice Inviter");
+    expect(call.html).toContain(`/invite/accept?token=${INVITATION_TOKEN}`);
+    expect(call.text).toContain(`/invite/accept?token=${INVITATION_TOKEN}`);
+  });
+
+  it("falls back to a generic inviter when inviterUserId is null", async () => {
+    const sender = makeSender();
+    await processTeamInviteEmail(
+      { tenantId: ORG_ID, invitationId: INVITATION_ID, inviterUserId: null },
+      { sender },
+    );
+    const call = sender.send.mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    if (!call) return;
+    // Subject still contains the tenant name; inviter falls back to "A colleague".
+    expect(call.subject).toContain("A colleague");
+  });
+
+  it("picks the French template when country=FR", async () => {
+    const sender = makeSender();
+    await processTeamInviteEmail(
+      {
+        tenantId: ORG_ID_FR,
+        invitationId: INVITATION_ID_FR,
+        inviterUserId: null,
+        country: "FR",
+      },
+      { sender },
+    );
+    const call = sender.send.mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    if (!call) return;
+    expect(call.subject).toContain("Assoc Demo");
+    expect(call.subject).toMatch(/invite à rejoindre/);
+    expect(call.html).toContain(`/invite/accept?token=${INVITATION_TOKEN_FR}`);
+  });
+
+  it("no-ops on an already-accepted invitation", async () => {
+    const sender = makeSender();
+    const result = await processTeamInviteEmail(
+      { tenantId: ORG_ID_ACCEPTED, invitationId: INVITATION_ID_ACCEPTED },
+      { sender },
+    );
+    expect(result).toEqual({ sent: false, reason: "already_accepted" });
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the invitation id does not match the tenant", async () => {
+    const sender = makeSender();
+    const result = await processTeamInviteEmail(
+      { tenantId: ORG_ID, invitationId: randomUUID() },
+      { sender },
+    );
+    expect(result).toEqual({ sent: false, reason: "not_found" });
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -16,6 +16,10 @@ import {
   type SignupEmailJobPayload,
 } from "./processors/signup-email.js";
 import { processStripeWebhook } from "./processors/stripe-webhook.js";
+import {
+  processTeamInviteEmail,
+  type TeamInviteEmailJobPayload,
+} from "./processors/team-invite-email.js";
 import { processTenantLifecycle } from "./processors/tenant-lifecycle.js";
 
 /** Create a fresh ioredis connection — BullMQ requires separate connections for Queue vs Worker */
@@ -131,6 +135,25 @@ async function processDomainEvent(job: Job): Promise<void> {
     // `not_found` / `already_accepted` are terminal no-ops (old token rotated,
     // or user already verified) — do not throw, the outbox event is done.
     log.info({ invitationId: emailPayload.invitationId, ...result }, "Signup email dispatched");
+    return;
+  }
+
+  if (
+    type === "invitation.created" ||
+    type === "invitation.resent" ||
+    type === "tenant.first_admin_invited"
+  ) {
+    const invitationId = payload.invitationId as string;
+    const inviterUserId = typeof payload.inviterUserId === "string" ? payload.inviterUserId : null;
+    const country = typeof payload.country === "string" ? payload.country : undefined;
+    const emailPayload: TeamInviteEmailJobPayload = {
+      tenantId,
+      invitationId,
+      inviterUserId,
+      country,
+    };
+    const result = await processTeamInviteEmail(emailPayload);
+    log.info({ invitationId, eventType: type, ...result }, "Team-invite email dispatched");
     return;
   }
 


### PR DESCRIPTION
## Summary

Closes #145. Wires the team-invitation flow from "insert a row + return a token" all the way to a usable end-to-end experience, applying every hard-won pattern from PR #143's self-serve signup work.

The five critical blockers + three production-quality items from the issue are all in. The accept endpoint now collapses every failure mode to a generic 410 (no enumeration oracle), the worker actually sends the email (and finally handles `tenant.first_admin_invited` instead of logging "Unhandled event type"), and org_admins have a Members settings page to invite, resend, and revoke.

### What's in
- **API service** (`packages/api/src/modules/invitations/service.ts`) — create, list, revoke, resend, accept. Same recovery-state matrix and hijack-vs-takeover discriminator as `verifySignup`: FOR UPDATE on the invitation row, owner-role DB on the unauthenticated accept path, KC org adoption only when `attributes.org_id` matches THIS tenant, UUID-shape preflight on the KC org id, outbox dedup via `xmax=0`, SEC-7 (no raw token in outbox payloads).
- **Routes** — `GET /v1/invitations`, `DELETE /v1/invitations/:id`, `POST /v1/invitations/:id/resend`; accept endpoint collapses all failure modes to 410.
- **Worker** — `processTeamInviteEmail` + bilingual EN/FR `renderTeamInviteEmail`; dispatcher routes `invitation.created`, `invitation.resent`, AND `tenant.first_admin_invited` (the super-admin seeding path that was previously dropped).
- **Web admin UI** — `/settings/members` (server) + `members-table` (client) with invite dialog, resend, and revoke. New "Members" entry in the settings nav.
- **Web invitee UI** — `/invite/accept?token=...` mirrors `/signup/verify` (firstName + lastName + password, redirect to KC login on success).
- **i18n** — `settings.members.*` and `auth.inviteAccept.*` in EN and FR.

### Tests
- **19 API integration tests** (`team-invitations.test.ts`) — happy path, the two recovery half-states (existing users row with null KC id, existing users row with bound KC id), hijack defence (`KeycloakUserExistsError` → 410, no users row written), KC org adoption guard (foreign `org_id` attribute → fail loud), purpose discriminator (signup_verification token → 410), idempotency (second accept → 410), expiry, and password validation.
- **5 worker integration tests** (`team-invite-email.test.ts`) — EN + FR templates, inviter personalisation fallback, no-op on `already_accepted` / `not_found`.
- Updated the auth-rbac accept test for the new 410 collapse.

### Pipeline
All green: `install`, `build`, `format`, `lint`, `typecheck`, `test` — **384 API + 17 worker + 28 web** tests passing.

## Status (process tracker)

This PR follows the documented PR pipeline. Currently at step **3 of 7**:

- [x] **1. Understand the issue** — read #145, #143, signup/service.ts, worker dispatcher, settings UI
- [x] **2. Build** — service + routes + worker processor + admin UI + invitee UI + i18n + tests
- [x] **3. Draft PR open** — you are here
- [x] **4. Multi-agent review** (security, data, web, qa) — running next
- [x] **5. Apply review fixes**
- [x] **6. Verify on dev server** (`pnpm dev:up` + Mailpit happy path)
- [x] **7. Mark ready for review**

## Test plan

- [x] CI green (typecheck, lint, build, test)
- [x] Multi-agent review surfaces no blocking issues, all M-class findings resolved or filed
- [x] Dev-server smoke test: org_admin invites a teammate via `/settings/members`, the email lands in Mailpit within ~1s, the invitee can accept via `/invite/accept`, log in via Keycloak, land on `/dashboard` of the inviter's tenant
- [x] Hijack-defence smoke: invite `admin@givernance.org` (the seeded super_admin) → invitee accept attempt 410s, super_admin password unchanged

## Notes for reviewers
- The two-tx structure in `createTeamInvitation` (membership precheck → insert) is a deliberate UX hint, not an authorisation gate — the underlying `users.org_id, users.email` unique constraint is the actual race-safety guarantee. Same shape as the signup flow's slug-precheck.
- The accept endpoint lazy-resolves the KC admin client AFTER the row guard so a bogus token doesn't 500 in environments where the KC admin client isn't configured (e.g. RBAC-only test files that don't stub KC).
- Revoke is a hard DELETE, not a soft-revoked flag, to keep the accept lookup's WHERE clause minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)