### PR TITLE
fix(tenant-admin): confirm ownership and sort tenant tables

### DIFF
--- a/docs/03-data-model.md
+++ b/docs/03-data-model.md
@@ -93,6 +93,7 @@ ALTER TABLE tenants
     ADD COLUMN created_via     VARCHAR(32) NOT NULL DEFAULT 'enterprise'
         CHECK (created_via IN ('self_serve','enterprise','invitation')),
     ADD COLUMN verified_at     TIMESTAMPTZ,
+    ADD COLUMN ownership_confirmed_at TIMESTAMPTZ, -- BO-only review of self-serve ownership; no user-access impact
     ADD COLUMN keycloak_org_id TEXT,             -- Keycloak 26 Organization id (bound 1:1)
     ADD COLUMN primary_domain  VARCHAR(255);     -- convenience; source of truth = tenant_domains
 ```

--- a/docs/22-tenant-onboarding.md
+++ b/docs/22-tenant-onboarding.md
@@ -21,6 +21,7 @@ Designing for only one of these segments is a known failure mode (documented in 
 | **Tenant** | A row in `tenants` with its own `org_id`; the RLS boundary for all tenant-scoped data. |
 | **Organization** | Business-facing synonym for tenant. Keycloak 26's first-class `Organization` entity maps 1:1 to a Givernance tenant. |
 | **Track** | How a tenant came into existence: `self_serve` / `enterprise` / `invitation`. Stored as `tenants.created_via`. Drives UI affordances but not data access. |
+| **Ownership confirmation** | Back-office-only confirmation that a self-serve tenant's workspace ownership has been reviewed by the Givernance team. Stored as `tenants.ownership_confirmed_at`. Does not gate end-user access. |
 | **Tenant domain** | A DNS domain claimed by a tenant (e.g., `croix-rouge.fr`). Verified via DNS TXT. Used for Home IdP Discovery. Optional. |
 | **IdP binding** | A per-tenant OIDC/SAML identity provider (Entra, Okta, Google Workspace) registered in the shared Keycloak realm and bound to the tenant's Keycloak Organization. |
 | **Provisional admin** | The first user of a self-serve tenant; holds `org_admin` role for a 7-day grace period during which other verified members can dispute. |
@@ -124,6 +125,7 @@ ALTER TABLE tenants
   ADD COLUMN created_via      VARCHAR(32) NOT NULL DEFAULT 'enterprise'
       CHECK (created_via IN ('self_serve','enterprise','invitation')),
   ADD COLUMN verified_at      TIMESTAMPTZ,
+  ADD COLUMN ownership_confirmed_at TIMESTAMPTZ,
   ADD COLUMN keycloak_org_id  TEXT,            -- Keycloak Organization id
   ADD COLUMN primary_domain   VARCHAR(255);
 ```
@@ -190,6 +192,7 @@ All new endpoints respect the RLS 3-role pattern:
 | `POST /v1/public/signup/verify` | Anonymous | Complete the Keycloak Required Action from the email link |
 | `GET /v1/public/tenants/lookup?email=…` | Anonymous | Return `{ hasExistingTenant, hint }` for the login flow; used by Home IdP Discovery hint + "join your existing org" nudge |
 | `POST /v1/admin/tenants` | `super_admin` | Enterprise-track tenant creation; returns DNS TXT to publish |
+| `POST /v1/superadmin/tenants/:id/confirm-ownership` | `super_admin` | Mark a self-serve tenant as ownership-reviewed in the back office, without changing tenant access |
 | `POST /v1/admin/tenants/:id/provision-idp` | `super_admin` | Create + bind the tenant's OIDC/SAML IdP via Keycloak Admin API |
 | `POST /v1/tenants/:id/domains` | `org_admin` | Claim a domain on an existing tenant |
 | `POST /v1/tenants/:id/domains/:domain/verify` | `org_admin` | Trigger DNS TXT lookup and transition to `verified` |

--- a/packages/api/migrations/0030_common_namorita.sql
+++ b/packages/api/migrations/0030_common_namorita.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "tenants" ADD COLUMN "ownership_confirmed_at" timestamp with time zone;

