### PR TITLE
feat(invitations): show "Invited by" column on /settings/members (#151)

### DIFF
--- a/packages/api/src/modules/invitations/routes.ts
+++ b/packages/api/src/modules/invitations/routes.ts
@@ -81,6 +81,12 @@ const InvitationListItem = Type.Object({
   email: Type.String(),
   role: RoleSchema,
   invitedById: Type.Union([Type.Null(), UuidSchema]),
+  /**
+   * Display name of the inviter ("First Last"). Null when the inviter
+   * row was deleted (FK ON DELETE SET NULL) or when the invitation was
+   * created by the super-admin seeding path with `invitedById = null`.
+   */
+  invitedByName: Type.Union([Type.Null(), Type.String()]),
   acceptedAt: Type.Union([Type.Null(), Type.String()]),
   expiresAt: Type.String(),
   createdAt: Type.String(),
@@ -200,6 +206,7 @@ export async function invitationRoutes(app: FastifyInstance) {
       return reply.status(200).send({
         data: result.data.map((row) => ({
           ...serializeInvitation(row),
+          invitedByName: row.invitedByName,
           status: row.status,
         })),
         pagination: result.pagination,

--- a/packages/api/src/modules/invitations/service.ts
+++ b/packages/api/src/modules/invitations/service.ts
@@ -288,6 +288,12 @@ export interface InvitationSummary {
   email: string;
   role: InviteRole;
   invitedById: string | null;
+  /**
+   * Display name of the inviter ("First Last"), or null when the inviter
+   * row no longer exists (FK is `ON DELETE SET NULL`) or the invitation
+   * was created by the super-admin seeding path with `invitedById = null`.
+   */
+  invitedByName: string | null;
   acceptedAt: Date | null;
   expiresAt: Date;
   createdAt: Date;
@@ -317,6 +323,13 @@ export async function listTeamInvitations(
 
   const now = new Date();
   return withTenantContext(input.orgId, async (tx) => {
+    // Left join to `users` so the members page can show "Invited by Alice"
+    // without a second round-trip. `invited_by_id` is nullable (super-admin
+    // seeding path leaves it null) and the FK is `ON DELETE SET NULL`, so
+    // the join must tolerate both a missing FK and a deleted inviter — left
+    // join + null-safe formatting below covers both cases. Both tables are
+    // scoped to the same tenant via FORCE RLS, so the join is naturally
+    // tenant-scoped under `withTenantContext`.
     const rows = await tx
       .select({
         id: invitations.id,
@@ -324,11 +337,14 @@ export async function listTeamInvitations(
         email: invitations.email,
         role: invitations.role,
         invitedById: invitations.invitedById,
+        inviterFirstName: users.firstName,
+        inviterLastName: users.lastName,
         acceptedAt: invitations.acceptedAt,
         expiresAt: invitations.expiresAt,
         createdAt: invitations.createdAt,
       })
       .from(invitations)
+      .leftJoin(users, eq(users.id, invitations.invitedById))
       .where(and(eq(invitations.orgId, input.orgId), eq(invitations.purpose, "team_invite")))
       .orderBy(desc(invitations.createdAt))
       .limit(perPage)
@@ -340,15 +356,28 @@ export async function listTeamInvitations(
       .where(and(eq(invitations.orgId, input.orgId), eq(invitations.purpose, "team_invite")));
     const total = Number(totalRows[0]?.total ?? 0);
 
-    const data: InvitationSummary[] = rows.map((r) => ({
-      ...r,
-      role: r.role as InviteRole,
-      status: r.acceptedAt
-        ? ("accepted" as const)
-        : r.expiresAt < now
-          ? ("expired" as const)
-          : ("pending" as const),
-    }));
+    const data: InvitationSummary[] = rows.map((r) => {
+      const inviterName =
+        r.inviterFirstName || r.inviterLastName
+          ? `${r.inviterFirstName ?? ""} ${r.inviterLastName ?? ""}`.trim()
+          : null;
+      return {
+        id: r.id,
+        orgId: r.orgId,
+        email: r.email,
+        role: r.role as InviteRole,
+        invitedById: r.invitedById,
+        invitedByName: inviterName,
+        acceptedAt: r.acceptedAt,
+        expiresAt: r.expiresAt,
+        createdAt: r.createdAt,
+        status: r.acceptedAt
+          ? ("accepted" as const)
+          : r.expiresAt < now
+            ? ("expired" as const)
+            : ("pending" as const),
+      };
+    });
 
     return {
       data,

--- a/packages/api/src/tests/integration/team-invitations.test.ts
+++ b/packages/api/src/tests/integration/team-invitations.test.ts
@@ -309,6 +309,55 @@ describe("GET /v1/invitations", () => {
     });
     expect(res.statusCode).toBe(403);
   });
+
+  it("joins invitedById to users and returns invitedByName, null-safe (issue #151)", async () => {
+    const f = await makeFixture();
+
+    // 1. Invitation created via the create endpoint — invitedById resolves
+    //    to the inviter fixture, so invitedByName must be "Inviter Admin".
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email: `with-inviter+${f.slug}@example.org`, role: "user" },
+    });
+    expect(create.statusCode).toBe(201);
+
+    // 2. Direct insert with invitedById = null — mirrors the super-admin
+    //    seeding path (`inviteFirstEnterpriseUser`). invitedByName must be
+    //    null without the join nuking the row.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
+      await tx.insert(invitations).values({
+        orgId: f.orgId,
+        email: `null-inviter+${f.slug}@example.org`,
+        role: "user",
+        purpose: "team_invite",
+        invitedById: null,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      });
+    });
+
+    const list = await app.inject({
+      method: "GET",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+    });
+    expect(list.statusCode).toBe(200);
+    const body = list.json<{
+      data: Array<{ email: string; invitedById: string | null; invitedByName: string | null }>;
+    }>();
+
+    const withInviter = body.data.find((row) => row.email.startsWith("with-inviter+"));
+    expect(withInviter).toBeDefined();
+    expect(withInviter?.invitedById).toBe(f.inviterUserId);
+    expect(withInviter?.invitedByName).toBe("Inviter Admin");
+
+    const nullInviter = body.data.find((row) => row.email.startsWith("null-inviter+"));
+    expect(nullInviter).toBeDefined();
+    expect(nullInviter?.invitedById).toBeNull();
+    expect(nullInviter?.invitedByName).toBeNull();
+  });
 });
 
 // ─── Resend ─────────────────────────────────────────────────────────────────

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -592,6 +592,7 @@
       "email": "Email",
       "role": "Role",
       "status": "Status",
+      "invitedBy": "Invited by",
       "createdAt": "Invited",
       "actions": "Actions"
     },

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -592,6 +592,7 @@
       "email": "Email",
       "role": "Rôle",
       "status": "Statut",
+      "invitedBy": "Invité·e par",
       "createdAt": "Invité·e le",
       "actions": "Actions"
     },

--- a/packages/web/src/app/(app)/settings/members/members-table.tsx
+++ b/packages/web/src/app/(app)/settings/members/members-table.tsx
@@ -134,6 +134,20 @@ export function MembersTable({ invitations, pagination, canManageMembers }: Memb
         ),
       },
       {
+        id: "invitedBy",
+        accessorKey: "invitedByName",
+        header: () => t("columns.invitedBy"),
+        enableSorting: false,
+        // Hidden on narrow viewports — the table already overflows on mobile
+        // and "Invited by" is the lowest-priority column for triage.
+        meta: { className: "hidden md:table-cell" },
+        cell: ({ row }) => (
+          <span className="whitespace-nowrap text-on-surface-variant">
+            {row.original.invitedByName ?? "—"}
+          </span>
+        ),
+      },
+      {
         id: "createdAt",
         accessorKey: "createdAt",
         header: () => t("columns.createdAt"),

--- a/packages/web/src/components/ui/data-table.tsx
+++ b/packages/web/src/components/ui/data-table.tsx
@@ -68,11 +68,13 @@ function HeaderCell<TData>({ header, padding }: HeaderCellProps<TData>) {
   const isSortable = header.column.getCanSort();
   const sortDirection = header.column.getIsSorted();
   const content = flexRender(header.column.columnDef.header, header.getContext());
+  const metaClassName = (header.column.columnDef.meta as { className?: string } | undefined)
+    ?.className;
 
   return (
     <th
       scope="col"
-      className={cn("px-5 font-medium", padding)}
+      className={cn("px-5 font-medium", padding, metaClassName)}
       aria-sort={sortDirectionAriaValue(sortDirection)}
     >
       {isSortable ? (
@@ -210,14 +212,23 @@ export function DataTable<TData>({
                     onRowClick && "cursor-pointer",
                   )}
                 >
-                  {row.getVisibleCells().map((cell) => (
-                    <td
-                      key={cell.id}
-                      className={cn("px-5 text-sm text-on-surface align-middle", rowPadding)}
-                    >
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </td>
-                  ))}
+                  {row.getVisibleCells().map((cell) => {
+                    const metaClassName = (
+                      cell.column.columnDef.meta as { className?: string } | undefined
+                    )?.className;
+                    return (
+                      <td
+                        key={cell.id}
+                        className={cn(
+                          "px-5 text-sm text-on-surface align-middle",
+                          rowPadding,
+                          metaClassName,
+                        )}
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    );
+                  })}
                 </tr>
               ))
             ) : (

--- a/packages/web/src/models/invitation.ts
+++ b/packages/web/src/models/invitation.ts
@@ -9,6 +9,12 @@ export interface Invitation {
   email: string;
   role: InvitationRole;
   invitedById: string | null;
+  /**
+   * Display name of the inviter ("First Last"). Null when the inviter row
+   * was deleted or the invitation came from the super-admin seeding path.
+   * Only populated by the list endpoint; the create endpoint omits it.
+   */
+  invitedByName?: string | null;
   acceptedAt: string | null;
   expiresAt: string;
   createdAt: string;


### PR DESCRIPTION
Closes #151.

## Summary
- API `GET /v1/invitations` now left-joins `invited_by_id → users` and returns `invitedByName` ("First Last") alongside `invitedById`. Null-safe for the super-admin seeding path (`invited_by_id IS NULL`) and the FK's `ON DELETE SET NULL` fallback (inviter row deleted).
- Web `MembersTable` adds an "Invited by" column between Status and Invited; hidden under `md:` since the table already overflows on mobile.
- Renders "—" when the inviter is unknown.

## Implementation notes
- `DataTable` gained `meta.className` passthrough on the column def — it's the smallest generic primitive that lets a column declare per-breakpoint visibility without wrapper hacks. Both `<th>` and `<td>` honor it.
- Web `Invitation.invitedByName` is `string | null | undefined` — the list endpoint always emits the field, but `InvitationService.createInvitation` returns the create response which doesn't include it, so the optional shape keeps both call sites typed honestly.

## Test plan
- [x] `pnpm typecheck` — clean across all packages
- [x] `pnpm test` — API 415/415, web 44/44, worker 17/17
- [x] New integration test in `team-invitations.test.ts` asserts both branches:
  - invitation created via the create endpoint → `invitedByName === "Inviter Admin"`, `invitedById === inviterUserId`
  - invitation inserted with `invitedById = null` (mirrors super-admin seeding) → both fields null, no row dropped from the join
- [x] `pnpm run lint` / `pnpm run format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)