### PR TITLE
chore(locale): drop transitional payload.country fallback (#160)

### DIFF
--- a/packages/api/src/modules/signup/service.ts
+++ b/packages/api/src/modules/signup/service.ts
@@ -48,9 +48,7 @@
  *  - PR #143 review: KC org-adoption requires `org_id` attribute match;
  *    KC user-create 409 fails loud (no silent takeover); outbox events
  *    gated on actual state changes (no duplicate `tenant.verified` or
- *    `user.jit_provisioned` on recovery re-runs); resend payload
- *    carries `country` recovered from the original requested-event for
- *    EN/FR template selection.
+ *    `user.jit_provisioned` on recovery re-runs).
  */
 
 import { randomUUID } from "node:crypto";
@@ -291,12 +289,7 @@ export async function signup(input: SignupInput): Promise<SignupResult> {
             tenantId: t.id,
             invitationId,
             expiresAt: expiresAt.toISOString(),
-            // Issue #153: `locale` is the authoritative field the worker reads.
-            // `country` is kept for one transitional release so in-flight jobs
-            // emitted before the worker upgrade still resolve a locale via the
-            // worker-side fallback; remove after the queue has drained.
             locale: defaultLocale,
-            country: normalisedCountry,
           },
         },
       ]);
@@ -384,12 +377,11 @@ export async function resendVerification(email: string): Promise<ResendResult> {
     .select({
       tenantId: tenants.id,
       status: tenants.status,
-      // Issue #153: read country + default_locale directly from the row so
-      // the resend payload can stamp the right `locale` without walking the
-      // outbox. Both columns are populated at signup time (or backfilled by
-      // migration 0027) so a NULL here only happens for legacy archived
-      // tenants the resend wouldn't match anyway.
-      country: tenants.country,
+      // Issue #153: read default_locale directly from the row so the resend
+      // payload can stamp the right `locale` without walking the outbox.
+      // Populated at signup time (or backfilled by migration 0027) so a NULL
+      // here only happens for legacy archived tenants the resend wouldn't
+      // match anyway.
       defaultLocale: tenants.defaultLocale,
       invitationId: invitations.id,
       invitationToken: invitations.token,
@@ -460,11 +452,7 @@ export async function resendVerification(email: string): Promise<ResendResult> {
         tenantId: row.tenantId,
         invitationId: row.invitationId,
         expiresAt: expiresAt.toISOString(),
-        // `locale` is authoritative; `country` is kept for one transitional
-        // release so jobs already on the queue continue to render correctly
-        // before the worker upgrade lands.
         locale: localeForResend,
-        ...(row.country ? { country: row.country } : {}),
       },
     });
   });

