### PR TITLE
fix(web): static locale message imports to fix donation-create ENOENT

### DIFF
--- a/packages/web/src/i18n/request.ts
+++ b/packages/web/src/i18n/request.ts
@@ -1,7 +1,24 @@
 import { APP_DEFAULT_LOCALE, isSupportedLocale, type Locale } from "@givernance/shared/i18n";
 import { cookies, headers } from "next/headers";
 import { getRequestConfig } from "next-intl/server";
+import enMessages from "../../messages/en.json";
+import frMessages from "../../messages/fr.json";
 import { createServerApiClient } from "@/lib/api/client-server";
+
+/**
+ * Static locale → message-bundle map. Replaces a previous template-literal
+ * dynamic import (`await import(\`../../messages/${locale}.json\`)`) which
+ * Next.js 16 was bundling against a path that resolved correctly in dev
+ * but pointed outside the standalone `.next/server` tree at runtime in the
+ * monorepo image — surface: `ENOENT: open '/app/packages/messages/fr.json'`
+ * when the donation-create flow re-rendered an i18n boundary. Static
+ * imports give the bundler explicit references so both files are emitted
+ * to the server bundle.
+ */
+const MESSAGES_BY_LOCALE: Record<Locale, typeof enMessages> = {
+  en: enMessages,
+  fr: frMessages,
+};
 
 /**
  * Supported locales — ADR-015: fr (default), en for Phase 2.
@@ -87,6 +104,6 @@ export default getRequestConfig(async () => {
 
   return {
     locale,
-    messages: (await import(`../../messages/${locale}.json`)).default,
+    messages: MESSAGES_BY_LOCALE[locale],
   };
 });

--- a/packages/web/src/i18n/request.ts
+++ b/packages/web/src/i18n/request.ts
@@ -1,9 +1,9 @@
 import { APP_DEFAULT_LOCALE, isSupportedLocale, type Locale } from "@givernance/shared/i18n";
 import { cookies, headers } from "next/headers";
 import { getRequestConfig } from "next-intl/server";
+import { createServerApiClient } from "@/lib/api/client-server";
 import enMessages from "../../messages/en.json";
 import frMessages from "../../messages/fr.json";
-import { createServerApiClient } from "@/lib/api/client-server";
 
 /**
  * Static locale → message-bundle map. Replaces a previous template-literal


### PR DESCRIPTION
## Summary
- Donation-create flow on staging logged `ENOENT: no such file or directory, open '/app/packages/messages/fr.json'` on every i18n boundary that re-rendered after the server action.
- Root cause: `packages/web/src/i18n/request.ts` resolved messages with a template-literal dynamic import — `await import(\`../../messages/${locale}.json\`)`. In dev the relative path resolves correctly; in production Next.js 16 bundles `request.ts` into the standalone server output and the `../../` resolves outside `.next/server` rather than to `packages/web/messages`. The JSON files ship in the image at `/app/packages/web/messages/{en,fr}.json` but the bundle was looking under `/app/packages/messages/...`.
- Fix: swap the dynamic import for two static imports and a `MESSAGES_BY_LOCALE` map. The bundler now has explicit references to both JSONs and emits them into the chunk the request resolver loads, so locale lookup is in-memory at runtime.

## Test plan
- [x] `pnpm --filter @givernance/web build` succeeds
- [x] `pnpm --filter @givernance/web test` (19 files, 57 tests, all green)
- [ ] Run **Deploy to Staging** workflow against this branch (`workflow_dispatch`)
- [ ] After deploy, log in to https://staging.givernance.org and create a donation — confirm no `ENOENT` toast / page error
- [ ] Tail web logs (`docker logs givernance-web` on staging VPS) — `ENOENT.*messages` should be absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)