### PR TITLE
fix(deploy): bake server-side API_URL into the Next.js build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,14 @@ COPY . .
 # Install dependencies using cache
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
+# Bake the server-side API URL into the Next.js build. `next.config.ts`
+# rewrites `/api/v1/:path*` to `${API_URL}/v1/:path*`, and that destination
+# string is materialised in `routes-manifest.json` at build time — runtime
+# env injection (Kamal `env.clear`) cannot replace it. The default targets
+# the local dev API; deployment pipelines override via Kamal `builder.args`.
+ARG API_URL=http://localhost:4000
+ENV API_URL=$API_URL
+
 # Build all workspace projects
 RUN pnpm run -r build
 

--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -78,6 +78,11 @@ env:
 builder:
   arch: amd64
   dockerfile: Dockerfile
+  args:
+    # The Next.js rewrite destination is baked into routes-manifest.json
+    # at build time (see Dockerfile ARG API_URL comment). `env.clear`
+    # injection at runtime cannot reach it.
+    API_URL: https://api.staging.givernance.org
 
 # Use accessories for external services
 accessories:


### PR DESCRIPTION
## Summary
- Browser-side mutating calls (`PUT /v1/constituents/:id`, `PUT /v1/campaigns/:id/public-page`) and SSR list fetches (`campaigns?page=…`, `funds?page=…`) all returned **500** on staging once the Keycloak path was clean. Web container logs:

  ```
  Failed to proxy http://localhost:4000/v1/funds?page=1&perPage=100
  AggregateError: ECONNREFUSED 127.0.0.1:4000
  ```

- **Root cause**: `packages/web/next.config.ts` rewrites `/api/v1/:path*` to `${process.env.API_URL || "http://localhost:4000"}/v1/:path*`. Next.js materialises the destination string into `routes-manifest.json` at `next build` time. The manifest is then frozen into the image — Kamal's runtime `env.clear` injection cannot reach it. With `API_URL` unset during `pnpm run -r build` inside the Docker stage, the rewrite was baked with the dev fallback, and every client-side hit through the rewrite resolved to localhost on the web container.

- **Fix**: declare `ARG API_URL=http://localhost:4000` in the Dockerfile (still defaults to dev), and pass the staging target via Kamal `builder.args.API_URL`. Same image artifact still needs to be rebuilt per environment, but the immutable image now reaches the right upstream at runtime without further env coupling.

- **Same fix unblocks four downstream user-visible symptoms**:
  - Tenant settings page rendered empty (`TenantService.getTenant` failing through the rewrite).
  - Donation form constituent picker stayed empty (`ConstituentService.listConstituents` catch-swallowed the 500).
  - Campaign edit form's "load campaigns/funds" toast (parallel fetches both 500'd).
  - `PUT /v1/constituents/:id`, `PUT /v1/campaigns/:id/public-page` 500s.

## Test plan
- [x] `pnpm typecheck` (all 6 packages pass)
- [x] `pnpm biome check .` (9 pre-existing warnings, 0 errors)
- [ ] Run **Deploy to Staging** workflow against this branch (`workflow_dispatch`)
- [ ] After deploy, ssh root@VPS and verify the web container logs are free of `localhost:4000` proxy errors
- [ ] Reload `https://staging.givernance.org/dashboard`, then exercise:
  - tenant settings form loads with the org name pre-filled
  - donation form constituent picker shows the constituent list
  - editing a campaign's public page and saving as published succeeds (no 500)
  - editing a constituent and saving succeeds (no 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)