--- a/packages/worker/src/lib/payload-locale.test.ts
+++ b/packages/worker/src/lib/payload-locale.test.ts
@@ -1,63 +1,21 @@
 /**
- * Unit coverage for `resolvePayloadLocale` (issue #153 / PR #158 QA review).
- *
- * Covers the rolling-deploy invariant: a job enqueued by the pre-#158 API
- * (carrying only `country`) must still render in the right language when
- * drained by a post-#158 worker. Once the queue has drained and the
- * legacy `country` branch is removed, this suite shrinks to the happy
- * path + the default-fallback case.
+ * Unit coverage for `resolvePayloadLocale` (issue #153).
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { resolvePayloadLocale } from "./payload-locale.js";
 
-function makeLog() {
-  return { warn: vi.fn() };
-}
-
 describe("resolvePayloadLocale", () => {
-  it("prefers payload.locale when it's a supported BCP-47 value", () => {
-    const log = makeLog();
-    expect(resolvePayloadLocale({ locale: "fr" }, log)).toBe("fr");
-    expect(resolvePayloadLocale({ locale: "en" }, log)).toBe("en");
-    // Happy path emits no warn — only the fallbacks do.
-    expect(log.warn).not.toHaveBeenCalled();
+  it("returns the payload locale when it's a supported BCP-47 value", () => {
+    expect(resolvePayloadLocale({ locale: "fr" })).toBe("fr");
+    expect(resolvePayloadLocale({ locale: "en" })).toBe("en");
   });
 
-  it("ignores an unsupported locale and falls back to country", () => {
-    const log = makeLog();
-    expect(resolvePayloadLocale({ locale: "de", country: "FR" }, log)).toBe("fr");
-    expect(log.warn).toHaveBeenCalledOnce();
+  it("falls back to APP_DEFAULT_LOCALE ('fr') when the locale is unsupported", () => {
+    expect(resolvePayloadLocale({ locale: "de" })).toBe("fr");
   });
 
-  it("derives 'fr' from a legacy country='FR' payload (case-insensitive)", () => {
-    const log = makeLog();
-    expect(resolvePayloadLocale({ country: "FR" }, log)).toBe("fr");
-    expect(resolvePayloadLocale({ country: "fr" }, log)).toBe("fr");
-    expect(log.warn).toHaveBeenCalledTimes(2);
-    // Each warn carries the country for SRE breadcrumbs.
-    expect(log.warn.mock.calls[0]?.[0]).toMatchObject({ country: "FR" });
-  });
-
-  it("derives 'en' from a legacy non-FR country payload", () => {
-    const log = makeLog();
-    expect(resolvePayloadLocale({ country: "BE" }, log)).toBe("en");
-    expect(resolvePayloadLocale({ country: "DE" }, log)).toBe("en");
-    expect(log.warn).toHaveBeenCalledTimes(2);
-  });
-
-  it("falls back to APP_DEFAULT_LOCALE ('fr') when neither field is present", () => {
-    const log = makeLog();
-    expect(resolvePayloadLocale({}, log)).toBe("fr");
-    expect(log.warn).toHaveBeenCalledOnce();
-    // The "missing both fields" warn carries an empty object so SRE can
-    // grep on the message text without filtering by `country`.
-    expect(log.warn.mock.calls[0]?.[0]).toEqual({});
-  });
-
-  it("treats empty / whitespace-only country as missing", () => {
-    const log = makeLog();
-    expect(resolvePayloadLocale({ country: "" }, log)).toBe("fr");
-    expect(resolvePayloadLocale({ country: "   " }, log)).toBe("fr");
+  it("falls back to APP_DEFAULT_LOCALE ('fr') when the locale is missing", () => {
+    expect(resolvePayloadLocale({})).toBe("fr");
   });
 });

--- a/packages/worker/src/lib/payload-locale.ts
+++ b/packages/worker/src/lib/payload-locale.ts
@@ -1,18 +1,9 @@
 /**
  * BCP-47 locale resolution for email job payloads (issue #153).
  *
- * The API stamps `locale` on every signup/invitation outbox payload after
- * #158 lands. For one transitional release we still accept the legacy
- * `country` field so jobs already enqueued before the upgrade render
- * correctly: same FR→fr / else-→en mapping the prior worker used. Once
- * the queue has drained post-deploy, a follow-up cleanup PR removes the
- * country branch (tracked separately).
- *
- * Returns `APP_DEFAULT_LOCALE` ('fr') if the payload carries neither —
- * the email still goes out, the user just sees the app's default
- * language. We log a warn so SRE can spot legacy producers, but do not
- * throw (the worker would retry until the attempt budget is exhausted
- * and the email would never land).
+ * Returns `APP_DEFAULT_LOCALE` ('fr') if the payload doesn't carry a
+ * supported locale — the email still goes out, the user just sees the
+ * app's default language.
  *
  * Lives in its own module so the unit test can import it without booting
  * the worker singletons that fire at the bottom of `worker.ts`.
@@ -20,23 +11,6 @@
 
 import { APP_DEFAULT_LOCALE, isSupportedLocale, type Locale } from "@givernance/shared/i18n";
 
-/** Minimal shape of the structured logger this helper needs. */
-export interface PayloadLocaleLogger {
-  warn(obj: Record<string, unknown>, msg: string): void;
-}
-
-export function resolvePayloadLocale(
-  payload: Record<string, unknown>,
-  log: PayloadLocaleLogger,
-): Locale {
-  if (isSupportedLocale(payload.locale)) return payload.locale;
-  if (typeof payload.country === "string" && payload.country.trim().length > 0) {
-    log.warn(
-      { country: payload.country },
-      "Email job carries legacy `country` only; falling back to country-derived locale (issue #153 transitional)",
-    );
-    return payload.country.toUpperCase() === "FR" ? "fr" : "en";
-  }
-  log.warn({}, "Email job carries no `locale` or `country`; falling back to APP_DEFAULT_LOCALE");
-  return APP_DEFAULT_LOCALE;
+export function resolvePayloadLocale(payload: Record<string, unknown>): Locale {
+  return isSupportedLocale(payload.locale) ? payload.locale : APP_DEFAULT_LOCALE;
 }

--- a/packages/worker/src/processors/signup-email.ts
+++ b/packages/worker/src/processors/signup-email.ts
@@ -22,10 +22,8 @@ export interface SignupEmailJobPayload {
   invitationId: string;
   expiresAt: string;
   /**
-   * BCP-47 locale resolved at enqueue time (issue #153). The worker
-   * trusts this value and does not infer locale from country. The
-   * dispatcher fills it for us — see `worker.ts` for the legacy-payload
-   * fallback that handles in-flight jobs from before issue #153 shipped.
+   * BCP-47 locale resolved at enqueue time (issue #153). The dispatcher
+   * fills it from the outbox payload via `resolvePayloadLocale`.
    */
   locale: Locale;
 }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -134,7 +134,7 @@ async function processDomainEvent(job: Job): Promise<void> {
       tenantId,
       invitationId: payload.invitationId as string,
       expiresAt: payload.expiresAt as string,
-      locale: resolvePayloadLocale(payload, log),
+      locale: resolvePayloadLocale(payload),
     };
     const result = await processSignupVerificationEmail(emailPayload);
     // `not_found` / `already_accepted` are terminal no-ops (old token rotated,
@@ -154,7 +154,7 @@ async function processDomainEvent(job: Job): Promise<void> {
       tenantId,
       invitationId,
       inviterUserId,
-      locale: resolvePayloadLocale(payload, log),
+      locale: resolvePayloadLocale(payload),
     };
     const result = await processTeamInviteEmail(emailPayload);
     log.info({ invitationId, eventType: type, ...result }, "Team-invite email dispatched");


### PR DESCRIPTION
## Summary

- The transitional `country` fallback in `resolvePayloadLocale` (and the matching `country` field on `signup_verification_*` outbox payloads) was added in #158 to bridge in-flight BullMQ jobs across a worker upgrade in production.
- Givernance is pre-deployment — no live queue, no in-flight jobs, no Loki to tail — so the fallback never had work to do. Shipping it through the first deploy and removing it later would just carry dead code unnecessarily.
- Closes #160. The original \"wait one release after deploy\" gate from that issue doesn't apply because there's no prior release to wait on.

## Changes

- `packages/worker/src/lib/payload-locale.ts` — collapse to a one-line `isSupportedLocale` check; drop the `PayloadLocaleLogger` parameter (no warns left to emit).
- `packages/worker/src/worker.ts` — update both `resolvePayloadLocale` call sites to drop the `log` argument.
- `packages/worker/src/processors/signup-email.ts` — trim the doc comment that referenced the removed legacy-payload fallback.
- `packages/api/src/modules/signup/service.ts` — stop emitting `country` on the email-bound outbox payloads (`tenant.signup_verification_requested` / `tenant.signup_verification_resent`). The `tenant.self_signup_started` payload keeps `country` since that's an analytics/legal event, not an email driver. Drop the now-unused `country: tenants.country` SELECT on resend.
- `packages/worker/src/lib/payload-locale.test.ts` — reduce to the three non-transitional cases (supported locale, unsupported locale, missing locale).

Net diff: **24 insertions / 106 deletions** across 5 files.

## What's preserved (not part of the cleanup)

- `tenants.country` column and the migration 0027 backfill — still load-bearing for analytics + the per-tenant `default_locale` derivation.
- `country` on the `tenant.self_signup_started` outbox event — analytics/legal, not consumed by the email worker.
- `tests/integration/locale-resolution.test.ts` — exercises migration 0027's outbox-walking backfill against historically-shaped rows it seeds itself; not affected by what new code emits.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm build` — passes
- [x] `pnpm run format` / `pnpm run lint` — clean (3 pre-existing warnings unchanged)
- [x] `pnpm test` — 496 API + 20 worker + 57 web = **573/573 passing** locally
- [x] `signup.test.ts` outbox assertions still pass (they assert `payload.locale`, not `payload.country`)
- [x] `payload-locale.test.ts` retained: supported locale, unsupported locale, missing locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)