--- a/packages/api/migrations/meta/0030_snapshot.json
+++ b/packages/api/migrations/meta/0030_snapshot.json
@@ -1,0 +1,3300 @@
+{
+  "id": "ef4dac0d-5982-449c-a285-a6d44bacc60d",
+  "prevId": "641fb89a-5cbb-4dee-80d2-51a454d026e9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_logs_org_id_idx": {
+          "name": "audit_logs_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_user_id_idx": {
+          "name": "audit_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_actor_id_idx": {
+          "name": "audit_logs_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_resource_idx": {
+          "name": "audit_logs_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_org_id_tenants_id_fk": {
+          "name": "audit_logs_org_id_tenants_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_documents": {
+      "name": "campaign_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constituent_id": {
+          "name": "constituent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "campaign_document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_documents_org_id_idx": {
+          "name": "campaign_documents_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "campaign_documents_campaign_id_idx": {
+          "name": "campaign_documents_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_documents_org_id_tenants_id_fk": {
+          "name": "campaign_documents_org_id_tenants_id_fk",
+          "tableFrom": "campaign_documents",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_documents_campaign_id_campaigns_id_fk": {
+          "name": "campaign_documents_campaign_id_campaigns_id_fk",
+          "tableFrom": "campaign_documents",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_documents_constituent_id_constituents_id_fk": {
+          "name": "campaign_documents_constituent_id_constituents_id_fk",
+          "tableFrom": "campaign_documents",
+          "tableTo": "constituents",
+          "columnsFrom": [
+            "constituent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_funds": {
+      "name": "campaign_funds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fund_id": {
+          "name": "fund_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_funds_org_id_idx": {
+          "name": "campaign_funds_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "campaign_funds_campaign_id_idx": {
+          "name": "campaign_funds_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "campaign_funds_fund_id_idx": {
+          "name": "campaign_funds_fund_id_idx",
+          "columns": [
+            {
+              "expression": "fund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_funds_org_id_tenants_id_fk": {
+          "name": "campaign_funds_org_id_tenants_id_fk",
+          "tableFrom": "campaign_funds",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_funds_campaign_id_campaigns_id_fk": {
+          "name": "campaign_funds_campaign_id_campaigns_id_fk",
+          "tableFrom": "campaign_funds",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_funds_fund_id_funds_id_fk": {
+          "name": "campaign_funds_fund_id_funds_id_fk",
+          "tableFrom": "campaign_funds",
+          "tableTo": "funds",
+          "columnsFrom": [
+            "fund_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "campaign_funds_org_campaign_fund_uniq": {
+          "name": "campaign_funds_org_campaign_fund_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "campaign_id",
+            "fund_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_public_pages": {
+      "name": "campaign_public_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "public_page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_primary": {
+          "name": "color_primary",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_amount_cents": {
+          "name": "goal_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_public_pages_org_id_idx": {
+          "name": "campaign_public_pages_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "campaign_public_pages_campaign_id_idx": {
+          "name": "campaign_public_pages_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_public_pages_org_id_tenants_id_fk": {
+          "name": "campaign_public_pages_org_id_tenants_id_fk",
+          "tableFrom": "campaign_public_pages",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_public_pages_campaign_id_campaigns_id_fk": {
+          "name": "campaign_public_pages_campaign_id_campaigns_id_fk",
+          "tableFrom": "campaign_public_pages",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "campaign_public_pages_campaign_id_unique": {
+          "name": "campaign_public_pages_campaign_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "campaign_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_qr_codes": {
+      "name": "campaign_qr_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constituent_id": {
+          "name": "constituent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_qr_codes_org_id_idx": {
+          "name": "campaign_qr_codes_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "campaign_qr_codes_campaign_id_idx": {
+          "name": "campaign_qr_codes_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_qr_codes_org_id_tenants_id_fk": {
+          "name": "campaign_qr_codes_org_id_tenants_id_fk",
+          "tableFrom": "campaign_qr_codes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_qr_codes_campaign_id_campaigns_id_fk": {
+          "name": "campaign_qr_codes_campaign_id_campaigns_id_fk",
+          "tableFrom": "campaign_qr_codes",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaign_qr_codes_constituent_id_constituents_id_fk": {
+          "name": "campaign_qr_codes_constituent_id_constituents_id_fk",
+          "tableFrom": "campaign_qr_codes",
+          "tableTo": "constituents",
+          "columnsFrom": [
+            "constituent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "campaign_qr_codes_org_code_uniq": {
+          "name": "campaign_qr_codes_org_code_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "campaign_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "campaign_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operational_cost_cents": {
+          "name": "operational_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_fees_cents": {
+          "name": "platform_fees_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaigns_org_id_idx": {
+          "name": "campaigns_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "campaigns_org_parent_id_idx": {
+          "name": "campaigns_org_parent_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaigns_org_id_tenants_id_fk": {
+          "name": "campaigns_org_id_tenants_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_parent_id_campaigns_id_fk": {
+          "name": "campaigns_parent_id_campaigns_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.constituents": {
+      "name": "constituents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'donor'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "constituents_org_id_tenants_id_fk": {
+          "name": "constituents_org_id_tenants_id_fk",
+          "tableFrom": "constituents",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donation_allocations": {
+      "name": "donation_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donation_id": {
+          "name": "donation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fund_id": {
+          "name": "fund_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "donation_allocations_org_id_idx": {
+          "name": "donation_allocations_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "donation_allocations_donation_id_idx": {
+          "name": "donation_allocations_donation_id_idx",
+          "columns": [
+            {
+              "expression": "donation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "donation_allocations_fund_id_idx": {
+          "name": "donation_allocations_fund_id_idx",
+          "columns": [
+            {
+              "expression": "fund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "donation_allocations_org_id_tenants_id_fk": {
+          "name": "donation_allocations_org_id_tenants_id_fk",
+          "tableFrom": "donation_allocations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "donation_allocations_donation_id_donations_id_fk": {
+          "name": "donation_allocations_donation_id_donations_id_fk",
+          "tableFrom": "donation_allocations",
+          "tableTo": "donations",
+          "columnsFrom": [
+            "donation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "donation_allocations_fund_id_funds_id_fk": {
+          "name": "donation_allocations_fund_id_funds_id_fk",
+          "tableFrom": "donation_allocations",
+          "tableTo": "funds",
+          "columnsFrom": [
+            "fund_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donations": {
+      "name": "donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constituent_id": {
+          "name": "constituent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_base_cents": {
+          "name": "amount_base_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "donation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cleared'"
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_ref": {
+          "name": "payment_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "donated_at": {
+          "name": "donated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "fiscal_year": {
+          "name": "fiscal_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_amount": {
+          "name": "receipt_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "donations_org_id_idx": {
+          "name": "donations_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "donations_constituent_id_idx": {
+          "name": "donations_constituent_id_idx",
+          "columns": [
+            {
+              "expression": "constituent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "donations_donated_at_idx": {
+          "name": "donations_donated_at_idx",
+          "columns": [
+            {
+              "expression": "donated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "donations_campaign_id_idx": {
+          "name": "donations_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "donations_org_id_tenants_id_fk": {
+          "name": "donations_org_id_tenants_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "donations_constituent_id_constituents_id_fk": {
+          "name": "donations_constituent_id_constituents_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "constituents",
+          "columnsFrom": [
+            "constituent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "donations_campaign_id_campaigns_id_fk": {
+          "name": "donations_campaign_id_campaigns_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "donations_org_payment_uniq": {
+          "name": "donations_org_payment_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "payment_method",
+            "payment_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exchange_rates": {
+      "name": "exchange_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exchange_rates_currency_idx": {
+          "name": "exchange_rates_currency_idx",
+          "columns": [
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_rates_base_currency_idx": {
+          "name": "exchange_rates_base_currency_idx",
+          "columns": [
+            {
+              "expression": "base_currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_rates_date_idx": {
+          "name": "exchange_rates_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exchange_rates_currency_base_date_uniq": {
+          "name": "exchange_rates_currency_base_date_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "currency",
+            "base_currency",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funds": {
+      "name": "funds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "fund_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unrestricted'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "funds_org_id_idx": {
+          "name": "funds_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funds_org_id_tenants_id_fk": {
+          "name": "funds_org_id_tenants_id_fk",
+          "tableFrom": "funds",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "funds_org_name_uniq": {
+          "name": "funds_org_name_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'team_invite'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_org_id_idx": {
+          "name": "invitations_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_token_idx": {
+          "name": "invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_purpose_idx": {
+          "name": "invitations_purpose_idx",
+          "columns": [
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_org_id_tenants_id_fk": {
+          "name": "invitations_org_id_tenants_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_id_users_id_fk": {
+          "name": "invitations_invited_by_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merge_history": {
+      "name": "merge_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survivor_id": {
+          "name": "survivor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_id": {
+          "name": "merged_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_by_user_id": {
+          "name": "merged_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_by_actor_id": {
+          "name": "merged_by_actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "survivor_before": {
+          "name": "survivor_before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_before": {
+          "name": "merged_before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survivor_after": {
+          "name": "survivor_after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "merge_history_org_id_idx": {
+          "name": "merge_history_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merge_history_survivor_id_idx": {
+          "name": "merge_history_survivor_id_idx",
+          "columns": [
+            {
+              "expression": "survivor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merge_history_merged_id_idx": {
+          "name": "merge_history_merged_id_idx",
+          "columns": [
+            {
+              "expression": "merged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "merge_history_org_id_tenants_id_fk": {
+          "name": "merge_history_org_id_tenants_id_fk",
+          "tableFrom": "merge_history",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbox_events": {
+      "name": "outbox_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pledge_installments": {
+      "name": "pledge_installments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pledge_id": {
+          "name": "pledge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donation_id": {
+          "name": "donation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_at": {
+          "name": "expected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installment_status": {
+          "name": "installment_status",
+          "type": "installment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fund_id": {
+          "name": "fund_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pledge_installments_org_id_idx": {
+          "name": "pledge_installments_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pledge_installments_pledge_id_idx": {
+          "name": "pledge_installments_pledge_id_idx",
+          "columns": [
+            {
+              "expression": "pledge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pledge_installments_fund_id_idx": {
+          "name": "pledge_installments_fund_id_idx",
+          "columns": [
+            {
+              "expression": "fund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pledge_installments_org_id_tenants_id_fk": {
+          "name": "pledge_installments_org_id_tenants_id_fk",
+          "tableFrom": "pledge_installments",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pledge_installments_pledge_id_pledges_id_fk": {
+          "name": "pledge_installments_pledge_id_pledges_id_fk",
+          "tableFrom": "pledge_installments",
+          "tableTo": "pledges",
+          "columnsFrom": [
+            "pledge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pledge_installments_donation_id_donations_id_fk": {
+          "name": "pledge_installments_donation_id_donations_id_fk",
+          "tableFrom": "pledge_installments",
+          "tableTo": "donations",
+          "columnsFrom": [
+            "donation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pledge_installments_fund_id_funds_id_fk": {
+          "name": "pledge_installments_fund_id_funds_id_fk",
+          "tableFrom": "pledge_installments",
+          "tableTo": "funds",
+          "columnsFrom": [
+            "fund_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pledges": {
+      "name": "pledges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constituent_id": {
+          "name": "constituent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "pledge_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pledge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_gateway": {
+          "name": "payment_gateway",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_mandate_id": {
+          "name": "stripe_mandate_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mandate_accepted_at": {
+          "name": "mandate_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mandate_ip_hash": {
+          "name": "mandate_ip_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pledges_org_id_idx": {
+          "name": "pledges_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pledges_constituent_id_idx": {
+          "name": "pledges_constituent_id_idx",
+          "columns": [
+            {
+              "expression": "constituent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pledges_org_id_tenants_id_fk": {
+          "name": "pledges_org_id_tenants_id_fk",
+          "tableFrom": "pledges",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pledges_constituent_id_constituents_id_fk": {
+          "name": "pledges_constituent_id_constituents_id_fk",
+          "tableFrom": "pledges",
+          "tableTo": "constituents",
+          "columnsFrom": [
+            "constituent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipt_sequences": {
+      "name": "receipt_sequences",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiscal_year": {
+          "name": "fiscal_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_val": {
+          "name": "next_val",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "receipt_sequences_org_id_tenants_id_fk": {
+          "name": "receipt_sequences_org_id_tenants_id_fk",
+          "tableFrom": "receipt_sequences",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipt_sequences_pkey": {
+          "name": "receipt_sequences_pkey",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "fiscal_year"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipts": {
+      "name": "receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donation_id": {
+          "name": "donation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiscal_year": {
+          "name": "fiscal_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_path": {
+          "name": "s3_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "receipts_org_id_idx": {
+          "name": "receipts_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_donation_id_idx": {
+          "name": "receipts_donation_id_idx",
+          "columns": [
+            {
+              "expression": "donation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "receipts_org_id_tenants_id_fk": {
+          "name": "receipts_org_id_tenants_id_fk",
+          "tableFrom": "receipts",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "receipts_donation_id_donations_id_fk": {
+          "name": "receipts_donation_id_donations_id_fk",
+          "tableFrom": "receipts",
+          "tableTo": "donations",
+          "columnsFrom": [
+            "donation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipts_org_fiscal_number_uniq": {
+          "name": "receipts_org_fiscal_number_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "fiscal_year",
+            "receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant_admin_disputes": {
+      "name": "tenant_admin_disputes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disputer_id": {
+          "name": "disputer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisional_admin_id": {
+          "name": "provisional_admin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_admin_disputes_org_id_idx": {
+          "name": "tenant_admin_disputes_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_admin_disputes_org_id_tenants_id_fk": {
+          "name": "tenant_admin_disputes_org_id_tenants_id_fk",
+          "tableFrom": "tenant_admin_disputes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tenant_admin_disputes_disputer_id_users_id_fk": {
+          "name": "tenant_admin_disputes_disputer_id_users_id_fk",
+          "tableFrom": "tenant_admin_disputes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "disputer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tenant_admin_disputes_provisional_admin_id_users_id_fk": {
+          "name": "tenant_admin_disputes_provisional_admin_id_users_id_fk",
+          "tableFrom": "tenant_admin_disputes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "provisional_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tenant_admin_disputes_resolved_by_users_id_fk": {
+          "name": "tenant_admin_disputes_resolved_by_users_id_fk",
+          "tableFrom": "tenant_admin_disputes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant_domains": {
+      "name": "tenant_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_dns'"
+        },
+        "dns_txt_value": {
+          "name": "dns_txt_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_domains_org_id_idx": {
+          "name": "tenant_domains_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_domains_state_idx": {
+          "name": "tenant_domains_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_domains_org_id_tenants_id_fk": {
+          "name": "tenant_domains_org_id_tenants_id_fk",
+          "tableFrom": "tenant_domains",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starter'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enterprise'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership_confirmed_at": {
+          "name": "ownership_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keycloak_org_id": {
+          "name": "keycloak_org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_domain": {
+          "name": "primary_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fr'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_status_idx": {
+          "name": "tenants_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenants_created_via_idx": {
+          "name": "tenants_created_via_idx",
+          "columns": [
+            {
+              "expression": "created_via",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "tenants_stripe_account_id_uniq": {
+          "name": "tenants_stripe_account_id_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "keycloak_id": {
+          "name": "keycloak_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_admin": {
+          "name": "first_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provisional_until": {
+          "name": "provisional_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_org_id_idx": {
+          "name": "users_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_org_id_tenants_id_fk": {
+          "name": "users_org_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_org_id_email_uniq": {
+          "name": "users_org_id_email_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "livemode": {
+          "name": "livemode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_events_stripe_event_id_idx": {
+          "name": "webhook_events_stripe_event_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_events_stripe_event_id_unique": {
+          "name": "webhook_events_stripe_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.campaign_document_status": {
+      "name": "campaign_document_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "generated",
+        "failed"
+      ]
+    },
+    "public.campaign_status": {
+      "name": "campaign_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "closed"
+      ]
+    },
+    "public.campaign_type": {
+      "name": "campaign_type",
+      "schema": "public",
+      "values": [
+        "nominative_postal",
+        "door_drop",
+        "digital"
+      ]
+    },
+    "public.donation_status": {
+      "name": "donation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "cleared",
+        "refunded",
+        "failed"
+      ]
+    },
+    "public.fund_type": {
+      "name": "fund_type",
+      "schema": "public",
+      "values": [
+        "restricted",
+        "unrestricted"
+      ]
+    },
+    "public.installment_status": {
+      "name": "installment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "paid",
+        "failed"
+      ]
+    },
+    "public.pledge_frequency": {
+      "name": "pledge_frequency",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "yearly"
+      ]
+    },
+    "public.pledge_status": {
+      "name": "pledge_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "cancelled"
+      ]
+    },
+    "public.public_page_status": {
+      "name": "public_page_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.receipt_status": {
+      "name": "receipt_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "generated",
+        "failed"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "org_admin",
+        "user",
+        "viewer"
+      ]
+    },
+    "public.webhook_event_status": {
+      "name": "webhook_event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1777280400000,
       "tag": "0029_invitation_profile_prefill",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1777287854238,
+      "tag": "0030_common_namorita",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/modules/tenant-admin/routes.ts
+++ b/packages/api/src/modules/tenant-admin/routes.ts
@@ -37,6 +37,7 @@ import {
 } from "../../lib/schemas.js";
 import {
   claimDomain,
+  confirmTenantOwnership,
   createEnterpriseTenant,
   deleteIdp,
   getTenantDetail,
@@ -103,6 +104,7 @@ const TenantSummarySchema = Type.Object({
   status: Type.String(),
   createdVia: Type.String(),
   verifiedAt: Type.Union([Type.String(), Type.Null()]),
+  ownershipConfirmedAt: Type.Union([Type.String(), Type.Null()]),
   primaryDomain: Type.Union([Type.String(), Type.Null()]),
   keycloakOrgId: Type.Union([Type.String(), Type.Null()]),
   defaultLocale: FirstAdminLocaleSchema,
@@ -114,6 +116,23 @@ const TenantListQuery = Type.Object({
   status: Type.Optional(Type.String({ maxLength: 32 })),
   createdVia: Type.Optional(Type.String({ maxLength: 32 })),
   q: Type.Optional(Type.String({ maxLength: 255 })),
+  sort: Type.Optional(
+    Type.Union([
+      Type.Literal("name"),
+      Type.Literal("status"),
+      Type.Literal("plan"),
+      Type.Literal("primaryDomain"),
+      Type.Literal("createdVia"),
+      Type.Literal("ownershipConfirmedAt"),
+      Type.Literal("createdAt"),
+      Type.Literal("updatedAt"),
+    ]),
+  ),
+  order: Type.Optional(Type.Union([Type.Literal("asc"), Type.Literal("desc")])),
+});
+
+const ConfirmOwnershipResponse = Type.Object({
+  ownershipConfirmedAt: Type.String(),
 });
 
 const TenantDetailResponse = Type.Object({
@@ -331,6 +350,42 @@ export async function tenantAdminRoutes(app: FastifyInstance) {
       const query = request.query as { status?: string; createdVia?: string; q?: string };
       const rows = await listTenantsForAdmin(query);
       return reply.send({ data: rows });
+    },
+  );
+
+  /** POST /v1/superadmin/tenants/:id/confirm-ownership — self-serve BO confirmation. */
+  app.post(
+    "/superadmin/tenants/:id/confirm-ownership",
+    {
+      preHandler: requireSuperAdmin,
+      schema: {
+        tags: ["Tenant Admin"],
+        params: OrgIdParams,
+        response: {
+          200: DataResponse(ConfirmOwnershipResponse),
+          409: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const res = await confirmTenantOwnership(id, auditFromRequest(request));
+      if (!res.ok) {
+        if (res.error === "tenant_not_found") {
+          return reply.status(404).send(problemDetail(404, "Not Found", "Tenant not found."));
+        }
+        return reply
+          .status(409)
+          .send(
+            problemDetail(
+              409,
+              "Conflict",
+              "Only self-serve tenants can be confirmed from the back office.",
+            ),
+          );
+      }
+      return reply.send({ data: { ownershipConfirmedAt: res.ownershipConfirmedAt } });
     },
   );
 

--- a/packages/api/src/modules/tenant-admin/service.ts
+++ b/packages/api/src/modules/tenant-admin/service.ts
@@ -38,7 +38,7 @@ import {
   users,
 } from "@givernance/shared/schema";
 import { validateTenantSlug } from "@givernance/shared/validators";
-import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { db, withTenantContext } from "../../lib/db.js";
 import {
   createSystemTxtResolver,
@@ -660,6 +660,7 @@ export interface TenantSummary {
   status: string;
   createdVia: string;
   verifiedAt: string | null;
+  ownershipConfirmedAt: string | null;
   primaryDomain: string | null;
   keycloakOrgId: string | null;
   /**
@@ -673,10 +674,67 @@ export interface TenantSummary {
   updatedAt: string;
 }
 
+export type TenantListSortField =
+  | "name"
+  | "status"
+  | "plan"
+  | "primaryDomain"
+  | "createdVia"
+  | "ownershipConfirmedAt"
+  | "createdAt"
+  | "updatedAt";
+
+export type TenantListSortOrder = "asc" | "desc";
+
+const TENANT_SORT_FIELDS = new Set<TenantListSortField>([
+  "name",
+  "status",
+  "plan",
+  "primaryDomain",
+  "createdVia",
+  "ownershipConfirmedAt",
+  "createdAt",
+  "updatedAt",
+]);
+
+function normalizeTenantSortField(value: string | undefined): TenantListSortField {
+  if (value && TENANT_SORT_FIELDS.has(value as TenantListSortField)) {
+    return value as TenantListSortField;
+  }
+  return "createdAt";
+}
+
+function normalizeTenantSortOrder(value: string | undefined): TenantListSortOrder {
+  return value === "asc" ? "asc" : "desc";
+}
+
+function tenantOrderBy(
+  sort: TenantListSortField,
+  order: TenantListSortOrder,
+): ReturnType<typeof asc>[] {
+  const sortDirection = order === "asc" ? asc : desc;
+  if (sort === "name") return [sortDirection(sql`lower(${tenants.name})`), asc(tenants.id)];
+  if (sort === "status") return [sortDirection(sql`lower(${tenants.status})`), asc(tenants.id)];
+  if (sort === "plan") return [sortDirection(sql`lower(${tenants.plan})`), asc(tenants.id)];
+  if (sort === "primaryDomain") {
+    return [sortDirection(sql`coalesce(lower(${tenants.primaryDomain}), '')`), asc(tenants.id)];
+  }
+  if (sort === "createdVia") {
+    return [sortDirection(sql`lower(${tenants.createdVia})`), asc(tenants.id)];
+  }
+  if (sort === "ownershipConfirmedAt") {
+    return [sortDirection(tenants.ownershipConfirmedAt), asc(tenants.id)];
+  }
+  if (sort === "updatedAt") return [sortDirection(tenants.updatedAt), asc(tenants.id)];
+  return [sortDirection(tenants.createdAt), asc(tenants.id)];
+}
+
 export async function listTenantsForAdmin(filters: {
   status?: string;
   createdVia?: string;
   q?: string;
+  sort?: string;
+  order?: string;
 }): Promise<TenantSummary[]> {
   const conditions = [];
   if (filters.status) conditions.push(eq(tenants.status, filters.status as TenantStatus));
@@ -691,6 +749,8 @@ export async function listTenantsForAdmin(filters: {
   }
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const sort = normalizeTenantSortField(filters.sort);
+  const order = normalizeTenantSortOrder(filters.order);
   const rows = await db
     .select({
       id: tenants.id,
@@ -700,6 +760,7 @@ export async function listTenantsForAdmin(filters: {
       status: tenants.status,
       createdVia: tenants.createdVia,
       verifiedAt: tenants.verifiedAt,
+      ownershipConfirmedAt: tenants.ownershipConfirmedAt,
       primaryDomain: tenants.primaryDomain,
       keycloakOrgId: tenants.keycloakOrgId,
       defaultLocale: tenants.defaultLocale,
@@ -708,7 +769,7 @@ export async function listTenantsForAdmin(filters: {
     })
     .from(tenants)
     .where(where ?? sql`true`)
-    .orderBy(sql`${tenants.createdAt} DESC`)
+    .orderBy(...tenantOrderBy(sort, order))
     .limit(200);
 
   return rows.map((r) => ({
@@ -719,6 +780,7 @@ export async function listTenantsForAdmin(filters: {
     status: r.status,
     createdVia: r.createdVia,
     verifiedAt: r.verifiedAt?.toISOString() ?? null,
+    ownershipConfirmedAt: r.ownershipConfirmedAt?.toISOString() ?? null,
     primaryDomain: r.primaryDomain,
     keycloakOrgId: r.keycloakOrgId,
     defaultLocale: r.defaultLocale,
@@ -769,6 +831,7 @@ export async function getTenantDetail(orgId: string): Promise<{
       status: tenants.status,
       createdVia: tenants.createdVia,
       verifiedAt: tenants.verifiedAt,
+      ownershipConfirmedAt: tenants.ownershipConfirmedAt,
       primaryDomain: tenants.primaryDomain,
       keycloakOrgId: tenants.keycloakOrgId,
       defaultLocale: tenants.defaultLocale,
@@ -825,6 +888,7 @@ export async function getTenantDetail(orgId: string): Promise<{
     tenant: {
       ...tenant,
       verifiedAt: tenant.verifiedAt?.toISOString() ?? null,
+      ownershipConfirmedAt: tenant.ownershipConfirmedAt?.toISOString() ?? null,
       createdAt: tenant.createdAt.toISOString(),
       updatedAt: tenant.updatedAt.toISOString(),
     },
@@ -916,6 +980,53 @@ async function loadFirstAdminInvitation(
     acceptedAt: row.acceptedAt?.toISOString() ?? null,
     createdAt: row.createdAt.toISOString(),
   };
+}
+
+export async function confirmTenantOwnership(
+  orgId: string,
+  audit: AuditContext,
+): Promise<
+  | { ok: true; ownershipConfirmedAt: string }
+  | { ok: false; error: "tenant_not_found" | "invalid_track" }
+> {
+  if (!isUuid(orgId)) return { ok: false, error: "tenant_not_found" };
+
+  const [tenant] = await db
+    .select({
+      id: tenants.id,
+      createdVia: tenants.createdVia,
+      ownershipConfirmedAt: tenants.ownershipConfirmedAt,
+    })
+    .from(tenants)
+    .where(eq(tenants.id, orgId))
+    .limit(1);
+  if (!tenant) return { ok: false, error: "tenant_not_found" };
+  if (tenant.createdVia !== "self_serve") return { ok: false, error: "invalid_track" };
+  if (tenant.ownershipConfirmedAt) {
+    return { ok: true, ownershipConfirmedAt: tenant.ownershipConfirmedAt.toISOString() };
+  }
+
+  const confirmedAt = await db.transaction(async (tx) => {
+    const now = new Date();
+    await tx.update(tenants).set({ ownershipConfirmedAt: now }).where(eq(tenants.id, orgId));
+
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${orgId}, true)`);
+    await tx.insert(auditLogs).values({
+      orgId,
+      userId: audit.actorUserId,
+      action: "tenant.ownership_confirmed",
+      resourceType: "tenant",
+      resourceId: orgId,
+      newValues: { ownershipConfirmedAt: now.toISOString() },
+      oldValues: { ownershipConfirmedAt: null },
+      ipHash: audit.ipHash,
+      userAgent: audit.userAgent,
+    });
+
+    return now;
+  });
+
+  return { ok: true, ownershipConfirmedAt: confirmedAt.toISOString() };
 }
 
 // ─── Lifecycle transitions ──────────────────────────────────────────────────

--- a/packages/api/src/tests/integration/tenant-admin.test.ts
+++ b/packages/api/src/tests/integration/tenant-admin.test.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from "node:crypto";
+import { auditLogs, tenants } from "@givernance/shared/schema";
+import { eq, inArray, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { createServer } from "../../server.js";
+import { authHeader, signToken } from "../helpers/auth.js";
+
+let app: FastifyInstance;
+
+const seededTenantIds = new Set<string>();
+
+function makeSuperAdminToken(): string {
+  return signToken(app, {
+    sub: `super-${randomUUID().slice(0, 8)}`,
+    org_id: randomUUID(),
+    email: `super+${randomUUID().slice(0, 8)}@givernance.app`,
+    role: "viewer",
+    realm_access: { roles: ["super_admin"] },
+  });
+}
+
+async function seedTenant(input: {
+  name: string;
+  slug: string;
+  createdVia: "self_serve" | "enterprise";
+  createdAt?: string;
+  verifiedAt?: string | null;
+  ownershipConfirmedAt?: string | null;
+}): Promise<string> {
+  const id = randomUUID();
+  await db.execute(sql`
+    INSERT INTO tenants (
+      id,
+      name,
+      slug,
+      status,
+      created_via,
+      verified_at,
+      ownership_confirmed_at,
+      created_at,
+      updated_at
+    ) VALUES (
+      ${id},
+      ${input.name},
+      ${input.slug},
+      'active',
+      ${input.createdVia},
+      ${input.verifiedAt ?? null},
+      ${input.ownershipConfirmedAt ?? null},
+      ${input.createdAt ?? new Date().toISOString()},
+      ${input.createdAt ?? new Date().toISOString()}
+    )
+  `);
+  seededTenantIds.add(id);
+  return id;
+}
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+afterEach(async () => {
+  if (seededTenantIds.size === 0) return;
+  const ids = [...seededTenantIds];
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL session_replication_role = 'replica'`);
+    await tx.delete(auditLogs).where(inArray(auditLogs.orgId, ids));
+    await tx.delete(tenants).where(inArray(tenants.id, ids));
+  });
+  seededTenantIds.clear();
+});
+
+describe("GET /v1/superadmin/tenants", () => {
+  it("sorts tenants from API query params", async () => {
+    const token = makeSuperAdminToken();
+    await seedTenant({
+      name: "Zulu Relief",
+      slug: `zulu-${randomUUID().slice(0, 6)}`,
+      createdVia: "enterprise",
+      createdAt: "2026-04-20T10:00:00.000Z",
+    });
+    await seedTenant({
+      name: "Alpha Relief",
+      slug: `alpha-${randomUUID().slice(0, 6)}`,
+      createdVia: "enterprise",
+      createdAt: "2026-04-21T10:00:00.000Z",
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/superadmin/tenants?q=relief&sort=name&order=asc",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: Array<{ name: string }> }>();
+    expect(body.data.slice(0, 2).map((row) => row.name)).toEqual(["Alpha Relief", "Zulu Relief"]);
+  });
+});
+
+describe("POST /v1/superadmin/tenants/:id/confirm-ownership", () => {
+  it("confirms ownership for self-serve tenants and writes an audit log", async () => {
+    const token = makeSuperAdminToken();
+    const tenantId = await seedTenant({
+      name: "Self Serve Review",
+      slug: `self-serve-${randomUUID().slice(0, 6)}`,
+      createdVia: "self_serve",
+      verifiedAt: "2026-04-27T09:00:00.000Z",
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/superadmin/tenants/${tenantId}/confirm-ownership`,
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { ownershipConfirmedAt: string } }>();
+    expect(body.data.ownershipConfirmedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const [tenant] = await db
+      .select({ ownershipConfirmedAt: tenants.ownershipConfirmedAt })
+      .from(tenants)
+      .where(eq(tenants.id, tenantId));
+    expect(tenant?.ownershipConfirmedAt).not.toBeNull();
+
+    const { rows: audit } = await db.execute<{ action: string }>(
+      sql`SELECT action FROM audit_logs WHERE org_id = ${tenantId} ORDER BY created_at DESC LIMIT 1`,
+    );
+    expect(audit[0]?.action).toBe("tenant.ownership_confirmed");
+  });
+
+  it("rejects enterprise tenants", async () => {
+    const token = makeSuperAdminToken();
+    const tenantId = await seedTenant({
+      name: "Enterprise Review",
+      slug: `enterprise-${randomUUID().slice(0, 6)}`,
+      createdVia: "enterprise",
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/superadmin/tenants/${tenantId}/confirm-ownership`,
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+});

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -114,6 +114,12 @@ export const tenants = pgTable(
       .$type<TenantCreatedVia>(),
     /** Email verification timestamp for self-serve signup; NULL until the first admin verifies. */
     verifiedAt: timestamp("verified_at", { withTimezone: true }),
+    /**
+     * Back-office ownership confirmation timestamp for self-serve tenants.
+     * This is distinct from `verifiedAt`: the user keeps access after signup
+     * verification, while super-admins confirm the workspace's ownership later.
+     */
+    ownershipConfirmedAt: timestamp("ownership_confirmed_at", { withTimezone: true }),
     /** Keycloak 26 Organization id (UUID) bound to this tenant; enforced by CHECK in migration 0021. */
     keycloakOrgId: varchar("keycloak_org_id", { length: 64 }),
     /** Convenience pointer to the tenant's verified primary domain — denormalised; source of truth is `tenant_domains`. */

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -363,7 +363,7 @@
     "tenants": {
       "list": {
         "title": "Tenant management",
-        "subtitle": "Inspect every enterprise tenant and drill into lifecycle state, domains, users, and recent audit events.",
+        "subtitle": "Inspect every self-serve, enterprise, and invitation tenant, and manage lifecycle state, ownership review, domains, users, and recent audit events.",
         "createCta": "+ New enterprise tenant",
         "columns": {
           "name": "Tenant",
@@ -371,6 +371,8 @@
           "plan": "Plan",
           "primaryDomain": "Primary domain",
           "createdVia": "Created via",
+          "ownership": "Ownership",
+          "createdAt": "Created at",
           "updatedAt": "Last updated"
         },
         "statuses": {
@@ -378,9 +380,10 @@
           "suspended": "Suspended",
           "archived": "Archived"
         },
-        "verification": {
-          "verified": "Verified",
-          "pending": "Pending"
+        "ownership": {
+          "confirmed": "Ownership confirmed",
+          "pending": "Ownership pending",
+          "notApplicable": "N/A"
         },
         "empty": {
           "title": "No tenants found",
@@ -454,9 +457,17 @@
           "suspended": "Suspended",
           "archived": "Archived"
         },
-        "verification": {
-          "verified": "Verified",
-          "pending": "Pending"
+        "ownership": {
+          "confirmed": "Ownership confirmed",
+          "pending": "Ownership pending confirmation",
+          "notApplicable": "N/A",
+          "title": "Ownership confirmation",
+          "pendingHelp": "This self-serve tenant stays available to its users. Confirm ownership here after the back-office review.",
+          "confirmedHelp": "Ownership for this self-serve tenant has already been confirmed from the back office.",
+          "action": "Confirm ownership",
+          "submitting": "Confirming…",
+          "success": "Ownership confirmed.",
+          "error": "Could not confirm ownership. Please retry."
         },
         "tabs": {
           "overview": "Overview",
@@ -473,6 +484,7 @@
             "keycloakOrgId": "Keycloak org ID",
             "createdAt": "Created at",
             "updatedAt": "Updated at",
+            "ownershipConfirmedAt": "Ownership confirmed at",
             "verifiedAt": "Verified at"
           }
         },

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -363,7 +363,7 @@
     "tenants": {
       "list": {
         "title": "Gestion des tenants",
-        "subtitle": "Consultez l’ensemble des tenants enterprise et accédez à leur cycle de vie, domaines, utilisateurs et audit récent.",
+        "subtitle": "Consultez l’ensemble des tenants self-serve, enterprise et invitation, et pilotez leur cycle de vie, ownership, domaines, utilisateurs et audit récent.",
         "createCta": "+ Nouveau tenant enterprise",
         "columns": {
           "name": "Tenant",
@@ -371,6 +371,8 @@
           "plan": "Plan",
           "primaryDomain": "Domaine principal",
           "createdVia": "Créé via",
+          "ownership": "Ownership",
+          "createdAt": "Créé le",
           "updatedAt": "Dernière mise à jour"
         },
         "statuses": {
@@ -378,9 +380,10 @@
           "suspended": "Suspendu",
           "archived": "Archivé"
         },
-        "verification": {
-          "verified": "Vérifié",
-          "pending": "En attente"
+        "ownership": {
+          "confirmed": "Ownership confirmé",
+          "pending": "Ownership à confirmer",
+          "notApplicable": "Sans objet"
         },
         "empty": {
           "title": "Aucun tenant",
@@ -454,9 +457,17 @@
           "suspended": "Suspendu",
           "archived": "Archivé"
         },
-        "verification": {
-          "verified": "Vérifié",
-          "pending": "En attente"
+        "ownership": {
+          "confirmed": "Ownership confirmé",
+          "pending": "Ownership à confirmer",
+          "notApplicable": "Sans objet",
+          "title": "Confirmation d'ownership",
+          "pendingHelp": "Ce tenant self-serve reste accessible à ses utilisateurs. Confirmez l'ownership ici après revue back-office.",
+          "confirmedHelp": "L'ownership de ce tenant self-serve a été confirmé depuis le back-office.",
+          "action": "Confirmer l'ownership",
+          "submitting": "Confirmation…",
+          "success": "Ownership confirmé.",
+          "error": "Impossible de confirmer l'ownership. Veuillez réessayer."
         },
         "tabs": {
           "overview": "Vue d’ensemble",
@@ -473,6 +484,7 @@
             "keycloakOrgId": "ID org Keycloak",
             "createdAt": "Créé le",
             "updatedAt": "Mis à jour le",
+            "ownershipConfirmedAt": "Ownership confirmé le",
             "verifiedAt": "Vérifié le"
           }
         },

--- a/packages/web/src/app/(admin)/admin/tenants/[id]/page.tsx
+++ b/packages/web/src/app/(admin)/admin/tenants/[id]/page.tsx
@@ -7,11 +7,12 @@ import {
   formatTenantUserName,
   normalizeTenantToken,
   renderJsonPreview,
+  TenantOwnershipBadge,
   TenantStatusBadge,
-  TenantVerificationBadge,
 } from "@/components/admin/tenant-admin-shared";
 import { TenantDetailTabs } from "@/components/admin/tenant-detail-tabs";
 import { TenantLifecycleActions } from "@/components/admin/tenant-lifecycle-actions";
+import { TenantOwnershipActions } from "@/components/admin/tenant-ownership-actions";
 import {
   Table,
   TableBody,
@@ -89,6 +90,10 @@ export default async function TenantDetailPage({
       <DetailCard
         label={t("overview.fields.updatedAt")}
         value={formatAdminDate(tenant.updatedAt)}
+      />
+      <DetailCard
+        label={t("overview.fields.ownershipConfirmedAt")}
+        value={tenant.ownershipConfirmedAt ? formatAdminDate(tenant.ownershipConfirmedAt) : "—"}
       />
       <DetailCard
         label={t("overview.fields.verifiedAt")}
@@ -226,10 +231,12 @@ export default async function TenantDetailPage({
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <TenantStatusBadge status={tenant.status} label={tenantStatusLabel(t, tenant.status)} />
-            <TenantVerificationBadge
-              verifiedAt={tenant.verifiedAt}
-              verifiedLabel={t("verification.verified")}
-              pendingLabel={t("verification.pending")}
+            <TenantOwnershipBadge
+              createdVia={tenant.createdVia}
+              ownershipConfirmedAt={tenant.ownershipConfirmedAt}
+              confirmedLabel={t("ownership.confirmed")}
+              pendingLabel={t("ownership.pending")}
+              notApplicableLabel={t("ownership.notApplicable")}
             />
           </div>
         </div>
@@ -244,6 +251,11 @@ export default async function TenantDetailPage({
        */}
       {firstAdminInvitation === null && users.length === 0 ? (
         <>
+          <TenantOwnershipActions
+            tenantId={tenant.id}
+            createdVia={tenant.createdVia}
+            ownershipConfirmedAt={tenant.ownershipConfirmedAt}
+          />
           <FirstAdminCard
             tenantId={tenant.id}
             tenantDefaultLocale={tenant.defaultLocale}
@@ -256,6 +268,11 @@ export default async function TenantDetailPage({
         </>
       ) : (
         <>
+          <TenantOwnershipActions
+            tenantId={tenant.id}
+            createdVia={tenant.createdVia}
+            ownershipConfirmedAt={tenant.ownershipConfirmedAt}
+          />
           <TenantLifecycleActions tenantId={tenant.id} currentStatus={tenant.status} />
           <FirstAdminCard
             tenantId={tenant.id}

--- a/packages/web/src/app/(admin)/admin/tenants/page.tsx
+++ b/packages/web/src/app/(admin)/admin/tenants/page.tsx
@@ -4,17 +4,54 @@ import { getTranslations } from "next-intl/server";
 import { TenantsTable } from "@/components/admin/tenants-table";
 import { Button } from "@/components/ui/button";
 import { createServerApiClient } from "@/lib/api/client-server";
-import type { AdminTenantListResponse, AdminTenantSummary } from "@/services/TenantAdminService";
+import type {
+  AdminTenantListResponse,
+  AdminTenantSortField,
+  AdminTenantSortOrder,
+  AdminTenantSummary,
+} from "@/services/TenantAdminService";
 
 export const dynamic = "force-dynamic";
 
-export default async function TenantListPage() {
+const TENANT_SORT_FIELDS = new Set<AdminTenantSortField>([
+  "name",
+  "status",
+  "plan",
+  "primaryDomain",
+  "createdVia",
+  "ownershipConfirmedAt",
+  "createdAt",
+  "updatedAt",
+]);
+
+function normalizeSort(value: string | undefined): AdminTenantSortField {
+  if (value && TENANT_SORT_FIELDS.has(value as AdminTenantSortField)) {
+    return value as AdminTenantSortField;
+  }
+  return "createdAt";
+}
+
+function normalizeOrder(value: string | undefined): AdminTenantSortOrder {
+  return value === "asc" ? "asc" : "desc";
+}
+
+export default async function TenantListPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ sort?: string; order?: string }>;
+}) {
+  const search = await searchParams;
   const t = await getTranslations("admin.tenants.list");
   const api = await createServerApiClient();
+  const sort = normalizeSort(search.sort);
+  const order = normalizeOrder(search.order);
 
   let tenants: AdminTenantSummary[] = [];
   try {
-    const res = await api.get<AdminTenantListResponse>("/v1/superadmin/tenants");
+    const params = new URLSearchParams({ sort, order });
+    const res = await api.get<AdminTenantListResponse>(
+      `/v1/superadmin/tenants?${params.toString()}`,
+    );
     tenants = res.data;
   } catch {
     tenants = [];
@@ -32,7 +69,7 @@ export default async function TenantListPage() {
         </Button>
       </header>
 
-      <TenantsTable tenants={tenants} />
+      <TenantsTable tenants={tenants} sort={sort} order={order} />
     </div>
   );
 }

--- a/packages/web/src/components/admin/tenant-admin-shared.tsx
+++ b/packages/web/src/components/admin/tenant-admin-shared.tsx
@@ -67,3 +67,27 @@ export function TenantVerificationBadge({
     <Badge variant="warning">{pendingLabel}</Badge>
   );
 }
+
+export function TenantOwnershipBadge({
+  createdVia,
+  ownershipConfirmedAt,
+  confirmedLabel,
+  pendingLabel,
+  notApplicableLabel,
+}: {
+  createdVia: string;
+  ownershipConfirmedAt: string | null;
+  confirmedLabel: string;
+  pendingLabel: string;
+  notApplicableLabel: string;
+}) {
+  const normalized = normalizeToken(createdVia);
+  if (normalized !== "self_serve") {
+    return <Badge variant="neutral">{notApplicableLabel}</Badge>;
+  }
+  return ownershipConfirmedAt ? (
+    <Badge variant="success">{confirmedLabel}</Badge>
+  ) : (
+    <Badge variant="warning">{pendingLabel}</Badge>
+  );
+}

--- a/packages/web/src/components/admin/tenant-ownership-actions.test.tsx
+++ b/packages/web/src/components/admin/tenant-ownership-actions.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { mockApiClient, mockRouter, mockToast } from "@/tests/mocks";
+
+import { TenantOwnershipActions } from "./tenant-ownership-actions";
+
+describe("TenantOwnershipActions", () => {
+  it("confirms a self-serve tenant ownership and refreshes the route", async () => {
+    const user = userEvent.setup();
+    mockApiClient.post.mockResolvedValue({ ownershipConfirmedAt: "2026-04-27T10:00:00.000Z" });
+
+    render(
+      <TenantOwnershipActions
+        tenantId="tenant-1"
+        createdVia="self_serve"
+        ownershipConfirmedAt={null}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Confirm ownership" }));
+
+    await waitFor(() => {
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        "/v1/superadmin/tenants/tenant-1/confirm-ownership",
+      );
+    });
+    expect(mockToast.success).toHaveBeenCalledWith("Ownership confirmed.");
+    expect(mockRouter.refresh).toHaveBeenCalled();
+  });
+
+  it("hides the card for non self-serve tenants", () => {
+    const { container } = render(
+      <TenantOwnershipActions
+        tenantId="tenant-2"
+        createdVia="enterprise"
+        ownershipConfirmedAt={null}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/web/src/components/admin/tenant-ownership-actions.tsx
+++ b/packages/web/src/components/admin/tenant-ownership-actions.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import { confirmTenantOwnership } from "@/services/TenantAdminService";
+
+interface TenantOwnershipActionsProps {
+  tenantId: string;
+  createdVia: string;
+  ownershipConfirmedAt: string | null;
+}
+
+function normalizeTrack(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function TenantOwnershipActions({
+  tenantId,
+  createdVia,
+  ownershipConfirmedAt,
+}: TenantOwnershipActionsProps) {
+  const router = useRouter();
+  const t = useTranslations("admin.tenants.detail.ownership");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (normalizeTrack(createdVia) !== "self_serve") return null;
+
+  async function onConfirm() {
+    setIsSubmitting(true);
+    try {
+      await confirmTenantOwnership(tenantId);
+      toast.success(t("success"));
+      router.refresh();
+    } catch {
+      toast.error(t("error"));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold text-text-secondary">{t("title")}</h2>
+        <p className="text-sm text-text-muted">
+          {ownershipConfirmedAt ? t("confirmedHelp") : t("pendingHelp")}
+        </p>
+      </div>
+
+      <div className="mt-4">
+        <Button
+          disabled={Boolean(ownershipConfirmedAt) || isSubmitting}
+          onClick={() => void onConfirm()}
+        >
+          {isSubmitting ? t("submitting") : t("action")}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/admin/tenants-table.test.tsx
+++ b/packages/web/src/components/admin/tenants-table.test.tsx
@@ -6,6 +6,38 @@ import { mockRouter } from "@/tests/mocks";
 import { TenantsTable } from "./tenants-table";
 
 describe("TenantsTable", () => {
+  it("pushes sort params when a sortable header is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TenantsTable
+        tenants={[
+          {
+            id: "tenant-1",
+            name: "Acme Foundation",
+            slug: "acme-foundation",
+            plan: "enterprise",
+            status: "active",
+            createdVia: "enterprise",
+            verifiedAt: null,
+            ownershipConfirmedAt: null,
+            primaryDomain: "acme.org",
+            keycloakOrgId: "kc-acme",
+            defaultLocale: "fr",
+            createdAt: "2026-04-10T10:00:00.000Z",
+            updatedAt: "2026-04-21T10:00:00.000Z",
+          },
+        ]}
+        sort="createdAt"
+        order="desc"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /tenant/i }));
+
+    expect(mockRouter.push).toHaveBeenCalledWith("/settings/funds?sort=name&order=asc");
+  });
+
   it("renders tenant rows and navigates to the detail page on row click", async () => {
     const user = userEvent.setup();
 
@@ -20,6 +52,7 @@ describe("TenantsTable", () => {
             status: "active",
             createdVia: "sales-led",
             verifiedAt: "2026-04-20T10:00:00.000Z",
+            ownershipConfirmedAt: null,
             primaryDomain: "acme.org",
             keycloakOrgId: "kc-acme",
             defaultLocale: "fr",
@@ -27,11 +60,14 @@ describe("TenantsTable", () => {
             updatedAt: "2026-04-21T10:00:00.000Z",
           },
         ]}
+        sort="createdAt"
+        order="desc"
       />,
     );
 
     expect(screen.getByText("Acme Foundation")).toBeInTheDocument();
-    expect(screen.getByText("Verified")).toBeInTheDocument();
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+    expect(screen.getAllByText(/10 Apr 2026/).length).toBeGreaterThan(0);
 
     await user.click(screen.getByText("Acme Foundation"));
 

--- a/packages/web/src/components/admin/tenants-table.tsx
+++ b/packages/web/src/components/admin/tenants-table.tsx
@@ -1,20 +1,24 @@
 "use client";
 
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { Building2 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import { EmptyState } from "@/components/shared/empty-state";
 import { DataTable } from "@/components/ui/data-table";
-import type { AdminTenantSummary } from "@/services/TenantAdminService";
+import type {
+  AdminTenantSortField,
+  AdminTenantSortOrder,
+  AdminTenantSummary,
+} from "@/services/TenantAdminService";
 
 import {
   formatAdminDate,
   normalizeTenantToken,
+  TenantOwnershipBadge,
   TenantStatusBadge,
-  TenantVerificationBadge,
 } from "./tenant-admin-shared";
 
 function tenantStatusLabel(
@@ -30,11 +34,37 @@ function tenantStatusLabel(
 
 interface TenantsTableProps {
   tenants: AdminTenantSummary[];
+  sort: AdminTenantSortField;
+  order: AdminTenantSortOrder;
 }
 
-export function TenantsTable({ tenants }: TenantsTableProps) {
+export function TenantsTable({ tenants, sort, order }: TenantsTableProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const t = useTranslations("admin.tenants.list");
+
+  const sorting = useMemo<SortingState>(
+    () => [{ id: sort, desc: order === "desc" }],
+    [order, sort],
+  );
+
+  const onSortingChange = useCallback(
+    (nextSorting: SortingState) => {
+      const [next] = nextSorting;
+      const params = new URLSearchParams(searchParams.toString());
+      if (!next) {
+        params.delete("sort");
+        params.delete("order");
+      } else {
+        params.set("sort", next.id);
+        params.set("order", next.desc ? "desc" : "asc");
+      }
+      const query = params.toString();
+      router.push(query ? `${pathname}?${query}` : pathname);
+    },
+    [pathname, router, searchParams],
+  );
 
   const columns = useMemo<ColumnDef<AdminTenantSummary>[]>(
     () => [
@@ -42,6 +72,7 @@ export function TenantsTable({ tenants }: TenantsTableProps) {
         id: "name",
         accessorKey: "name",
         header: () => t("columns.name"),
+        enableSorting: true,
         cell: ({ row }) => (
           <div>
             <p className="font-medium text-on-surface">{row.original.name}</p>
@@ -53,6 +84,7 @@ export function TenantsTable({ tenants }: TenantsTableProps) {
         id: "status",
         accessorKey: "status",
         header: () => t("columns.status"),
+        enableSorting: true,
         cell: ({ row }) => (
           <TenantStatusBadge
             status={row.original.status}
@@ -64,31 +96,48 @@ export function TenantsTable({ tenants }: TenantsTableProps) {
         id: "plan",
         accessorKey: "plan",
         header: () => t("columns.plan"),
+        enableSorting: true,
       },
       {
-        id: "domain",
+        id: "primaryDomain",
         accessorKey: "primaryDomain",
         header: () => t("columns.primaryDomain"),
-        cell: ({ row }) => (
-          <div className="space-y-1">
-            <p className="text-on-surface">{row.original.primaryDomain ?? "—"}</p>
-            <TenantVerificationBadge
-              verifiedAt={row.original.verifiedAt}
-              verifiedLabel={t("verification.verified")}
-              pendingLabel={t("verification.pending")}
-            />
-          </div>
-        ),
+        enableSorting: true,
+        cell: ({ row }) => <p className="text-on-surface">{row.original.primaryDomain ?? "—"}</p>,
       },
       {
         id: "createdVia",
         accessorKey: "createdVia",
         header: () => t("columns.createdVia"),
+        enableSorting: true,
+      },
+      {
+        id: "ownershipConfirmedAt",
+        accessorKey: "ownershipConfirmedAt",
+        header: () => t("columns.ownership"),
+        enableSorting: true,
+        cell: ({ row }) => (
+          <TenantOwnershipBadge
+            createdVia={row.original.createdVia}
+            ownershipConfirmedAt={row.original.ownershipConfirmedAt}
+            confirmedLabel={t("ownership.confirmed")}
+            pendingLabel={t("ownership.pending")}
+            notApplicableLabel={t("ownership.notApplicable")}
+          />
+        ),
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: () => t("columns.createdAt"),
+        enableSorting: true,
+        cell: ({ row }) => formatAdminDate(row.original.createdAt),
       },
       {
         id: "updatedAt",
         accessorKey: "updatedAt",
         header: () => t("columns.updatedAt"),
+        enableSorting: true,
         cell: ({ row }) => formatAdminDate(row.original.updatedAt),
       },
     ],
@@ -106,6 +155,8 @@ export function TenantsTable({ tenants }: TenantsTableProps) {
         totalPages: 1,
       }}
       onPageChange={() => {}}
+      sorting={sorting}
+      onSortingChange={onSortingChange}
       onRowClick={(row) => router.push(`/admin/tenants/${row.original.id}`)}
       emptyState={
         <EmptyState

--- a/packages/web/src/components/ui/data-table.tsx
+++ b/packages/web/src/components/ui/data-table.tsx
@@ -4,11 +4,20 @@ import {
   type ColumnDef,
   flexRender,
   getCoreRowModel,
+  getSortedRowModel,
   type Header,
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import { ChevronLeft, ChevronRight, Rows2, Rows3 } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+  Rows2,
+  Rows3,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
@@ -53,10 +62,10 @@ function sortDirectionAriaValue(sort: "asc" | "desc" | false) {
   return "none" as const;
 }
 
-function sortDirectionIndicator(sort: "asc" | "desc" | false) {
-  if (sort === "asc") return " ▲";
-  if (sort === "desc") return " ▼";
-  return "";
+function SortDirectionIndicator({ sort }: { sort: "asc" | "desc" | false }) {
+  if (sort === "asc") return <ArrowUp size={14} aria-hidden="true" />;
+  if (sort === "desc") return <ArrowDown size={14} aria-hidden="true" />;
+  return <ArrowUpDown size={14} aria-hidden="true" className="opacity-60" />;
 }
 
 interface HeaderCellProps<TData> {
@@ -84,7 +93,7 @@ function HeaderCell<TData>({ header, padding }: HeaderCellProps<TData>) {
           className="inline-flex items-center gap-1 hover:text-on-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         >
           {content}
-          {sortDirectionIndicator(sortDirection)}
+          <SortDirectionIndicator sort={sortDirection} />
         </button>
       ) : (
         content
@@ -111,6 +120,7 @@ export function DataTable<TData>({
 
   const sorting = controlledSorting ?? internalSorting;
   const setSorting = onSortingChange ?? setInternalSorting;
+  const manualSorting = controlledSorting !== undefined || onSortingChange !== undefined;
 
   const table = useReactTable({
     data,
@@ -121,8 +131,9 @@ export function DataTable<TData>({
       setSorting(next);
     },
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: manualSorting ? undefined : getSortedRowModel(),
     manualPagination: true,
-    manualSorting: true,
+    manualSorting,
     pageCount: pagination.totalPages,
   });
 

--- a/packages/web/src/services/TenantAdminService.ts
+++ b/packages/web/src/services/TenantAdminService.ts
@@ -18,6 +18,7 @@ export interface AdminTenantSummary {
   status: string;
   createdVia: string;
   verifiedAt: string | null;
+  ownershipConfirmedAt: string | null;
   primaryDomain: string | null;
   keycloakOrgId: string | null;
   /**
@@ -78,6 +79,16 @@ export interface AdminTenantDetailResponse {
 }
 
 export type TenantLifecycleAction = "suspend" | "archive" | "activate";
+export type AdminTenantSortField =
+  | "name"
+  | "status"
+  | "plan"
+  | "primaryDomain"
+  | "createdVia"
+  | "ownershipConfirmedAt"
+  | "createdAt"
+  | "updatedAt";
+export type AdminTenantSortOrder = "asc" | "desc";
 
 export async function triggerTenantLifecycle(
   tenantId: string,
@@ -91,6 +102,15 @@ export async function triggerTenantLifecycle(
       action,
       reason: reason?.trim() ? reason.trim() : undefined,
     },
+  );
+}
+
+export async function confirmTenantOwnership(
+  tenantId: string,
+): Promise<{ ownershipConfirmedAt: string }> {
+  const api = createClientApiClient();
+  return api.post<{ ownershipConfirmedAt: string }>(
+    `/v1/superadmin/tenants/${encodeURIComponent(tenantId)}/confirm-ownership`,
   );
 }
 


### PR DESCRIPTION
## Summary
Implémentation de l'issue #165 (Back-Office & Tables) :
- Ajout d'une colonne `ownership_confirmed_at` dans la table `tenants` pour valider manuellement l'ownership des tenants self-serve en BO, sans bloquer l'accès utilisateur.
- Ajout d'un encart d'action `TenantOwnershipActions` sur la page de détail d'un tenant pour le confirmer.
- Remplacement des flèches ASCII par des icônes Lucide (`ArrowUp`, `ArrowDown`, `ArrowUpDown`) dans `DataTable`.
- Implémentation du tri backend + frontend sur la liste des tenants (`sort`, `order`).
- Ajout de la colonne `createdAt` dans le tableau des tenants.