### PR TITLE
fix(security): Phase 1 RBAC for donations, pledges, campaigns (#176, #177, #178)

### DIFF
--- a/docs/security/rbac-audit-2026-04-27.md
+++ b/docs/security/rbac-audit-2026-04-27.md
@@ -353,10 +353,10 @@ Severity legend repeated for clarity:
 | API-1 | constituents | `POST /v1/constituents` | `requireAuth` → `requireWrite` | **High** | Original symptom of issue #162. **Fixed in this PR.** |
 | API-2 | constituents | `PUT /v1/constituents/:id` | `requireAuth` → `requireWrite` | **High** | Viewer can update any constituent. **Fixed in this PR.** |
 | API-3 | constituents | `GET /v1/constituents/duplicates/search` | `requireAuth` → `requireWrite` | Medium | Viewer can fuzzy-search PII pre-flight. **Fixed in this PR.** |
-| API-4 | donations | `POST /v1/donations` | `requireAuth` → `requireWrite` | **High** | Viewer can record manual donations — financial write. |
-| API-5 | donations | `PATCH /v1/donations/:id` | `requireAuth` → `requireWrite` | **High** | Viewer can edit financial history. |
-| API-6 | donations | `DELETE /v1/donations/:id` | `requireAuth` → `requireOrgAdmin` | **High** | Viewer (and any non-admin) can delete donations — accounting + audit + GDPR risk. |
-| API-7 | pledges | `POST /v1/pledges` | `requireAuth` → `requireWrite` | **High** | Viewer can create recurring-giving commitments. |
+| API-4 | donations | `POST /v1/donations` | `requireAuth` → `requireWrite` | **High** | Viewer can record manual donations — financial write. **Fixed in #176.** |
+| API-5 | donations | `PATCH /v1/donations/:id` | `requireAuth` → `requireWrite` | **High** | Viewer can edit financial history. **Fixed in #176.** |
+| API-6 | donations | `DELETE /v1/donations/:id` | `requireAuth` → `requireOrgAdmin` | **High** | Viewer (and any non-admin) can delete donations — accounting + audit + GDPR risk. **Fixed in #176.** |
+| API-7 | pledges | `POST /v1/pledges` | `requireAuth` → `requireWrite` | **High** | Viewer can create recurring-giving commitments. **Fixed in #177.** |
 
 #### Frontend gaps
 
@@ -366,30 +366,32 @@ Severity legend repeated for clarity:
 | FE-2 | `/constituents/new` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reached the form. **Fixed in this PR.** |
 | FE-3 | `/constituents/[id]` | hide "Edit" for `viewer` | Low | Dead-end CTA. **Fixed in this PR.** |
 | FE-4 | `/constituents/[id]/edit` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reached the form. **Fixed in this PR.** |
-| FE-5 | `/donations` (list) | hide "+ New" for `viewer` | Low | Dead-end CTA once API-4 lands. |
-| FE-6 | `/donations/new` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reaches the form; submit will 403 once API-4 lands. |
-| FE-7 | `/donations/[id]` | hide "Edit"+"Delete" for `viewer` (Delete: hide unless `org_admin` once API-6 lands) | Low | Dead-end buttons. |
-| FE-8 | `/donations/[id]/edit` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reaches the form. |
-| FE-9 | `/campaigns` (list) | hide "+ New" for `viewer` | Low | Dead-end CTA — `POST /v1/campaigns` already requires `requireWrite` (so submit would 403 today). |
-| FE-10 | `/campaigns/new` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reaches the form even though API rejects submission. |
-| FE-11 | `/campaigns/[id]` | hide "Edit" for `viewer` | Low | Dead-end CTA. |
-| FE-12 | `/campaigns/[id]/edit` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reaches the form even though API rejects PATCH. |
+| FE-5 | `/donations` (list) | hide "+ New" for `viewer` | Low | Dead-end CTA once API-4 lands. **Fixed in #176.** |
+| FE-6 | `/donations/new` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reaches the form; submit will 403 once API-4 lands. **Fixed in #176.** |
+| FE-7 | `/donations/[id]` | hide "Edit"+"Delete" for `viewer` (Delete: hide unless `org_admin` once API-6 lands) | Low | Dead-end buttons. **Fixed in #176.** |
+| FE-8 | `/donations/[id]/edit` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reaches the form. **Fixed in #176.** |
+| FE-9 | `/campaigns` (list) | hide "+ New" for `viewer` | Low | Dead-end CTA — `POST /v1/campaigns` already requires `requireWrite` (so submit would 403 today). **Fixed in #178.** |
+| FE-10 | `/campaigns/new` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reaches the form even though API rejects submission. **Fixed in #178.** |
+| FE-11 | `/campaigns/[id]` | hide "Edit" for `viewer` | Low | Dead-end CTA. **Fixed in #178.** |
+| FE-12 | `/campaigns/[id]/edit` | `requireAuth()` → `requirePermission("write")` | Medium | Viewer reaches the form even though API rejects PATCH. **Fixed in #178.** |
 
-Total gaps: **7 API rows + 12 frontend rows = 19**, of which **7 are
-already fixed in this PR** (API-1 through -3, FE-1 through -4).
+Total gaps: **7 API rows + 12 frontend rows = 19**, **all fixed**: API-1
+through -3 + FE-1 through -4 in PR #170 (constituents); API-4 through -6
++ FE-5 through -8 in #176 (donations); API-7 in #177 (pledges); FE-9
+through -12 in #178 (campaigns frontend).
 
 ### C.2 — Severity breakdown
 
-| Severity | Count | Already fixed in this PR | Outstanding |
-|---|---|---|---|
-| High | 6 | 2 | 4 |
-| Medium | 8 | 2 | 6 |
-| Low | 5 | 3 | 2 (the donations FE list/detail rows track API-4..6) |
+| Severity | Count | Fixed in #170 (constituents) | Fixed in #176 / #177 / #178 (this PR) | Outstanding |
+|---|---|---|---|---|
+| High | 6 | 2 | 4 (API-4..6 in #176, API-7 in #177) | 0 |
+| Medium | 8 | 2 | 6 (FE-6, FE-8 in #176; FE-10, FE-12 in #178; mixed) | 0 |
+| Low | 5 | 3 | 2 | 0 |
 
-The four outstanding **High** items (API-4, -5, -6, -7) are all
-financial-write endpoints that today permit `viewer` to record / edit /
-delete donations and create pledges. These are the priority for the
-follow-up issues below.
+All Phase 1 RBAC gaps are now closed. The four originally-outstanding
+**High** rows (API-4..7) — viewer creating / editing / deleting donations
+and creating pledges — landed in #176 and #177. Frontend affordance
+hiding for donations and campaigns landed in #176 and #178.
 
 ### C.3 — Follow-up issue plan
 

--- a/docs/security/rbac-audit-2026-04-27.md
+++ b/docs/security/rbac-audit-2026-04-27.md
@@ -94,9 +94,9 @@ Frontend permission map
 | disputes | PATCH `/v1/admin/disputes/:id` | `modules/disputes/routes.ts:178` | `requireSuperAdmin` | Resolution. |
 | donations | GET `/v1/donations` | `modules/donations/routes.ts:170` | `requireAuth` | Paginated list with filters. |
 | donations | GET `/v1/donations/:id` | `modules/donations/routes.ts:214` | `requireAuth` | Detail with allocations. |
-| donations | POST `/v1/donations` | `modules/donations/routes.ts:251` | `requireAuth` | Idempotency-keyed manual donation. **Gap.** |
-| donations | PATCH `/v1/donations/:id` | `modules/donations/routes.ts:327` | `requireAuth` | Update. **Gap.** |
-| donations | DELETE `/v1/donations/:id` | `modules/donations/routes.ts:385` | `requireAuth` | Delete. **Gap.** |
+| donations | POST `/v1/donations` | `modules/donations/routes.ts:251` | `requireWrite` (#176) | Idempotency-keyed manual donation. |
+| donations | PATCH `/v1/donations/:id` | `modules/donations/routes.ts:327` | `requireWrite` (#176) | Update. |
+| donations | DELETE `/v1/donations/:id` | `modules/donations/routes.ts:385` | `requireOrgAdmin` (#176) | Delete; admin-only — accounting + audit + GDPR. |
 | donations | GET `/v1/donations/:id/receipt` | `modules/donations/routes.ts:422` | `requireAuth` | Presigned S3 URL for tax receipt. |
 | funds | GET `/v1/funds` | `modules/funds/routes.ts:54` | `requireAuth` | List. |
 | funds | POST `/v1/funds` | `modules/funds/routes.ts:80` | `requireOrgAdmin` | Create. |
@@ -113,7 +113,7 @@ Frontend permission map
 | invitations | POST `/v1/invitations/:token/accept` | `modules/invitations/routes.ts:419` | none (rate-limited) | Public accept; token IS the credential. |
 | payments | POST `/v1/admin/stripe-connect` | `modules/payments/routes.ts:30` | `requireOrgAdmin` | Stripe Connect onboarding. |
 | payments | POST `/v1/donations/stripe-webhook` | `modules/payments/routes.ts:81` | none (signature-verified, rate-limited) | Stripe webhook; signature is the credential. |
-| pledges | POST `/v1/pledges` | `modules/pledges/routes.ts:76` | `requireAuth` | Idempotency-keyed pledge create. **Gap.** |
+| pledges | POST `/v1/pledges` | `modules/pledges/routes.ts:76` | `requireWrite` (#177) | Idempotency-keyed pledge create. |
 | pledges | GET `/v1/pledges/:id/installments` | `modules/pledges/routes.ts:114` | `requireAuth` | List installments. |
 | public | GET `/v1/campaigns/:id/public-page` | `modules/public/routes.ts:61` | `requireOrgAdmin` | Admin fetch of public-page config. |
 | public | GET `/v1/public/campaigns/:id/page` | `modules/public/routes.ts:95` | none | Published page config — public. |

--- a/packages/api/src/modules/donations/routes.ts
+++ b/packages/api/src/modules/donations/routes.ts
@@ -2,7 +2,7 @@
 
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
-import { requireAuth } from "../../lib/guards.js";
+import { requireAuth, requireOrgAdmin, requireWrite } from "../../lib/guards.js";
 import { resolveTranslations } from "../../lib/i18n.js";
 import { getReceiptPresignedUrl } from "../../lib/s3.js";
 import {
@@ -252,7 +252,7 @@ export async function donationRoutes(app: FastifyInstance) {
     "/donations",
     {
       config: { idempotency: { routeKey: "POST:/v1/donations" } },
-      preHandler: requireAuth,
+      preHandler: requireWrite,
       schema: {
         tags: ["Donations"],
         body: DonationCreateBody,
@@ -327,7 +327,7 @@ export async function donationRoutes(app: FastifyInstance) {
   app.patch(
     "/donations/:id",
     {
-      preHandler: requireAuth,
+      preHandler: requireWrite,
       schema: {
         tags: ["Donations"],
         params: IdParams,
@@ -385,7 +385,7 @@ export async function donationRoutes(app: FastifyInstance) {
   app.delete(
     "/donations/:id",
     {
-      preHandler: requireAuth,
+      preHandler: requireOrgAdmin,
       schema: {
         tags: ["Donations"],
         params: IdParams,

--- a/packages/api/src/modules/pledges/routes.ts
+++ b/packages/api/src/modules/pledges/routes.ts
@@ -2,7 +2,7 @@
 
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
-import { requireAuth } from "../../lib/guards.js";
+import { requireAuth, requireWrite } from "../../lib/guards.js";
 import {
   CurrencySchema,
   DataArrayResponseNoPagination,
@@ -77,7 +77,7 @@ export async function pledgeRoutes(app: FastifyInstance) {
     "/pledges",
     {
       config: { idempotency: { routeKey: "POST:/v1/pledges" } },
-      preHandler: requireAuth,
+      preHandler: requireWrite,
       schema: {
         tags: ["Pledges"],
         body: PledgeCreateBody,

--- a/packages/api/src/tests/integration/donations.test.ts
+++ b/packages/api/src/tests/integration/donations.test.ts
@@ -625,3 +625,282 @@ describe("Pledges unauthenticated access", () => {
     expect(res.statusCode).toBe(401);
   });
 });
+
+// ─── Donations viewer-role enforcement (issue #176) ─────────────────────────
+//
+// Mirrors the constituents pattern from PR #170: viewer must hit 403 on every
+// write endpoint, user keeps parity with org_admin on POST/PATCH but is
+// blocked on DELETE (org_admin-only), and reads stay open to viewer so we
+// don't over-block. At least one viewer-403 path locks the RFC 9457 problem
+// body shape so a regression to `{ error }` or a stripped `type` URI breaks
+// here, not in unrelated SDK / web parsing.
+
+describe("Donations viewer-role enforcement (issue #176)", () => {
+  it("POST /v1/donations returns 403 for viewer with RFC 9457 problem body", async () => {
+    const viewerToken = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(viewerToken),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 1000,
+        currency: "EUR",
+        paymentMethod: "cash",
+        paymentRef: `VIEWER-BLOCK-${Date.now()}`,
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    const body = res.json<{ type: string; title: string; status: number; detail: string }>();
+    expect(body.type).toBe("https://httpproblems.com/http-status/403");
+    expect(body.title).toBe("Forbidden");
+    expect(body.status).toBe(403);
+    expect(body.detail).toMatch(/write access required/i);
+  });
+
+  it("PATCH /v1/donations/:id returns 403 for viewer", async () => {
+    // Seed via admin so a target row exists.
+    const tokenA = signToken(app);
+    const seed = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 4200,
+        currency: "EUR",
+        paymentMethod: "cash",
+        paymentRef: `VIEWER-PATCH-SEED-${Date.now()}`,
+      },
+    });
+    const targetId = seed.json<{ data: { id: string } }>().data.id;
+
+    const viewerToken = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/donations/${targetId}`,
+      headers: authHeader(viewerToken),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 9999,
+        currency: "EUR",
+      },
+    });
+    expect(res.statusCode).toBe(403);
+
+    // Sanity: the row was not touched.
+    const check = await app.inject({
+      method: "GET",
+      url: `/v1/donations/${targetId}`,
+      headers: authHeader(tokenA),
+    });
+    expect(check.json<{ data: { amountCents: number } }>().data.amountCents).toBe(4200);
+  });
+
+  it("DELETE /v1/donations/:id returns 403 for viewer", async () => {
+    const viewerToken = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/v1/donations/00000000-0000-0000-0000-000000000001",
+      headers: authHeader(viewerToken),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("DELETE /v1/donations/:id returns 403 for user role (org_admin only)", async () => {
+    const userToken = signToken(app, { role: "user" });
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/v1/donations/00000000-0000-0000-0000-000000000001",
+      headers: authHeader(userToken),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("user role can still POST /v1/donations (parity with org_admin)", async () => {
+    const userToken = signToken(app, { role: "user" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(userToken),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 2500,
+        currency: "EUR",
+        paymentMethod: "cash",
+        paymentRef: `USER-POST-${Date.now()}`,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("user role can still PATCH /v1/donations/:id", async () => {
+    const tokenA = signToken(app);
+    const seed = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 3300,
+        currency: "EUR",
+        paymentMethod: "cash",
+        paymentRef: `USER-PATCH-SEED-${Date.now()}`,
+      },
+    });
+    const id = seed.json<{ data: { id: string } }>().data.id;
+
+    const userToken = signToken(app, { role: "user" });
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/donations/${id}`,
+      headers: authHeader(userToken),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 3400,
+        currency: "EUR",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("org_admin can DELETE /v1/donations/:id", async () => {
+    const tokenA = signToken(app);
+    const seed = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 1100,
+        currency: "EUR",
+        paymentMethod: "cash",
+        paymentRef: `ADMIN-DELETE-${Date.now()}`,
+      },
+    });
+    const id = seed.json<{ data: { id: string } }>().data.id;
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/donations/${id}`,
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  // Sanity: tightening writes mustn't over-block reads. If a future change
+  // mass-replaces `requireAuth` → `requireWrite` on GET endpoints, this test
+  // catches it for donations.
+  it("GET /v1/donations stays accessible to viewer (read-only)", async () => {
+    const viewerToken = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/donations",
+      headers: authHeader(viewerToken),
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("GET /v1/donations/:id stays accessible to viewer (read-only)", async () => {
+    const tokenA = signToken(app);
+    const seed = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 600,
+        currency: "EUR",
+        paymentMethod: "cash",
+        paymentRef: `VIEWER-READ-${Date.now()}`,
+      },
+    });
+    const id = seed.json<{ data: { id: string } }>().data.id;
+
+    const viewerToken = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/donations/${id}`,
+      headers: authHeader(viewerToken),
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+// ─── Pledges viewer-role enforcement (issue #177) ───────────────────────────
+
+describe("Pledges viewer-role enforcement (issue #177)", () => {
+  it("POST /v1/pledges returns 403 for viewer with RFC 9457 problem body", async () => {
+    const viewerToken = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/pledges",
+      headers: authHeader(viewerToken),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 1000,
+        frequency: "monthly",
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    const body = res.json<{ type: string; title: string; status: number; detail: string }>();
+    expect(body.type).toBe("https://httpproblems.com/http-status/403");
+    expect(body.title).toBe("Forbidden");
+    expect(body.status).toBe(403);
+    expect(body.detail).toMatch(/write access required/i);
+  });
+
+  it("user role can still POST /v1/pledges", async () => {
+    const userToken = signToken(app, { role: "user" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/pledges",
+      headers: authHeader(userToken),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 1500,
+        frequency: "monthly",
+      },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("org_admin can still POST /v1/pledges", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/pledges",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 1800,
+        frequency: "yearly",
+      },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  // Sanity: read endpoint must stay open to viewer per audit Table B1.
+  it("GET /v1/pledges/:id/installments stays accessible to viewer", async () => {
+    const tokenA = signToken(app);
+    const seed = await app.inject({
+      method: "POST",
+      url: "/v1/pledges",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 700,
+        frequency: "monthly",
+      },
+    });
+    const pledgeId = seed.json<{ data: { id: string } }>().data.id;
+
+    const viewerToken = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/pledges/${pledgeId}/installments`,
+      headers: authHeader(viewerToken),
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/packages/api/src/tests/integration/donations.test.ts
+++ b/packages/api/src/tests/integration/donations.test.ts
@@ -651,6 +651,11 @@ describe("Donations viewer-role enforcement (issue #176)", () => {
       },
     });
     expect(res.statusCode).toBe(403);
+    // Lock the wire format: today guards send `application/json` carrying an
+    // RFC 9457-shaped body. The accept-both regex catches a future tightening
+    // to `application/problem+json` AND a regression to plain-string error
+    // bodies (which would drop the JSON content-type entirely).
+    expect(res.headers["content-type"]).toMatch(/^application\/(problem\+)?json/);
     const body = res.json<{ type: string; title: string; status: number; detail: string }>();
     expect(body.type).toBe("https://httpproblems.com/http-status/403");
     expect(body.title).toBe("Forbidden");
@@ -788,6 +793,46 @@ describe("Donations viewer-role enforcement (issue #176)", () => {
     expect(res.statusCode).toBe(200);
   });
 
+  // SOC observability lock: viewer-403 attempts MUST land in audit_logs so a
+  // dashboard can surface "viewer probing write endpoints". A future change
+  // that skips audit emission on 4xx (perf optimisation, PII concerns) would
+  // silently kill the SOC signal for RBAC denials. Catch it here.
+  it("POST /v1/donations 403 still emits an audit_logs row (SOC observability)", async () => {
+    const before = await db.execute(
+      sql`SELECT count(*)::int AS c FROM audit_logs
+          WHERE org_id = ${ORG_A} AND action = 'POST:/v1/donations'`,
+    );
+    const beforeCount = (before.rows[0] as { c: number }).c;
+
+    const viewerToken = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(viewerToken),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 1000,
+        currency: "EUR",
+        paymentMethod: "cash",
+        paymentRef: `AUDIT-LOCK-${Date.now()}`,
+      },
+    });
+    expect(res.statusCode).toBe(403);
+
+    // Audit hook fires on `onResponse`, which is async after `inject` resolves.
+    // Poll briefly so we don't depend on lifecycle internals.
+    let afterCount = beforeCount;
+    for (let attempt = 0; attempt < 10 && afterCount === beforeCount; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const after = await db.execute(
+        sql`SELECT count(*)::int AS c FROM audit_logs
+            WHERE org_id = ${ORG_A} AND action = 'POST:/v1/donations'`,
+      );
+      afterCount = (after.rows[0] as { c: number }).c;
+    }
+    expect(afterCount).toBe(beforeCount + 1);
+  });
+
   // Sanity: tightening writes mustn't over-block reads. If a future change
   // mass-replaces `requireAuth` → `requireWrite` on GET endpoints, this test
   // catches it for donations.
@@ -843,6 +888,7 @@ describe("Pledges viewer-role enforcement (issue #177)", () => {
       },
     });
     expect(res.statusCode).toBe(403);
+    expect(res.headers["content-type"]).toMatch(/^application\/(problem\+)?json/);
     const body = res.json<{ type: string; title: string; status: number; detail: string }>();
     expect(body.type).toBe("https://httpproblems.com/http-status/403");
     expect(body.title).toBe("Forbidden");

--- a/packages/web/src/app/(app)/campaigns/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { CampaignForm } from "@/components/campaigns/campaign-form";
 import { PageHeader } from "@/components/shared/page-header";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { requireAuth } from "@/lib/auth/guards";
+import { requirePermission } from "@/lib/auth/guards";
 import type { Campaign } from "@/models/campaign";
 import { CampaignService } from "@/services/CampaignService";
 
@@ -26,7 +26,7 @@ async function fetchCampaignOrNotFound(id: string): Promise<Campaign> {
 }
 
 export default async function EditCampaignPage({ params }: EditCampaignPageProps) {
-  await requireAuth();
+  await requirePermission("write");
   const { id } = await params;
   const campaign = await fetchCampaignOrNotFound(id);
 

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -13,7 +13,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { requireAuth } from "@/lib/auth/guards";
+import { hasPermission, requireAuth } from "@/lib/auth/guards";
 import { formatCurrency, formatDate, formatNumber, formatPercent } from "@/lib/format";
 import type { Campaign, CampaignRoiMetrics, CampaignStats } from "@/models/campaign";
 import type { DonationListResponse } from "@/models/donation";
@@ -77,6 +77,7 @@ export default async function CampaignDetailPage({
   searchParams,
 }: CampaignDetailPageProps) {
   const auth = await requireAuth();
+  const canWrite = hasPermission(auth, "write");
   const { id } = await params;
   const sp = await searchParams;
   const donationsPage = parsePositiveInt(sp.page, 1);
@@ -131,12 +132,14 @@ export default async function CampaignDetailPage({
                 {t("actions.back")}
               </Link>
             </Button>
-            <Button asChild size="sm">
-              <Link href={`/campaigns/${campaign.id}/edit`}>
-                <Pencil size={16} aria-hidden="true" />
-                {t("actions.edit")}
-              </Link>
-            </Button>
+            {canWrite ? (
+              <Button asChild size="sm">
+                <Link href={`/campaigns/${campaign.id}/edit`}>
+                  <Pencil size={16} aria-hidden="true" />
+                  {t("actions.edit")}
+                </Link>
+              </Button>
+            ) : null}
             {auth.roles.includes("org_admin") ? (
               <Button asChild variant="secondary" size="sm">
                 <Link href={`/campaigns/${campaign.id}/public-page`}>

--- a/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
+++ b/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
@@ -59,6 +59,11 @@ interface CampaignsTableProps {
   campaigns: CampaignWithStats[];
   pagination: DataTablePagination;
   /**
+   * Viewer cannot Edit — `/campaigns/[id]/edit` is `requirePermission("write")`
+   * and would 404. Hide the row's Edit affordance to avoid a dead-end.
+   */
+  canWrite: boolean;
+  /**
    * `Close` is `requireOrgAdmin` server-side; when `false`, the row's
    * dropdown only shows Edit. Mirrors the donations + members + constituents
    * shortcut pattern.
@@ -77,6 +82,7 @@ function isCampaignStatus(value: string): value is CampaignStatus {
 export function CampaignsTable({
   campaigns,
   pagination,
+  canWrite,
   canManageAdminActions,
 }: CampaignsTableProps) {
   const router = useRouter();
@@ -215,28 +221,37 @@ export function CampaignsTable({
           </span>
         ),
       },
-      {
-        id: "actions",
-        header: () => <span className="sr-only">{t("columns.actions")}</span>,
-        enableSorting: false,
-        cell: ({ row }) => {
-          const campaign = row.original.campaign;
-          const canClose =
-            canManageAdminActions && (campaign.status === "draft" || campaign.status === "active");
-          return (
-            <CampaignRowActions
-              campaign={campaign}
-              canClose={canClose}
-              onClose={() => setCloseTarget(campaign)}
-              menuLabel={t("actions.menu", { name: campaign.name })}
-              editLabel={t("actions.edit")}
-              closeLabel={t("actions.close")}
-            />
-          );
-        },
-      },
+      // Drop the actions column entirely when no row action is available
+      // (viewer with no write access AND no admin actions). Mirrors the
+      // donations + constituents tables.
+      ...(canWrite || canManageAdminActions
+        ? [
+            {
+              id: "actions",
+              header: () => <span className="sr-only">{t("columns.actions")}</span>,
+              enableSorting: false,
+              cell: ({ row }: { row: { original: CampaignWithStats } }) => {
+                const campaign = row.original.campaign;
+                const canClose =
+                  canManageAdminActions &&
+                  (campaign.status === "draft" || campaign.status === "active");
+                return (
+                  <CampaignRowActions
+                    campaign={campaign}
+                    canEdit={canWrite}
+                    canClose={canClose}
+                    onClose={() => setCloseTarget(campaign)}
+                    menuLabel={t("actions.menu", { name: campaign.name })}
+                    editLabel={t("actions.edit")}
+                    closeLabel={t("actions.close")}
+                  />
+                );
+              },
+            } satisfies ColumnDef<CampaignWithStats>,
+          ]
+        : []),
     ],
-    [canManageAdminActions, t, locale],
+    [canManageAdminActions, canWrite, t, locale],
   );
 
   return (
@@ -291,6 +306,7 @@ export function CampaignsTable({
 
 interface CampaignRowActionsProps {
   campaign: Campaign;
+  canEdit: boolean;
   canClose: boolean;
   onClose: () => void;
   menuLabel: string;
@@ -300,12 +316,16 @@ interface CampaignRowActionsProps {
 
 function CampaignRowActions({
   campaign,
+  canEdit,
   canClose,
   onClose,
   menuLabel,
   editLabel,
   closeLabel,
 }: CampaignRowActionsProps) {
+  if (!canEdit && !canClose) {
+    return null;
+  }
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -319,15 +339,17 @@ function CampaignRowActions({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
-        <DropdownMenuItem asChild>
-          <Link
-            href={`/campaigns/${campaign.id}/edit`}
-            onClick={(event) => event.stopPropagation()}
-          >
-            <Pencil size={16} aria-hidden="true" />
-            {editLabel}
-          </Link>
-        </DropdownMenuItem>
+        {canEdit ? (
+          <DropdownMenuItem asChild>
+            <Link
+              href={`/campaigns/${campaign.id}/edit`}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Pencil size={16} aria-hidden="true" />
+              {editLabel}
+            </Link>
+          </DropdownMenuItem>
+        ) : null}
         {canClose ? (
           <DropdownMenuItem
             onSelect={(event) => {

--- a/packages/web/src/app/(app)/campaigns/new/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/new/page.tsx
@@ -2,10 +2,10 @@ import { getTranslations } from "next-intl/server";
 
 import { CampaignForm } from "@/components/campaigns/campaign-form";
 import { PageHeader } from "@/components/shared/page-header";
-import { requireAuth } from "@/lib/auth/guards";
+import { requirePermission } from "@/lib/auth/guards";
 
 export default async function NewCampaignPage() {
-  await requireAuth();
+  await requirePermission("write");
   const t = await getTranslations("campaigns.form");
   const tCampaigns = await getTranslations("campaigns");
 

--- a/packages/web/src/app/(app)/campaigns/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/page.tsx
@@ -85,6 +85,7 @@ export default async function CampaignsPage({ searchParams }: CampaignsPageProps
         <CampaignsTable
           campaigns={campaignsWithStats}
           pagination={result.pagination}
+          canWrite={canWrite}
           canManageAdminActions={canManageAdminActions}
         />
       ) : (

--- a/packages/web/src/app/(app)/campaigns/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/page.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from "@/components/shared/page-header";
 import { Button } from "@/components/ui/button";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { requireAuth } from "@/lib/auth/guards";
+import { hasPermission, requireAuth } from "@/lib/auth/guards";
 import type { CampaignListResponse } from "@/models/campaign";
 import { CampaignService } from "@/services/CampaignService";
 
@@ -30,6 +30,7 @@ function parsePositiveInt(value: string | string[] | undefined, fallback: number
 export default async function CampaignsPage({ searchParams }: CampaignsPageProps) {
   const auth = await requireAuth();
   const canManageAdminActions = auth.roles.includes("org_admin");
+  const canWrite = hasPermission(auth, "write");
   const params = await searchParams;
   const t = await getTranslations("campaigns");
 
@@ -69,12 +70,14 @@ export default async function CampaignsPage({ searchParams }: CampaignsPageProps
         }
         breadcrumbs={[{ label: t("breadcrumbRoot"), href: "/dashboard" }, { label: t("title") }]}
         actions={
-          <Button asChild variant="primary" size="sm">
-            <Link href="/campaigns/new">
-              <Plus size={16} aria-hidden="true" />
-              {t("actions.new")}
-            </Link>
-          </Button>
+          canWrite ? (
+            <Button asChild variant="primary" size="sm">
+              <Link href="/campaigns/new">
+                <Plus size={16} aria-hidden="true" />
+                {t("actions.new")}
+              </Link>
+            </Button>
+          ) : null
         }
       />
 

--- a/packages/web/src/app/(app)/dashboard/page.tsx
+++ b/packages/web/src/app/(app)/dashboard/page.tsx
@@ -33,16 +33,10 @@ interface CampaignWithStats {
  */
 export default async function DashboardPage() {
   const auth = await requireAuth();
-  /**
-   * Hide all three Quick Actions for `viewer` — not just the constituents
-   * one. The donations CTA links to `/donations/new`, whose `POST /v1/donations`
-   * is still `requireAuth` server-side (issue #176, audit row API-4) and
-   * would today let a viewer succeed at recording a manual donation. Hiding
-   * the section is therefore a real protective measure, not just affordance
-   * polish, until #176 lands. The campaigns CTA is a dead-end (campaigns API
-   * is already `requireWrite`), but bundling it keeps the section coherent —
-   * splitting "+ Donation hidden, + Campaign visible" would be confusing.
-   */
+  // Quick Actions are write-only affordances — all three CTAs link to
+  // `requireWrite`-gated POST endpoints (constituents in PR #170, donations
+  // in #176, campaigns already correct), so hiding them for `viewer` matches
+  // the API surface exactly.
   const canWrite = hasPermission(auth, "write");
   const t = (await getTranslations("dashboard")) as unknown as DashboardT;
   const locale = await getLocale();

--- a/packages/web/src/app/(app)/donations/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/donations/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { DonationForm } from "@/components/donations/donation-form";
 import { PageHeader } from "@/components/shared/page-header";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { requireAuth } from "@/lib/auth/guards";
+import { requirePermission } from "@/lib/auth/guards";
 import { type DonationDetail, donationDetailDonorName } from "@/models/donation";
 import { DonationService } from "@/services/DonationService";
 
@@ -28,7 +28,7 @@ async function fetchDonationOrNotFound(id: string): Promise<DonationDetail> {
 }
 
 export default async function EditDonationPage({ params }: EditDonationPageProps) {
-  await requireAuth();
+  await requirePermission("write");
   const { id } = await params;
   const donation = await fetchDonationOrNotFound(id);
 

--- a/packages/web/src/app/(app)/donations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/donations/[id]/page.tsx
@@ -43,7 +43,7 @@ async function fetchDonationOrNotFound(id: string): Promise<DonationDetail> {
 export default async function DonationDetailPage({ params }: DonationDetailPageProps) {
   const auth = await requireAuth();
   const canWrite = hasPermission(auth, "write");
-  const canDelete = auth.roles.includes("org_admin");
+  const canDelete = hasPermission(auth, "admin");
   const { id } = await params;
   const donation = await fetchDonationOrNotFound(id);
 

--- a/packages/web/src/app/(app)/donations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/donations/[id]/page.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/table";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { requireAuth } from "@/lib/auth/guards";
+import { hasPermission, requireAuth } from "@/lib/auth/guards";
 import { formatCurrency, formatDate } from "@/lib/format";
 import type { DonationAllocation, DonationDetail } from "@/models/donation";
 import { donationDetailDonorName } from "@/models/donation";
@@ -41,7 +41,9 @@ async function fetchDonationOrNotFound(id: string): Promise<DonationDetail> {
 }
 
 export default async function DonationDetailPage({ params }: DonationDetailPageProps) {
-  await requireAuth();
+  const auth = await requireAuth();
+  const canWrite = hasPermission(auth, "write");
+  const canDelete = auth.roles.includes("org_admin");
   const { id } = await params;
   const donation = await fetchDonationOrNotFound(id);
 
@@ -72,17 +74,21 @@ export default async function DonationDetailPage({ params }: DonationDetailPageP
                 {t("actions.back")}
               </Link>
             </Button>
-            <Button asChild size="sm">
-              <Link href={`/donations/${donation.id}/edit`}>
-                <Pencil size={16} aria-hidden="true" />
-                {t("actions.edit")}
-              </Link>
-            </Button>
+            {canWrite ? (
+              <Button asChild size="sm">
+                <Link href={`/donations/${donation.id}/edit`}>
+                  <Pencil size={16} aria-hidden="true" />
+                  {t("actions.edit")}
+                </Link>
+              </Button>
+            ) : null}
             <ReceiptPreviewButton donationId={donation.id} />
-            <DeleteDonationButton
-              donationId={donation.id}
-              donorName={donationDetailDonorName(donation) || null}
-            />
+            {canDelete ? (
+              <DeleteDonationButton
+                donationId={donation.id}
+                donorName={donationDetailDonorName(donation) || null}
+              />
+            ) : null}
           </>
         }
       />

--- a/packages/web/src/app/(app)/donations/donations-table.tsx
+++ b/packages/web/src/app/(app)/donations/donations-table.tsx
@@ -165,8 +165,8 @@ export function DonationsTable({
           return <Badge variant={RECEIPT_VARIANTS[status]}>{t(`receiptStatus.${status}`)}</Badge>;
         },
       },
-      // Drop the actions column entirely for viewers (no Edit, no Delete) so
-      // we don't render an `sr-only` "Actions" header above empty cells.
+      // Drop the actions column entirely when no row action is available,
+      // so we don't render an `sr-only` "Actions" header above empty cells.
       // Mirrors the constituents-table pattern from PR #170.
       ...(canWrite || canDelete
         ? [

--- a/packages/web/src/app/(app)/donations/donations-table.tsx
+++ b/packages/web/src/app/(app)/donations/donations-table.tsx
@@ -44,9 +44,16 @@ const RECEIPT_VARIANTS: Record<ReceiptStatus, BadgeVariant> = {
 interface DonationsTableProps {
   donations: DonationListRow[];
   pagination: DataTablePagination;
+  canWrite: boolean;
+  canDelete: boolean;
 }
 
-export function DonationsTable({ donations, pagination }: DonationsTableProps) {
+export function DonationsTable({
+  donations,
+  pagination,
+  canWrite,
+  canDelete,
+}: DonationsTableProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -158,24 +165,33 @@ export function DonationsTable({ donations, pagination }: DonationsTableProps) {
           return <Badge variant={RECEIPT_VARIANTS[status]}>{t(`receiptStatus.${status}`)}</Badge>;
         },
       },
-      {
-        id: "actions",
-        header: () => <span className="sr-only">{t("columns.actions")}</span>,
-        enableSorting: false,
-        cell: ({ row }) => (
-          <DonationActions
-            donation={row.original}
-            onDelete={() => setDonationToDelete(row.original)}
-            menuLabel={t("actions.menu", {
-              name: donationDonorName(row.original) ?? t("anonymousDonor"),
-            })}
-            editLabel={t("actions.edit")}
-            deleteLabel={t("actions.delete")}
-          />
-        ),
-      },
+      // Drop the actions column entirely for viewers (no Edit, no Delete) so
+      // we don't render an `sr-only` "Actions" header above empty cells.
+      // Mirrors the constituents-table pattern from PR #170.
+      ...(canWrite || canDelete
+        ? [
+            {
+              id: "actions",
+              header: () => <span className="sr-only">{t("columns.actions")}</span>,
+              enableSorting: false,
+              cell: ({ row }: { row: { original: DonationListRow } }) => (
+                <DonationActions
+                  donation={row.original}
+                  canEdit={canWrite}
+                  canDelete={canDelete}
+                  onDelete={() => setDonationToDelete(row.original)}
+                  menuLabel={t("actions.menu", {
+                    name: donationDonorName(row.original) ?? t("anonymousDonor"),
+                  })}
+                  editLabel={t("actions.edit")}
+                  deleteLabel={t("actions.delete")}
+                />
+              ),
+            } satisfies ColumnDef<DonationListRow>,
+          ]
+        : []),
     ],
-    [locale, t],
+    [canDelete, canWrite, locale, t],
   );
 
   return (
@@ -234,6 +250,8 @@ export function DonationsTable({ donations, pagination }: DonationsTableProps) {
 
 interface DonationActionsProps {
   donation: DonationListRow;
+  canEdit: boolean;
+  canDelete: boolean;
   onDelete: () => void;
   menuLabel: string;
   editLabel: string;
@@ -242,11 +260,16 @@ interface DonationActionsProps {
 
 function DonationActions({
   donation,
+  canEdit,
+  canDelete,
   onDelete,
   menuLabel,
   editLabel,
   deleteLabel,
 }: DonationActionsProps) {
+  if (!canEdit && !canDelete) {
+    return null;
+  }
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -260,26 +283,30 @@ function DonationActions({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
-        <DropdownMenuItem asChild>
-          <Link
-            href={`/donations/${donation.id}/edit`}
-            onClick={(event) => event.stopPropagation()}
+        {canEdit ? (
+          <DropdownMenuItem asChild>
+            <Link
+              href={`/donations/${donation.id}/edit`}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Pencil size={16} aria-hidden="true" />
+              {editLabel}
+            </Link>
+          </DropdownMenuItem>
+        ) : null}
+        {canDelete ? (
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onDelete();
+            }}
+            className="text-error focus:text-error"
           >
-            <Pencil size={16} aria-hidden="true" />
-            {editLabel}
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            onDelete();
-          }}
-          className="text-error focus:text-error"
-        >
-          <Trash2 size={16} aria-hidden="true" />
-          {deleteLabel}
-        </DropdownMenuItem>
+            <Trash2 size={16} aria-hidden="true" />
+            {deleteLabel}
+          </DropdownMenuItem>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/web/src/app/(app)/donations/new/page.tsx
+++ b/packages/web/src/app/(app)/donations/new/page.tsx
@@ -2,10 +2,10 @@ import { getTranslations } from "next-intl/server";
 
 import { DonationForm } from "@/components/donations/donation-form";
 import { PageHeader } from "@/components/shared/page-header";
-import { requireAuth } from "@/lib/auth/guards";
+import { requirePermission } from "@/lib/auth/guards";
 
 export default async function NewDonationPage() {
-  await requireAuth();
+  await requirePermission("write");
   const t = await getTranslations("donations.form");
   const tDonations = await getTranslations("donations");
 

--- a/packages/web/src/app/(app)/donations/page.tsx
+++ b/packages/web/src/app/(app)/donations/page.tsx
@@ -44,7 +44,7 @@ function parseUuid(value: string | string[] | undefined): string | undefined {
 export default async function DonationsPage({ searchParams }: DonationsPageProps) {
   const auth = await requireAuth();
   const canWrite = hasPermission(auth, "write");
-  const canDelete = auth.roles.includes("org_admin");
+  const canDelete = hasPermission(auth, "admin");
   const params = await searchParams;
   const t = await getTranslations("donations");
 

--- a/packages/web/src/app/(app)/donations/page.tsx
+++ b/packages/web/src/app/(app)/donations/page.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from "@/components/shared/page-header";
 import { Button } from "@/components/ui/button";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { requireAuth } from "@/lib/auth/guards";
+import { hasPermission, requireAuth } from "@/lib/auth/guards";
 import type { DonationListResponse } from "@/models/donation";
 import { DonationService } from "@/services/DonationService";
 
@@ -42,7 +42,9 @@ function parseUuid(value: string | string[] | undefined): string | undefined {
 }
 
 export default async function DonationsPage({ searchParams }: DonationsPageProps) {
-  await requireAuth();
+  const auth = await requireAuth();
+  const canWrite = hasPermission(auth, "write");
+  const canDelete = auth.roles.includes("org_admin");
   const params = await searchParams;
   const t = await getTranslations("donations");
 
@@ -87,19 +89,26 @@ export default async function DonationsPage({ searchParams }: DonationsPageProps
         }
         breadcrumbs={[{ label: t("breadcrumbRoot"), href: "/dashboard" }, { label: t("title") }]}
         actions={
-          <Button asChild variant="primary" size="sm">
-            <Link href="/donations/new">
-              <Plus size={16} aria-hidden="true" />
-              {t("actions.new")}
-            </Link>
-          </Button>
+          canWrite ? (
+            <Button asChild variant="primary" size="sm">
+              <Link href="/donations/new">
+                <Plus size={16} aria-hidden="true" />
+                {t("actions.new")}
+              </Link>
+            </Button>
+          ) : null
         }
       />
 
       <DonationsFilters dateFrom={dateFrom ?? ""} dateTo={dateTo ?? ""} />
 
       {hasAny ? (
-        <DonationsTable donations={result.data} pagination={result.pagination} />
+        <DonationsTable
+          donations={result.data}
+          pagination={result.pagination}
+          canWrite={canWrite}
+          canDelete={canDelete}
+        />
       ) : (
         <div className="rounded-2xl bg-surface-container-lowest shadow-card">
           <EmptyState icon={Gift} title={t("empty.title")} description={t("empty.seedHint")} />


### PR DESCRIPTION
## Summary

Closes the remaining Phase 1 RBAC audit gaps from parent #162, bundled into a single PR per the audit's §C.3 split (one issue per module — donations #176, pledges #177, campaigns #178). Pattern mirrors PR #170 (constituents): write endpoints use `requireWrite`, destructive endpoints use `requireOrgAdmin`, frontend write affordances are hidden via `hasPermission()` so viewers never see dead-end CTAs.

Close #176
Close #177
Close #178.

## API changes

| Route | Before | After | Audit row |
|---|---|---|---|
| `POST /v1/donations` | `requireAuth` | `requireWrite` | API-4 (#176) |
| `PATCH /v1/donations/:id` | `requireAuth` | `requireWrite` | API-5 (#176) |
| `DELETE /v1/donations/:id` | `requireAuth` | `requireOrgAdmin` | API-6 (#176) |
| `POST /v1/pledges` | `requireAuth` | `requireWrite` | API-7 (#177) |

GET endpoints stay on `requireAuth` per audit Table B1 — reads are intentionally open to viewer.

## Frontend changes

**Donations** (#176):
- `/donations` list: hide "+ New" CTA + per-row Edit/Delete dropdown for viewer; row Delete only renders for `org_admin` (FE-5, FE-7)
- `/donations/new`, `/donations/[id]/edit`: `requireAuth()` → `requirePermission("write")` (FE-6, FE-8)
- `/donations/[id]` detail: Edit hidden unless `canWrite`, Delete hidden unless `org_admin` (FE-7)

**Campaigns** (#178 — API was already correct, web-only fix):
- `/campaigns` list: hide "+ New" CTA for viewer (FE-9)
- `/campaigns/[id]` detail: hide "Edit" for viewer (FE-11)
- `/campaigns/new`, `/campaigns/[id]/edit`: `requireAuth()` → `requirePermission("write")` (FE-10, FE-12)

**Dashboard**: removed the Quick-Actions caveat block — donations CTA is now backed by `requireWrite` server-side, so the comment promising the follow-up is obsolete.

## Tests

`packages/api/src/tests/integration/donations.test.ts`:
- **Donations viewer-role enforcement (issue #176)** — 9 tests covering both directions of the boundary:
  - viewer-403 on POST/PATCH/DELETE (one with RFC 9457 body-shape lock)
  - user-200/201 on POST/PATCH (parity with org_admin)
  - user-403 on DELETE (org_admin only)
  - org_admin-200 on DELETE
  - viewer-200 on GET list + GET detail (sanity: don't over-block reads)
- **Pledges viewer-role enforcement (issue #177)** — 4 tests:
  - viewer-403 on POST (with RFC 9457 body-shape lock)
  - user-201 + org_admin-201 (parity)
  - viewer-200 on GET installments (audit Table B1)

All 42 donations.test.ts tests pass. Pre-existing tenant-admin failures on local DB are unrelated (missing `ownership_confirmed_at` column from another branch's migration) — confirmed by checking out main locally and reproducing the same failures.

## Audit doc

`docs/security/rbac-audit-2026-04-27.md` §C.1: API-4..7 and FE-5..12 marked "Fixed in #176/#177/#178". §C.2 severity table now shows zero outstanding rows across High/Medium/Low — Phase 1 RBAC is complete.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [x] `pnpm run format` — clean
- [x] `pnpm run lint` — only pre-existing warnings (`p/[id]/page.tsx`, `proxy.ts`)
- [x] `pnpm exec vitest run src/tests/integration/donations.test.ts` — 42/42 pass
- [x] Browser smoke test: viewer JWT cannot reach `/donations/new`, `/donations/[id]/edit`, `/campaigns/new`, `/campaigns/[id]/edit` (404), and CTAs are hidden on list + detail pages
- [x] Multi-agent review (security, frontend, API, log analyst) — running next

🤖 Generated with [Claude Code](https://claude.com/claude-code)