### PR TITLE
feat(payments): Stripe Connect settings UI + donor Payment Element + local setup docs

### DIFF
--- a/.claude/skills/stripe-best-practices/SKILL.md
+++ b/.claude/skills/stripe-best-practices/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: stripe-best-practices
+description: >-
+  Guides Stripe integration decisions — API selection (Checkout Sessions vs
+  PaymentIntents), Connect platform setup (Accounts v2, controller properties),
+  billing/subscriptions, Treasury financial accounts, integration surfaces
+  (Checkout, Payment Element), migrating from deprecated Stripe APIs, and
+  security best practices (API key management, restricted keys, webhooks,
+  OAuth). Use when building, modifying, or reviewing any Stripe integration —
+  including accepting payments, building marketplaces, integrating Stripe,
+  processing payments, setting up subscriptions, creating connected accounts, or
+  implementing secure key handling.
+
+---
+
+Latest Stripe API version: **2026-04-22.dahlia**. Always use the latest API version and SDK unless the user specifies otherwise.
+
+## Integration routing
+
+| Building…                                                                | Recommended API                     | Details                  |
+| ------------------------------------------------------------------------ | ----------------------------------- | ------------------------ |
+| One-time payments                                                        | Checkout Sessions                   | <references/payments.md> |
+| Custom payment form with embedded UI                                     | Checkout Sessions + Payment Element | <references/payments.md> |
+| Saving a payment method for later                                        | Setup Intents                       | <references/payments.md> |
+| Connect platform or marketplace                                          | Accounts v2 (`/v2/core/accounts`)   | <references/connect.md>  |
+| Subscriptions or recurring billing                                       | Billing APIs + Checkout Sessions    | <references/billing.md>  |
+| Embedded financial accounts / banking                                    | v2 Financial Accounts               | <references/treasury.md> |
+| Security (key management, RAKs, webhooks, OAuth, 2FA, Connect liability) | See security reference              | <references/security.md> |
+
+Read the relevant reference file before answering any integration question or writing code.
+
+## Key documentation
+
+When the user’s request does not clearly fit a single domain above, consult:
+
+- [Integration Options](https://docs.stripe.com/payments/payment-methods/integration-options.md) — Start here when designing any integration.
+- [API Tour](https://docs.stripe.com/payments-api/tour.md) — Overview of Stripe’s API surface.
+- [Go Live Checklist](https://docs.stripe.com/get-started/checklist/go-live.md) — Review before launching.

--- a/.claude/skills/stripe-best-practices/references/billing.md
+++ b/.claude/skills/stripe-best-practices/references/billing.md
@@ -1,0 +1,24 @@
+# Billing / Subscriptions
+
+## Table of contents
+
+- When to use Billing APIs
+- Recommended frontend pairing
+- Traps to avoid
+
+## When to use Billing APIs
+
+If the user has a recurring revenue model (subscriptions, usage-based billing, seat-based pricing), use the Billing APIs to [plan their integration](https://docs.stripe.com/billing/subscriptions/design-an-integration.md) instead of a direct PaymentIntent integration.
+
+Review the [Subscription Use Cases](https://docs.stripe.com/billing/subscriptions/use-cases.md) and [SaaS guide](https://docs.stripe.com/saas.md) to find the right pattern for the user’s pricing model.
+
+## Recommended frontend pairing
+
+Combine Billing APIs with Stripe Checkout for the payment frontend. Checkout Sessions support `mode: 'subscription'` and handle the initial payment, trial management, and proration automatically.
+
+For self-service subscription management (upgrades, downgrades, cancellation, payment method updates), recommend the [Customer Portal](https://docs.stripe.com/customer-management/integrate-customer-portal.md).
+
+## Traps to avoid
+
+- Don’t build manual subscription renewal loops using raw PaymentIntents. Use the Billing APIs which handle renewal, retry logic, and dunning automatically.
+- Don’t use the deprecated `plan` object. Use [Prices](https://docs.stripe.com/api/prices.md) instead.

--- a/.claude/skills/stripe-best-practices/references/connect.md
+++ b/.claude/skills/stripe-best-practices/references/connect.md
@@ -1,0 +1,48 @@
+# Connect / platforms
+
+## Table of contents
+
+- Accounts v2 API
+- Controller properties
+- Charge types
+- Integration guides
+
+## Accounts v2 API
+
+For new Connect platforms, ALWAYS use the [Accounts v2 API](https://docs.stripe.com/connect/accounts-v2.md) (`POST /v2/core/accounts`). This is Stripe’s actively invested path and ensures long-term support.
+
+**Traps to avoid:** Don’t use the legacy `type` parameter (`type: 'express'`, `type: 'custom'`, `type: 'standard'`) in `POST /v1/accounts` for new platforms unless the user has explicitly requested v1.
+
+## Controller properties
+
+Configure connected accounts using `controller` properties instead of legacy account types:
+
+| Property                            | Controls                                     |
+| ----------------------------------- | -------------------------------------------- |
+| `controller.losses.payments`        | Who is liable for negative balances          |
+| `controller.fees.payer`             | Who pays Stripe fees                         |
+| `controller.stripe_dashboard.type`  | Dashboard access (`full`, `express`, `none`) |
+| `controller.requirement_collection` | Who collects onboarding requirements         |
+
+Use `defaults.responsibilities`, `dashboard`, and `configuration` as described in [connected account configuration](https://docs.stripe.com/connect/accounts-v2/connected-account-configuration.md).
+
+Always describe accounts in terms of their responsibility settings, dashboard access, and [capabilities](https://docs.stripe.com/connect/account-capabilities.md) to describe what connected accounts can do.
+
+**Traps to avoid:** Don’t use the terms “Standard”, “Express”, or “Custom” as account types. These are legacy categories that bundle together responsibility, dashboard, and requirement decisions into opaque labels. Controller properties give explicit control over each dimension.
+
+## Charge types
+
+Choose one charge type per integration — don’t mix them. For most platforms, start with destination charges:
+
+- **Destination charges** — Use when the platform accepts liability for negative balances. Funds route to the connected account via `transfer_data.destination`.
+- **Direct charges** — Use when the platform wants Stripe to take risk on the connected account. The charge is created on the connected account directly.
+
+Use `on_behalf_of` to control the merchant of record, but only after reading [how charges work in Connect](https://docs.stripe.com/connect/charges.md).
+
+**Traps to avoid:** Don’t use the Charges API for Connect fund flows — use PaymentIntents or Checkout Sessions with `transfer_data` or `on_behalf_of`. Don’t mix charge types within a single integration.
+
+## Integration guides
+
+- [SaaS platforms and marketplaces guide](https://docs.stripe.com/connect/saas-platforms-and-marketplaces.md) — Choosing the right integration shape.
+- [Interactive platform guide](https://docs.stripe.com/connect/interactive-platform-guide.md) — Step-by-step platform builder.
+- [Design an integration](https://docs.stripe.com/connect/design-an-integration.md) — Detailed risk and responsibility decisions.

--- a/.claude/skills/stripe-best-practices/references/payments.md
+++ b/.claude/skills/stripe-best-practices/references/payments.md
@@ -1,0 +1,63 @@
+# Payments
+
+## Table of contents
+
+- API hierarchy
+- Integration surfaces
+- Payment Element guidance
+- Saving payment methods
+- Dynamic payment methods
+- Deprecated APIs and migration paths
+- PCI compliance
+
+## API hierarchy
+
+Use the [Checkout Sessions API](https://docs.stripe.com/api/checkout/sessions.md) (`checkout.sessions.create`) for on-session payments. It supports one-time payments and subscriptions and handles taxes, discounts, shipping, and adaptive pricing automatically.
+
+Use the [PaymentIntents API](https://docs.stripe.com/payments/paymentintents/lifecycle.md) for off-session payments, or when the merchant needs to model checkout state independently and just create a charge.
+
+**Integrations should only use Checkout Sessions, PaymentIntents, SetupIntents, or higher-level solutions (Invoicing, Payment Links, subscription APIs).**
+
+## Integration surfaces
+
+Prioritize Stripe-hosted or embedded Checkout where possible. Use in this order of preference:
+
+1. **Payment Links** — No-code. Best for simple products.
+1. **Checkout** ([docs](https://docs.stripe.com/payments/checkout.md)) — Stripe-hosted or embedded form. Best for most web apps.
+1. **Payment Element** ([docs](https://docs.stripe.com/payments/payment-element.md)) — Embedded UI component for advanced customization.
+   - When using the Payment Element, back it with the Checkout Sessions API (via `ui_mode: 'custom'`) over a raw PaymentIntent where possible.
+
+**Traps to avoid:** Don’t recommend the legacy Card Element or the Payment Element in card-only mode. If the user asks for the Card Element, advise them to [migrate to the Payment Element](https://docs.stripe.com/payments/payment-element/migration.md).
+
+## Payment Element guidance
+
+For surcharging or inspecting card details before payment (e.g., rendering the Payment Element before creating a PaymentIntent or SetupIntent): use [Confirmation Tokens](https://docs.stripe.com/payments/finalize-payments-on-the-server.md). Don’t recommend `createPaymentMethod` or `createToken` from Stripe.js.
+
+## Saving payment methods
+
+Use the [Setup Intents API](https://docs.stripe.com/api/setup_intents.md) to save a payment method for later use.
+
+**Traps to avoid:** Don’t use the Sources API to save cards to customers. The Sources API is deprecated — Setup Intents is the correct approach.
+
+## Dynamic payment methods
+
+Advise users to enable dynamic payment methods in the Stripe Dashboard rather than passing specific [`payment_method_types`](https://docs.stripe.com/api/payment_intents/create.md#create_payment_intent-payment_method_types) in the PaymentIntent or SetupIntent. Stripe automatically selects payment methods based on the customer’s location, wallets, and preferences when the Payment Element is used.
+
+## Deprecated APIs and migration paths
+
+Never recommend the Charges API. If the user wants to use the Charges API, advise them to [migrate to Checkout Sessions or PaymentIntents](https://docs.stripe.com/payments/payment-intents/migration/charges.md).
+
+Don’t call other deprecated or outdated API endpoints unless there is a specific need and absolutely no other way.
+
+| API          | Status     | Use instead                         | Migration guide                                                                          |
+| ------------ | ---------- | ----------------------------------- | ---------------------------------------------------------------------------------------- |
+| Charges API  | Never use  | Checkout Sessions or PaymentIntents | [Migration guide](https://docs.stripe.com/payments/payment-intents/migration/charges.md) |
+| Sources API  | Deprecated | Setup Intents                       | [Setup Intents docs](https://docs.stripe.com/api/setup_intents.md)                       |
+| Tokens API   | Outdated   | Setup Intents or Checkout Sessions  | —                                                                                        |
+| Card Element | Legacy     | Payment Element                     | [Migration guide](https://docs.stripe.com/payments/payment-element/migration.md)         |
+
+## PCI compliance
+
+If a PCI-compliant user asks about sending server-side raw PAN data, advise them that they may need to prove PCI compliance to access options like [payment_method_data](https://docs.stripe.com/api/payment_intents/create.md#create_payment_intent-payment_method_data).
+
+For users migrating PAN data from another acquirer or payment processor, point them to [the PAN import process](https://docs.stripe.com/get-started/data-migrations/pan-import.md).

--- a/.claude/skills/stripe-best-practices/references/security.md
+++ b/.claude/skills/stripe-best-practices/references/security.md
@@ -1,0 +1,109 @@
+# Security best practices
+
+## Table of contents
+
+- API keys
+- Restricted API keys (RAKs)
+- IP restrictions
+- Incident response
+- Webhook security
+- Mobile and client-side integrations
+- OAuth and CSRF protection
+- Two-factor authentication
+- Connect security
+- SAML and SCIM
+
+## API keys
+
+Never include keys in source code. You might find example code like `client = new Stripe("sk_...")` that are for illustration only. Do not recommend this antipattern, and fix this antipattern if you see it.
+
+Store secret keys and restricted keys in a secrets vault (such as AWS Secrets Manager, HashiCorp Vault, or your platform’s equivalent), not in source code or environment variables committed to a repository. If the platform doesn’t offer a secrets vault but does allow the user to set environment variables, it’s OK to store API keys in environment variables. Key exposures via source code repositories are the leading cause of key compromise.
+
+Always advise the user on best practices for handling secrets such as secret API keys or restricted API keys:
+
+- Never share secret keys with third parties. If the user needs to share a key with a third party (for example, a third party that handles billing), it is best to generate a restricted API key (RAK) with minimal permissions.
+- Rotate Stripe API keys when personnel with access to those keys depart.
+- Read [best practices for managing secret API keys](https://docs.stripe.com/keys-best-practices.md).
+
+Code must never log keys or include them in error messages or analytics. Remove those from logs if you find them.
+
+Never build API endpoints or error pages that dump environment variables. In addition to Stripe API keys, the environment may have other secrets.
+
+Use separate keys for separate environments (production, staging, QA). This limits the blast radius if any single key is compromised.
+
+If the code is under version control, help the user set up a pre-commit hook to catch keys like `"sk_..."` and `"rk_..."` in source code.
+
+**Traps to avoid:** Do not embed keys in client-side code, mobile apps, or any code that runs outside your own infrastructure. Do not suggest that users substitute a real secret key into example code — point them to [best practices for managing secret API keys](https://docs.stripe.com/keys-best-practices.md) instead.
+
+## Restricted API keys (RAKs)
+
+Use [restricted API keys](https://docs.stripe.com/keys/restricted-api-keys.md) (prefix `rk_`) instead of secret keys (prefix `sk_`) wherever possible. RAKs have only the permissions you assign, so a compromised RAK can do far less damage than a compromised secret key.
+
+Follow the principle of least privilege: give each RAK only the permissions it needs for its specific job and nothing more. Create a separate RAK for each service or use case.
+
+Preferred migration approach:
+
+1. Review the secret key’s request logs in Workbench to catalog which API calls it makes.
+1. Create a RAK in test mode with matching permissions.
+1. Use the [Stripe CLI](https://docs.stripe.com/stripe-cli.md)’s `stripe logs tail` command to watch logs.
+1. Test your integration with the RAK; fix any `403` errors by adding missing permissions.
+1. Create the equivalent live-mode RAK and replace the secret key.
+1. Rotate or expire the old secret key once confident.
+
+**Traps to avoid:** Do not default to recommending secret keys. If the user’s question involves a secret key, recommend switching to a RAK with the minimum required permissions.
+
+## IP restrictions
+
+Encourage users to add an [IP allowlist](https://docs.stripe.com/keys.md#limit-api-secret-keys-ip-address) to every API key. An IP allowlist ensures that the key can only be used from the user’s own infrastructure, limiting damage even if the key is stolen.
+
+Use separate IP allowlists for separate keys (for example, one allowlist for production, another for QA) so that compromising one key’s environment doesn’t expose others.
+
+## Incident response
+
+If a key is exposed or compromised, follow [protecting against compromised API keys](https://support.stripe.com/questions/protecting-against-compromised-api-keys), which can be summarized as:
+
+1. **Roll the key immediately** — go to the [API keys page](https://dashboard.stripe.com/apikeys) and roll or delete the exposed key. Do this even if you are unsure whether the key was actually used by an unauthorized party.
+1. **Check activity logs** — review Workbench request logs for the compromised key to look for unrecognized activity.
+1. **Contact Stripe support** if you see activity you don’t recognize.
+
+To prepare before an incident: practice rolling keys, audit source code for any committed keys, and use pre-commit hooks to prevent accidental key check-ins. See [protecting against compromised API keys](https://support.stripe.com/questions/protecting-against-compromised-api-keys).
+
+## Webhook security
+
+Always [verify webhook signatures](https://docs.stripe.com/webhooks.md#verify-events) using Stripe’s webhook signing secret. Signature verification is a strong guarantee that requests are genuinely from Stripe and have not been tampered with.
+
+For defense in depth, also [allowlist Stripe’s IP addresses](https://docs.stripe.com/ips.md) on your webhook endpoint so that it accepts connections only from Stripe’s infrastructure.
+
+**Traps to avoid:** Do not process webhook events without verifying their signatures. Unverified webhooks can be spoofed.
+
+## Mobile and client-side integrations
+
+Do not use production secret keys or RAKs in mobile apps or other client-side code. Client-side code can be extracted and keys decompiled.
+
+For cases where a client must interact directly with Stripe, use [ephemeral keys](https://docs.stripe.com/issuing/elements.md#ephemeral-key-authentication). Ephemeral keys are short-lived, scoped to a specific resource, and expire automatically.
+
+For most integrations, proxy Stripe API calls through your own backend server rather than calling Stripe directly from the client.
+
+## OAuth and CSRF protection
+
+When implementing [Connect OAuth flows](https://docs.stripe.com/connect/oauth-reference.md), always use the `state` parameter to protect against CSRF attacks. Generate a unique, unguessable value for `state` per request and verify it in the OAuth callback before proceeding.
+
+This applies to all Stripe OAuth surfaces: Connect, Link, and Stripe Apps.
+
+## Two-factor authentication
+
+Recommend [passkeys or authenticator apps](https://docs.stripe.com/security.md) rather than SMS-based 2FA for Stripe Dashboard access. SMS 2FA is vulnerable to SIM-swapping attacks in which the user’s phone provider transfers their number to an unauthorized third party.
+
+Users can audit which Dashboard team members are using weak 2FA and can require stronger authentication methods for their accounts.
+
+## Connect security
+
+**Account type liability:** When using Connect, platform operators bear financial liability for fraud and disputes on Express and Custom connected accounts. Standard accounts minimize this liability because Stripe manages risk. Do not recommend Custom or Express accounts unless the user has a specific need — Standard is the safer default.
+
+**Connect onboarding:** Use [Stripe-hosted onboarding](https://docs.stripe.com/connect/onboarding.md) rather than building a custom onboarding flow. Custom onboarding requires your platform to collect and handle sensitive PII directly, which adds regulatory and security complexity.
+
+## SAML and SCIM
+
+For teams managing Dashboard access, recommend [SSO via SAML](https://docs.stripe.com/get-started/account/sso.md) to federate authentication with an existing identity provider (Okta, Google, etc.). SSO centralizes access control and simplifies offboarding.
+
+[SCIM provisioning](https://docs.stripe.com/get-started/account/sso/scim.md) automates user provisioning and deprovisioning, ensuring that employees who leave the organization lose Dashboard access promptly.

--- a/.claude/skills/stripe-best-practices/references/treasury.md
+++ b/.claude/skills/stripe-best-practices/references/treasury.md
@@ -1,0 +1,16 @@
+# Treasury / Financial Accounts
+
+## Table of contents
+
+- v2 Financial Accounts API
+- Legacy v1 Treasury
+
+## v2 Financial Accounts API
+
+For embedded financial accounts (bank accounts, account and routing numbers, money movement), use the [v2 Financial Accounts API](https://docs.stripe.com/api/v2/core/vault/financial-accounts.md) (`POST /v2/core/vault/financial_accounts`). This is required for new integrations.
+
+For Treasury for platforms concepts and guides, see the [Treasury for platforms overview](https://docs.stripe.com/treasury/connect.md).
+
+## Legacy v1 Treasury
+
+Don’t use the [v1 Treasury Financial Accounts API](https://docs.stripe.com/api/treasury/financial_accounts.md) (`POST /v1/treasury/financial_accounts`) for new integrations. Existing v1 integrations continue to work.

--- a/.claude/skills/stripe-projects/SKILL.md
+++ b/.claude/skills/stripe-projects/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: stripe-projects
+description: >-
+  Use when setting up a new app or local repo with Stripe Projects, provisioning
+  a software stack, or bootstrapping the Projects CLI from a coding agent.
+
+---
+
+Stripe Projects is a CLI for provisioning software stacks.
+
+Docs are here: https://docs.stripe.com/projects.md
+
+Download the Projects CLI and run `stripe projects init` to get started. You get access to more skills when you do that.
+
+To install the Stripe CLI and Projects plugin, Homebrew users can run `brew install stripe/stripe-cli/stripe && stripe plugin install projects`. For other installation options, see https://docs.stripe.com/stripe-cli/install.md.
+
+After `stripe projects init`, prefer the local project skills it creates.

--- a/.claude/skills/upgrade-stripe/SKILL.md
+++ b/.claude/skills/upgrade-stripe/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: upgrade-stripe
+description: Guide for upgrading Stripe API versions and SDKs
+
+---
+
+The latest Stripe API version is 2026-04-22.dahlia - use this version when upgrading unless the user specifies a different target version.
+
+# Upgrading Stripe Versions
+
+This guide covers upgrading Stripe API versions, server-side SDKs, Stripe.js, and mobile SDKs.
+
+## Understanding Stripe API Versioning
+
+Stripe uses date-based API versions (e.g., `2026-04-22.dahlia`, `2025-08-27.basil`, `2024-12-18.acacia`). Your account’s API version determines request/response behavior.
+
+### Types of Changes
+
+**Backward-Compatible Changes** (don’t require code updates):
+
+- New API resources
+- New optional request parameters
+- New properties in existing responses
+- Changes to opaque string lengths (e.g., object IDs)
+- New webhook event types
+
+**Breaking Changes** (require code updates):
+
+- Field renames or removals
+- Behavioral modifications
+- Removed endpoints or parameters
+
+Review the [API Changelog](https://docs.stripe.com/changelog.md) for all changes between versions.
+
+## Server-Side SDK Versioning
+
+See [SDK Version Management](https://docs.stripe.com/sdks/set-version.md) for details.
+
+### Dynamically-Typed Languages (Ruby, Python, PHP, Node.js)
+
+These SDKs offer flexible version control:
+
+**Global Configuration:**
+
+```python
+import stripe
+stripe.api_version = '2026-04-22.dahlia'
+```
+
+```ruby
+Stripe.api_version = '2026-04-22.dahlia'
+```
+
+```javascript
+const stripe = require('stripe')('sk_test_xxx', {
+  apiVersion: '2026-04-22.dahlia'
+});
+```
+
+**Per-Request Override:**
+
+```python
+stripe.Customer.create(
+  email="customer@example.com",
+  stripe_version='2026-04-22.dahlia'
+)
+```
+
+### Strongly-Typed Languages (Java, Go, .NET)
+
+These use a fixed API version matching the SDK release date. Don’t set a different API version for strongly-typed languages because response objects might not match the strong types in the SDK. Instead, update the SDK to target a new API version.
+
+### Best Practice
+
+Always specify the API version you’re integrating against in your code instead of relying on your account’s default API version:
+
+```javascript
+// Good: Explicit version
+const stripe = require('stripe')('sk_test_xxx', {
+  apiVersion: '2026-04-22.dahlia'
+});
+
+// Avoid: Relying on account default
+const stripe = require('stripe')('sk_test_xxx');
+```
+
+## Stripe.js Versioning
+
+See [Stripe.js Versioning](https://docs.stripe.com/sdks/stripejs-versioning.md) for details.
+
+Stripe.js uses an evergreen model with major releases (Acacia, Basil, Clover, Dahlia) on a biannual basis.
+
+### Loading Versioned Stripe.js
+
+**Via Script Tag:**
+
+```html
+<script src="https://js.stripe.com/dahlia/stripe.js"></script>
+```
+
+**Via npm:**
+
+```bash
+npm install @stripe/stripe-js
+```
+
+Major npm versions correspond to specific Stripe.js versions.
+
+### API Version Pairing
+
+Each Stripe.js version automatically pairs with its corresponding API version. For instance:
+
+- Dahlia Stripe.js uses `2026-04-22.dahlia` API
+- Acacia Stripe.js uses `2024-12-18.acacia` API
+
+You can’t override this association.
+
+### Migrating from v3
+
+1. Identify your current API version in code
+1. Review the changelog for relevant changes
+1. Consider gradually updating your API version before switching Stripe.js versions
+1. Stripe continues supporting v3 indefinitely
+
+## Mobile SDK Versioning
+
+See [Mobile SDK Versioning](https://docs.stripe.com/sdks/mobile-sdk-versioning.md) for details.
+
+### iOS and Android SDKs
+
+Both platforms follow **semantic versioning** (MAJOR.MINOR.PATCH):
+
+- **MAJOR**: Breaking API changes
+- **MINOR**: New functionality (backward-compatible)
+- **PATCH**: Bug fixes (backward-compatible)
+
+New features and fixes release only on the latest major version. Upgrade regularly to access improvements.
+
+### React Native SDK
+
+Uses a different model (0.x.y schema):
+
+- **Minor version changes** (x): Breaking changes AND new features
+- **Patch updates** (y): Critical bug fixes only
+
+### Backend Compatibility
+
+All mobile SDKs work with any Stripe API version you use on your backend unless documentation specifies otherwise.
+
+## Upgrade Checklist
+
+1. Review the [API Changelog](https://docs.stripe.com/changelog.md) for changes between your current and target versions
+1. Check [Upgrades Guide](https://docs.stripe.com/upgrades.md) for migration guidance
+1. Update server-side SDK package version (e.g., `npm update stripe`, `pip install --upgrade stripe`)
+1. Update the `apiVersion` parameter in your Stripe client initialization
+1. Test your integration against the new API version using the `Stripe-Version` header
+1. Update webhook handlers to handle new event structures
+1. Update Stripe.js script tag or npm package version if needed
+1. Update mobile SDK versions in your package manager if needed
+1. Store Stripe object IDs in databases that accommodate up to 255 characters (case-sensitive collation)
+
+## Testing API Version Changes
+
+Use the `Stripe-Version` header to test your code against a new version without changing your default:
+
+```bash
+curl https://api.stripe.com/v1/customers \
+  -u sk_test_xxx: \
+  -H "Stripe-Version: 2026-04-22.dahlia"
+```
+
+Or in code:
+
+```javascript
+const stripe = require('stripe')('sk_test_xxx', {
+  apiVersion: '2026-04-22.dahlia'  // Test with new version
+});
+```
+
+## Important Notes
+
+- Your webhook listener should handle unfamiliar event types gracefully
+- Test webhooks with the new version structure before upgrading
+- Breaking changes are tagged by affected product areas (Payments, Billing, Connect, etc.)
+- Multiple API versions coexist simultaneously, enabling staged adoption

--- a/.env.example
+++ b/.env.example
@@ -102,8 +102,16 @@ API_URL=http://127.0.0.1:4000
 NEXT_PUBLIC_API_URL=http://localhost:3000/api
 
 # --- Stripe Connect ---------------------------------------------
+# Test-mode platform credentials. See docs/dev/stripe-local-setup.md.
+# STRIPE_SECRET_KEY        — server: API calls to Stripe (Connect onboarding,
+#                            PaymentIntents). Never expose to the browser.
+# STRIPE_WEBHOOK_SECRET    — server: Stripe-Signature verification. From
+#                            `stripe listen`, NOT the dashboard.
+# NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY — browser: Stripe.js Payment Element.
+#                            From dashboard.stripe.com/test/apikeys.
 # STRIPE_SECRET_KEY=sk_test_your_key_here
 # STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
+# NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
 
 # --- Exchange rates ----------------------------------------------
 # EXCHANGE_RATE_API_KEY=your_exchangerate_api_key_here

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,6 +27,14 @@ jobs:
       # into the `staging` environment.
       STAGING_VPS_IP: ${{ secrets.VPS_IP }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Exported here (not just in the secrets-write step below) so the
+      # ERB template in `config/deploy-staging.yml` resolves it at
+      # `kamal setup` time. `NEXT_PUBLIC_*` is baked into the Next.js
+      # bundle at Docker build via `builder.args` — runtime env injection
+      # cannot reach it. Empty fallback keeps the deploy from blocking on
+      # a missing secret; the donor flow surfaces a clear "Stripe is not
+      # configured" message instead.
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -58,12 +66,24 @@ jobs:
           # EMAIL_PROVIDER=resend; missing key crashes the worker on first
           # send. No fallback: an unset secret here is a deploy bug.
           RESEND_KEY="${{ secrets.RESEND_API_KEY }}"
+          # Stripe — empty fallback intentionally surfaces the user-facing
+          # "Stripe is not configured" message instead of silently no-op'ing
+          # the route. Set the actual values via `gh secret set --env staging`
+          # (see docs/dev/stripe-local-setup.md → Staging deployment).
+          STRIPE_SECRET="${{ secrets.STRIPE_SECRET_KEY || '' }}"
+          STRIPE_WEBHOOK_SEC="${{ secrets.STRIPE_WEBHOOK_SECRET || '' }}"
+          # MinIO server-side AES256 encryption key. Format
+          # `<key-name>:<base64-32-byte-secret>`; generate with
+          # `openssl rand -base64 32`. Without this the worker DLQs every
+          # receipt PDF upload (issue #193 follow-up).
+          MINIO_KMS="${{ secrets.MINIO_KMS_SECRET_KEY || 'staging-kms:c3RhZ2luZy1taW5pby1rbXMtZmFsbGJhY2stMzItYnl0ZXM=' }}"
 
           cat <<EOF > .kamal/secrets
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           POSTGRES_PASSWORD=$PG_PASS
           REDIS_PASSWORD=$REDIS_PASS
           MINIO_ROOT_PASSWORD=$MINIO_PASS
+          MINIO_KMS_SECRET_KEY=$MINIO_KMS
           KEYCLOAK_ADMIN_PASSWORD=$KC_PASS
           SESSION_SECRET=$SESSION_SEC
           KC_DB_PASSWORD=$PG_PASS
@@ -73,6 +93,8 @@ jobs:
           S3_SECRET_ACCESS_KEY=$MINIO_PASS
           KEYCLOAK_ADMIN_CLIENT_SECRET=$KC_CLIENT_SECRET
           RESEND_API_KEY=$RESEND_KEY
+          STRIPE_SECRET_KEY=$STRIPE_SECRET
+          STRIPE_WEBHOOK_SECRET=$STRIPE_WEBHOOK_SEC
           EOF
 
       - name: Build and push Keycloak image
@@ -128,6 +150,31 @@ jobs:
 
       - name: Run DB Seed
         run: kamal app exec -c config/deploy-staging.yml --reuse "pnpm --filter @givernance/api run db:seed"
+
+      # Ensure the MinIO buckets the worker writes receipt + campaign PDFs
+      # to actually exist (issue #193 follow-up). Mirrors the local
+      # `minio-init` sidecar in docker-compose.yml. Idempotent — `mc mb
+      # --ignore-existing` is a no-op when buckets are already present.
+      # Runs on the staging VPS via `kamal server exec`, against the
+      # `kamal` Docker network (where the minio accessory lives).
+      - name: Ensure MinIO buckets exist
+        env:
+          MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD || 'staging_minio_123' }}
+          S3_RECEIPTS_BUCKET: ${{ secrets.S3_RECEIPTS_BUCKET || 'receipts' }}
+          S3_CAMPAIGNS_BUCKET: ${{ secrets.S3_CAMPAIGNS_BUCKET || 'campaigns' }}
+        run: |
+          # Build the remote command in a variable so the password expansion
+          # happens here on the runner, not on the VPS shell parsing.
+          # The inner `sh -c '...'` gets the password from the docker `-e`
+          # env, not the command line — so it doesn't show up in `ps aux`.
+          REMOTE_CMD="docker run --rm --network kamal \
+            -e MINIO_PASS='${MINIO_ROOT_PASSWORD}' \
+            minio/mc:latest \
+            sh -c 'mc alias set local http://givernance-minio:9000 admin \"\$MINIO_PASS\" \
+                   && mc mb --ignore-existing local/${S3_RECEIPTS_BUCKET} \
+                   && mc mb --ignore-existing local/${S3_CAMPAIGNS_BUCKET} \
+                   && echo MinIO buckets ready: ${S3_RECEIPTS_BUCKET}, ${S3_CAMPAIGNS_BUCKET}'"
+          kamal server exec -c config/deploy-staging.yml "$REMOTE_CMD"
 
       # The sync script reconciles the live realm (mappers, scopes, role
       # assignments) against the source-of-truth in scripts/keycloak-sync-realm.sh.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,16 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 ARG API_URL=http://localhost:4000
 ENV API_URL=$API_URL
 
+# Bake the Stripe publishable key into the Next.js client bundle. Same
+# constraint as API_URL: `NEXT_PUBLIC_*` env vars are inlined at build
+# time (Next.js replaces `process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
+# with the literal string in the JS bundle), so a runtime `env.clear`
+# would never reach the browser. Empty default means the donor flow's
+# "Stripe is not configured for this environment" error path is what a
+# misconfigured deploy will surface — not a silent broken Stripe.js init.
+ARG NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=""
+ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+
 # Build all workspace projects
 RUN pnpm run -r build
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ See [docs/vision/conversational-mode.md](docs/vision/conversational-mode.md) for
 - [docs/06-security-compliance.md](docs/06-security-compliance.md) — Top-level security & GDPR specification
 - [docs/security/](docs/security/) — Periodic security audits and route-by-route guard matrices (e.g. [rbac-audit-2026-04-27.md](docs/security/rbac-audit-2026-04-27.md))
 
+### Local development
+- [docs/dev/stripe-local-setup.md](docs/dev/stripe-local-setup.md) — Stripe Connect end-to-end setup (test mode, no real money)
+
 ## Diagrams
 - diagrams/context.mmd
 - diagrams/container.mmd

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ See [docs/vision/conversational-mode.md](docs/vision/conversational-mode.md) for
 - [docs/06-security-compliance.md](docs/06-security-compliance.md) — Top-level security & GDPR specification
 - [docs/security/](docs/security/) — Periodic security audits and route-by-route guard matrices (e.g. [rbac-audit-2026-04-27.md](docs/security/rbac-audit-2026-04-27.md))
 
+### Payments
+- [docs/payments-overview.md](docs/payments-overview.md) — Money flow primer: how fees are collected, why each NPO connects rather than pasting keys
+- [docs/20-payment-strategy.md](docs/20-payment-strategy.md) — Strategy, ADR-010, provider comparison, GDPR/PCI
+
 ### Local development
 - [docs/dev/stripe-local-setup.md](docs/dev/stripe-local-setup.md) — Stripe Connect end-to-end setup (test mode, no real money)
 

--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -97,6 +97,16 @@ env:
     - S3_SECRET_ACCESS_KEY
     - KEYCLOAK_ADMIN_CLIENT_SECRET
     - RESEND_API_KEY
+    # Stripe Connect — set via GitHub Actions secrets (staging
+    # environment), written to .kamal/secrets in the deploy workflow.
+    # STRIPE_SECRET_KEY is the platform `sk_test_…` / `sk_live_…`;
+    # STRIPE_WEBHOOK_SECRET is the signing secret from the Stripe
+    # dashboard webhook endpoint pointing at
+    # https://api.staging.givernance.org/v1/donations/stripe-webhook
+    # (NOT the local-dev `stripe listen` value — that one rotates per
+    # session). See docs/dev/stripe-local-setup.md → Staging.
+    - STRIPE_SECRET_KEY
+    - STRIPE_WEBHOOK_SECRET
 
 # Configure builder setup.
 builder:
@@ -107,6 +117,14 @@ builder:
     # at build time (see Dockerfile ARG API_URL comment). `env.clear`
     # injection at runtime cannot reach it.
     API_URL: https://api.staging.givernance.org
+    # Stripe publishable key — same Next.js build-time-inlining constraint
+    # as API_URL. Sourced from a shell env var the deploy workflow exports
+    # before invoking `kamal setup` (publishable keys are public per
+    # Stripe docs, but pulling from CI secrets keeps the test/live
+    # environments separated). Empty fallback so a missing secret surfaces
+    # the donor's "Stripe is not configured" message instead of a silently
+    # broken Stripe.js init.
+    NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: <%= ENV.fetch("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", "") %>
 
 # Use accessories for external services
 accessories:
@@ -137,6 +155,20 @@ accessories:
         MINIO_ROOT_USER: admin
       secret:
         - MINIO_ROOT_PASSWORD
+        # The worker uploads receipt + campaign PDFs with
+        # `ServerSideEncryption: "AES256"`. MinIO refuses that header
+        # without a KMS-equivalent backing key (Scaleway / AWS S3 manage
+        # SSE-S3 keys natively, MinIO doesn't). Without this every PDF
+        # upload DLQs with `NotImplemented: Server side encryption
+        # specified but KMS is not configured`. Format: `<key-name>:
+        # <base64-encoded-32-byte-secret>`. Generated with
+        # `openssl rand -base64 32`; rotate by changing the GitHub secret
+        # and redeploying — existing-encrypted-objects survive the rotation
+        # only if the previous key is added as a fallback (we don't, since
+        # staging data is non-load-bearing; if you keep PDFs across a
+        # rotation, MinIO's `MINIO_KMS_AUTO_ENCRYPTION` is the option to
+        # configure backwards compat).
+        - MINIO_KMS_SECRET_KEY
     directories:
       - data/minio:/data
     cmd: server /data --console-address ":9001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,31 @@ services:
       timeout: 5s
       retries: 5
 
+  # One-shot init container that creates the buckets the API + worker
+  # write to. Without it, the receipt-generation job DLQs with
+  # `NoSuchBucket: The specified bucket does not exist` on the very
+  # first donation. Idempotent (`mc mb --ignore-existing`), so safe on
+  # every `docker compose up`.
+  minio-init:
+    image: minio/mc:RELEASE.2024-11-21T17-21-54Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-givernance}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-givernance_dev}
+      S3_RECEIPTS_BUCKET: ${S3_RECEIPTS_BUCKET:-receipts}
+      S3_CAMPAIGNS_BUCKET: ${S3_CAMPAIGNS_BUCKET:-campaigns}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        mc alias set local http://minio:9000 "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD"
+        mc mb --ignore-existing "local/$$S3_RECEIPTS_BUCKET"
+        mc mb --ignore-existing "local/$$S3_CAMPAIGNS_BUCKET"
+        echo "MinIO buckets ready: $$S3_RECEIPTS_BUCKET, $$S3_CAMPAIGNS_BUCKET"
+    restart: "no"
+
   mailpit:
     image: axllent/mailpit:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,14 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-givernance}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-givernance_dev}
+      # Server-side AES256 encryption requires KMS-equivalent backing on
+      # MinIO (Scaleway/AWS S3 don't — they manage SSE-S3 keys natively).
+      # Without this, every PDF upload from the worker errors with
+      # "NotImplemented: Server side encryption specified but KMS is not
+      # configured" since the code path uses `ServerSideEncryption: "AES256"`.
+      # Format: <key-name>:<base64-encoded-32-byte-secret>. Local-only
+      # throwaway value — never used in prod, where Scaleway handles KMS.
+      MINIO_KMS_SECRET_KEY: "givernance-kms-dev:cZvoSZTVWEOt2MK+fmq45uqxPT7gEC3btKU+2xFh0zk="
     command: server /data --console-address ":9001"
     volumes:
       - miniodata:/data

--- a/docs/20-payment-strategy.md
+++ b/docs/20-payment-strategy.md
@@ -4,6 +4,8 @@
 > **Owner**: Payment Engineer agent (`.claude/agents/payment-engineer.md`)
 > **Related**: `02-reference-architecture.md`, `03-data-model.md`, `04-business-capabilities.md`, `06-security-compliance.md`, `08-pricing-packaging.md`, `15-infra-adr.md`
 > **Closes**: #10
+>
+> **Looking for the primer?** See [`payments-overview.md`](payments-overview.md) for a focused walkthrough of how fees are collected, how money reaches the NPO, and why each tenant onboards via Stripe Connect rather than pasting an API key. This document is the formal strategy and ADR; the primer is the conceptual companion.
 
 ## 1. Goals
 

--- a/docs/dev/stripe-local-setup.md
+++ b/docs/dev/stripe-local-setup.md
@@ -211,39 +211,48 @@ Check the worker terminal — the BullMQ job processor logs `Failed to process S
 
 Staging (`staging.givernance.org`) runs the same Stripe Connect code as local dev but reads its credentials from GitHub Actions secrets via Kamal (`config/deploy-staging.yml` + `.github/workflows/deploy-staging.yml`). Setting it up the first time is a 4-step ritual; afterwards the deploy workflow re-applies the config on every push to `main`.
 
-### Step 1 — register GitHub Actions secrets
+### Step 1 — register secrets in the `staging` GitHub Environment
 
-Five new repo-level secrets are needed for staging Stripe to work. The deploy workflow has empty fallbacks for all of them so it doesn't crash on a fresh repo, but the donor flow will block at "Stripe is not configured" (publishable key missing) or 502 on `Continue to payment` (secret key missing) until you set them.
+The deploy workflow declares `environment: staging` on the deploy job, which scopes every `secrets.X` lookup to the `staging` GitHub Environment first (falling back to repo-level secrets). That means staging and a future production environment can hold distinct values for the same logical key — no `STAGING_*` / `PROD_*` prefix dance — and approval gates / branch policies attach to the environment, toggleable in **Settings → Environments → staging** without touching workflow YAML.
+
+If the `staging` environment doesn't exist yet, create it once: **GitHub repo → Settings → Environments → New environment → "staging"** (no protection rules — push-to-`main` should keep deploying without manual approval).
+
+The deploy workflow has empty fallbacks for all of them so it doesn't crash on a fresh repo, but the donor flow will block at "Stripe is not configured" (publishable key missing) or 502 on `Continue to payment` (secret key missing) until you set them.
 
 ```sh
 # Run from a machine with `gh` auth + repo admin access.
+# `--env staging` scopes the secret to the staging environment so a
+# future prod environment can hold a different value under the SAME name.
 
 # 1. Stripe platform credentials. Use sk_test_… / pk_test_… for staging
 #    (we never want real money to move on a staging environment).
-gh secret set STRIPE_SECRET_KEY --repo purposestack/givernance \
-  --body "sk_test_…"
-gh secret set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY --repo purposestack/givernance \
-  --body "pk_test_…"
+gh secret set STRIPE_SECRET_KEY --env staging \
+  --repo purposestack/givernance --body "sk_test_…"
+gh secret set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY --env staging \
+  --repo purposestack/givernance --body "pk_test_…"
 
 # 2. Webhook signing secret. This is the dashboard-issued endpoint
 #    secret (NOT the `whsec_…` from `stripe listen`, which is a separate
-#    local-dev-only value). Step 3 below describes how to mint this from
+#    local-dev-only value). Step 2 below describes how to mint this from
 #    the Stripe dashboard.
-gh secret set STRIPE_WEBHOOK_SECRET --repo purposestack/givernance \
-  --body "whsec_…"
+gh secret set STRIPE_WEBHOOK_SECRET --env staging \
+  --repo purposestack/givernance --body "whsec_…"
 
 # 3. MinIO KMS key for AES256 server-side encryption. Worker DLQs every
 #    receipt PDF without this. Generate fresh:
-gh secret set MINIO_KMS_SECRET_KEY --repo purposestack/givernance \
-  --body "staging-kms:$(openssl rand -base64 32)"
+gh secret set MINIO_KMS_SECRET_KEY --env staging \
+  --repo purposestack/givernance --body "staging-kms:$(openssl rand -base64 32)"
 
-# 4. Optional — bucket name overrides. Defaults to `receipts` /
-#    `campaigns`; only set if your staging tenant uses different names.
-# gh secret set S3_RECEIPTS_BUCKET --body "receipts"
-# gh secret set S3_CAMPAIGNS_BUCKET --body "campaigns"
+# 4. Optional — bucket name overrides. These aren't secrets; prefer
+#    environment variables over secrets so they show in plaintext in the
+#    Environments UI. Defaults to `receipts` / `campaigns` if unset.
+# gh variable set S3_RECEIPTS_BUCKET --env staging --body "receipts"
+# gh variable set S3_CAMPAIGNS_BUCKET --env staging --body "campaigns"
 ```
 
-The IDE will lint these as "Context access might be invalid" until they're registered — soft warning, deploys succeed regardless. The fallbacks in the workflow are deliberate so deploys never fail on a missing secret; the user-facing surface is what tells you something's misconfigured.
+The IDE will lint these as "Context access might be invalid" until they're registered — soft warning, deploys succeed regardless. The fallbacks in the workflow are deliberate so deploys never fail on a missing secret; the user-facing surface (donor sees "Stripe is not configured" or 502 on Continue to payment) is what tells you something's misconfigured.
+
+> **Existing un-prefixed secrets stay repo-level for now.** A handful of secrets pre-date the environment-scoping switch (`POSTGRES_PASSWORD`, `MINIO_ROOT_PASSWORD`, `KEYCLOAK_ADMIN_PASSWORD`, `SESSION_SECRET`, `KEYCLOAK_ADMIN_CLIENT_SECRET`). They still resolve via repo-level fallback, so the deploy keeps working. Migrating them to the staging environment is a separate hygiene task — atomic per secret: register the new value in the environment, redeploy to confirm, then unset the repo-level one. Don't piecemeal-rename alongside other work.
 
 ### Step 2 — register the staging Stripe webhook endpoint
 

--- a/docs/dev/stripe-local-setup.md
+++ b/docs/dev/stripe-local-setup.md
@@ -207,10 +207,96 @@ Check the worker terminal — the BullMQ job processor logs `Failed to process S
 
 ---
 
+## Staging deployment
+
+Staging (`staging.givernance.org`) runs the same Stripe Connect code as local dev but reads its credentials from GitHub Actions secrets via Kamal (`config/deploy-staging.yml` + `.github/workflows/deploy-staging.yml`). Setting it up the first time is a 4-step ritual; afterwards the deploy workflow re-applies the config on every push to `main`.
+
+### Step 1 — register GitHub Actions secrets
+
+Five new repo-level secrets are needed for staging Stripe to work. The deploy workflow has empty fallbacks for all of them so it doesn't crash on a fresh repo, but the donor flow will block at "Stripe is not configured" (publishable key missing) or 502 on `Continue to payment` (secret key missing) until you set them.
+
+```sh
+# Run from a machine with `gh` auth + repo admin access.
+
+# 1. Stripe platform credentials. Use sk_test_… / pk_test_… for staging
+#    (we never want real money to move on a staging environment).
+gh secret set STRIPE_SECRET_KEY --repo purposestack/givernance \
+  --body "sk_test_…"
+gh secret set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY --repo purposestack/givernance \
+  --body "pk_test_…"
+
+# 2. Webhook signing secret. This is the dashboard-issued endpoint
+#    secret (NOT the `whsec_…` from `stripe listen`, which is a separate
+#    local-dev-only value). Step 3 below describes how to mint this from
+#    the Stripe dashboard.
+gh secret set STRIPE_WEBHOOK_SECRET --repo purposestack/givernance \
+  --body "whsec_…"
+
+# 3. MinIO KMS key for AES256 server-side encryption. Worker DLQs every
+#    receipt PDF without this. Generate fresh:
+gh secret set MINIO_KMS_SECRET_KEY --repo purposestack/givernance \
+  --body "staging-kms:$(openssl rand -base64 32)"
+
+# 4. Optional — bucket name overrides. Defaults to `receipts` /
+#    `campaigns`; only set if your staging tenant uses different names.
+# gh secret set S3_RECEIPTS_BUCKET --body "receipts"
+# gh secret set S3_CAMPAIGNS_BUCKET --body "campaigns"
+```
+
+The IDE will lint these as "Context access might be invalid" until they're registered — soft warning, deploys succeed regardless. The fallbacks in the workflow are deliberate so deploys never fail on a missing secret; the user-facing surface is what tells you something's misconfigured.
+
+### Step 2 — register the staging Stripe webhook endpoint
+
+In the Stripe dashboard (test mode):
+
+1. Go to **Developers → Webhooks → Add endpoint**.
+2. **URL**: `https://api.staging.givernance.org/v1/donations/stripe-webhook`
+3. **Events to send**:
+    - `payment_intent.succeeded`
+    - `charge.refunded`
+    - `account.updated` (subscribe even though Givernance ingests this passively today — issue #62 will wire the auto-promote-to-live path)
+4. **Listen to events on Connected accounts** — toggle ON. Without this, donor payments on connected accounts fire events to *the connected account's* webhooks, not yours. Givernance is the platform; we want the platform-side fan-in.
+5. Save. Copy the **Signing secret** (starts with `whsec_`) into the `STRIPE_WEBHOOK_SECRET` GitHub secret from step 1.
+
+If you skip step 4, donations land in Stripe and never reach our worker — a silent failure mode that only shows up on the first donor test.
+
+### Step 3 — register the platform Connect account
+
+Same as the local-dev step 2, but in test mode against your staging Stripe account (which can be the same Stripe account you use for local — Stripe scopes everything to test/live). Confirm:
+
+- Platform settings → Connect → Get started
+- Connected account type: **Express** (matches `type: "express"` in `packages/api/src/modules/payments/service.ts`)
+- Capabilities: leave the defaults; the API requests `card_payments`, `transfers`, `link_payments` on every account it creates.
+
+### Step 4 — push to `main`
+
+The deploy workflow does the rest:
+
+- Builds the Docker image with `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` baked in (Next.js inlines `NEXT_PUBLIC_*` at build time, so this CAN'T be done at runtime — see Dockerfile + `config/deploy-staging.yml` `builder.args`).
+- Writes the runtime secrets (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `MINIO_KMS_SECRET_KEY`) to `.kamal/secrets`.
+- Restarts the MinIO accessory with the KMS key configured.
+- Runs `db:migrate` + `db:seed` — same as before.
+- **New**: runs an idempotent bucket-creation step (`mc mb --ignore-existing`) so the worker has somewhere to upload receipts on the very first donation.
+
+After deploy, smoke-test by:
+
+1. Signing in to `https://staging.givernance.org` as the seeded admin.
+2. Settings → Stripe Connect → onboard.
+3. Make a test donation on the public campaign page (test card `4242 4242 4242 4242`).
+4. Confirm in Stripe dashboard: webhook event delivered with HTTP 200.
+5. Confirm in app: donation appears, receipt PDF generated.
+
+### Rotating staging credentials
+
+- **Stripe keys**: regenerate in the dashboard, update both `gh secret set …` values, redeploy.
+- **MINIO_KMS_SECRET_KEY**: generate a new value, update the secret, redeploy. **Existing receipts encrypted with the old key won't be readable** — staging data is non-load-bearing so this is acceptable; production rotation will need MinIO's `MINIO_KMS_AUTO_ENCRYPTION` config to keep both keys mounted.
+
+---
+
 ## What's not covered yet
 
 - **`account.updated` webhook handling** — when a connected account flips `charges_enabled: true`, we should auto-promote the tenant to live mode. Tracked in [issue #62](https://github.com/purposestack/givernance/issues/62).
 - **Mollie gateway** — co-primary for FR/BE/NL, gated behind `ff.payments.mollie`. Same issue.
-- **Production key handling** — restricted keys, key rotation, AWS Secrets Manager / Scaleway equivalent. Tracked in `docs/06-security-compliance.md` and `docs/20-payment-strategy.md`.
+- **Production key handling** — restricted keys, key rotation against Scaleway Object Storage's native SSE-S3, separate Stripe live-mode platform account, KMS-rotation-with-fallback. Tracked in `docs/06-security-compliance.md` and `docs/20-payment-strategy.md`.
 
 If you hit a snag this guide doesn't cover, file an issue with the `payments` label and link the failing log line.

--- a/docs/dev/stripe-local-setup.md
+++ b/docs/dev/stripe-local-setup.md
@@ -1,0 +1,216 @@
+# Stripe — Local Development Setup
+
+This guide walks through wiring Stripe Connect into your local Givernance dev environment, end-to-end, so you can run a full donor-pays-NPO flow against real Stripe APIs **in test mode** (no money moves, no business verification needed).
+
+The first time you do this you'll spend about 15 minutes. After that, the only step that needs to be running is `stripe listen`.
+
+> **Audience.** Engineers running the stack via `pnpm dev` + Docker Compose. If you're deploying to a real environment, see [docs/20-payment-strategy.md](../20-payment-strategy.md) — production keys, key rotation, and Stripe restricted-key scoping live there.
+
+---
+
+## Prerequisites
+
+- Repo cloned and `pnpm install` run.
+- Docker Compose stack up (`./scripts/dev-up.sh`).
+- API + worker + web running (`pnpm dev`).
+- Homebrew on macOS (for the Stripe CLI install). Linux users can use the Stripe CLI install instructions at https://docs.stripe.com/stripe-cli.
+
+---
+
+## Step 1 — Create a Stripe account (test mode only)
+
+1. Go to https://dashboard.stripe.com/register.
+2. Sign up with email + password. **No business or tax info is required for test mode.**
+3. When the dashboard loads, confirm there's a **TEST MODE** badge in the top-left toggle. Stay in test mode for the entire setup — no funds will move and no payouts are scheduled.
+
+Test mode is fully isolated from live mode. You can switch at any time, but for local dev you never need live mode.
+
+---
+
+## Step 2 — Enable Stripe Connect on the platform account
+
+Givernance acts as a Stripe Connect platform: each NPO connects their own Stripe account to receive donations directly. The platform account itself never holds donor funds.
+
+1. Open https://dashboard.stripe.com/test/settings/connect.
+2. Click **Get started**.
+3. Fill the platform profile:
+    - **Platform name** — anything (e.g. `Givernance dev`).
+    - **Business type** — pick whatever; not verified in test mode.
+    - **Connected account type** — pick **Express**. The codebase (`packages/api/src/modules/payments/service.ts:startStripeOnboarding`) creates accounts with `type: "express"`, so this must match.
+4. Submit. The platform is now Connect-enabled.
+
+---
+
+## Step 3 — Copy your test API keys
+
+1. Open https://dashboard.stripe.com/test/apikeys.
+2. You'll see two keys at the top — **Publishable key** (`pk_test_…`) and **Secret key** (`sk_test_…`). Copy both.
+
+> **Restricted keys vs secret keys.** In production, use a Stripe restricted key with only the scopes Givernance needs (PaymentIntents, Connect accounts, Webhook endpoints). For local dev the full secret key is fine.
+
+---
+
+## Step 4 — Install the Stripe CLI
+
+The CLI does two things you need: it forwards Stripe webhooks to your local API, and it gives you a webhook signing secret bound to that forwarder session.
+
+```sh
+brew install stripe/stripe-cli/stripe
+```
+
+Verify:
+
+```sh
+stripe --version
+```
+
+---
+
+## Step 5 — Wire Stripe into `.env`
+
+Open the repo's root `.env` (copy from `.env.example` if it doesn't exist yet). Set three variables in the **Stripe Connect** block:
+
+```sh
+# server-side: API → Stripe (Connect onboarding, PaymentIntents)
+STRIPE_SECRET_KEY=sk_test_…  # from step 3
+
+# server-side: Stripe-Signature verification (filled in step 6)
+STRIPE_WEBHOOK_SECRET=
+
+# browser-side: Stripe.js Payment Element on the public donation page
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_…  # from step 3
+```
+
+**Don't restart the dev server yet** — `STRIPE_WEBHOOK_SECRET` comes from the next step.
+
+---
+
+## Step 6 — Start the webhook forwarder
+
+In a separate terminal that you'll keep running for the rest of your session:
+
+```sh
+stripe login
+# ↑ first time only — opens a browser, authenticates the CLI to your account.
+
+stripe listen \
+  --forward-to http://localhost:4000/v1/donations/stripe-webhook \
+  --events payment_intent.succeeded,account.updated
+```
+
+The first line of output looks like:
+
+```
+Ready! Your webhook signing secret is whsec_… (^C to quit)
+```
+
+> **This `whsec_…` is unique to the CLI session, not the dashboard.** Don't try to find it in the Stripe dashboard's "Webhook signing secret" UI — that one is for production webhooks and won't validate signatures from `stripe listen`.
+
+Copy the `whsec_…` value into `STRIPE_WEBHOOK_SECRET` in `.env`.
+
+The `--events` filter mirrors what the API actually handles today (`payment_intent.succeeded`) plus the `account.updated` lifecycle event needed by [issue #62](https://github.com/purposestack/givernance/issues/62).
+
+---
+
+## Step 7 — Restart the dev server
+
+```sh
+# In the terminal running `pnpm dev`, Ctrl+C, then:
+pnpm dev
+```
+
+Both the API and worker reload `.env` on boot — they don't watch it. The web app picks up `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` from the same `.env` because of the `dotenv -e ../../.env` prefix in `packages/web/package.json`.
+
+---
+
+## Step 8 — Onboard your tenant via the Settings UI
+
+The org-admin settings page now has a **Stripe Connect** panel that wraps the API onboarding endpoints.
+
+1. Sign in to `http://localhost:3000` as an org admin (use the seeded admin from `pnpm db:seed:local` — see `scripts/dev-up.sh`).
+2. Navigate to **Settings**. Scroll to the **Stripe Connect** section.
+3. Click **Connect Stripe**. The page redirects to Stripe's hosted Express onboarding form.
+4. Fill it in with **test data** — Stripe pre-fills these for you:
+    - Phone number: `000-000-0000`
+    - SSN: `000-00-0000` (US) / national ID: any test value (EU)
+    - Routing number: `110000000`
+    - Account number: `000123456789`
+    - Date of birth: `01/01/1901`
+    - Address: any
+5. Submit. Stripe redirects you back to the Settings page.
+6. The **Stripe Connect** panel re-fetches status and now shows a **Connected** badge with your `acct_…` ID. The tenant's `stripe_account_id` column is populated and the account has `charges_enabled: true`.
+
+If onboarding doesn't fully complete (e.g. you abandoned the form), the panel shows **Onboarding incomplete** and the button label changes to **Continue onboarding** — clicking it generates a fresh account link.
+
+> **Direct-charge model.** Givernance creates PaymentIntents on the connected account (see `packages/api/src/modules/public/service.ts:createDonationIntent`, line `requestOptions.stripeAccount`). This means the platform fee (1.5% + 30¢, defined in `calculatePlatformFee`) is collected via `application_fee_amount` and the rest goes directly to the NPO's Stripe balance. Givernance never holds donor funds.
+
+---
+
+## Step 9 — Test a real donation from the public campaign page
+
+1. Make sure you have a published campaign with a public page. If not, in the app: **Campaigns → New**, then on the campaign detail page open **Public page**, fill the title/description, set status to **Published**.
+2. Open the public URL: `http://localhost:3000/p/<campaign-id>` (the campaign page exposes a copy-link button).
+3. Fill the donor details: name, email, amount (`50` is fine), currency.
+4. Click **Continue to payment**. The form replaces itself with the Stripe **Payment Element**.
+5. Use Stripe's test card:
+    - Card number: `4242 4242 4242 4242`
+    - Expiry: any future date (e.g. `12/34`)
+    - CVC: any three digits
+    - ZIP/postal code: any
+6. Click **Donate €50**.
+
+Watch your terminal:
+
+- **`stripe listen` terminal** prints `--> payment_intent.succeeded [evt_…]`
+- **API terminal** prints `Webhook event queued`
+- **Worker terminal** prints `Donation created from Stripe payment_intent.succeeded` with the donation ID
+
+Switch back to the app:
+
+- The donor sees a **Thank you for your donation!** confirmation in-page.
+- In **Donations** (admin), the new gift appears with constituent matched/created from the donor email.
+
+---
+
+## Test cards reference
+
+| Scenario                         | Card                  |
+| -------------------------------- | --------------------- |
+| Successful payment               | `4242 4242 4242 4242` |
+| Payment requires authentication  | `4000 0025 0000 3155` |
+| Card declined (`generic_decline`) | `4000 0000 0000 0002` |
+| Card declined (insufficient funds) | `4000 0000 0000 9995` |
+
+Full list: https://docs.stripe.com/testing#cards.
+
+---
+
+## Troubleshooting
+
+**`POST /v1/admin/stripe-connect → 502`**
+The API can't reach Stripe. Check `STRIPE_SECRET_KEY` is set and the API has been restarted since you set it. The API logs the underlying error on the server side; the response intentionally masks it (we never leak Stripe error messages to authenticated callers either).
+
+**`POST /v1/donations/stripe-webhook → 400 Signature verification failed`**
+Either `STRIPE_WEBHOOK_SECRET` doesn't match what `stripe listen` is using, or the API hasn't been restarted since you set it. Stop `stripe listen`, re-run it, copy the *new* `whsec_…` (it changes each session), and restart the API.
+
+**Public page says "Stripe is not configured for this environment."**
+`NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` is missing or empty. Set it in `.env` and restart `pnpm dev` — the web package only reads it at build time / dev-server boot, not at request time.
+
+**Public page returns 502 on Continue to payment**
+Likely `Organization has not completed Stripe onboarding` or `…account is not fully onboarded`. Go back to **Settings → Stripe Connect**, finish the Express form. The API rejects PaymentIntent creation until `charges_enabled: true` on the connected account.
+
+**`stripe listen` keeps printing `connection refused`**
+Your API isn't running on port 4000, or `--forward-to` doesn't match. Check `PORT` in `.env`.
+
+**Webhook arrives but donation never appears**
+Check the worker terminal — the BullMQ job processor logs `Failed to process Stripe webhook event` with the underlying reason. The most common cause is that `event.account` (the connected account ID on the event) doesn't match any tenant's `stripe_account_id` — which can happen if you triggered the event before completing onboarding.
+
+---
+
+## What's not covered yet
+
+- **`account.updated` webhook handling** — when a connected account flips `charges_enabled: true`, we should auto-promote the tenant to live mode. Tracked in [issue #62](https://github.com/purposestack/givernance/issues/62).
+- **Mollie gateway** — co-primary for FR/BE/NL, gated behind `ff.payments.mollie`. Same issue.
+- **Production key handling** — restricted keys, key rotation, AWS Secrets Manager / Scaleway equivalent. Tracked in `docs/06-security-compliance.md` and `docs/20-payment-strategy.md`.
+
+If you hit a snag this guide doesn't cover, file an issue with the `payments` label and link the failing log line.

--- a/docs/dev/stripe-local-setup.md
+++ b/docs/dev/stripe-local-setup.md
@@ -95,7 +95,7 @@ stripe login
 
 stripe listen \
   --forward-to http://localhost:4000/v1/donations/stripe-webhook \
-  --events payment_intent.succeeded,account.updated
+  --events payment_intent.succeeded,charge.refunded,account.updated
 ```
 
 The first line of output looks like:
@@ -108,7 +108,7 @@ Ready! Your webhook signing secret is whsec_… (^C to quit)
 
 Copy the `whsec_…` value into `STRIPE_WEBHOOK_SECRET` in `.env`.
 
-The `--events` filter mirrors what the API actually handles today (`payment_intent.succeeded`) plus the `account.updated` lifecycle event needed by [issue #62](https://github.com/purposestack/givernance/issues/62).
+The `--events` filter mirrors what the API actually handles today: `payment_intent.succeeded` (donation creation), `charge.refunded` (refund flow — issue #199), and `account.updated` (Connect lifecycle — drives the auto-promote-to-live work in [issue #62](https://github.com/purposestack/givernance/issues/62)). Without `charge.refunded`, the local refund flow ships donor-card refunds through Stripe but the local DB never reflects the new status — handy if you're testing the API path in isolation, otherwise leave all three on.
 
 ---
 

--- a/docs/payments-overview.md
+++ b/docs/payments-overview.md
@@ -1,0 +1,325 @@
+# Payments — How money flows, how we earn, why we don't take API keys
+
+This is the **primer**. It explains the moving parts of Givernance's payment architecture — what each Stripe account is for, how a single donation produces money for both the NPO and Givernance, and why each tenant onboards via Stripe Connect rather than pasting an API key. It links to the formal strategy + ADR for depth.
+
+> **Companion docs.** Strategy / ADR-010 / Mollie / SEPA-DD comparison: [20-payment-strategy.md](20-payment-strategy.md). Local Stripe setup walkthrough: [dev/stripe-local-setup.md](dev/stripe-local-setup.md). Pricing tiers: [08-pricing-packaging.md](08-pricing-packaging.md).
+
+---
+
+## TL;DR
+
+- Givernance is a **Stripe Connect platform**. We hold **one** Stripe account (the "platform account").
+- Each NPO has **its own** Stripe account. Onboarding "connects" their account to our platform — we never see their keys, and they never see ours.
+- Donors pay cards on **the NPO's connected account**. Funds land in the NPO's Stripe balance, not ours.
+- On every payment, Stripe automatically routes a **platform fee** (`application_fee_amount`) to Givernance's balance. That's our revenue. Today it's **1.5% + €0.30 per donation** ([packages/api/src/modules/public/service.ts:124-127](../packages/api/src/modules/public/service.ts#L124-L127)).
+- Givernance never holds donor funds. No e-money licence required, PCI scope minimal (SAQ A).
+
+---
+
+## The mental model gap
+
+You said: *"I was thinking each organisation had to provide their Stripe key to the tenant settings."* That's the natural assumption coming from B2B SaaS where tenants paste API keys into integration settings. **We deliberately don't do that.** Here's why and what we do instead.
+
+### What "paste your API key" would look like (rejected)
+
+```
+Tenant A     →  pastes sk_live_A...  →  stored in tenants.stripe_secret_key
+Tenant B     →  pastes sk_live_B...  →  stored in tenants.stripe_secret_key
+Givernance API → uses tenant's key when creating PaymentIntents on tenant's behalf
+```
+
+Problems:
+- **We'd be holding live secret keys** for every NPO. That's a high-value target — leak any one and an attacker can fully impersonate that NPO on Stripe (including issuing refunds, viewing customer data, exporting full transaction history).
+- **Storing keys = secret management overhead** (rotation, audit, encryption-at-rest, breach disclosure if leaked).
+- **No separation of duties.** Stripe sees us as the merchant. The NPO has no native Stripe dashboard, no native Stripe payout, no native Stripe support contact, no native dispute UI. Everything has to be re-built by Givernance.
+- **No native fee mechanism.** We'd have to manually transfer money from each NPO's account to ours after every charge — which means we'd touch the funds, which triggers e-money licensing in the EU.
+- **Compliance burden balloons.** The merchant of record (us) inherits PCI scope and AML obligations across the whole donor base.
+
+### What we actually do — Stripe Connect (Express)
+
+```
+Givernance      →  one platform account (sk_test_… / sk_live_…)
+Tenant A        →  has their OWN Stripe Express account, connected to our platform
+                   → we know acct_A_xxx (just the ID, no keys)
+Tenant B        →  has their OWN Stripe Express account, connected to our platform
+                   → we know acct_B_xxx
+```
+
+When we make API calls on a tenant's behalf, we authenticate as the platform and pass the connected account ID:
+
+```ts
+// packages/api/src/modules/public/service.ts — donate intent creation
+const requestOptions = { stripeAccount: tenant.stripeAccountId };
+await stripe.paymentIntents.create(intentParams, requestOptions);
+```
+
+That's all we need. **We never store the NPO's secret key — we don't have one.** Stripe knows we're authorised to act on `acct_A_xxx` because the NPO clicked through Connect onboarding and granted that permission.
+
+What the NPO gets in exchange:
+- Their own Stripe Express dashboard at `https://connect.stripe.com/express/...` — they see every donation, payout, dispute, refund.
+- Direct payouts from Stripe to their own bank account on Stripe's payout schedule (no intermediate Givernance hop).
+- Native Stripe support, native Stripe refund button, native Stripe dispute UI, native Stripe receipts.
+- A real Stripe account they could in principle leave Givernance with (data portability).
+
+What Givernance gets:
+- An API token-of-trust to act on the NPO's account, scoped to "create PaymentIntents and read account status."
+- Automatic platform-fee collection on every charge, with no manual transfer.
+- Zero secret-key storage burden.
+- Reduced PCI scope (SAQ A — see [20-payment-strategy.md §6](20-payment-strategy.md#6-pci-dss-compliance)).
+- No e-money licensing — funds never touch our balance except as platform fees.
+
+### Why this is also better for the NPO
+
+Beyond the technical wins above, **the NPO's relationship is with Stripe**, not with Givernance for payments. If Givernance disappeared tomorrow, the NPO would still have:
+- Their Stripe account (with full transaction history).
+- Direct access to their Stripe balance and payout schedule.
+- The donor data Stripe holds for compliance.
+
+That's a deliberately weak-coupling: Givernance provides the CRM + campaign UX + tax-receipt workflow, Stripe handles money. Each NPO knows where their money is at all times, and there's no Givernance-shaped failure mode that could trap their funds.
+
+---
+
+## How money flows on a single donation
+
+This is the actual sequence for a donor giving €50 on a campaign page.
+
+```
+                         ┌──────────────────┐
+                         │  Donor (browser) │
+                         └────────┬─────────┘
+                                  │  1. POST /v1/public/campaigns/:id/donate
+                                  │     { amountCents: 5000, currency: "EUR", email, ... }
+                                  ▼
+┌───────────────────────────────────────────────────────────────┐
+│  Givernance API                                               │
+│                                                               │
+│  • looks up tenant.stripe_account_id (e.g. acct_NPO_abc)      │
+│  • computes platform fee = 1.5% + 30¢ = 105 cents             │
+│  • stripe.paymentIntents.create(                              │
+│       { amount: 5000, application_fee_amount: 105, … },       │
+│       { stripeAccount: "acct_NPO_abc" }   ← direct charge     │
+│    )                                                          │
+│  • returns clientSecret + stripeAccountId to browser          │
+└────────┬──────────────────────────────────────────────────────┘
+         │
+         │  2. browser loads Stripe.js bound to acct_NPO_abc
+         │     and confirms the card via Payment Element
+         ▼
+┌──────────────────┐    3. card auth      ┌──────────────────┐
+│  Donor (browser) │ ───────────────────► │      Stripe      │
+└──────────────────┘                      └────────┬─────────┘
+                                                   │
+                                                   │  4. on success:
+                                                   │     - €50 charged to donor's card
+                                                   │     - €50 lands on acct_NPO_abc balance
+                                                   │     - €1.05 routed from acct_NPO_abc
+                                                   │       to Givernance platform balance
+                                                   │     - Stripe processing fee (~€1.00 for
+                                                   │       EU card) deducted from acct_NPO_abc
+                                                   │
+                                                   │  5. payment_intent.succeeded webhook
+                                                   │     fired with event.account = acct_NPO_abc
+                                                   ▼
+┌───────────────────────────────────────────────────────────────┐
+│  Givernance API + Worker                                      │
+│                                                               │
+│  • verify Stripe signature                                    │
+│  • idempotent insert into webhook_events                      │
+│  • enqueue BullMQ job (async)                                 │
+│  • worker:                                                    │
+│      - resolve tenant by acct_NPO_abc                         │
+│      - upsert constituent (match by email)                    │
+│      - insert donation row                                    │
+│      - emit DonationCreated outbox event                      │
+└───────────────────────────────────────────────────────────────┘
+
+       Eventually (Stripe's payout schedule, typically 2-7 days):
+
+acct_NPO_abc (Stripe balance)  ──────►  NPO's bank account
+Givernance platform balance    ──────►  Givernance's bank account
+```
+
+Three things happen on a single Stripe charge, automatically and atomically:
+
+1. **Donor's card → connected account** (gross amount).
+2. **Connected account → platform account** (`application_fee_amount`). This is the slice that's our revenue. Stripe deducts it from the connected account's incoming balance and credits it to the platform's balance. **No manual transfer needed.**
+3. **Stripe processing fee** is deducted from the connected account (default for direct charges). This is the cost the NPO pays Stripe — it's *not* Givernance revenue.
+
+### Worked example — €50 donation in EUR
+
+| Line item                                           | Amount  | Goes to        |
+| --------------------------------------------------- | ------- | -------------- |
+| Donor charged                                       | €50.00  | (out of donor) |
+| Stripe processing fee (~1.5% + €0.25, EU card)      | -€1.00  | Stripe         |
+| Givernance platform fee (1.5% + €0.30)              | -€1.05  | Givernance     |
+| **Net to NPO Stripe balance**                       | **€47.95** | NPO       |
+
+The numbers above show what the NPO actually receives; the donor is charged the full €50.
+
+> **Stripe's processing fee can vary** by card type, country of issue, currency, and your Stripe agreement. The figure above is the typical EU card baseline — see https://stripe.com/pricing for the current schedule. Givernance does not control that fee.
+
+> **The platform fee is configurable.** Today it's hardcoded at `1.5% + 30¢` in [packages/api/src/modules/public/service.ts:125](../packages/api/src/modules/public/service.ts#L125). When pricing tiers ship (per [docs/08-pricing-packaging.md](08-pricing-packaging.md)), this becomes a per-tenant value driven by their plan.
+
+### Why we use direct charges (not destination charges)
+
+Two Stripe Connect charge models exist:
+
+- **Direct charges** — PaymentIntent created on the connected account. Funds land directly in the NPO's balance. Application fee splits to platform. *This is what we use.*
+- **Destination charges** — PaymentIntent created on the platform. Funds initially land in the platform balance, then transferred to connected account. Platform sees full gross.
+
+Direct charges are the right pick for Givernance because:
+- Funds never touch our balance, even briefly. That keeps us out of e-money licensing scope (see [20-payment-strategy.md §4 ADR-010](20-payment-strategy.md#4-adr-010--payment-provider-selection)).
+- Stripe's receipts/disputes flow stays NPO-branded — the donor sees the NPO's name, not Givernance's, on their card statement.
+- Refunds process directly against the NPO's balance — no Givernance involvement.
+
+The trade-off: each NPO's Stripe account name is what donors see on their statement. That's actually what we want — donors gave to *the NPO*, not to *Givernance*.
+
+---
+
+## What an NPO sees, end-to-end
+
+1. **Onboarding** — org admin opens **Settings → Stripe Connect → Connect Stripe**. Redirects to Stripe's hosted Express form. Fills business info, bank details, identity verification. Lands back on Givernance with a "Connected" badge. (Test mode: takes ~60 seconds with placeholder data, no verification.)
+2. **Receiving donations** — every public donation page now shows the Payment Element. Donors pay; charges appear in the NPO's Stripe Express dashboard within seconds.
+3. **Payouts** — Stripe automatically pays out the NPO's balance to their bank account on Stripe's schedule (typically 2-7 days for new accounts, faster once established). The NPO sees the payout schedule in their Express dashboard.
+4. **Refunds & disputes** — handled in the NPO's Stripe dashboard or via Givernance UI (the latter just calls Stripe APIs on the NPO's behalf). When a refund is issued, the platform fee is automatically returned to the NPO too — Stripe rolls it back.
+5. **Tax receipts** — handled by Givernance (the NPO's CRM). The Stripe receipt email is separate.
+
+---
+
+## What Givernance sees
+
+- **Platform balance**: shows the cumulative `application_fee_amount` collected across all NPOs.
+- **Platform dashboard**: every connected account is listed at https://dashboard.stripe.com/test/connect/accounts/overview — we can see each NPO's KYC status, charges enabled, payout health.
+- **Database**: `tenants.stripe_account_id` stores the NPO's `acct_…` ID. Every donation row in `donations` has `payment_method = "stripe"` and `payment_ref = pi_…`.
+- **Auditable money trail**: each `donation` ↔ `webhook_event` ↔ Stripe `pi_…` is one-to-one and signed.
+
+---
+
+## Why this maps to the impact-based business model
+
+You said: *"Our business model is based on impact — based on the payments done to donate. We take a fee."*
+
+Stripe Connect maps to this model exactly:
+
+- **Per-donation fee** (1.5% + 30¢) — collected automatically as `application_fee_amount`. **No invoicing, no manual reconciliation, no late payments.** When the NPO grows in donations, our revenue scales with it. When they don't raise money, we don't collect a fee.
+- **No fixed seat licence required** — we *can* layer one on top later (per `08-pricing-packaging.md`), but the core engine ("we earn when NPOs raise") is already wired.
+- **Visible & honest** — the NPO sees the application fee in their Stripe dashboard, line by line. Nothing is hidden in a separate billing system.
+- **Aligned incentives** — if Givernance helps an NPO raise more, both sides win on the same dollar. There's no "we charge €X/month regardless."
+
+The fee is **set per tenant** (currently a hardcoded constant, per-tenant later). Future plans (per [docs/08-pricing-packaging.md](08-pricing-packaging.md)) include:
+- Tiered fee % based on tenant size or plan.
+- Custom fee for partner NPOs / discount codes.
+- Override to 0% for free-tier or trial tenants.
+
+The implementation hook is [`calculatePlatformFee(amountCents)`](../packages/api/src/modules/public/service.ts#L125). Today it returns `Math.round(amountCents * 0.015 + 30)`. Replacing that with a per-tenant lookup (`getPlatformFee(tenantId, amountCents)`) is the path to plan-gated fees.
+
+---
+
+## Where the code lives
+
+| Concern                          | File                                                                                                | Notes                                                                |
+| -------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Onboarding (start)               | [packages/api/src/modules/payments/service.ts](../packages/api/src/modules/payments/service.ts)     | `startStripeOnboarding` creates Express account + onboarding link    |
+| Onboarding (status)              | same file                                                                                           | `getStripeConnectStatus` reads live capability flags                 |
+| Settings UI                      | [packages/web/src/components/settings/stripe-connect-panel.tsx](../packages/web/src/components/settings/stripe-connect-panel.tsx) | Calls the two endpoints above                                        |
+| PaymentIntent creation           | [packages/api/src/modules/public/service.ts](../packages/api/src/modules/public/service.ts)         | `createDonationIntent` — direct charge on connected account          |
+| Platform fee formula             | same file, `calculatePlatformFee`                                                                   | `1.5% + 30¢` (hardcoded today)                                       |
+| Donor Payment Element            | [packages/web/src/components/campaigns/public-donation-payment-step.tsx](../packages/web/src/components/campaigns/public-donation-payment-step.tsx) | `loadStripe(pk, { stripeAccount })`                                  |
+| Webhook ingestion                | [packages/api/src/modules/payments/routes.ts](../packages/api/src/modules/payments/routes.ts)       | Signature verification → idempotent insert → enqueue                 |
+| Donation row creation            | [packages/worker/src/processors/stripe-webhook.ts](../packages/worker/src/processors/stripe-webhook.ts) | Resolves tenant by `acct_…`, upserts constituent, inserts donation   |
+| Schema                           | [packages/shared/src/schema/index.ts](../packages/shared/src/schema/index.ts) — `tenants.stripe_account_id`, `webhook_events` | One ID per tenant; idempotency via `(provider, provider_event_id)`    |
+
+---
+
+## The rejected alternative — "we collect, we pay out monthly"
+
+The natural alternative architecture (the one most people imagine when they first hear the problem) is:
+
+> "Donors pay Givernance directly. We track per-NPO totals in our DB. End of month, we send each NPO a single bulk payment to their bank account."
+
+This is sometimes called the **payment-aggregator** or **platform-of-record** model. It is real, it's used in production by serious players (HelloAsso in France is the best-known nonprofit example), and we considered it. Here's why we picked Stripe Connect instead.
+
+### What an aggregator model would look like
+
+```
+Donor (France)   →  €50 →  Givernance's Stripe account  →  €50 sits in our balance
+Donor (Germany)  →  €30 →  Givernance's Stripe account  →  €30 sits in our balance
+…
+End of month:    Givernance →  bulk SEPA transfer →  each NPO's bank account
+```
+
+NPO experience:
+- No Stripe sign-up. They give us a bank account number, that's it.
+- Payouts arrive monthly (or on whatever cadence we set).
+- Donor's card statement reads "Givernance" — they have to recognise our brand, not the NPO's.
+- All disputes/refunds/chargebacks land on us; we pass the cost on to the NPO somehow.
+
+### Why this is a bigger lift than it looks
+
+The blockers are mostly regulatory, and they're load-bearing.
+
+1. **EU payment-institution licensing (PSD2).** When you hold third-party funds with the intent to forward them — even briefly — you're operating as a payment intermediary. Under PSD2 in the EU, that requires either an **EMI** (Electronic Money Institution) or **PI** (Payment Institution) licence from a national regulator (ACPR in France, BaFin in Germany, FCA in the UK, etc.). Floor cost:
+    - Minimum capital requirement: €350k (PI scope) up to €2M (EMI).
+    - Application timeline: 6-18 months from filing.
+    - Ongoing compliance: AML/KYC programme, fraud monitoring, segregated client-money accounts, regulatory reporting, internal audit, periodic regulator inspections.
+    - Total runway: typically 12-24 months and €1-3M before first donation lands.
+2. **AML/KYC obligation moves onto us.** With Connect, Stripe KYCs every NPO connected account before allowing charges — they have an EMI licence and that's their job. With aggregator, *we* are the financial institution, *we* KYC every NPO, *we* are liable if a fake "NPO" launders money through our platform. The investigation, sanction-screening, beneficial-ownership, periodic-refresh apparatus has to be built in-house.
+3. **Chargebacks become our balance-sheet risk.** Donor calls their bank, says "I don't recognise this charge from Givernance." Bank claws back the €50 from our Stripe balance. With Connect, the same scenario claws back from the NPO's balance — Givernance is unaffected. With aggregator, the NPO's monthly payout is short by €50 and we have to either eat the difference, claw it back from the NPO's next payout, or run a collections process.
+4. **Tax/receipts cross borders messily.** Donor in France giving to a Belgian NPO, in the aggregator model, is two transactions: (a) donor → Givernance France, (b) Givernance → NPO Belgium. That's potentially two VAT events, two tax-receipt jurisdictions, two reporting obligations. With direct charges, the NPO is the merchant of record — one transaction, one jurisdiction.
+5. **Cash-flow visibility for the NPO.** Monthly payouts mean the NPO waits 0-30 days, sees totals only after we send them, and has no native dashboard. With Connect Express, the NPO sees every donation land in real time, sees the payout schedule, and can talk to Stripe support directly.
+6. **Concentration of trust.** "If Givernance has cash-flow issues or banking trouble, your monthly payout is at risk" is a harder pitch to a finance director than "your money lives in your own Stripe account."
+
+### When we'd revisit this decision
+
+Connect isn't a hill to die on — it's the right call *for the current product, scale, and timeline*. We'd legitimately reopen the question if any of the following changed:
+
+- We want to onboard NPOs that **cannot** sign up to Stripe (jurisdiction not supported, or NPO too small / informal to satisfy Stripe's KYC). Today, ~95% of EU/UK nonprofits qualify for a Stripe Express account. The exceptions are mostly rural, very-small associations, or ones operating in jurisdictions Stripe hasn't covered yet (parts of Eastern Europe, some niches).
+- We have a strategic reason to be the merchant of record — e.g., we want to issue *Givernance-branded* receipts (currently the receipt comes from each NPO).
+- The fee structure of an aggregator model (volume-discounted Stripe rates we'd negotiate as a single high-volume merchant, then re-distribute) becomes materially better for NPOs than them paying retail Stripe rates individually. This requires us doing many millions of euros / month in volume.
+- Compliance / legal lifts the regulatory blocker (e.g., we acquire or partner with an existing PI/EMI licence-holder).
+
+A hybrid is also possible: Connect as the default, with an **aggregator fallback** for the long tail of NPOs that can't onboard with Stripe. That's a real product direction — track it as a separate spike when the demand surfaces.
+
+### Where this decision lives
+
+This is one of the core decisions in **ADR-010** ([20-payment-strategy.md §4](20-payment-strategy.md#4-adr-010--payment-provider-selection)). Notably, the explicit rationale recorded there is:
+
+> "Platform commission model: `application_fee_amount` on each charge enables Givernance to collect its platform fee without handling e-money flows — **no e-money licence required**"
+
+So the strategy was deliberately chosen, with the licence-avoidance benefit as one of the load-bearing arguments. The other major payment-aggregator player in our space (HelloAsso, France) operates under a payment-institution licence specifically — which validates that the alternative model is viable but expensive to enter.
+
+If we want to revisit this in light of new information (a partnership opportunity, a regulatory change, a long-tail-of-NPOs problem we want to solve), the path is a new ADR superseding ADR-010, not a quiet re-architecture.
+
+---
+
+## What's not in production yet
+
+This document describes the architecture that is **implemented today**. Several extensions are tracked but not built:
+
+- **Auto-promote to live mode** when `account.updated.charges_enabled = true` — [issue #62](https://github.com/purposestack/givernance/issues/62).
+- **Mollie as co-primary** for FR/BE/NL (lower fee on iDEAL/Bancontact) — [issue #62](https://github.com/purposestack/givernance/issues/62), gated by `ff.payments.mollie`.
+- **SEPA Direct Debit** for recurring donations — [issue #26](https://github.com/purposestack/givernance/issues/26).
+- **Per-tenant fee** (driven by plan instead of a constant) — pending pricing finalisation in [docs/08-pricing-packaging.md](08-pricing-packaging.md).
+- **Restricted Stripe keys with scoped permissions** for the live key — see [20-payment-strategy.md §6](20-payment-strategy.md#6-pci-dss-compliance).
+
+---
+
+## Common questions
+
+**Q: When an NPO refunds a donation, do we keep the platform fee?**
+No. By Stripe Connect default, refunding a charge also refunds the application fee. The €1.05 we collected is returned to the NPO's balance and the donor gets the full €50 back. We can override this (`refund_application_fee: false`) but currently don't.
+
+**Q: What if Stripe is down?**
+Donor sees a payment error. No PaymentIntent is created, no donation row is written. Givernance is operationally fine — the rest of the CRM keeps working. Stripe outages are rare and short.
+
+**Q: What if our webhook signature secret rotates?**
+Webhooks fail signature verification (400 response). Stripe retries automatically with exponential backoff for up to 3 days. As long as we deploy the new secret within that window, no donation rows are lost. The PaymentIntent itself succeeded regardless — funds are in the NPO's balance even before our webhook handler sees the event.
+
+**Q: Can an NPO leave Givernance and keep their Stripe account?**
+Yes. The Stripe Express account is theirs. Disconnecting from our platform means we lose the API permission to act on their behalf, but their account, balance, donation history, and payout schedule all continue. (We don't currently expose an in-app "disconnect" button — they'd revoke from Stripe's side.)
+
+**Q: What about countries where Stripe doesn't operate?**
+That's the Mollie / Mangopay / SIX comparison in [20-payment-strategy.md §3](20-payment-strategy.md#3-provider-comparison). Stripe covers most EU/EEA + UK + US + a few others; for jurisdictions Stripe doesn't support, we'd route through a different provider via the `PaymentGateway` factory.
+
+**Q: Why 1.5% + 30¢ specifically?**
+Placeholder rounded-to-be-readable. The actual final platform fee is unsettled — see [docs/08-pricing-packaging.md](08-pricing-packaging.md) for pricing-tier work. The 30¢ floor exists so micro-donations (€1, €2) don't disappear into the platform fee entirely; on a €50 donation it's a small slice, but on a €1 donation a flat 1.5% would be 1.5¢, which is below Stripe's processing minimum cost to us.

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -94,6 +94,40 @@ if (process.env.NODE_ENV === "production" && !value.KEYCLOAK_ADMIN_CLIENT_SECRET
   process.exit(1);
 }
 
+// Stripe secret key + webhook secret — fail fast at boot in production
+// instead of letting `getStripe()` crash on the first donation. (PR #193
+// review, finding #6.) Local dev keeps both Optional so an env without
+// Stripe still boots — the user-facing surface (Settings panel 502, donor
+// flow blocked) tells the operator what's missing.
+if (process.env.NODE_ENV === "production") {
+  if (!value.STRIPE_SECRET_KEY) {
+    console.error(
+      "[api] STRIPE_SECRET_KEY is strictly required in production — without it every donation attempt 502s.",
+    );
+    process.exit(1);
+  }
+  // Format sanity-check so a typo'd value (e.g. swapped publishable key)
+  // surfaces at boot rather than on the first PaymentIntent.create.
+  if (!/^sk_(test|live)_/.test(value.STRIPE_SECRET_KEY)) {
+    console.error(
+      "[api] STRIPE_SECRET_KEY must start with `sk_test_` or `sk_live_` — looks like a publishable key or restricted key was set instead.",
+    );
+    process.exit(1);
+  }
+  if (!value.STRIPE_WEBHOOK_SECRET) {
+    console.error(
+      "[api] STRIPE_WEBHOOK_SECRET is strictly required in production — without it every webhook 400s on signature verification.",
+    );
+    process.exit(1);
+  }
+  if (!value.STRIPE_WEBHOOK_SECRET.startsWith("whsec_")) {
+    console.error(
+      "[api] STRIPE_WEBHOOK_SECRET must start with `whsec_` — got something else, likely the wrong dashboard field copied.",
+    );
+    process.exit(1);
+  }
+}
+
 const adminUrl = value.KEYCLOAK_ADMIN_URL ?? value.KEYCLOAK_INTERNAL_URL ?? value.KEYCLOAK_URL;
 const isLocalHost =
   /^(https?:\/\/)?(localhost|127\.0\.0\.1|0\.0\.0\.0|givernance-keycloak)(:|$|\/)/i.test(adminUrl);

--- a/packages/api/src/modules/donations/routes.ts
+++ b/packages/api/src/modules/donations/routes.ts
@@ -12,9 +12,11 @@ import {
   ErrorResponses,
   IdParams,
   PaginationQuery,
+  ProblemDetailSchema,
   problemDetail,
   UuidSchema,
 } from "../../lib/schemas.js";
+import { getStripe } from "../payments/service.js";
 import {
   AllocationSumMismatchError,
   CrossTenantReferenceError,
@@ -23,6 +25,7 @@ import {
   getDonation,
   getReceiptByDonation,
   listDonations,
+  refundDonation,
   updateDonation,
 } from "./service.js";
 
@@ -131,6 +134,13 @@ const DonationListRow = Type.Object({
   ]),
 });
 
+const DonationStatusSchema = Type.Union([
+  Type.Literal("pending"),
+  Type.Literal("cleared"),
+  Type.Literal("refunded"),
+  Type.Literal("failed"),
+]);
+
 const DonationDetailResponse = Type.Object({
   id: UuidSchema,
   orgId: UuidSchema,
@@ -140,6 +150,10 @@ const DonationDetailResponse = Type.Object({
   campaignId: Type.Union([UuidSchema, Type.Null()]),
   paymentMethod: Type.Union([Type.String(), Type.Null()]),
   paymentRef: Type.Union([Type.String(), Type.Null()]),
+  // Issue #199: exposed so the donation detail UI can hide the refund
+  // button on already-refunded rows and the refund flow doesn't surprise
+  // a donor who clicked twice.
+  status: DonationStatusSchema,
   donatedAt: Type.String(),
   fiscalYear: Type.Union([Type.Integer(), Type.Null()]),
   createdAt: Type.String(),
@@ -420,6 +434,81 @@ export async function donationRoutes(app: FastifyInstance) {
       }
 
       return { data: deleted };
+    },
+  );
+
+  /**
+   * Refund a Stripe donation (issue #199). Only org_admins, only Stripe-
+   * sourced donations, and only ones not already refunded.
+   *
+   * The actual donation-row update happens twice for idempotency: once
+   * synchronously here for snappy UI, and again on the `charge.refunded`
+   * webhook (which the worker handles regardless of refund origin — our
+   * UI or the NPO's Stripe dashboard). Both paths set `status =
+   * "refunded"`; the second one is a no-op when it sees the row is
+   * already refunded.
+   */
+  app.post(
+    "/donations/:id/refund",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Donations"],
+        params: IdParams,
+        response: {
+          200: DataResponse(Type.Object({ id: UuidSchema, status: Type.Literal("refunded") })),
+          422: ProblemDetailSchema,
+          502: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const t = resolveTranslations(request);
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", t("errors.unauthorized")));
+      }
+
+      const { id } = request.params as { id: string };
+      const stripe = getStripe();
+      const result = await refundDonation(orgId, id, stripe.refunds);
+
+      switch (result.kind) {
+        case "ok":
+          return { data: { id, status: "refunded" as const } };
+        case "not_found":
+          return reply
+            .status(404)
+            .send(
+              problemDetail(
+                404,
+                "Not Found",
+                t("errors.notFound", { resource: t("resources.donation") }),
+              ),
+            );
+        case "already_refunded":
+          return reply
+            .status(422)
+            .send(problemDetail(422, "Unprocessable Entity", "Donation already refunded"));
+        case "not_stripe":
+          return reply
+            .status(422)
+            .send(
+              problemDetail(
+                422,
+                "Unprocessable Entity",
+                "Only Stripe-sourced donations can be refunded through this endpoint",
+              ),
+            );
+        case "stripe_error":
+          // Sanitised log; donor-/operator-facing message stays generic
+          // (memory: don't leak Stripe internals to authenticated callers).
+          request.log.error({ errMessage: result.message, donationId: id }, "Stripe refund failed");
+          return reply
+            .status(502)
+            .send(problemDetail(502, "Bad Gateway", "Payment provider error, please try again"));
+      }
     },
   );
 

--- a/packages/api/src/modules/donations/service.ts
+++ b/packages/api/src/modules/donations/service.ts
@@ -474,3 +474,96 @@ export async function deleteDonation(orgId: string, id: string) {
     return deleted ?? null;
   });
 }
+
+/**
+ * Result of `refundDonation`. Discriminated union so the route layer
+ * can map each precondition failure to the right HTTP status without
+ * inspecting strings (issue #199).
+ */
+export type RefundDonationResult =
+  | { kind: "ok" }
+  | { kind: "not_found" }
+  | { kind: "not_stripe" }
+  | { kind: "already_refunded" }
+  | { kind: "stripe_error"; message: string };
+
+/**
+ * Issue a Stripe refund against the original PaymentIntent of a donation
+ * and roll back the platform fee with `refund_application_fee: true`. The
+ * actual donation-row update + campaign fee decrement happens in the
+ * `charge.refunded` webhook handler (worker) so the change is observed
+ * exactly once whether the refund originated from our UI or from the
+ * NPO's Stripe dashboard. This route ALSO marks the donation as
+ * `refunded` immediately for snappy UI feedback — the webhook handler
+ * is idempotent on already-refunded rows.
+ *
+ * @returns discriminated union the route layer maps to HTTP status.
+ */
+export async function refundDonation(
+  orgId: string,
+  donationId: string,
+  refundsApi: {
+    create: (params: {
+      payment_intent: string;
+      refund_application_fee?: boolean;
+    }) => Promise<unknown>;
+  },
+): Promise<RefundDonationResult> {
+  return withTenantContext(orgId, async (tx) => {
+    const [donation] = await tx
+      .select({
+        id: donations.id,
+        status: donations.status,
+        paymentMethod: donations.paymentMethod,
+        paymentRef: donations.paymentRef,
+      })
+      .from(donations)
+      .where(and(eq(donations.id, donationId), eq(donations.orgId, orgId)));
+
+    if (!donation) return { kind: "not_found" } as const;
+    if (donation.status === "refunded") return { kind: "already_refunded" } as const;
+    if (donation.paymentMethod !== "stripe" || !donation.paymentRef) {
+      // Off-Stripe donations (cash, SEPA imported, check) need their own
+      // refund mechanism — out of scope here; route returns 422.
+      return { kind: "not_stripe" } as const;
+    }
+
+    try {
+      // `refund_application_fee: true` rolls back the 1.5%+30¢ platform
+      // fee to the connected account at the same time as refunding the
+      // donor — donor experience: "I got my €50 back, no fee."
+      await refundsApi.create({
+        payment_intent: donation.paymentRef,
+        refund_application_fee: true,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Stripe refund failed";
+      return { kind: "stripe_error", message } as const;
+    }
+
+    // Mark the row refunded immediately so the operator sees instant
+    // feedback in the UI. The `charge.refunded` webhook handler will
+    // observe `status === "refunded"` and short-circuit, keeping the
+    // pipeline idempotent.
+    await tx
+      .update(donations)
+      .set({ status: "refunded" })
+      .where(and(eq(donations.id, donationId), eq(donations.orgId, orgId)));
+
+    // Emit the domain event from the API path too — mirrors what the
+    // webhook handler does. Outbox is keyed on `(tenantId, type,
+    // payload->>donationId)` only; if a duplicate emit happens, the
+    // relay's at-least-once delivery + downstream idempotency handles it.
+    await tx.insert(outboxEvents).values({
+      tenantId: orgId,
+      type: "donation.refunded",
+      payload: {
+        donationId,
+        paymentRef: donation.paymentRef,
+        source: "donation_refund_route",
+      },
+    });
+
+    return { kind: "ok" } as const;
+  });
+}

--- a/packages/api/src/modules/donations/service.ts
+++ b/packages/api/src/modules/donations/service.ts
@@ -509,8 +509,19 @@ export async function refundDonation(
     }) => Promise<unknown>;
   },
 ): Promise<RefundDonationResult> {
-  return withTenantContext(orgId, async (tx) => {
-    const [donation] = await tx
+  // Three-phase flow so we never hold a Postgres connection through a
+  // network call to Stripe (PR #193 review, finding #2):
+  //   1. Read-and-validate transaction (RLS-scoped, fast).
+  //   2. Stripe API call OUTSIDE any DB transaction.
+  //   3. Write-back transaction (RLS-scoped, fast).
+  // Holding a tx open across the Stripe call would pin a connection for
+  // the full latency of `refunds.create` (variable, can timeout). Under
+  // a burst of concurrent refunds the pool drains and unrelated requests
+  // start queuing.
+
+  // Phase 1 — read state, decide whether to call Stripe.
+  const validation = await withTenantContext(orgId, async (tx) => {
+    const [row] = await tx
       .select({
         id: donations.id,
         status: donations.status,
@@ -519,32 +530,37 @@ export async function refundDonation(
       })
       .from(donations)
       .where(and(eq(donations.id, donationId), eq(donations.orgId, orgId)));
+    return row ?? null;
+  });
 
-    if (!donation) return { kind: "not_found" } as const;
-    if (donation.status === "refunded") return { kind: "already_refunded" } as const;
-    if (donation.paymentMethod !== "stripe" || !donation.paymentRef) {
-      // Off-Stripe donations (cash, SEPA imported, check) need their own
-      // refund mechanism — out of scope here; route returns 422.
-      return { kind: "not_stripe" } as const;
-    }
+  if (!validation) return { kind: "not_found" } as const;
+  if (validation.status === "refunded") return { kind: "already_refunded" } as const;
+  if (validation.paymentMethod !== "stripe" || !validation.paymentRef) {
+    // Off-Stripe donations (cash, SEPA imported, check) need their own
+    // refund mechanism — out of scope here; route returns 422.
+    return { kind: "not_stripe" } as const;
+  }
+  const paymentRef = validation.paymentRef;
 
-    try {
-      // `refund_application_fee: true` rolls back the 1.5%+30¢ platform
-      // fee to the connected account at the same time as refunding the
-      // donor — donor experience: "I got my €50 back, no fee."
-      await refundsApi.create({
-        payment_intent: donation.paymentRef,
-        refund_application_fee: true,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Stripe refund failed";
-      return { kind: "stripe_error", message } as const;
-    }
+  // Phase 2 — Stripe call. NO DB transaction held during this network
+  // request. `refund_application_fee: true` rolls back the 1.5%+30¢
+  // platform fee to the connected account at the same time as refunding
+  // the donor — donor experience: "I got my €50 back, no fee."
+  try {
+    await refundsApi.create({
+      payment_intent: paymentRef,
+      refund_application_fee: true,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Stripe refund failed";
+    return { kind: "stripe_error", message } as const;
+  }
 
-    // Mark the row refunded immediately so the operator sees instant
-    // feedback in the UI. The `charge.refunded` webhook handler will
-    // observe `status === "refunded"` and short-circuit, keeping the
-    // pipeline idempotent.
+  // Phase 3 — persist the local state change. There's a tiny race window
+  // between phase 2 and phase 3 where the `charge.refunded` webhook can
+  // fire before we mark the row; both writers are idempotent on
+  // `status === "refunded"` so the second one short-circuits cleanly.
+  await withTenantContext(orgId, async (tx) => {
     await tx
       .update(donations)
       .set({ status: "refunded" })
@@ -559,11 +575,11 @@ export async function refundDonation(
       type: "donation.refunded",
       payload: {
         donationId,
-        paymentRef: donation.paymentRef,
+        paymentRef,
         source: "donation_refund_route",
       },
     });
-
-    return { kind: "ok" } as const;
   });
+
+  return { kind: "ok" } as const;
 }

--- a/packages/api/src/modules/payments/routes.ts
+++ b/packages/api/src/modules/payments/routes.ts
@@ -178,6 +178,15 @@ export async function stripeWebhookRoute(app: FastifyInstance) {
   // (Black-Friday-scale donation spike) shares a single source — too low a
   // cap forces Stripe into exponential-backoff retries and queues up
   // donations on its side. 50 was overly conservative.
+  //
+  // Defence-in-depth at the edge (PR #193 review, finding #5): Stripe
+  // publishes its webhook source IPs at
+  // https://stripe.com/docs/ips#webhook-notifications. In production, the
+  // platform proxy / reverse-proxy SHOULD allowlist those IPs so an
+  // attacker can't drown legitimate webhook traffic by burning the per-IP
+  // rate limit. This is infra-side config, not application code. Today
+  // signature verification on every event is the primary defence; the
+  // rate limit + allowlist together protect availability.
   await app.register(rateLimit, {
     max: 300,
     timeWindow: "1 minute",

--- a/packages/api/src/modules/payments/routes.ts
+++ b/packages/api/src/modules/payments/routes.ts
@@ -54,17 +54,35 @@ const StripeConnectResponse = Type.Object({
   accountId: Type.String(),
 });
 
+const StripeCapabilityStatusSchema = Type.Union([
+  Type.Literal("active"),
+  Type.Literal("pending"),
+  Type.Literal("inactive"),
+  Type.Literal("unrequested"),
+]);
+
 /**
  * GET response — the "connection status" resource always exists for any
  * authenticated org, but `accountId` is `null` when the tenant has not yet
  * onboarded. Contrast with `StripeConnectResponse.accountId` (POST) which
  * is non-null because POST always produces an account.
+ *
+ * `requirementsCurrentlyDue` + `disabledReason` + per-capability statuses
+ * (issue #201) let the Settings UI tell the operator *why* charges aren't
+ * enabled instead of "Onboarding incomplete" with no remediation hint.
  */
 const StripeConnectStatusResponse = Type.Object({
   accountId: Type.Union([Type.String(), Type.Null()]),
   chargesEnabled: Type.Boolean(),
   payoutsEnabled: Type.Boolean(),
   detailsSubmitted: Type.Boolean(),
+  requirementsCurrentlyDue: Type.Array(Type.String()),
+  disabledReason: Type.Union([Type.String(), Type.Null()]),
+  capabilities: Type.Object({
+    cardPayments: StripeCapabilityStatusSchema,
+    transfers: StripeCapabilityStatusSchema,
+    linkPayments: StripeCapabilityStatusSchema,
+  }),
 });
 
 export async function paymentRoutes(app: FastifyInstance) {

--- a/packages/api/src/modules/payments/routes.ts
+++ b/packages/api/src/modules/payments/routes.ts
@@ -8,7 +8,12 @@ import type { FastifyInstance } from "fastify";
 import { requireOrgAdmin } from "../../lib/guards.js";
 import { redis } from "../../lib/redis.js";
 import { DataResponse, ErrorResponses, problemDetail } from "../../lib/schemas.js";
-import { createWebhookEvent, startStripeOnboarding, verifyStripeWebhook } from "./service.js";
+import {
+  createWebhookEvent,
+  getStripeConnectStatus,
+  startStripeOnboarding,
+  verifyStripeWebhook,
+} from "./service.js";
 
 const webhooksQueue = new Queue(QUEUE_NAMES.WEBHOOKS, { connection: redis });
 
@@ -22,7 +27,47 @@ const StripeConnectResponse = Type.Object({
   accountId: Type.String(),
 });
 
+const StripeConnectStatusResponse = Type.Object({
+  accountId: Type.Union([Type.String(), Type.Null()]),
+  chargesEnabled: Type.Boolean(),
+  payoutsEnabled: Type.Boolean(),
+  detailsSubmitted: Type.Boolean(),
+});
+
 export async function paymentRoutes(app: FastifyInstance) {
+  /**
+   * Read Stripe Connect status for the authenticated org. Returns a
+   * "not connected" shape (`accountId: null`, all flags false) when the
+   * tenant has no Stripe account yet so the settings UI can render a
+   * single panel without a 404 branch.
+   */
+  app.get(
+    "/admin/stripe-connect",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Payments"],
+        response: { 200: DataResponse(StripeConnectStatusResponse), ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+
+      try {
+        const status = await getStripeConnectStatus(orgId);
+        return { data: status };
+      } catch (err) {
+        request.log.error({ err }, "Stripe Connect status fetch failed");
+        return reply
+          .status(502)
+          .send(problemDetail(502, "Bad Gateway", "Payment provider error, please try again"));
+      }
+    },
+  );
+
   /**
    * Start Stripe Connect onboarding for the authenticated org.
    * Creates an Express connected account if needed, returns the Account Link URL.

--- a/packages/api/src/modules/payments/routes.ts
+++ b/packages/api/src/modules/payments/routes.ts
@@ -7,7 +7,12 @@ import { Queue } from "bullmq";
 import type { FastifyInstance } from "fastify";
 import { requireOrgAdmin } from "../../lib/guards.js";
 import { redis } from "../../lib/redis.js";
-import { DataResponse, ErrorResponses, problemDetail } from "../../lib/schemas.js";
+import {
+  DataResponse,
+  ErrorResponses,
+  ProblemDetailSchema,
+  problemDetail,
+} from "../../lib/schemas.js";
 import {
   createWebhookEvent,
   getStripeConnectStatus,
@@ -17,16 +22,44 @@ import {
 
 const webhooksQueue = new Queue(QUEUE_NAMES.WEBHOOKS, { connection: redis });
 
+/**
+ * Pino-safe shape for Stripe error logging. The raw `Stripe.errors.StripeError`
+ * carries `requestId`, full message, raw HTTP body, and possibly tenant-scoped
+ * ids (`account`, `payment_intent.id`) which would cross-contaminate a shared
+ * log index. `{message, code}` is enough to triage a 502 in ops without
+ * spilling identifiers across tenants.
+ */
+function logStripeError(err: unknown) {
+  if (err instanceof Error) {
+    const code = (err as { code?: string }).code;
+    return code ? { errMessage: err.message, errCode: code } : { errMessage: err.message };
+  }
+  return { errMessage: String(err) };
+}
+
 const StripeConnectBody = Type.Object({
-  refreshUrl: Type.String({ minLength: 1 }),
-  returnUrl: Type.String({ minLength: 1 }),
+  /** Stripe redirects here if the operator abandons the hosted onboarding form. */
+  refreshUrl: Type.String({ minLength: 1, format: "uri" }),
+  /** Stripe redirects here when the operator finishes (or short-circuits) onboarding. */
+  returnUrl: Type.String({ minLength: 1, format: "uri" }),
 });
 
+/**
+ * POST response — `accountId` is **always** populated since we either
+ * created the account in this call or returned an existing one. Contrast
+ * with `StripeConnectStatusResponse.accountId` which is nullable.
+ */
 const StripeConnectResponse = Type.Object({
   url: Type.String(),
   accountId: Type.String(),
 });
 
+/**
+ * GET response — the "connection status" resource always exists for any
+ * authenticated org, but `accountId` is `null` when the tenant has not yet
+ * onboarded. Contrast with `StripeConnectResponse.accountId` (POST) which
+ * is non-null because POST always produces an account.
+ */
 const StripeConnectStatusResponse = Type.Object({
   accountId: Type.Union([Type.String(), Type.Null()]),
   chargesEnabled: Type.Boolean(),
@@ -39,15 +72,22 @@ export async function paymentRoutes(app: FastifyInstance) {
    * Read Stripe Connect status for the authenticated org. Returns a
    * "not connected" shape (`accountId: null`, all flags false) when the
    * tenant has no Stripe account yet so the settings UI can render a
-   * single panel without a 404 branch.
+   * single panel without a 404 branch. Calls `accounts.retrieve` on Stripe
+   * for live capability flags — per-route rate-limited so a misbehaving
+   * Settings page can't burn the platform's Stripe API budget.
    */
   app.get(
     "/admin/stripe-connect",
     {
       preHandler: requireOrgAdmin,
+      config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
       schema: {
         tags: ["Payments"],
-        response: { 200: DataResponse(StripeConnectStatusResponse), ...ErrorResponses },
+        response: {
+          200: DataResponse(StripeConnectStatusResponse),
+          502: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
       },
     },
     async (request, reply) => {
@@ -60,7 +100,7 @@ export async function paymentRoutes(app: FastifyInstance) {
         const status = await getStripeConnectStatus(orgId);
         return { data: status };
       } catch (err) {
-        request.log.error({ err }, "Stripe Connect status fetch failed");
+        request.log.error(logStripeError(err), "Stripe Connect status fetch failed");
         return reply
           .status(502)
           .send(problemDetail(502, "Bad Gateway", "Payment provider error, please try again"));
@@ -79,7 +119,11 @@ export async function paymentRoutes(app: FastifyInstance) {
       schema: {
         tags: ["Payments"],
         body: StripeConnectBody,
-        response: { 200: DataResponse(StripeConnectResponse), ...ErrorResponses },
+        response: {
+          200: DataResponse(StripeConnectResponse),
+          502: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
       },
     },
     async (request, reply) => {
@@ -97,7 +141,7 @@ export async function paymentRoutes(app: FastifyInstance) {
         const result = await startStripeOnboarding(orgId, refreshUrl, returnUrl);
         return { data: result };
       } catch (err) {
-        request.log.error({ err }, "Stripe Connect onboarding failed");
+        request.log.error(logStripeError(err), "Stripe Connect onboarding failed");
         return reply
           .status(502)
           .send(problemDetail(502, "Bad Gateway", "Payment provider error, please try again"));
@@ -111,9 +155,13 @@ export async function paymentRoutes(app: FastifyInstance) {
  * raw-body content-type parser doesn't affect other JSON routes.
  */
 export async function stripeWebhookRoute(app: FastifyInstance) {
-  // Per-IP rate limit for the public webhook endpoint
+  // Per-IP rate limit for the public webhook endpoint. 300/min: Stripe sends
+  // from a small fixed pool of source IPs, so legitimate burst traffic
+  // (Black-Friday-scale donation spike) shares a single source — too low a
+  // cap forces Stripe into exponential-backoff retries and queues up
+  // donations on its side. 50 was overly conservative.
   await app.register(rateLimit, {
-    max: 50,
+    max: 300,
     timeWindow: "1 minute",
     redis,
   });

--- a/packages/api/src/modules/payments/service.test.ts
+++ b/packages/api/src/modules/payments/service.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Service-level tests for `startStripeOnboarding` covering the
+ * capability-request branches that the route-level integration test
+ * (`tests/integration/payments.test.ts`) skips by mocking the whole
+ * service symbol.
+ *
+ * What we lock:
+ *   - `accounts.create` is called with `card_payments`, `transfers`,
+ *     `link_payments` requested when the tenant has no stripe account yet.
+ *   - The new `acct_…` is persisted to `tenants.stripe_account_id`.
+ *   - On the existing-account path, `accounts.update` is called with the
+ *     same capability shape so accounts created before any of these
+ *     capabilities were requested can be repaired by clicking "Re-open
+ *     Stripe onboarding" (issue #192 follow-up).
+ *
+ * Why this matters: dropping any capability silently produces a working-
+ * looking onboarding flow that errors at the FIRST `paymentIntents.create`
+ * with "card_payments capability not enabled." A whole-service mock can't
+ * catch that — only mocking the Stripe SDK can.
+ */
+
+import { tenants } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "../../lib/db.js";
+import { ORG_A } from "../../tests/helpers/auth.js";
+
+const { mockAccountsCreate, mockAccountsUpdate, mockAccountLinksCreate } = vi.hoisted(() => ({
+  mockAccountsCreate: vi.fn(),
+  mockAccountsUpdate: vi.fn(),
+  mockAccountLinksCreate: vi.fn(),
+}));
+
+// Mock only the Stripe SDK — keep the real DB writes so we can assert
+// `tenants.stripe_account_id` is persisted on the create path.
+vi.mock("stripe", () => {
+  const StripeMock = vi.fn().mockImplementation(() => ({
+    accounts: {
+      create: mockAccountsCreate,
+      update: mockAccountsUpdate,
+    },
+    accountLinks: {
+      create: mockAccountLinksCreate,
+    },
+  }));
+  return { default: StripeMock };
+});
+
+// Need the test tenant row to exist for `startStripeOnboarding` to find it.
+beforeAll(async () => {
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug) VALUES (${ORG_A}, 'Org A', 'test-org-a') ON CONFLICT (id) DO NOTHING`,
+  );
+});
+
+afterAll(async () => {
+  // Reset the fixture so we don't leak a stripe_account_id into other tests.
+  await db.update(tenants).set({ stripeAccountId: null }).where(eq(tenants.id, ORG_A));
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  // Each test starts with a tenant that has no Stripe account yet.
+  await db.update(tenants).set({ stripeAccountId: null }).where(eq(tenants.id, ORG_A));
+  // Default account-link return so handlers don't NPE.
+  mockAccountLinksCreate.mockResolvedValue({
+    url: "https://connect.stripe.com/setup/s/abc",
+  });
+});
+
+describe("startStripeOnboarding — capability requesting", () => {
+  it("requests card_payments + transfers + link_payments on `accounts.create` when the tenant has no Stripe account", async () => {
+    const { startStripeOnboarding } = await import("./service.js");
+
+    mockAccountsCreate.mockResolvedValueOnce({ id: "acct_test_new_001" });
+
+    await startStripeOnboarding(
+      ORG_A,
+      "https://app.givernance.test/settings",
+      "https://app.givernance.test/settings",
+    );
+
+    expect(mockAccountsCreate).toHaveBeenCalledTimes(1);
+    expect(mockAccountsUpdate).not.toHaveBeenCalled();
+
+    const [params] = mockAccountsCreate.mock.calls[0] ?? [];
+    expect(params).toMatchObject({
+      type: "express",
+      capabilities: {
+        card_payments: { requested: true },
+        transfers: { requested: true },
+        link_payments: { requested: true },
+      },
+    });
+  });
+
+  it("persists the new acct_… to tenants.stripe_account_id on the create path", async () => {
+    const { startStripeOnboarding } = await import("./service.js");
+
+    mockAccountsCreate.mockResolvedValueOnce({ id: "acct_test_new_002" });
+
+    await startStripeOnboarding(
+      ORG_A,
+      "https://app.givernance.test/settings",
+      "https://app.givernance.test/settings",
+    );
+
+    const [row] = await db
+      .select({ stripeAccountId: tenants.stripeAccountId })
+      .from(tenants)
+      .where(eq(tenants.id, ORG_A));
+    expect(row?.stripeAccountId).toBe("acct_test_new_002");
+  });
+
+  it("re-asserts capabilities via `accounts.update` on the existing-account path (recovery for pre-fix tenants)", async () => {
+    // Tenant already has a Stripe account from a previous (pre-fix) onboarding
+    await db
+      .update(tenants)
+      .set({ stripeAccountId: "acct_test_existing_003" })
+      .where(eq(tenants.id, ORG_A));
+
+    const { startStripeOnboarding } = await import("./service.js");
+
+    await startStripeOnboarding(
+      ORG_A,
+      "https://app.givernance.test/settings",
+      "https://app.givernance.test/settings",
+    );
+
+    expect(mockAccountsCreate).not.toHaveBeenCalled();
+    expect(mockAccountsUpdate).toHaveBeenCalledTimes(1);
+    const [accountId, params] = mockAccountsUpdate.mock.calls[0] ?? [];
+    expect(accountId).toBe("acct_test_existing_003");
+    expect(params).toMatchObject({
+      capabilities: {
+        card_payments: { requested: true },
+        transfers: { requested: true },
+        link_payments: { requested: true },
+      },
+    });
+  });
+});

--- a/packages/api/src/modules/payments/service.ts
+++ b/packages/api/src/modules/payments/service.ts
@@ -113,3 +113,46 @@ export async function findTenantByStripeAccount(stripeAccountId: string) {
 
   return tenant ?? null;
 }
+
+export interface StripeConnectStatus {
+  accountId: string | null;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+}
+
+/**
+ * Read the current Stripe Connect status for a tenant. Returns a "not connected"
+ * shape when the tenant has no `stripe_account_id` yet, so the settings UI can
+ * render a single panel without a separate 404 path.
+ *
+ * When the account exists, we hit `accounts.retrieve` so the booleans reflect
+ * Stripe's truth — the local DB only stores the account id, not its capabilities.
+ * Issue #62 will replace the live retrieve with cached state populated by the
+ * `account.updated` webhook, but the retrieve-on-read shape stays the same.
+ */
+export async function getStripeConnectStatus(orgId: string): Promise<StripeConnectStatus> {
+  const [tenant] = await db
+    .select({ stripeAccountId: tenants.stripeAccountId })
+    .from(tenants)
+    .where(eq(tenants.id, orgId));
+
+  if (!tenant?.stripeAccountId) {
+    return {
+      accountId: null,
+      chargesEnabled: false,
+      payoutsEnabled: false,
+      detailsSubmitted: false,
+    };
+  }
+
+  const stripe = getStripe();
+  const account = await stripe.accounts.retrieve(tenant.stripeAccountId);
+
+  return {
+    accountId: tenant.stripeAccountId,
+    chargesEnabled: account.charges_enabled,
+    payoutsEnabled: account.payouts_enabled,
+    detailsSubmitted: account.details_submitted,
+  };
+}

--- a/packages/api/src/modules/payments/service.ts
+++ b/packages/api/src/modules/payments/service.ts
@@ -9,12 +9,23 @@ import { db } from "../../lib/db.js";
 /** Lazily initialized Stripe client — null when STRIPE_SECRET_KEY is not configured */
 let stripeClient: Stripe | null = null;
 
+/**
+ * Pin the Stripe API version explicitly. Without this, `new Stripe(key)`
+ * uses whatever version the SDK ships with at install time — a patch bump
+ * to `stripe@22.x` can silently shift the version and break the worker's
+ * webhook payload parsing (`payload.amount`, `payload.application_fee_amount`,
+ * etc.). Bump this constant + the SDK together when adopting a new version.
+ *
+ * Current: matches the default of `stripe@22.0.1` (see SDK `apiVersion.js`).
+ */
+const STRIPE_API_VERSION = "2026-03-25.dahlia" as const;
+
 export function getStripe(): Stripe {
   if (!env.STRIPE_SECRET_KEY) {
     throw new Error("STRIPE_SECRET_KEY is not configured");
   }
   if (!stripeClient) {
-    stripeClient = new Stripe(env.STRIPE_SECRET_KEY);
+    stripeClient = new Stripe(env.STRIPE_SECRET_KEY, { apiVersion: STRIPE_API_VERSION });
   }
   return stripeClient;
 }
@@ -25,17 +36,21 @@ export function getStripe(): Stripe {
  * a charge on a connected account without the `card_payments` capability
  * enabled." `transfers` is requested alongside so the account can receive
  * funds via destination charges if we ever switch off the direct-charge
- * model. SEPA Direct Debit (`sepa_debit_payments`) is intentionally
- * out-of-scope for Phase 1 — see ADR-010 §11.
+ * model. `link_payments` is requested because Stripe Link is enabled on
+ * the Payment Element by default and EU one-click checkout requires this
+ * capability on the connected account; without it the donor sees a
+ * downgraded payment experience. SEPA Direct Debit (`sepa_debit_payments`)
+ * is intentionally out-of-scope for Phase 1 — see ADR-010 §11.
  *
- * Both keys are idempotent on Stripe's side: re-requesting an already-
- * requested capability is a no-op, so the same shape covers both
+ * All three keys are idempotent on Stripe's side: re-requesting an
+ * already-requested capability is a no-op, so the same shape covers both
  * `accounts.create` (new accounts) and `accounts.update` (recovering
- * accounts created before this fix landed — issue #192 follow-up).
+ * accounts created before any of these capabilities were requested).
  */
 const REQUESTED_CAPABILITIES = {
   card_payments: { requested: true },
   transfers: { requested: true },
+  link_payments: { requested: true },
 } as const;
 
 /**

--- a/packages/api/src/modules/payments/service.ts
+++ b/packages/api/src/modules/payments/service.ts
@@ -16,7 +16,15 @@ let stripeClient: Stripe | null = null;
  * webhook payload parsing (`payload.amount`, `payload.application_fee_amount`,
  * etc.). Bump this constant + the SDK together when adopting a new version.
  *
- * Current: matches the default of `stripe@22.0.1` (see SDK `apiVersion.js`).
+ * On the version suffix: Stripe's API versions follow `YYYY-MM-DD.<codename>`,
+ * where the codename is the *release-train* identifier, NOT a "preview"
+ * marker. `2026-03-25.dahlia` is the GA stable version that ships with
+ * `stripe@22.0.1` — see https://docs.stripe.com/upgrades for the schedule.
+ * (PR #193 review, finding #7: the codename suffix can read like a preview
+ * channel, so noting it here.) Upgrading is a coordinated change: bump the
+ * SDK in `package.json`, update this constant, re-run the worker tests
+ * against the new payload shapes, and check the Stripe upgrade-guide
+ * deltas for `payment_intent.succeeded` / `charge.refunded` / `account.*`.
  */
 const STRIPE_API_VERSION = "2026-03-25.dahlia" as const;
 

--- a/packages/api/src/modules/payments/service.ts
+++ b/packages/api/src/modules/payments/service.ts
@@ -20,9 +20,30 @@ export function getStripe(): Stripe {
 }
 
 /**
+ * Capabilities Givernance requests on every connected account. Without
+ * `card_payments`, `paymentIntents.create` errors with "You cannot create
+ * a charge on a connected account without the `card_payments` capability
+ * enabled." `transfers` is requested alongside so the account can receive
+ * funds via destination charges if we ever switch off the direct-charge
+ * model. SEPA Direct Debit (`sepa_debit_payments`) is intentionally
+ * out-of-scope for Phase 1 — see ADR-010 §11.
+ *
+ * Both keys are idempotent on Stripe's side: re-requesting an already-
+ * requested capability is a no-op, so the same shape covers both
+ * `accounts.create` (new accounts) and `accounts.update` (recovering
+ * accounts created before this fix landed — issue #192 follow-up).
+ */
+const REQUESTED_CAPABILITIES = {
+  card_payments: { requested: true },
+  transfers: { requested: true },
+} as const;
+
+/**
  * Create a Stripe Connect Account Link for onboarding.
  * Creates an Express connected account if the tenant doesn't have one yet,
- * then returns the onboarding URL.
+ * otherwise re-asserts the requested capabilities on the existing account
+ * so accounts created before the capability fix can be repaired by
+ * clicking "Re-open Stripe onboarding".
  */
 export async function startStripeOnboarding(
   orgId: string,
@@ -42,6 +63,7 @@ export async function startStripeOnboarding(
     const account = await stripe.accounts.create(
       {
         type: "express",
+        capabilities: REQUESTED_CAPABILITIES,
         metadata: { givernance_org_id: orgId },
       },
       { idempotencyKey: `acct-create-${orgId}` },
@@ -52,6 +74,11 @@ export async function startStripeOnboarding(
       .update(tenants)
       .set({ stripeAccountId: accountId, updatedAt: new Date() })
       .where(eq(tenants.id, orgId));
+  } else {
+    // Idempotent — Stripe ignores already-requested capabilities. This is
+    // the recovery path for accounts created before capabilities were
+    // requested at creation time.
+    await stripe.accounts.update(accountId, { capabilities: REQUESTED_CAPABILITIES });
   }
 
   const accountLink = await stripe.accountLinks.create(

--- a/packages/api/src/modules/payments/service.ts
+++ b/packages/api/src/modules/payments/service.ts
@@ -161,6 +161,38 @@ export interface StripeConnectStatus {
   chargesEnabled: boolean;
   payoutsEnabled: boolean;
   detailsSubmitted: boolean;
+  /**
+   * Requirements Stripe wants the connected account to satisfy before
+   * `charges_enabled` flips on. Empty array when fully onboarded. Used by
+   * the Settings panel to tell the operator *why* charges aren't enabled
+   * (issue #201) instead of "Onboarding incomplete" with no detail.
+   */
+  requirementsCurrentlyDue: string[];
+  /**
+   * Stripe's machine-readable reason for `charges_enabled: false`, e.g.
+   * `requirements.past_due`, `requirements.pending_verification`. Null
+   * when the account is healthy.
+   */
+  disabledReason: string | null;
+  /**
+   * Per-capability status. Reflects whether each capability we requested
+   * is `active` (working), `pending` (Stripe is verifying), or `inactive`
+   * (blocked on requirements / not yet requested).
+   */
+  capabilities: {
+    cardPayments: StripeCapabilityStatus;
+    transfers: StripeCapabilityStatus;
+    linkPayments: StripeCapabilityStatus;
+  };
+}
+
+export type StripeCapabilityStatus = "active" | "pending" | "inactive" | "unrequested";
+
+function normaliseCapability(value: string | undefined): StripeCapabilityStatus {
+  if (value === "active" || value === "pending" || value === "inactive") {
+    return value;
+  }
+  return "unrequested";
 }
 
 /**
@@ -185,6 +217,13 @@ export async function getStripeConnectStatus(orgId: string): Promise<StripeConne
       chargesEnabled: false,
       payoutsEnabled: false,
       detailsSubmitted: false,
+      requirementsCurrentlyDue: [],
+      disabledReason: null,
+      capabilities: {
+        cardPayments: "unrequested",
+        transfers: "unrequested",
+        linkPayments: "unrequested",
+      },
     };
   }
 
@@ -196,5 +235,12 @@ export async function getStripeConnectStatus(orgId: string): Promise<StripeConne
     chargesEnabled: account.charges_enabled,
     payoutsEnabled: account.payouts_enabled,
     detailsSubmitted: account.details_submitted,
+    requirementsCurrentlyDue: account.requirements?.currently_due ?? [],
+    disabledReason: account.requirements?.disabled_reason ?? null,
+    capabilities: {
+      cardPayments: normaliseCapability(account.capabilities?.card_payments),
+      transfers: normaliseCapability(account.capabilities?.transfers),
+      linkPayments: normaliseCapability(account.capabilities?.link_payments),
+    },
   };
 }

--- a/packages/api/src/modules/public/routes.ts
+++ b/packages/api/src/modules/public/routes.ts
@@ -4,7 +4,13 @@ import { CampaignPublicPageSchema } from "@givernance/shared/validators";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { requireOrgAdmin } from "../../lib/guards.js";
-import { DataResponse, ErrorResponses, problemDetail, UuidSchema } from "../../lib/schemas.js";
+import {
+  DataResponse,
+  ErrorResponses,
+  ProblemDetailSchema,
+  problemDetail,
+  UuidSchema,
+} from "../../lib/schemas.js";
 import {
   createDonationIntent,
   getAdminPublicPage,
@@ -15,6 +21,19 @@ import {
 
 const CampaignIdParams = Type.Object({ id: UuidSchema });
 
+/**
+ * Currencies the public donation flow accepts. Narrower than the application
+ * `CurrencySchema` (which covers internal-reporting currencies) — we only
+ * accept what Stripe Connect direct-charge supports natively across our
+ * primary target jurisdictions today. Used in both request body validation
+ * and the published-page response shape so they cannot drift.
+ */
+const PublicDonationCurrencySchema = Type.Union([
+  Type.Literal("EUR"),
+  Type.Literal("GBP"),
+  Type.Literal("CHF"),
+]);
+
 const PublicPageResponse = Type.Object({
   id: UuidSchema,
   campaignId: UuidSchema,
@@ -22,18 +41,28 @@ const PublicPageResponse = Type.Object({
   description: Type.Union([Type.String(), Type.Null()]),
   colorPrimary: Type.Union([Type.String(), Type.Null()]),
   goalAmountCents: Type.Union([Type.Integer(), Type.Null()]),
-  defaultCurrency: Type.Union([Type.Literal("EUR"), Type.Literal("GBP"), Type.Literal("CHF")]),
+  defaultCurrency: PublicDonationCurrencySchema,
 });
 
 const DonateBody = Type.Object({
   amountCents: Type.Integer({ minimum: 100, maximum: 1000000 }),
-  currency: Type.Union([Type.Literal("EUR"), Type.Literal("GBP"), Type.Literal("CHF")]),
+  currency: PublicDonationCurrencySchema,
   email: Type.String({ format: "email" }),
   firstName: Type.String({ minLength: 1, maxLength: 255 }),
   lastName: Type.String({ minLength: 1, maxLength: 255 }),
 });
 
 const DonateHeaders = Type.Object({
+  /**
+   * Forwarded directly to Stripe's `paymentIntents.create` as the SDK-level
+   * idempotency key. **Not** stored in the application's idempotency table
+   * — the route is unauthenticated and the local plugin keys on
+   * `(orgId, route, fingerprint)` which we don't have here. Practical
+   * effects: a retry that fails before reaching Stripe is NOT deduped on
+   * our side; a retry that reaches Stripe will get the original
+   * PaymentIntent back. If you ever need local dedup on this route, key
+   * on `(publicPage.orgId, campaignId, sha256(headerValue))`.
+   */
   "idempotency-key": Type.Optional(Type.String({ minLength: 1, maxLength: 255 })),
 });
 
@@ -177,10 +206,10 @@ export async function publicDonationRoutes(app: FastifyInstance) {
         body: DonateBody,
         response: {
           200: DataResponse(DonateResponse),
-          400: Type.Any(),
-          429: Type.Any(),
-          502: Type.Any(),
-          ...ErrorResponses,
+          400: ProblemDetailSchema,
+          404: ProblemDetailSchema,
+          429: ProblemDetailSchema,
+          502: ProblemDetailSchema,
         },
       },
     },
@@ -208,12 +237,25 @@ export async function publicDonationRoutes(app: FastifyInstance) {
       try {
         const result = await createDonationIntent(id, body, idempotencyKey);
         if (!result) {
+          // `createDonationIntent` returns `null` for several distinct reasons
+          // (invalid uuid, no public page found, no campaign row) — collapsing
+          // to a single 404 is deliberate so an enumerator can't distinguish
+          // "campaign exists but unpublished" from "campaign doesn't exist".
           return reply.status(404).send(problemDetail(404, "Not Found", "Campaign not found"));
         }
         return { data: result };
       } catch (err) {
-        const message = err instanceof Error ? err.message : "Payment processing failed";
-        request.log.error({ err: message, campaignId: id }, "Donation intent creation failed");
+        // Sanitised log: drop the raw Stripe Error object — it carries
+        // `requestId`, `payment_intent.id`, and possibly the connected
+        // `acct_…` id which would cross tenant boundaries in a shared log
+        // index. The donor-facing 502 stays generic; ops can recover the
+        // raw error from Stripe's dashboard via the donor email + timestamp.
+        const errMessage = err instanceof Error ? err.message : "Payment processing failed";
+        const errCode = err instanceof Error ? (err as { code?: string }).code : undefined;
+        request.log.error(
+          { errMessage, errCode, campaignId: id },
+          "Donation intent creation failed",
+        );
         return reply
           .status(502)
           .send(problemDetail(502, "Bad Gateway", "Payment processing failed"));

--- a/packages/api/src/modules/public/routes.ts
+++ b/packages/api/src/modules/public/routes.ts
@@ -39,6 +39,7 @@ const DonateHeaders = Type.Object({
 
 const DonateResponse = Type.Object({
   clientSecret: Type.String(),
+  stripeAccountId: Type.String(),
 });
 
 const PublicPageCreateBody = CampaignPublicPageSchema;

--- a/packages/api/src/modules/public/routes.ts
+++ b/packages/api/src/modules/public/routes.ts
@@ -42,6 +42,25 @@ const PublicPageResponse = Type.Object({
   colorPrimary: Type.Union([Type.String(), Type.Null()]),
   goalAmountCents: Type.Union([Type.Integer(), Type.Null()]),
   defaultCurrency: PublicDonationCurrencySchema,
+  /**
+   * Connected account id for the campaign's tenant. Null when the tenant
+   * hasn't onboarded with Stripe yet (donor flow blocks at the donate step
+   * with a 502 in that case). Public per Stripe docs — donor's Stripe.js
+   * binds to it for both intent confirmation and 3DS post-redirect retrieve.
+   */
+  stripeAccountId: Type.Union([Type.String(), Type.Null()]),
+  /**
+   * Cumulative cleared donations against this campaign in the tenant's base
+   * currency (issue #200). Drives the public hero's progress bar.
+   */
+  raisedCents: Type.Integer(),
+  /**
+   * Distinct donor count for cleared donations (issue #200). Anonymous
+   * donors get a fresh constituent row per gift, which slightly inflates
+   * the count — acceptable since donor-count is a social-proof signal,
+   * not an audit number.
+   */
+  donorCount: Type.Integer(),
 });
 
 const DonateBody = Type.Object({

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -9,8 +9,23 @@ import {
 } from "@givernance/shared/schema";
 import { and, eq, sql } from "drizzle-orm";
 import { db, withTenantContext } from "../../lib/db.js";
+import { redis } from "../../lib/redis.js";
 import { isUuid } from "../../lib/schemas.js";
 import { getStripe } from "../payments/service.js";
+
+/**
+ * 30s Redis cache for the public-page payload (issue #193 review,
+ * finding #4). The aggregate query (`SUM(amount_base_cents)` +
+ * `COUNT(DISTINCT constituent_id)`) is full-scan-prone on a campaign
+ * with many donations; a viral campaign drives every visitor through
+ * that scan. 30s is short enough that "raised so far" stays
+ * recognisably-fresh to a donor and long enough to flatten a Black-
+ * Friday-shaped traffic spike. Invalidation is implicit — donations
+ * are eventually-consistent on the donor's view, which is fine since
+ * the funds have already cleared in Stripe by the time the row exists.
+ */
+const PUBLIC_PAGE_CACHE_TTL_SECONDS = 30;
+const PUBLIC_PAGE_CACHE_PREFIX = "public-page:v1:";
 
 /**
  * Resolve an opaque QR code scanned from a printed campaign letter.
@@ -63,6 +78,32 @@ export async function getPublicPage(campaignId: string) {
     return null;
   }
 
+  // Cache hit — return the snapshot. We cache the full payload (config +
+  // aggregates) since the donate flow is the only consumer and 30s
+  // staleness on either piece is acceptable. `null` is cached as the
+  // string "404" to distinguish "we know there's no page" from a cache
+  // miss; saves DB hits on a scraper hammering unknown campaign ids.
+  const cacheKey = `${PUBLIC_PAGE_CACHE_PREFIX}${campaignId}`;
+  const cached = await redis.get(cacheKey);
+  if (cached === "404") return null;
+  if (cached !== null) {
+    try {
+      return JSON.parse(cached) as Awaited<ReturnType<typeof loadPublicPage>>;
+    } catch {
+      // Bad JSON — fall through to a fresh fetch + overwrite.
+    }
+  }
+
+  const fresh = await loadPublicPage(campaignId);
+  if (fresh === null) {
+    await redis.set(cacheKey, "404", "EX", PUBLIC_PAGE_CACHE_TTL_SECONDS);
+  } else {
+    await redis.set(cacheKey, JSON.stringify(fresh), "EX", PUBLIC_PAGE_CACHE_TTL_SECONDS);
+  }
+  return fresh;
+}
+
+async function loadPublicPage(campaignId: string) {
   // Find the page without RLS to get the orgId.
   // campaign_public_pages does not enforce RLS for reads.
   const [basicPage] = await db
@@ -242,6 +283,33 @@ export async function createDonationIntent(
     if (!intent.client_secret) {
       throw new Error("Stripe returned a PaymentIntent without a client_secret");
     }
+
+    // Orphan-PI observability hook (PR #193 review, finding #10): emit a
+    // structured `donation_intent.created` log line per PI creation so
+    // an ops query of the form
+    //   donation_intent.created events without a matching
+    //   payment_intent.succeeded webhook within 24h
+    // surfaces the donor abandon rate. A donor who closes the tab
+    // between `paymentIntents.create` and `confirmPayment` leaves the
+    // intent in `requires_payment_method` — Stripe auto-cancels after
+    // 7 days, but in the meantime we have no signal to reconcile.
+    //
+    // Not implemented here: a cleanup worker that explicitly calls
+    // `paymentIntents.cancel` on orphans (24h+ stale, no match in our
+    // `donations` table). The platform-finance dashboard (#206) is the
+    // natural home for the abandon metric and the cleanup job; both are
+    // tracked there, deliberately not bundled into this PR.
+    //
+    // biome-ignore lint/suspicious/noConsole: structured ops log; pino is request-scoped, not in this code path
+    console.info(
+      JSON.stringify({
+        event: "donation_intent.created",
+        paymentIntentId: intent.id,
+        stripeAccountId: tenant.stripeAccountId,
+        campaignId,
+        ts: new Date().toISOString(),
+      }),
+    );
 
     return {
       clientSecret: intent.client_secret,

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -4,6 +4,7 @@ import {
   campaignPublicPages,
   campaignQrCodes,
   campaigns,
+  donations,
   tenants,
 } from "@givernance/shared/schema";
 import { and, eq, sql } from "drizzle-orm";
@@ -89,12 +90,39 @@ export async function getPublicPage(campaignId: string) {
         colorPrimary: campaignPublicPages.colorPrimary,
         goalAmountCents: campaignPublicPages.goalAmountCents,
         defaultCurrency: campaigns.defaultCurrency,
+        // Connect direct-charge requires the browser SDK to bind to the
+        // connected account — exposed on this public endpoint so the donor
+        // page can both (a) initialise Stripe.js and (b) handle 3DS
+        // post-redirect retrieves without round-tripping to the donate
+        // endpoint first. `acct_…` ids are public per Stripe docs (issue #197).
+        stripeAccountId: tenants.stripeAccountId,
       })
       .from(campaignPublicPages)
       .innerJoin(campaigns, eq(campaigns.id, campaignPublicPages.campaignId))
+      .innerJoin(tenants, eq(tenants.id, campaigns.orgId))
       .where(eq(campaignPublicPages.campaignId, campaignId));
 
-    return page ?? null;
+    if (!page) return null;
+
+    // Aggregate raised total and donor count for the public hero (issue #200).
+    // Cleared donations only — pending/refunded/failed don't count toward the
+    // displayed progress. `count(distinct constituent_id)` is the donor-count;
+    // anonymous donors get a fresh constituent each so we slightly over-count
+    // anonymity, which is the right direction (donors prefer to feel
+    // "many people are giving" over an exact-and-lower number).
+    const [stats] = await tx
+      .select({
+        raisedCents: sql<number>`COALESCE(SUM(${donations.amountBaseCents}), 0)::int`,
+        donorCount: sql<number>`COUNT(DISTINCT ${donations.constituentId})::int`,
+      })
+      .from(donations)
+      .where(and(eq(donations.campaignId, campaignId), eq(donations.status, "cleared")));
+
+    return {
+      ...page,
+      raisedCents: stats?.raisedCents ?? 0,
+      donorCount: stats?.donorCount ?? 0,
+    };
   });
 }
 

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -205,7 +205,14 @@ export async function createDonationIntent(
 
     const intent = await stripe.paymentIntents.create(intentParams, requestOptions);
 
-    return { clientSecret: intent.client_secret };
+    if (!intent.client_secret) {
+      throw new Error("Stripe returned a PaymentIntent without a client_secret");
+    }
+
+    return {
+      clientSecret: intent.client_secret,
+      stripeAccountId: tenant.stripeAccountId,
+    };
   });
 }
 

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -179,6 +179,12 @@ export async function createDonationIntent(
     if (!stripeAccountDetails.charges_enabled) {
       throw new Error("Organization Stripe account is not fully onboarded");
     }
+    // Platform fee. NOTE for the future refund handler: Stripe's default on
+    // direct charges is to keep the application fee on refund — the platform
+    // pockets the 1.5%+30¢ even when the donor is fully refunded. To match
+    // donor expectations ("I got my €50 back, I didn't pay any fee"), the
+    // refund call must pass `refund_application_fee: true`. Tracked in the
+    // refund-flow follow-up issue.
     const applicationFeeAmount = calculatePlatformFee(body.amountCents);
 
     const intentParams: Parameters<typeof stripe.paymentIntents.create>[0] = {

--- a/packages/api/src/tests/integration/donations.test.ts
+++ b/packages/api/src/tests/integration/donations.test.ts
@@ -1,7 +1,7 @@
 import { funds } from "@givernance/shared/schema";
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { db, withTenantContext } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
@@ -12,6 +12,17 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+
+// Stub the Stripe SDK so the refund route doesn't hit real Stripe. Only
+// `getStripe()` is mocked — the rest of the service runs unmodified.
+const { mockRefundsCreate } = vi.hoisted(() => ({ mockRefundsCreate: vi.fn() }));
+vi.mock("../../modules/payments/service.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../modules/payments/service.js")>();
+  return {
+    ...actual,
+    getStripe: () => ({ refunds: { create: mockRefundsCreate } }),
+  };
+});
 
 let app: FastifyInstance;
 const MULTI_CURRENCY_ORG = "00000000-0000-0000-0000-000000000126";
@@ -381,6 +392,159 @@ describe("Donations CRUD", () => {
 
     expect(rows.rows.length).toBe(1);
     expect((rows.rows[0] as { type: string }).type).toBe("donation.created");
+  });
+});
+
+// ─── Refund flow (issue #199) ───────────────────────────────────────────────
+
+describe("POST /v1/donations/:id/refund", () => {
+  it("calls Stripe with refund_application_fee=true and flips status to refunded", async () => {
+    mockRefundsCreate.mockResolvedValueOnce({ id: "re_test_1", status: "succeeded" });
+
+    // Seed a Stripe-sourced cleared donation
+    const tokenA = signToken(app);
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 5000,
+        paymentMethod: "stripe",
+        paymentRef: `pi_test_refund_${Date.now()}`,
+      },
+    });
+    const donationId = createRes.json<{ data: { id: string } }>().data.id;
+    const paymentRef = createRes.json<{ data: { paymentRef: string } }>().data.paymentRef;
+
+    const refundRes = await app.inject({
+      method: "POST",
+      url: `/v1/donations/${donationId}/refund`,
+      headers: authHeader(tokenA),
+    });
+
+    expect(refundRes.statusCode).toBe(200);
+    expect(refundRes.json()).toEqual({ data: { id: donationId, status: "refunded" } });
+
+    // Stripe was called with the right payload — `refund_application_fee:
+    // true` is the load-bearing flag that distinguishes our refund flow
+    // from a stock Stripe refund (issue #199 / docs/payments-overview.md).
+    expect(mockRefundsCreate).toHaveBeenCalledWith({
+      payment_intent: paymentRef,
+      refund_application_fee: true,
+    });
+
+    // Donation row reflects the refund immediately (UI doesn't have to wait
+    // for the webhook to fire — webhook handler is idempotent on already-
+    // refunded rows).
+    const getRes = await app.inject({
+      method: "GET",
+      url: `/v1/donations/${donationId}`,
+      headers: authHeader(tokenA),
+    });
+    expect(getRes.json<{ data: { status: string } }>().data.status).toBe("refunded");
+  });
+
+  it("returns 422 for already-refunded donations", async () => {
+    mockRefundsCreate.mockClear();
+    const tokenA = signToken(app);
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 1000,
+        paymentMethod: "stripe",
+        paymentRef: `pi_test_already_refunded_${Date.now()}`,
+      },
+    });
+    const donationId = createRes.json<{ data: { id: string } }>().data.id;
+
+    // First refund succeeds
+    mockRefundsCreate.mockResolvedValueOnce({ id: "re_test_2", status: "succeeded" });
+    await app.inject({
+      method: "POST",
+      url: `/v1/donations/${donationId}/refund`,
+      headers: authHeader(tokenA),
+    });
+
+    // Second call gets a 422 — Stripe is NOT re-invoked
+    const dupRes = await app.inject({
+      method: "POST",
+      url: `/v1/donations/${donationId}/refund`,
+      headers: authHeader(tokenA),
+    });
+    expect(dupRes.statusCode).toBe(422);
+    expect(mockRefundsCreate).toHaveBeenCalledTimes(1);
+    const body = dupRes.json<{ type: string; status: number; detail: string }>();
+    expect(body.type).toBe("https://httpproblems.com/http-status/422");
+    expect(body.status).toBe(422);
+  });
+
+  it("returns 422 when the donation isn't Stripe-sourced", async () => {
+    mockRefundsCreate.mockClear();
+    const tokenA = signToken(app);
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 1000,
+        paymentMethod: "cash",
+        paymentRef: `CASH-RECEIPT-${Date.now()}-${Math.random()}`,
+      },
+    });
+    const donationId = createRes.json<{ data: { id: string } }>().data.id;
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/donations/${donationId}/refund`,
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(422);
+    expect(mockRefundsCreate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { role: "viewer" as const },
+    { role: "user" as const },
+  ])("returns 403 for role $role (org_admin only)", async ({ role }) => {
+    const token = signToken(app, { role });
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/donations/00000000-0000-0000-0000-ffffffffffff/refund",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 502 with masked detail when Stripe rejects the refund", async () => {
+    mockRefundsCreate.mockRejectedValueOnce(new Error("Stripe internal failure detail"));
+    const tokenA = signToken(app);
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 1000,
+        paymentMethod: "stripe",
+        paymentRef: `pi_test_stripe_fail_${Date.now()}`,
+      },
+    });
+    const donationId = createRes.json<{ data: { id: string } }>().data.id;
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/donations/${donationId}/refund`,
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(502);
+    const body = res.json<{ detail: string }>();
+    expect(body.detail).not.toContain("internal failure detail");
+    expect(body.detail).toContain("Payment provider error");
   });
 });
 

--- a/packages/api/src/tests/integration/payments.test.ts
+++ b/packages/api/src/tests/integration/payments.test.ts
@@ -56,6 +56,29 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+/**
+ * Default Stripe Connect status — fully populated so the route's TypeBox
+ * response validation passes. Tests override the fields they care about.
+ * Mirrors the `StripeConnectStatus` interface in
+ * `modules/payments/service.ts`.
+ */
+function makeStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    accountId: null,
+    chargesEnabled: false,
+    payoutsEnabled: false,
+    detailsSubmitted: false,
+    requirementsCurrentlyDue: [],
+    disabledReason: null,
+    capabilities: {
+      cardPayments: "unrequested",
+      transfers: "unrequested",
+      linkPayments: "unrequested",
+    },
+    ...overrides,
+  };
+}
+
 // ─── Stripe Connect Status ─────────────────────────────────────────────────
 
 describe("GET /v1/admin/stripe-connect", () => {
@@ -93,12 +116,19 @@ describe("GET /v1/admin/stripe-connect", () => {
     // `getStripeConnectStatus` is mocked, so we assert the route passes
     // the **caller's** orgId through, not the params or body. Tenant B's
     // org_admin sees Tenant B's account, never Tenant A's.
-    mockGetStripeConnectStatus.mockResolvedValueOnce({
-      accountId: "acct_test_tenant_b",
-      chargesEnabled: true,
-      payoutsEnabled: true,
-      detailsSubmitted: true,
-    });
+    mockGetStripeConnectStatus.mockResolvedValueOnce(
+      makeStatus({
+        accountId: "acct_test_tenant_b",
+        chargesEnabled: true,
+        payoutsEnabled: true,
+        detailsSubmitted: true,
+        capabilities: {
+          cardPayments: "active",
+          transfers: "active",
+          linkPayments: "active",
+        },
+      }),
+    );
     const token = signTokenB(app);
     const res = await app.inject({
       method: "GET",
@@ -115,12 +145,7 @@ describe("GET /v1/admin/stripe-connect", () => {
   });
 
   it("returns the not-connected shape for a fresh tenant", async () => {
-    mockGetStripeConnectStatus.mockResolvedValueOnce({
-      accountId: null,
-      chargesEnabled: false,
-      payoutsEnabled: false,
-      detailsSubmitted: false,
-    });
+    mockGetStripeConnectStatus.mockResolvedValueOnce(makeStatus());
 
     const token = signToken(app);
     const res = await app.inject({
@@ -136,17 +161,31 @@ describe("GET /v1/admin/stripe-connect", () => {
         chargesEnabled: false,
         payoutsEnabled: false,
         detailsSubmitted: false,
+        requirementsCurrentlyDue: [],
+        disabledReason: null,
+        capabilities: {
+          cardPayments: "unrequested",
+          transfers: "unrequested",
+          linkPayments: "unrequested",
+        },
       },
     });
   });
 
   it("returns the live capability flags when the tenant has a connected account", async () => {
-    mockGetStripeConnectStatus.mockResolvedValueOnce({
-      accountId: "acct_test_456",
-      chargesEnabled: true,
-      payoutsEnabled: true,
-      detailsSubmitted: true,
-    });
+    mockGetStripeConnectStatus.mockResolvedValueOnce(
+      makeStatus({
+        accountId: "acct_test_456",
+        chargesEnabled: true,
+        payoutsEnabled: true,
+        detailsSubmitted: true,
+        capabilities: {
+          cardPayments: "active",
+          transfers: "active",
+          linkPayments: "active",
+        },
+      }),
+    );
 
     const token = signToken(app);
     const res = await app.inject({
@@ -159,6 +198,46 @@ describe("GET /v1/admin/stripe-connect", () => {
     const body = res.json<{ data: { accountId: string; chargesEnabled: boolean } }>();
     expect(body.data.accountId).toBe("acct_test_456");
     expect(body.data.chargesEnabled).toBe(true);
+  });
+
+  it("surfaces requirements.currently_due + disabled_reason when account is partial (issue #201)", async () => {
+    mockGetStripeConnectStatus.mockResolvedValueOnce(
+      makeStatus({
+        accountId: "acct_test_partial",
+        chargesEnabled: false,
+        payoutsEnabled: false,
+        detailsSubmitted: true,
+        requirementsCurrentlyDue: ["external_account", "individual.id_number"],
+        disabledReason: "requirements.past_due",
+        capabilities: {
+          cardPayments: "inactive",
+          transfers: "inactive",
+          linkPayments: "inactive",
+        },
+      }),
+    );
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/stripe-connect",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        requirementsCurrentlyDue: string[];
+        disabledReason: string | null;
+        capabilities: { cardPayments: string };
+      };
+    }>();
+    expect(body.data.requirementsCurrentlyDue).toEqual([
+      "external_account",
+      "individual.id_number",
+    ]);
+    expect(body.data.disabledReason).toBe("requirements.past_due");
+    expect(body.data.capabilities.cardPayments).toBe("inactive");
   });
 
   it("masks Stripe errors as 502 (no provider details leak)", async () => {

--- a/packages/api/src/tests/integration/payments.test.ts
+++ b/packages/api/src/tests/integration/payments.test.ts
@@ -64,14 +64,54 @@ describe("GET /v1/admin/stripe-connect", () => {
     expect(res.statusCode).toBe(401);
   });
 
-  it("returns 403 for non-admin user (positive boundary check)", async () => {
-    const token = signToken(app, { role: "viewer" });
+  // Both negative roles must 403 — over-correcting a guard from
+  // `requireOrgAdmin` to `requireWrite` (which accepts `user`) would slip
+  // through with a single `viewer` test (memory:
+  // feedback_role_test_coverage_both_directions.md).
+  it.each([
+    { role: "viewer" as const },
+    { role: "user" as const },
+  ])("returns 403 for role $role", async ({ role }) => {
+    const token = signToken(app, { role });
     const res = await app.inject({
       method: "GET",
       url: "/v1/admin/stripe-connect",
       headers: authHeader(token),
     });
     expect(res.statusCode).toBe(403);
+    // Lock the RFC 9457 shape on the 403 path — a regression to a
+    // plain-string body or `{error}` envelope would silently pass a
+    // status-only assertion (memory: feedback_lock_rfc9457_body_in_tests.md).
+    const body = res.json<{ type: string; title: string; status: number; detail: string }>();
+    expect(body.type).toBe("https://httpproblems.com/http-status/403");
+    expect(body.title).toBe("Forbidden");
+    expect(body.status).toBe(403);
+    expect(typeof body.detail).toBe("string");
+  });
+
+  it("isolates GET to the calling org (cross-tenant)", async () => {
+    // `getStripeConnectStatus` is mocked, so we assert the route passes
+    // the **caller's** orgId through, not the params or body. Tenant B's
+    // org_admin sees Tenant B's account, never Tenant A's.
+    mockGetStripeConnectStatus.mockResolvedValueOnce({
+      accountId: "acct_test_tenant_b",
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      detailsSubmitted: true,
+    });
+    const token = signTokenB(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/stripe-connect",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { accountId: string } }>();
+    expect(body.data.accountId).toBe("acct_test_tenant_b");
+    // The mock was called with Tenant B's orgId, not Tenant A's
+    expect(mockGetStripeConnectStatus).toHaveBeenCalledTimes(1);
+    const calledWith = mockGetStripeConnectStatus.mock.calls[0]?.[0];
+    expect(calledWith).not.toBe("00000000-0000-0000-0000-0000000000a1");
   });
 
   it("returns the not-connected shape for a fresh tenant", async () => {
@@ -156,8 +196,11 @@ describe("POST /v1/admin/stripe-connect", () => {
     expect(res.statusCode).toBe(401);
   });
 
-  it("returns 403 for non-admin user", async () => {
-    const token = signToken(app, { role: "viewer" });
+  it.each([
+    { role: "viewer" as const },
+    { role: "user" as const },
+  ])("returns 403 for role $role", async ({ role }) => {
+    const token = signToken(app, { role });
     const res = await app.inject({
       method: "POST",
       url: "/v1/admin/stripe-connect",

--- a/packages/api/src/tests/integration/payments.test.ts
+++ b/packages/api/src/tests/integration/payments.test.ts
@@ -8,10 +8,16 @@ import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, signToken, signTokenB } from "../helpers/auth.js";
 
 // vi.hoisted runs before vi.mock hoisting — ensures mocks are defined before use
-const { mockQueueAdd, mockVerifyStripeWebhook, mockStartStripeOnboarding } = vi.hoisted(() => ({
+const {
+  mockQueueAdd,
+  mockVerifyStripeWebhook,
+  mockStartStripeOnboarding,
+  mockGetStripeConnectStatus,
+} = vi.hoisted(() => ({
   mockQueueAdd: vi.fn().mockResolvedValue({ id: "mock-job-id" }),
   mockVerifyStripeWebhook: vi.fn(),
   mockStartStripeOnboarding: vi.fn(),
+  mockGetStripeConnectStatus: vi.fn(),
 }));
 
 // Mock BullMQ Queue to avoid needing a real Redis queue connection for route tests
@@ -29,6 +35,7 @@ vi.mock("../../modules/payments/service.js", async (importOriginal) => {
     ...actual,
     verifyStripeWebhook: (...args: unknown[]) => mockVerifyStripeWebhook(...args),
     startStripeOnboarding: (...args: unknown[]) => mockStartStripeOnboarding(...args),
+    getStripeConnectStatus: (...args: unknown[]) => mockGetStripeConnectStatus(...args),
   };
 });
 
@@ -47,6 +54,91 @@ afterAll(async () => {
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+// ─── Stripe Connect Status ─────────────────────────────────────────────────
+
+describe("GET /v1/admin/stripe-connect", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "GET", url: "/v1/admin/stripe-connect" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 403 for non-admin user (positive boundary check)", async () => {
+    const token = signToken(app, { role: "viewer" });
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/stripe-connect",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns the not-connected shape for a fresh tenant", async () => {
+    mockGetStripeConnectStatus.mockResolvedValueOnce({
+      accountId: null,
+      chargesEnabled: false,
+      payoutsEnabled: false,
+      detailsSubmitted: false,
+    });
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/stripe-connect",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      data: {
+        accountId: null,
+        chargesEnabled: false,
+        payoutsEnabled: false,
+        detailsSubmitted: false,
+      },
+    });
+  });
+
+  it("returns the live capability flags when the tenant has a connected account", async () => {
+    mockGetStripeConnectStatus.mockResolvedValueOnce({
+      accountId: "acct_test_456",
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      detailsSubmitted: true,
+    });
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/stripe-connect",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { accountId: string; chargesEnabled: boolean } }>();
+    expect(body.data.accountId).toBe("acct_test_456");
+    expect(body.data.chargesEnabled).toBe(true);
+  });
+
+  it("masks Stripe errors as 502 (no provider details leak)", async () => {
+    mockGetStripeConnectStatus.mockRejectedValueOnce(new Error("Stripe is on fire"));
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/stripe-connect",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(502);
+    const body = res.json<{ type: string; title: string; status: number; detail: string }>();
+    expect(body.type).toBe("https://httpproblems.com/http-status/502");
+    expect(body.title).toBe("Bad Gateway");
+    expect(body.status).toBe(502);
+    expect(body.detail).not.toContain("on fire");
+    expect(body.detail).toContain("Payment provider error");
+  });
 });
 
 // ─── Stripe Connect Onboarding ─────────────────────────────────────────────

--- a/packages/api/src/tests/integration/public-donations.test.ts
+++ b/packages/api/src/tests/integration/public-donations.test.ts
@@ -296,6 +296,45 @@ describe("GET /v1/public/campaigns/:id/page", () => {
     expect(body.data.donorCount).toBe(0);
   });
 
+  it("caches the published page in Redis for 30s (PR #193 finding #4)", async () => {
+    // Lock the cache contract: a second call within the TTL returns the
+    // same payload even if the underlying DB row has been deleted out
+    // from under us. This both proves the cache layer is wired AND
+    // catches any future refactor that accidentally bypasses it (the
+    // public hero is the highest-traffic endpoint we have).
+    const campaign = await createTestCampaign("Public Page Test Cached");
+    const token = signToken(app);
+
+    await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: { title: "Cached Campaign", status: "published" },
+    });
+
+    // Prime the cache.
+    const first = await app.inject({
+      method: "GET",
+      url: `/v1/public/campaigns/${campaign.id}/page`,
+    });
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json<{ data: { title: string } }>();
+    expect(firstBody.data.title).toBe("Cached Campaign");
+
+    // Delete the page from the DB, bypassing any application-level cache
+    // invalidation. The next request MUST still return the cached
+    // response — that's the point of the cache.
+    await db.execute(sql`DELETE FROM campaign_public_pages WHERE campaign_id = ${campaign.id}`);
+
+    const second = await app.inject({
+      method: "GET",
+      url: `/v1/public/campaigns/${campaign.id}/page`,
+    });
+    expect(second.statusCode).toBe(200);
+    const secondBody = second.json<{ data: { title: string } }>();
+    expect(secondBody.data.title).toBe("Cached Campaign");
+  });
+
   it("returns 404 for draft page (not published)", async () => {
     const campaign = await createTestCampaign("Public Page Test Draft");
     const token = signToken(app);

--- a/packages/api/src/tests/integration/public-donations.test.ts
+++ b/packages/api/src/tests/integration/public-donations.test.ts
@@ -460,4 +460,93 @@ describe("POST /v1/public/campaigns/:id/donate", () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  // The two error paths below are the most common production failures
+  // (NPO clicks Connect Stripe but bails halfway, or Stripe disables
+  // their account). They were untested before — the QA review surfaced
+  // the gap. Both must mask to 502 + RFC 9457 body — no Stripe internal
+  // detail leaks (donor sees a generic message), and the body shape is
+  // locked so a regression to a plain-string response would fail the test.
+  it("returns 502 with RFC 9457 body when the tenant has no stripe_account_id (onboarding never started)", async () => {
+    const campaign = await createTestCampaign("Public Page Test Not Onboarded");
+    const token = signToken(app);
+    await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: { title: "Donate Page", status: "published" },
+    });
+
+    // Wipe the seed's stripe account so `createDonationIntent` hits the
+    // "Organization has not completed Stripe onboarding" branch.
+    await db.execute(sql`UPDATE tenants SET stripe_account_id = NULL WHERE id = ${ORG_A}`);
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: `/v1/public/campaigns/${campaign.id}/donate`,
+        payload: {
+          amountCents: 5000,
+          currency: "EUR",
+          email: "donor@example.org",
+          firstName: "Jane",
+          lastName: "Doe",
+        },
+      });
+
+      expect(res.statusCode).toBe(502);
+      const body = res.json<{ type: string; title: string; status: number; detail: string }>();
+      expect(body.type).toBe("https://httpproblems.com/http-status/502");
+      expect(body.title).toBe("Bad Gateway");
+      expect(body.status).toBe(502);
+      expect(body.detail).toBe("Payment processing failed");
+      // Donor must NOT see the underlying Stripe-onboarding message.
+      expect(body.detail).not.toContain("onboarding");
+    } finally {
+      // Restore the fixture so subsequent tests in the file pass.
+      await db.execute(
+        sql`UPDATE tenants SET stripe_account_id = 'acct_test_org_a' WHERE id = ${ORG_A}`,
+      );
+    }
+  });
+
+  it("returns 502 with RFC 9457 body when the connected account has charges disabled", async () => {
+    const campaign = await createTestCampaign("Public Page Test Charges Disabled");
+    const token = signToken(app);
+    await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: { title: "Donate Page", status: "published" },
+    });
+
+    // Stub the per-test Stripe `accounts.retrieve` to return charges_enabled=false
+    mockGetStripe.mockReturnValueOnce({
+      paymentIntents: { create: mockPaymentIntentsCreate },
+      accounts: {
+        retrieve: vi.fn().mockResolvedValue({ charges_enabled: false }),
+      },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/public/campaigns/${campaign.id}/donate`,
+      payload: {
+        amountCents: 5000,
+        currency: "EUR",
+        email: "donor@example.org",
+        firstName: "Jane",
+        lastName: "Doe",
+      },
+    });
+
+    expect(res.statusCode).toBe(502);
+    const body = res.json<{ type: string; title: string; status: number; detail: string }>();
+    expect(body.type).toBe("https://httpproblems.com/http-status/502");
+    expect(body.status).toBe(502);
+    expect(body.detail).toBe("Payment processing failed");
+    expect(body.detail).not.toContain("fully onboarded");
+    // Stripe wasn't asked to create a PaymentIntent — we short-circuited
+    // before that on the charges_enabled check.
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+  });
 });

--- a/packages/api/src/tests/integration/public-donations.test.ts
+++ b/packages/api/src/tests/integration/public-donations.test.ts
@@ -354,8 +354,11 @@ describe("POST /v1/public/campaigns/:id/donate", () => {
     });
 
     expect(res.statusCode).toBe(200);
-    const body = res.json<{ data: { clientSecret: string } }>();
+    const body = res.json<{ data: { clientSecret: string; stripeAccountId: string } }>();
     expect(body.data.clientSecret).toBe("pi_test_123_secret_abc");
+    // Connect direct-charge: client must know which connected account
+    // it's confirming against, so Stripe.js can pass `stripeAccount`.
+    expect(body.data.stripeAccountId).toBe("acct_test_org_a");
 
     // Verify Stripe was called with correct params
     expect(mockPaymentIntentsCreate).toHaveBeenCalledWith(

--- a/packages/api/src/tests/integration/public-donations.test.ts
+++ b/packages/api/src/tests/integration/public-donations.test.ts
@@ -275,11 +275,25 @@ describe("GET /v1/public/campaigns/:id/page", () => {
 
     expect(res.statusCode).toBe(200);
     const body = res.json<{
-      data: { title: string; description: string; goalAmountCents: number };
+      data: {
+        title: string;
+        description: string;
+        goalAmountCents: number;
+        stripeAccountId: string | null;
+        raisedCents: number;
+        donorCount: number;
+      };
     }>();
     expect(body.data.title).toBe("Public Campaign");
     expect(body.data.description).toBe("Donate now");
     expect(body.data.goalAmountCents).toBe(100000);
+    // Issue #197: connected account id is exposed so the donor SDK can
+    // bind to it (post-3DS retrieve, intent confirmation).
+    expect(body.data.stripeAccountId).toBe("acct_test_org_a");
+    // Issue #200: aggregate fields default to 0 when no cleared donations
+    // exist for the campaign yet — fresh campaigns mustn't crash the hero.
+    expect(body.data.raisedCents).toBe(0);
+    expect(body.data.donorCount).toBe(0);
   });
 
   it("returns 404 for draft page (not published)", async () => {

--- a/packages/api/src/tests/setup.ts
+++ b/packages/api/src/tests/setup.ts
@@ -16,6 +16,11 @@ process.env.S3_ENDPOINT ??= "http://localhost:9000";
 process.env.S3_ACCESS_KEY_ID ??= "minioadmin";
 process.env.S3_SECRET_ACCESS_KEY ??= "minioadmin";
 process.env.ADMIN_SECRET ??= "test-secret";
+// Stripe credentials — `getStripe()` requires a non-empty value to construct
+// the SDK client. The actual key is never used by tests (the `stripe` module
+// is mocked in test files that exercise the real service path); just needs
+// to pass the env-validation gate.
+process.env.STRIPE_SECRET_KEY ??= "sk_test_dummy_for_tests";
 process.env.LOG_LEVEL ??= "silent";
 
 const TEST_JWKS = {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -23,6 +23,8 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@sinclair/typebox": "^0.34.12",
+    "@stripe/react-stripe-js": "^6.3.0",
+    "@stripe/stripe-js": "^9.3.1",
     "@tanstack/react-query": "^5.99.0",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
@@ -40,11 +42,11 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@tailwindcss/postcss": "^4.1.4",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "jsdom": "^25.0.1",

--- a/packages/web/src/app/(app)/donations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/donations/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getLocale, getTranslations } from "next-intl/server";
 
 import { DeleteDonationButton } from "@/components/donations/delete-donation-button";
 import { ReceiptPreviewButton } from "@/components/donations/receipt-preview-button";
+import { RefundDonationButton } from "@/components/donations/refund-donation-button";
 import { PageHeader } from "@/components/shared/page-header";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -55,6 +56,15 @@ export default async function DonationDetailPage({ params }: DonationDetailPageP
 
   const donorName = donationDetailDonorName(donation) || t("anonymousDonor");
   const amountLabel = formatCurrency(donation.amountCents, locale, donation.currency);
+  // Refund button visible only when:
+  //   - the operator is an org_admin (`canDelete` proxies for "admin"),
+  //   - the donation came in via Stripe (only path our refund route supports),
+  //   - the donation isn't already refunded (avoids 422 on click).
+  // Off-Stripe donations (cash/SEPA/check) need their own refund flow,
+  // tracked separately — guarding by `paymentMethod` keeps this scoped
+  // to issue #199's contract without breaking other payment methods.
+  const canRefund =
+    canDelete && donation.paymentMethod === "stripe" && donation.status !== "refunded";
 
   return (
     <>
@@ -83,6 +93,13 @@ export default async function DonationDetailPage({ params }: DonationDetailPageP
               </Button>
             ) : null}
             <ReceiptPreviewButton donationId={donation.id} />
+            {canRefund ? (
+              <RefundDonationButton
+                donationId={donation.id}
+                amountLabel={amountLabel}
+                donorName={donationDetailDonorName(donation) || null}
+              />
+            ) : null}
             {canDelete ? (
               <DeleteDonationButton
                 donationId={donation.id}

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { SettingsNavigation } from "@/components/settings/settings-navigation";
 import { SettingsSnapshotPanel } from "@/components/settings/settings-snapshot-panel";
+import { StripeConnectPanel } from "@/components/settings/stripe-connect-panel";
 import { TenantSettingsForm } from "@/components/settings/tenant-settings-form";
 import { PageHeader } from "@/components/shared/page-header";
 import { requireAuth } from "@/lib/auth/guards";
@@ -23,6 +24,7 @@ export default async function SettingsPage() {
       />
       <SettingsNavigation />
       <TenantSettingsForm orgId={auth.orgId} canManageTenant={auth.roles.includes("org_admin")} />
+      <StripeConnectPanel canManageTenant={auth.roles.includes("org_admin")} />
       <SettingsSnapshotPanel orgId={auth.orgId} canExport={auth.roles.includes("org_admin")} />
     </div>
   );

--- a/packages/web/src/app/(public)/p/[id]/page.tsx
+++ b/packages/web/src/app/(public)/p/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { Globe2 } from "lucide-react";
+import { Globe2, Users } from "lucide-react";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
@@ -32,6 +32,16 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
     const colorPrimary = page.colorPrimary ?? DEFAULT_THEME_COLOR;
     const onPrimary = getReadableTextColor(colorPrimary);
     const hasGoal = page.goalAmountCents !== null && page.goalAmountCents > 0;
+    // Issue #200: render the mockup's progress bar + donor count when we have
+    // a goal AND there's been at least one donation. Falling back to the
+    // metric tiles if either signal is missing keeps fresh campaigns from
+    // showing an empty bar.
+    const showProgress = hasGoal && page.raisedCents > 0;
+    const goalCents = page.goalAmountCents ?? 0;
+    const progressPercent =
+      hasGoal && goalCents > 0
+        ? Math.min(100, Math.round((page.raisedCents / goalCents) * 100))
+        : 0;
 
     return (
       <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(9,100,71,0.14),_transparent_42%),linear-gradient(180deg,_var(--color-surface-container-lowest)_0%,_var(--color-surface)_100%)]">
@@ -63,17 +73,28 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
                 </p>
               </div>
 
-              <div
-                className={`grid gap-4 border-t border-outline-variant px-5 py-5 sm:px-8 sm:py-6 lg:px-10 lg:py-8 ${hasGoal ? "sm:grid-cols-2" : ""}`}
-              >
-                {hasGoal ? (
-                  <Metric
-                    label={t("metrics.goal")}
-                    value={formatCurrency(page.goalAmountCents!, locale)}
-                  />
-                ) : null}
-                <Metric label={t("metrics.trust")} value={t("metrics.trustValue")} />
-              </div>
+              {showProgress ? (
+                <Progress
+                  raisedCents={page.raisedCents}
+                  goalCents={goalCents}
+                  donorCount={page.donorCount}
+                  progressPercent={progressPercent}
+                  colorPrimary={colorPrimary}
+                  locale={locale}
+                  raisedLabel={t("metrics.raised")}
+                  goalSuffix={t("metrics.goalSuffix")}
+                  donorsLabel={t("metrics.donors", { count: page.donorCount })}
+                />
+              ) : (
+                <div
+                  className={`grid gap-4 border-t border-outline-variant px-5 py-5 sm:px-8 sm:py-6 lg:px-10 lg:py-8 ${hasGoal ? "sm:grid-cols-2" : ""}`}
+                >
+                  {hasGoal ? (
+                    <Metric label={t("metrics.goal")} value={formatCurrency(goalCents, locale)} />
+                  ) : null}
+                  <Metric label={t("metrics.trust")} value={t("metrics.trustValue")} />
+                </div>
+              )}
             </section>
 
             <PublicDonationForm
@@ -83,6 +104,7 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
               goalAmountCents={page.goalAmountCents}
               defaultCurrency={page.defaultCurrency}
               publishableKey={process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? null}
+              tenantStripeAccountId={page.stripeAccountId}
             />
           </div>
         </div>
@@ -103,6 +125,65 @@ function Metric({ label, value }: { label: string; value: string }) {
         {label}
       </p>
       <p className="mt-2 text-base font-semibold text-on-surface sm:text-lg">{value}</p>
+    </div>
+  );
+}
+
+function Progress({
+  raisedCents,
+  goalCents,
+  donorCount,
+  progressPercent,
+  colorPrimary,
+  locale,
+  raisedLabel,
+  goalSuffix,
+  donorsLabel,
+}: {
+  raisedCents: number;
+  goalCents: number;
+  donorCount: number;
+  progressPercent: number;
+  colorPrimary: string;
+  locale: string;
+  raisedLabel: string;
+  goalSuffix: string;
+  donorsLabel: string;
+}) {
+  return (
+    <div className="border-t border-outline-variant px-5 py-5 sm:px-8 sm:py-6 lg:px-10 lg:py-8">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-xs font-medium uppercase tracking-[0.14em] text-on-surface-variant">
+          {raisedLabel}
+        </p>
+        <p className="font-mono text-xs text-on-surface-variant">
+          {donorCount > 0 ? (
+            <span className="inline-flex items-center gap-1">
+              <Users size={12} aria-hidden="true" />
+              {donorsLabel}
+            </span>
+          ) : null}
+        </p>
+      </div>
+      <p className="mt-2 font-heading text-2xl text-on-surface sm:text-3xl">
+        <span className="font-semibold">{formatCurrency(raisedCents, locale)}</span>
+        <span className="ml-1 text-sm font-normal text-on-surface-variant">
+          {goalSuffix} {formatCurrency(goalCents, locale)}
+        </span>
+      </p>
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={progressPercent}
+        aria-label={raisedLabel}
+        className="mt-3 h-2.5 overflow-hidden rounded-full bg-surface-container"
+      >
+        <div
+          className="h-full rounded-full transition-[width] duration-slow"
+          style={{ width: `${progressPercent}%`, backgroundColor: colorPrimary }}
+        />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/app/(public)/p/[id]/page.tsx
+++ b/packages/web/src/app/(public)/p/[id]/page.tsx
@@ -89,6 +89,7 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
               locale={locale}
               goalAmountCents={page.goalAmountCents}
               defaultCurrency={page.defaultCurrency}
+              publishableKey={process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? null}
             />
           </div>
         </div>

--- a/packages/web/src/app/(public)/p/[id]/page.tsx
+++ b/packages/web/src/app/(public)/p/[id]/page.tsx
@@ -6,6 +6,7 @@ import { PublicDonationForm } from "@/components/campaigns/public-donation-form"
 import { Badge } from "@/components/ui/badge";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
+import { getReadableTextColor } from "@/lib/color";
 import { formatCurrency } from "@/lib/format";
 import { isUuid } from "@/lib/utils";
 import { CampaignPublicPageService } from "@/services/CampaignPublicPageService";
@@ -104,13 +105,4 @@ function Metric({ label, value }: { label: string; value: string }) {
       <p className="mt-2 text-base font-semibold text-on-surface sm:text-lg">{value}</p>
     </div>
   );
-}
-
-function getReadableTextColor(hex: string): "#FFFFFF" | "#111827" {
-  const normalized = hex.replace("#", "");
-  const r = Number.parseInt(normalized.slice(0, 2), 16);
-  const g = Number.parseInt(normalized.slice(2, 4), 16);
-  const b = Number.parseInt(normalized.slice(4, 6), 16);
-  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
-  return luminance > 0.6 ? "#111827" : "#FFFFFF";
 }

--- a/packages/web/src/app/(public)/p/[id]/page.tsx
+++ b/packages/web/src/app/(public)/p/[id]/page.tsx
@@ -1,11 +1,9 @@
-import { ArrowLeft, Globe2 } from "lucide-react";
-import Link from "next/link";
+import { Globe2 } from "lucide-react";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { PublicDonationForm } from "@/components/campaigns/public-donation-form";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { formatCurrency } from "@/lib/format";
@@ -37,13 +35,7 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
     return (
       <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(9,100,71,0.14),_transparent_42%),linear-gradient(180deg,_var(--color-surface-container-lowest)_0%,_var(--color-surface)_100%)]">
         <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-4 sm:px-8 sm:py-6 lg:px-10 lg:py-10">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <Button asChild variant="ghost" size="sm">
-              <Link href="/">
-                <ArrowLeft size={16} aria-hidden="true" />
-                {t("backHome")}
-              </Link>
-            </Button>
+          <div className="flex justify-end">
             <Badge variant="info">
               <Globe2 size={12} aria-hidden="true" />
               {t("badge")}

--- a/packages/web/src/components/campaigns/public-donation-form.test.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.test.tsx
@@ -6,8 +6,13 @@ import { mockToast, render, screen, userEvent, waitFor } from "../../tests/test-
 // Stub Stripe.js so the Payment Element step renders without trying to load
 // the real script in jsdom. We don't assert anything inside the iframe — the
 // integration test for confirmPayment lives in Stripe's own test mode.
+const { mockRetrievePaymentIntent } = vi.hoisted(() => ({
+  mockRetrievePaymentIntent: vi.fn(),
+}));
 vi.mock("@stripe/stripe-js", () => ({
-  loadStripe: vi.fn().mockResolvedValue(null),
+  loadStripe: vi.fn().mockResolvedValue({
+    retrievePaymentIntent: mockRetrievePaymentIntent,
+  }),
 }));
 
 vi.mock("@stripe/react-stripe-js", () => ({
@@ -30,6 +35,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={50000}
         publishableKey={null}
+        tenantStripeAccountId={null}
       />,
     );
 
@@ -56,6 +62,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={50000}
         publishableKey="pk_test_dummy"
+        tenantStripeAccountId="acct_test_999"
       />,
     );
 
@@ -103,6 +110,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey="pk_test_dummy"
+        tenantStripeAccountId="acct_test_999"
       />,
     );
 
@@ -141,6 +149,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey="pk_test_dummy"
+        tenantStripeAccountId="acct_test_999"
       />,
     );
 
@@ -172,6 +181,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey="pk_live_real_key"
+        tenantStripeAccountId="acct_live_888"
       />,
     );
 
@@ -201,6 +211,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey={null}
+        tenantStripeAccountId={null}
       />,
     );
 
@@ -233,6 +244,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey={null}
+        tenantStripeAccountId={null}
       />,
     );
 
@@ -243,5 +255,89 @@ describe("PublicDonationForm", () => {
     await user.click(screen.getByRole("button", { name: "Continue to payment" }));
 
     await waitFor(() => expect(mockToast.error).toHaveBeenCalledWith("Stripe is unavailable."));
+  });
+
+  // ─── Issue #197: Post-3DS return handler ────────────────────────────────
+
+  it("renders the post-3DS success state when ?payment_intent_client_secret is present and the intent succeeded", async () => {
+    // Stripe's redirect-back URL on a 3DS success.
+    const originalSearch = window.location.search;
+    window.history.replaceState(
+      {},
+      "",
+      "?payment_intent=pi_post3ds&payment_intent_client_secret=pi_post3ds_secret&redirect_status=succeeded",
+    );
+    mockRetrievePaymentIntent.mockResolvedValueOnce({
+      paymentIntent: {
+        id: "pi_post3ds",
+        amount: 5000,
+        currency: "eur",
+        status: "succeeded",
+      },
+      error: null,
+    });
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={null}
+        publishableKey="pk_test_dummy"
+        tenantStripeAccountId="acct_test_999"
+      />,
+    );
+
+    expect(await screen.findByText("Thank you for your donation!")).toBeInTheDocument();
+    // Donor-details form must NOT be shown — we'd be asking them to
+    // re-enter info they already submitted before the 3DS challenge.
+    expect(screen.queryByLabelText(/^First name/)).not.toBeInTheDocument();
+    // URL should be cleaned of redirect params so a refresh doesn't loop
+    // the retrieve call.
+    await waitFor(() =>
+      expect(window.location.search).not.toContain("payment_intent_client_secret"),
+    );
+
+    // Restore for downstream tests.
+    window.history.replaceState({}, "", originalSearch || "/");
+  });
+
+  it("renders a retry CTA when post-3DS status is requires_payment_method", async () => {
+    const originalSearch = window.location.search;
+    window.history.replaceState(
+      {},
+      "",
+      "?payment_intent=pi_post3ds_fail&payment_intent_client_secret=pi_post3ds_fail_secret&redirect_status=failed",
+    );
+    mockRetrievePaymentIntent.mockResolvedValueOnce({
+      paymentIntent: {
+        id: "pi_post3ds_fail",
+        amount: 5000,
+        currency: "eur",
+        status: "requires_payment_method",
+        last_payment_error: { message: "Your card was declined." },
+      },
+      error: null,
+    });
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={null}
+        publishableKey="pk_test_dummy"
+        tenantStripeAccountId="acct_test_999"
+      />,
+    );
+
+    // Retry CTA + Payment Element re-mounted on the SAME intent's
+    // clientSecret so the donor doesn't create a duplicate PaymentIntent.
+    expect(
+      await screen.findByText(/Your payment didn't complete\. Try a different card/i),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("stripe-payment-element")).toBeInTheDocument();
+
+    window.history.replaceState({}, "", originalSearch || "/");
   });
 });

--- a/packages/web/src/components/campaigns/public-donation-form.test.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.test.tsx
@@ -299,7 +299,10 @@ describe("PublicDonationForm", () => {
     );
 
     // Restore for downstream tests.
-    window.history.replaceState({}, "", originalSearch || "/");
+    // Restore. Using `pathname` rather than the `originalSearch || "/"`
+    // pattern because empty search → falsy → would redirect us to "/" and
+    // change the route under test (caught in PR #193 review).
+    window.history.replaceState({}, "", `${window.location.pathname}${originalSearch}`);
   });
 
   it("renders a retry CTA when post-3DS status is requires_payment_method", async () => {
@@ -338,6 +341,9 @@ describe("PublicDonationForm", () => {
     ).toBeInTheDocument();
     expect(screen.getByTestId("stripe-payment-element")).toBeInTheDocument();
 
-    window.history.replaceState({}, "", originalSearch || "/");
+    // Restore. Using `pathname` rather than the `originalSearch || "/"`
+    // pattern because empty search → falsy → would redirect us to "/" and
+    // change the route under test (caught in PR #193 review).
+    window.history.replaceState({}, "", `${window.location.pathname}${originalSearch}`);
   });
 });

--- a/packages/web/src/components/campaigns/public-donation-form.test.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.test.tsx
@@ -88,6 +88,44 @@ describe("PublicDonationForm", () => {
     expect(screen.queryByLabelText(/^First name/)).not.toBeInTheDocument();
   });
 
+  it("returns to the donor-details form with values preserved when 'Edit my donation' is clicked", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      clientSecret: "pi_secret_456",
+      stripeAccountId: "acct_test_123",
+    });
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={null}
+        publishableKey="pk_test_dummy"
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^First name/), "Jane");
+    await user.type(screen.getByLabelText(/^Last name/), "Doe");
+    await user.type(screen.getByLabelText(/^Email/), "jane@example.org");
+    await user.type(screen.getByLabelText(/^Amount/), "75");
+    await user.click(screen.getByRole("button", { name: "Continue to payment" }));
+
+    // Wait for the Payment Element to mount, confirming we transitioned.
+    expect(await screen.findByTestId("stripe-payment-element")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Edit my donation" }));
+
+    // Donor-details fields are back, AND the values they typed are still there
+    // (parent state preserves `values` across the session-clear).
+    expect(await screen.findByLabelText(/^First name/)).toHaveValue("Jane");
+    expect(screen.getByLabelText(/^Last name/)).toHaveValue("Doe");
+    expect(screen.getByLabelText(/^Email/)).toHaveValue("jane@example.org");
+    expect(screen.getByLabelText(/^Amount/)).toHaveValue(75);
+    expect(screen.queryByTestId("stripe-payment-element")).not.toBeInTheDocument();
+  });
+
   it("blocks at payment step with a clear message when publishableKey is not configured", async () => {
     const user = userEvent.setup();
 

--- a/packages/web/src/components/campaigns/public-donation-form.test.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.test.tsx
@@ -126,6 +126,66 @@ describe("PublicDonationForm", () => {
     expect(screen.queryByTestId("stripe-payment-element")).not.toBeInTheDocument();
   });
 
+  it("renders the test-mode banner when publishableKey starts with pk_test_", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      clientSecret: "pi_secret_999",
+      stripeAccountId: "acct_test_999",
+    });
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={null}
+        publishableKey="pk_test_dummy"
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^First name/), "Jane");
+    await user.type(screen.getByLabelText(/^Last name/), "Doe");
+    await user.type(screen.getByLabelText(/^Email/), "jane@example.org");
+    await user.type(screen.getByLabelText(/^Amount/), "50");
+    await user.click(screen.getByRole("button", { name: "Continue to payment" }));
+
+    expect(await screen.findByText("Test mode — no real charge")).toBeInTheDocument();
+    expect(screen.getByText("4242 4242 4242 4242")).toBeInTheDocument();
+  });
+
+  it("does NOT render the test-mode banner when publishableKey starts with pk_live_", async () => {
+    // Critical inverse: a flipped predicate would silently leak "Test mode"
+    // copy onto live-donor pages. We assert both the banner heading and the
+    // card hint are absent.
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      clientSecret: "pi_secret_888",
+      stripeAccountId: "acct_live_888",
+    });
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={null}
+        publishableKey="pk_live_real_key"
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^First name/), "Jane");
+    await user.type(screen.getByLabelText(/^Last name/), "Doe");
+    await user.type(screen.getByLabelText(/^Email/), "jane@example.org");
+    await user.type(screen.getByLabelText(/^Amount/), "50");
+    await user.click(screen.getByRole("button", { name: "Continue to payment" }));
+
+    expect(await screen.findByTestId("stripe-payment-element")).toBeInTheDocument();
+    expect(screen.queryByText("Test mode — no real charge")).not.toBeInTheDocument();
+    expect(screen.queryByText("4242 4242 4242 4242")).not.toBeInTheDocument();
+  });
+
   it("blocks at payment step with a clear message when publishableKey is not configured", async () => {
     const user = userEvent.setup();
 

--- a/packages/web/src/components/campaigns/public-donation-form.test.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.test.tsx
@@ -3,6 +3,22 @@ import { ApiProblem } from "@/lib/api";
 import { CampaignPublicPageService } from "@/services/CampaignPublicPageService";
 import { mockToast, render, screen, userEvent, waitFor } from "../../tests/test-utils";
 
+// Stub Stripe.js so the Payment Element step renders without trying to load
+// the real script in jsdom. We don't assert anything inside the iframe — the
+// integration test for confirmPayment lives in Stripe's own test mode.
+vi.mock("@stripe/stripe-js", () => ({
+  loadStripe: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@stripe/react-stripe-js", () => ({
+  Elements: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="stripe-elements">{children}</div>
+  ),
+  PaymentElement: () => <div data-testid="stripe-payment-element" />,
+  useStripe: () => null,
+  useElements: () => null,
+}));
+
 describe("PublicDonationForm", () => {
   it("shows inline validation errors before submission", async () => {
     const user = userEvent.setup();
@@ -13,6 +29,7 @@ describe("PublicDonationForm", () => {
         colorPrimary="#096447"
         locale="en"
         goalAmountCents={50000}
+        publishableKey={null}
       />,
     );
 
@@ -24,11 +41,12 @@ describe("PublicDonationForm", () => {
     expect(screen.getByText("Enter a donation amount.")).toBeInTheDocument();
   });
 
-  it("creates a donation intent with trimmed values and cents", async () => {
+  it("creates a donation intent and transitions to the Payment Element step", async () => {
     const user = userEvent.setup();
 
     vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
       clientSecret: "pi_secret_123",
+      stripeAccountId: "acct_test_123",
     });
 
     render(
@@ -37,6 +55,7 @@ describe("PublicDonationForm", () => {
         colorPrimary="#096447"
         locale="en"
         goalAmountCents={50000}
+        publishableKey="pk_test_dummy"
       />,
     );
 
@@ -62,9 +81,39 @@ describe("PublicDonationForm", () => {
     );
 
     expect(mockToast.success).toHaveBeenCalledWith(
-      "Your donation is ready. The Stripe payment step is the next integration.",
+      "Donation prepared — enter your card details below.",
     );
-    expect(await screen.findByText("Next step")).toBeInTheDocument();
+    // Transition: details form is gone, Stripe Elements mounted.
+    expect(await screen.findByTestId("stripe-payment-element")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^First name/)).not.toBeInTheDocument();
+  });
+
+  it("blocks at payment step with a clear message when publishableKey is not configured", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      clientSecret: "pi_secret_123",
+      stripeAccountId: "acct_test_123",
+    });
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={null}
+        publishableKey={null}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^First name/), "Jane");
+    await user.type(screen.getByLabelText(/^Last name/), "Doe");
+    await user.type(screen.getByLabelText(/^Email/), "jane@example.org");
+    await user.type(screen.getByLabelText(/^Amount/), "50");
+    await user.click(screen.getByRole("button", { name: "Continue to payment" }));
+
+    expect(await screen.findByText(/NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("stripe-payment-element")).not.toBeInTheDocument();
   });
 
   it("shows an API error toast when payment preparation fails", async () => {
@@ -85,6 +134,7 @@ describe("PublicDonationForm", () => {
         colorPrimary="#096447"
         locale="en"
         goalAmountCents={null}
+        publishableKey={null}
       />,
     );
 

--- a/packages/web/src/components/campaigns/public-donation-form.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.tsx
@@ -161,6 +161,10 @@ export function PublicDonationForm({
               onPaid={() => {
                 toast.success(tPayment("success.title"));
               }}
+              // Clearing `session` re-renders the donor-details form below.
+              // `values` is preserved in parent state so fields pre-fill —
+              // donor only edits what they want to change.
+              onBack={() => setSession(null)}
             />
           </div>
         ) : (

--- a/packages/web/src/components/campaigns/public-donation-form.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.tsx
@@ -4,6 +4,7 @@ import { HeartHandshake, LoaderCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { type FormEvent, type ReactNode, useState } from "react";
 
+import { PublicDonationPaymentStep } from "@/components/campaigns/public-donation-payment-step";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -26,6 +27,14 @@ interface PublicDonationFormProps {
   locale: string;
   goalAmountCents: number | null;
   defaultCurrency?: PublicDonationCurrency;
+  /**
+   * Stripe platform publishable key (`pk_test_...` / `pk_live_...`). Threaded
+   * from the server component so we don't have to re-evaluate
+   * `process.env.NEXT_PUBLIC_*` at every keystroke. `null` when the env var
+   * is not set — the form still collects donor info but blocks at the
+   * payment step with a clear message.
+   */
+  publishableKey: string | null;
 }
 
 interface PublicDonationFormValues {
@@ -41,6 +50,13 @@ interface FormErrors {
   lastName?: string;
   email?: string;
   amount?: string;
+}
+
+interface PaymentSession {
+  clientSecret: string;
+  stripeAccountId: string;
+  amountCents: number;
+  currency: PublicDonationCurrency;
 }
 
 const SUGGESTED_AMOUNTS = [25, 50, 100] as const;
@@ -60,15 +76,17 @@ export function PublicDonationForm({
   locale,
   goalAmountCents,
   defaultCurrency = "EUR",
+  publishableKey,
 }: PublicDonationFormProps) {
   const t = useTranslations("publicDonationPage.form");
+  const tPayment = useTranslations("publicDonationPage.payment");
   const [values, setValues] = useState<PublicDonationFormValues>({
     ...DEFAULT_VALUES,
     currency: defaultCurrency,
   });
   const [errors, setErrors] = useState<FormErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [clientSecret, setClientSecret] = useState<string | null>(null);
+  const [session, setSession] = useState<PaymentSession | null>(null);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -80,11 +98,12 @@ export function PublicDonationForm({
     setIsSubmitting(true);
 
     try {
+      const amountCents = parseAmountToCents(values.amount);
       const result = await CampaignPublicPageService.createPublicDonationIntent(
         createClientApiClient(),
         campaignId,
         {
-          amountCents: parseAmountToCents(values.amount),
+          amountCents,
           currency: values.currency,
           email: values.email.trim(),
           firstName: values.firstName.trim(),
@@ -93,7 +112,12 @@ export function PublicDonationForm({
         createIdempotencyKey(),
       );
 
-      setClientSecret(result.clientSecret);
+      setSession({
+        clientSecret: result.clientSecret,
+        stripeAccountId: result.stripeAccountId,
+        amountCents,
+        currency: values.currency,
+      });
       toast.success(t("success.intentCreated"));
     } catch (error) {
       const message =
@@ -125,6 +149,72 @@ export function PublicDonationForm({
 
       <p className="mt-3 text-sm leading-6 text-on-surface-variant">{t("description")}</p>
 
+      {session ? (
+        publishableKey ? (
+          <div className="mt-6">
+            <PublicDonationPaymentStep
+              clientSecret={session.clientSecret}
+              stripeAccountId={session.stripeAccountId}
+              publishableKey={publishableKey}
+              colorPrimary={colorPrimary}
+              amountSummary={formatCurrency(session.amountCents, locale, session.currency)}
+              onPaid={() => {
+                toast.success(tPayment("success.title"));
+              }}
+            />
+          </div>
+        ) : (
+          <p className="mt-6 rounded-2xl border border-error bg-error-container px-4 py-3 text-sm text-on-error-container">
+            {tPayment("errors.missingPublishableKey")}
+          </p>
+        )
+      ) : (
+        <DonorDetailsForm
+          values={values}
+          errors={errors}
+          isSubmitting={isSubmitting}
+          colorPrimary={colorPrimary}
+          locale={locale}
+          goalAmountCents={goalAmountCents}
+          defaultCurrency={defaultCurrency}
+          onValuesChange={setValues}
+          onErrorsChange={setErrors}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </section>
+  );
+}
+
+function DonorDetailsForm({
+  values,
+  errors,
+  isSubmitting,
+  colorPrimary,
+  locale,
+  goalAmountCents,
+  defaultCurrency,
+  onValuesChange,
+  onErrorsChange,
+  onSubmit,
+}: {
+  values: PublicDonationFormValues;
+  errors: FormErrors;
+  isSubmitting: boolean;
+  colorPrimary: string;
+  locale: string;
+  goalAmountCents: number | null;
+  defaultCurrency: PublicDonationCurrency;
+  onValuesChange: (next: (current: PublicDonationFormValues) => PublicDonationFormValues) => void;
+  onErrorsChange: (next: (current: FormErrors) => FormErrors) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  // Re-bind locally so next-intl's typed lookups stay specialised — passing
+  // a hoisted `t` as a prop loses the namespace generic and triggers
+  // TS2589 (`Type instantiation is excessively deep`).
+  const t = useTranslations("publicDonationPage.form");
+  return (
+    <>
       <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
         {SUGGESTED_AMOUNTS.map((amount) => (
           <button
@@ -137,8 +227,8 @@ export function PublicDonationForm({
                 values.amount === String(amount) ? getReadableTextColor(colorPrimary) : undefined,
             }}
             onClick={() => {
-              setValues((current) => ({ ...current, amount: String(amount) }));
-              setErrors((current) => ({ ...current, amount: undefined }));
+              onValuesChange((current) => ({ ...current, amount: String(amount) }));
+              onErrorsChange((current) => ({ ...current, amount: undefined }));
             }}
           >
             <span className="block text-center text-lg font-semibold sm:text-xl">
@@ -158,7 +248,7 @@ export function PublicDonationForm({
         </p>
       ) : null}
 
-      <form className="mt-6 space-y-4" onSubmit={handleSubmit} noValidate>
+      <form className="mt-6 space-y-4" onSubmit={onSubmit} noValidate>
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
             inputId="public-donation-first-name"
@@ -170,8 +260,8 @@ export function PublicDonationForm({
                 id="public-donation-first-name"
                 value={values.firstName}
                 onChange={(event) => {
-                  setValues((current) => ({ ...current, firstName: event.target.value }));
-                  setErrors((current) => ({ ...current, firstName: undefined }));
+                  onValuesChange((current) => ({ ...current, firstName: event.target.value }));
+                  onErrorsChange((current) => ({ ...current, firstName: undefined }));
                 }}
                 placeholder={t("fields.firstNamePlaceholder")}
                 aria-invalid={Boolean(errors.firstName)}
@@ -189,8 +279,8 @@ export function PublicDonationForm({
                 id="public-donation-last-name"
                 value={values.lastName}
                 onChange={(event) => {
-                  setValues((current) => ({ ...current, lastName: event.target.value }));
-                  setErrors((current) => ({ ...current, lastName: undefined }));
+                  onValuesChange((current) => ({ ...current, lastName: event.target.value }));
+                  onErrorsChange((current) => ({ ...current, lastName: undefined }));
                 }}
                 placeholder={t("fields.lastNamePlaceholder")}
                 aria-invalid={Boolean(errors.lastName)}
@@ -211,8 +301,8 @@ export function PublicDonationForm({
               type="email"
               value={values.email}
               onChange={(event) => {
-                setValues((current) => ({ ...current, email: event.target.value }));
-                setErrors((current) => ({ ...current, email: undefined }));
+                onValuesChange((current) => ({ ...current, email: event.target.value }));
+                onErrorsChange((current) => ({ ...current, email: undefined }));
               }}
               placeholder={t("fields.emailPlaceholder")}
               aria-invalid={Boolean(errors.email)}
@@ -238,8 +328,8 @@ export function PublicDonationForm({
                 step="1"
                 value={values.amount}
                 onChange={(event) => {
-                  setValues((current) => ({ ...current, amount: event.target.value }));
-                  setErrors((current) => ({ ...current, amount: undefined }));
+                  onValuesChange((current) => ({ ...current, amount: event.target.value }));
+                  onErrorsChange((current) => ({ ...current, amount: undefined }));
                 }}
                 placeholder={t("fields.amountPlaceholder")}
                 aria-invalid={Boolean(errors.amount)}
@@ -257,7 +347,7 @@ export function PublicDonationForm({
             <Select
               value={values.currency}
               onValueChange={(currency) =>
-                setValues((current) => ({
+                onValuesChange((current) => ({
                   ...current,
                   currency: currency as PublicDonationCurrency,
                 }))
@@ -276,13 +366,6 @@ export function PublicDonationForm({
             </Select>
           }
         />
-
-        {clientSecret ? (
-          <div className="rounded-2xl border border-outline-variant bg-surface px-4 py-3 text-sm text-on-surface-variant">
-            <p className="font-medium text-on-surface">{t("success.nextStepTitle")}</p>
-            <p className="mt-1">{t("success.nextStepBody")}</p>
-          </div>
-        ) : null}
 
         <Button
           type="submit"
@@ -304,7 +387,7 @@ export function PublicDonationForm({
           {t("footnote")}
         </p>
       </form>
-    </section>
+    </>
   );
 }
 

--- a/packages/web/src/components/campaigns/public-donation-form.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.tsx
@@ -17,6 +17,7 @@ import {
 import { toast } from "@/components/ui/toast";
 import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
+import { getReadableTextColor } from "@/lib/color";
 import { formatCurrency } from "@/lib/format";
 import type { PublicDonationCurrency } from "@/models/public-page";
 import { CampaignPublicPageService } from "@/services/CampaignPublicPageService";
@@ -219,31 +220,46 @@ function DonorDetailsForm({
   const t = useTranslations("publicDonationPage.form");
   return (
     <>
+      {/*
+        Suggested-amount chips. `aria-pressed` carries the toggle semantics
+        for AT users — donors can pick any chip OR type a custom amount in
+        the field below, which is why these are individual toggles rather
+        than a `<RadioGroup>`. The `Button` size="lg" + height override
+        gives a visibly tappable target on mobile while inheriting the
+        design-system focus ring and disabled handling.
+       */}
       <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
-        {SUGGESTED_AMOUNTS.map((amount) => (
-          <button
-            key={amount}
-            type="button"
-            className="rounded-2xl border border-outline-variant bg-surface px-4 py-4 text-center transition-colors hover:border-primary sm:py-5"
-            style={{
-              backgroundColor: values.amount === String(amount) ? colorPrimary : undefined,
-              color:
-                values.amount === String(amount) ? getReadableTextColor(colorPrimary) : undefined,
-            }}
-            onClick={() => {
-              onValuesChange((current) => ({ ...current, amount: String(amount) }));
-              onErrorsChange((current) => ({ ...current, amount: undefined }));
-            }}
-          >
-            <span className="block text-center text-lg font-semibold sm:text-xl">
+        {SUGGESTED_AMOUNTS.map((amount) => {
+          const isSelected = values.amount === String(amount);
+          return (
+            <Button
+              key={amount}
+              type="button"
+              variant={isSelected ? "primary" : "secondary"}
+              size="lg"
+              aria-pressed={isSelected}
+              className="h-auto py-4 text-lg font-semibold sm:py-5 sm:text-xl"
+              style={
+                isSelected
+                  ? {
+                      backgroundColor: colorPrimary,
+                      color: getReadableTextColor(colorPrimary),
+                    }
+                  : undefined
+              }
+              onClick={() => {
+                onValuesChange((current) => ({ ...current, amount: String(amount) }));
+                onErrorsChange((current) => ({ ...current, amount: undefined }));
+              }}
+            >
               {new Intl.NumberFormat(locale, {
                 style: "currency",
                 currency: values.currency,
                 maximumFractionDigits: 0,
               }).format(amount)}
-            </span>
-          </button>
-        ))}
+            </Button>
+          );
+        })}
       </div>
 
       {goalAmountCents !== null ? (
@@ -252,7 +268,12 @@ function DonorDetailsForm({
         </p>
       ) : null}
 
-      <form className="mt-6 space-y-4" onSubmit={onSubmit} noValidate>
+      <form
+        className="mt-6 space-y-4"
+        onSubmit={onSubmit}
+        noValidate
+        aria-busy={isSubmitting || undefined}
+      >
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
             inputId="public-donation-first-name"
@@ -466,13 +487,4 @@ function createIdempotencyKey(): string {
     return crypto.randomUUID();
   }
   return `public-donation-${Date.now()}`;
-}
-
-function getReadableTextColor(hex: string): "#FFFFFF" | "#111827" {
-  const normalized = hex.replace("#", "");
-  const r = Number.parseInt(normalized.slice(0, 2), 16);
-  const g = Number.parseInt(normalized.slice(2, 4), 16);
-  const b = Number.parseInt(normalized.slice(4, 6), 16);
-  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
-  return luminance > 0.6 ? "#111827" : "#FFFFFF";
 }

--- a/packages/web/src/components/campaigns/public-donation-form.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { HeartHandshake, LoaderCircle } from "lucide-react";
+import { CheckCircle2, HeartHandshake, LoaderCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { type FormEvent, type ReactNode, useState } from "react";
+import { type FormEvent, type ReactNode, useEffect, useState } from "react";
 
 import { PublicDonationPaymentStep } from "@/components/campaigns/public-donation-payment-step";
+import { retrievePostRedirectIntent } from "@/components/campaigns/public-donation-post-redirect";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -36,6 +37,15 @@ interface PublicDonationFormProps {
    * payment step with a clear message.
    */
   publishableKey: string | null;
+  /**
+   * Tenant's connected account id (`acct_…`). Available before the donor
+   * has submitted, so we can detect a 3DS post-redirect on mount and
+   * resolve the PaymentIntent without round-tripping to the donate
+   * endpoint first (issue #197). Null when the tenant hasn't onboarded
+   * yet — donor flow degrades gracefully (no post-redirect retrieval, the
+   * donate step itself blocks at 502).
+   */
+  tenantStripeAccountId: string | null;
 }
 
 interface PublicDonationFormValues {
@@ -60,6 +70,24 @@ interface PaymentSession {
   currency: PublicDonationCurrency;
 }
 
+/**
+ * Outcome resolved from `?payment_intent_client_secret=…` query params on
+ * mount — i.e., the donor was redirected here after a 3DS challenge. See
+ * `public-donation-post-redirect.ts` for the full type and rationale.
+ */
+type PostRedirectState =
+  | { kind: "checking" }
+  | { kind: "succeeded"; amountCents: number; currency: string }
+  | {
+      kind: "requires_action";
+      clientSecret: string;
+      amountCents: number;
+      currency: string;
+    }
+  | { kind: "processing" }
+  | { kind: "failed"; message: string }
+  | null;
+
 const SUGGESTED_AMOUNTS = [25, 50, 100] as const;
 
 const DEFAULT_VALUES: PublicDonationFormValues = {
@@ -78,6 +106,7 @@ export function PublicDonationForm({
   goalAmountCents,
   defaultCurrency = "EUR",
   publishableKey,
+  tenantStripeAccountId,
 }: PublicDonationFormProps) {
   const t = useTranslations("publicDonationPage.form");
   const tPayment = useTranslations("publicDonationPage.payment");
@@ -88,6 +117,42 @@ export function PublicDonationForm({
   const [errors, setErrors] = useState<FormErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [session, setSession] = useState<PaymentSession | null>(null);
+  // Detect 3DS post-redirect on mount. `checking` keeps the donor from
+  // briefly seeing the empty form before retrieve resolves; `null` means
+  // there's nothing to retrieve (most visits) and the form renders normally.
+  const initialPostRedirect: PostRedirectState =
+    typeof window !== "undefined" &&
+    publishableKey &&
+    tenantStripeAccountId &&
+    new URLSearchParams(window.location.search).has("payment_intent_client_secret")
+      ? { kind: "checking" }
+      : null;
+  const [postRedirect, setPostRedirect] = useState<PostRedirectState>(initialPostRedirect);
+
+  useEffect(() => {
+    if (!postRedirect || postRedirect.kind !== "checking") return;
+    if (!publishableKey || !tenantStripeAccountId) return;
+
+    let active = true;
+    void retrievePostRedirectIntent({ publishableKey, stripeAccountId: tenantStripeAccountId })
+      .then((outcome) => {
+        if (!active) return;
+        if (!outcome) {
+          setPostRedirect(null);
+          return;
+        }
+        setPostRedirect(outcome);
+      })
+      .catch(() => {
+        if (!active) return;
+        setPostRedirect({ kind: "failed", message: tPayment("errors.generic") });
+      });
+
+    return () => {
+      active = false;
+    };
+    // tPayment is stable per locale; we intentionally fire this once on mount.
+  }, [postRedirect, publishableKey, tenantStripeAccountId, tPayment]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -150,7 +215,24 @@ export function PublicDonationForm({
 
       <p className="mt-3 text-sm leading-6 text-on-surface-variant">{t("description")}</p>
 
-      {session ? (
+      {/*
+        Render priority:
+        1. Post-3DS return state (donor came back from a Stripe redirect; we
+           override everything else so they never see a blank form they
+           already filled out before the challenge).
+        2. Active payment session (donor in the Payment Element step).
+        3. Donor details form (initial state).
+      */}
+      {postRedirect ? (
+        <PostRedirectView
+          state={postRedirect}
+          colorPrimary={colorPrimary}
+          locale={locale}
+          publishableKey={publishableKey}
+          tenantStripeAccountId={tenantStripeAccountId}
+          onDismiss={() => setPostRedirect(null)}
+        />
+      ) : session ? (
         publishableKey ? (
           <div className="mt-6">
             <PublicDonationPaymentStep
@@ -487,4 +569,126 @@ function createIdempotencyKey(): string {
     return crypto.randomUUID();
   }
   return `public-donation-${Date.now()}`;
+}
+
+/**
+ * Render the donor's post-3DS-return state (issue #197). This intentionally
+ * mirrors the Payment Element's success styling for `succeeded`, exposes a
+ * retry path for `requires_action`, and degrades gracefully on `processing`
+ * / `failed`.
+ */
+function PostRedirectView({
+  state,
+  colorPrimary,
+  locale,
+  publishableKey,
+  tenantStripeAccountId,
+  onDismiss,
+}: {
+  state: NonNullable<PostRedirectState>;
+  colorPrimary: string;
+  locale: string;
+  publishableKey: string | null;
+  tenantStripeAccountId: string | null;
+  onDismiss: () => void;
+}) {
+  const t = useTranslations("publicDonationPage.payment");
+
+  if (state.kind === "checking") {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="mt-6 flex items-center gap-3 rounded-2xl border border-outline-variant bg-surface px-4 py-5 text-sm text-on-surface-variant"
+      >
+        <LoaderCircle size={18} className="animate-spin" aria-hidden="true" />
+        {t("postRedirect.checking")}
+      </div>
+    );
+  }
+
+  if (state.kind === "succeeded") {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="mt-6 flex flex-col items-start gap-3 rounded-2xl border border-outline-variant bg-surface px-4 py-5 text-sm text-on-surface"
+      >
+        <span
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full"
+          style={{ backgroundColor: `color-mix(in srgb, ${colorPrimary} 18%, white)` }}
+        >
+          <CheckCircle2 size={20} style={{ color: colorPrimary }} aria-hidden="true" />
+        </span>
+        <p className="font-medium text-on-surface">{t("success.title")}</p>
+        <p className="text-on-surface-variant">
+          {t("success.body", {
+            amount: formatCurrency(state.amountCents, locale, state.currency),
+          })}
+        </p>
+      </div>
+    );
+  }
+
+  if (state.kind === "processing") {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="mt-6 rounded-2xl border border-outline-variant bg-surface px-4 py-3 text-sm text-on-surface-variant"
+      >
+        {t("postRedirect.processing")}
+      </div>
+    );
+  }
+
+  if (state.kind === "requires_action") {
+    // Donor's 3DS attempt didn't complete. Re-mount the Payment Element
+    // against the SAME intent so they can pick a different card without
+    // creating a duplicate PaymentIntent on the connected account.
+    if (!publishableKey || !tenantStripeAccountId) {
+      return (
+        <p className="mt-6 rounded-2xl border border-error bg-error-container px-4 py-3 text-sm text-on-error-container">
+          {t("errors.missingPublishableKey")}
+        </p>
+      );
+    }
+    return (
+      <div className="mt-6 space-y-4">
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-2xl border border-error bg-error-container px-4 py-3 text-sm text-on-error-container"
+        >
+          {t("postRedirect.requiresAction")}
+        </div>
+        <PublicDonationPaymentStep
+          clientSecret={state.clientSecret}
+          stripeAccountId={tenantStripeAccountId}
+          publishableKey={publishableKey}
+          colorPrimary={colorPrimary}
+          amountSummary={formatCurrency(state.amountCents, locale, state.currency)}
+          onPaid={() => {
+            toast.success(t("success.title"));
+          }}
+          onBack={onDismiss}
+        />
+      </div>
+    );
+  }
+
+  // state.kind === "failed"
+  return (
+    <div className="mt-6 space-y-3">
+      <div
+        role="alert"
+        className="rounded-2xl border border-error bg-error-container px-4 py-3 text-sm text-on-error-container"
+      >
+        {state.message}
+      </div>
+      <Button variant="ghost" size="sm" onClick={onDismiss}>
+        {t("postRedirect.startOver")}
+      </Button>
+    </div>
+  );
 }

--- a/packages/web/src/components/campaigns/public-donation-payment-step.tsx
+++ b/packages/web/src/components/campaigns/public-donation-payment-step.tsx
@@ -31,8 +31,20 @@ interface PublicDonationPaymentStepProps {
  * production. Detecting the prefix is sufficient for gating the test-card
  * hint banner — checking server `NODE_ENV` would be wrong since a staging
  * web build can run against test-mode Stripe.
+ *
+ * Defence-in-depth (PR #193 review, finding #8): explicit-deny on
+ * `pk_live_` so a key with an unexpected prefix (empty string, malformed
+ * value, or some hypothetical Stripe future-key format) defaults to
+ * **not showing** the test banner. The previous `startsWith("pk_test_")`
+ * also returned false for live keys, but only by accident; if Stripe
+ * ever ships keys with a non-`pk_` prefix, the explicit live-rejection
+ * keeps live donors from seeing test-mode copy. An explicit
+ * `STRIPE_MODE=test|live` env var was considered and rejected: it
+ * duplicates information already encoded in the key name and adds
+ * config sprawl across local dev / staging / prod for no real gain.
  */
 function isTestModeKey(publishableKey: string): boolean {
+  if (publishableKey.startsWith("pk_live_")) return false;
   return publishableKey.startsWith("pk_test_");
 }
 

--- a/packages/web/src/components/campaigns/public-donation-payment-step.tsx
+++ b/packages/web/src/components/campaigns/public-donation-payment-step.tsx
@@ -156,15 +156,10 @@ function PaymentForm({
 
   return (
     <form className="space-y-4" onSubmit={handleSubmit} noValidate>
-      <button
-        type="button"
-        onClick={onBack}
-        disabled={submitting}
-        className="inline-flex items-center gap-1.5 text-sm font-medium text-on-surface-variant hover:text-on-surface disabled:opacity-50 disabled:cursor-not-allowed"
-      >
+      <Button variant="ghost" size="sm" onClick={onBack} disabled={submitting}>
         <ArrowLeft size={16} aria-hidden="true" />
         {t("actions.back")}
-      </button>
+      </Button>
 
       <div className="rounded-2xl border border-outline-variant bg-surface px-4 py-3 text-sm text-on-surface-variant">
         <p className="text-on-surface">{t("summary.title", { amount: amountSummary })}</p>

--- a/packages/web/src/components/campaigns/public-donation-payment-step.tsx
+++ b/packages/web/src/components/campaigns/public-donation-payment-step.tsx
@@ -2,7 +2,7 @@
 
 import { Elements, PaymentElement, useElements, useStripe } from "@stripe/react-stripe-js";
 import { loadStripe, type Stripe, type StripeElementsOptions } from "@stripe/stripe-js";
-import { CheckCircle2, LoaderCircle } from "lucide-react";
+import { CheckCircle2, FlaskConical, LoaderCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { type FormEvent, useMemo, useState } from "react";
 
@@ -15,6 +15,16 @@ interface PublicDonationPaymentStepProps {
   colorPrimary: string;
   amountSummary: string;
   onPaid: () => void;
+}
+
+/**
+ * Stripe publishable keys are `pk_test_…` in test mode and `pk_live_…` in
+ * production. Detecting the prefix is sufficient for gating the test-card
+ * hint banner — checking server `NODE_ENV` would be wrong since a staging
+ * web build can run against test-mode Stripe.
+ */
+function isTestModeKey(publishableKey: string): boolean {
+  return publishableKey.startsWith("pk_test_");
 }
 
 /**
@@ -55,6 +65,7 @@ export function PublicDonationPaymentStep(props: PublicDonationPaymentStepProps)
       <PaymentForm
         amountSummary={props.amountSummary}
         colorPrimary={props.colorPrimary}
+        testMode={isTestModeKey(props.publishableKey)}
         onPaid={props.onPaid}
       />
     </Elements>
@@ -64,10 +75,12 @@ export function PublicDonationPaymentStep(props: PublicDonationPaymentStepProps)
 function PaymentForm({
   amountSummary,
   colorPrimary,
+  testMode,
   onPaid,
 }: {
   amountSummary: string;
   colorPrimary: string;
+  testMode: boolean;
   onPaid: () => void;
 }) {
   const t = useTranslations("publicDonationPage.payment");
@@ -137,6 +150,25 @@ function PaymentForm({
         <p className="mt-1 text-xs">{t("summary.subtitle")}</p>
       </div>
 
+      {testMode ? (
+        <div
+          role="note"
+          className="flex items-start gap-3 rounded-2xl border border-tertiary bg-tertiary-container px-4 py-3 text-sm text-on-tertiary-container"
+        >
+          <FlaskConical size={18} aria-hidden="true" className="mt-0.5 shrink-0" />
+          <div className="space-y-1">
+            <p className="font-semibold">{t("testMode.title")}</p>
+            <p className="text-xs leading-5">
+              {t("testMode.bodyBefore")}{" "}
+              <code className="rounded bg-surface px-1.5 py-0.5 font-mono text-on-surface">
+                4242 4242 4242 4242
+              </code>{" "}
+              {t("testMode.bodyAfter")}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
       <PaymentElement options={{ layout: "tabs" }} />
 
       {error ? <p className="text-sm text-error">{error}</p> : null}
@@ -156,8 +188,6 @@ function PaymentForm({
           t("actions.pay", { amount: amountSummary })
         )}
       </Button>
-
-      <p className="text-center text-xs leading-5 text-on-surface-variant">{t("footnote")}</p>
     </form>
   );
 }

--- a/packages/web/src/components/campaigns/public-donation-payment-step.tsx
+++ b/packages/web/src/components/campaigns/public-donation-payment-step.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { Elements, PaymentElement, useElements, useStripe } from "@stripe/react-stripe-js";
+import { loadStripe, type Stripe, type StripeElementsOptions } from "@stripe/stripe-js";
+import { CheckCircle2, LoaderCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { type FormEvent, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface PublicDonationPaymentStepProps {
+  clientSecret: string;
+  stripeAccountId: string;
+  publishableKey: string;
+  colorPrimary: string;
+  amountSummary: string;
+  onPaid: () => void;
+}
+
+/**
+ * Mounts Stripe Elements against the given clientSecret + connected account
+ * and renders the Payment Element. Memoised by `(publishableKey,
+ * stripeAccountId)` so we don't reload Stripe.js on every parent re-render.
+ *
+ * Direct-charge note: the PaymentIntent lives on the connected account
+ * (`stripeAccount` request option in the API), so the browser-side SDK must
+ * also bind to that account via the `loadStripe` second arg — otherwise
+ * `confirmPayment` 404s the intent.
+ */
+export function PublicDonationPaymentStep(props: PublicDonationPaymentStepProps) {
+  const stripePromise = useMemo<Promise<Stripe | null>>(
+    () => loadStripe(props.publishableKey, { stripeAccount: props.stripeAccountId }),
+    [props.publishableKey, props.stripeAccountId],
+  );
+
+  const elementsOptions: StripeElementsOptions = useMemo(
+    () => ({
+      clientSecret: props.clientSecret,
+      appearance: {
+        theme: "stripe",
+        variables: {
+          colorPrimary: props.colorPrimary,
+          fontFamily: "var(--font-body), system-ui, sans-serif",
+          borderRadius: "12px",
+        },
+      },
+      // Keep Stripe's UI in the donor's locale; falls back to English.
+      locale: "auto",
+    }),
+    [props.clientSecret, props.colorPrimary],
+  );
+
+  return (
+    <Elements stripe={stripePromise} options={elementsOptions}>
+      <PaymentForm
+        amountSummary={props.amountSummary}
+        colorPrimary={props.colorPrimary}
+        onPaid={props.onPaid}
+      />
+    </Elements>
+  );
+}
+
+function PaymentForm({
+  amountSummary,
+  colorPrimary,
+  onPaid,
+}: {
+  amountSummary: string;
+  colorPrimary: string;
+  onPaid: () => void;
+}) {
+  const t = useTranslations("publicDonationPage.payment");
+  const stripe = useStripe();
+  const elements = useElements();
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [paid, setPaid] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!stripe || !elements) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    // `redirect: 'if_required'` keeps card payments in-page and only redirects
+    // when the donor's payment method genuinely needs it (3DS, wallets) —
+    // we still send a `return_url` because Stripe requires one for those
+    // fallback redirects.
+    const result = await stripe.confirmPayment({
+      elements,
+      confirmParams: { return_url: window.location.href },
+      redirect: "if_required",
+    });
+
+    if (result.error) {
+      // Stripe's docs recommend showing `error.message` directly — they're
+      // donor-facing strings already (localised by Stripe.js).
+      setError(result.error.message ?? t("errors.generic"));
+      setSubmitting(false);
+      return;
+    }
+
+    if (result.paymentIntent?.status === "succeeded") {
+      setPaid(true);
+      onPaid();
+    } else {
+      setError(t("errors.generic"));
+    }
+    setSubmitting(false);
+  }
+
+  if (paid) {
+    return (
+      <div
+        role="status"
+        className="flex flex-col items-start gap-3 rounded-2xl border border-outline-variant bg-surface px-4 py-5 text-sm text-on-surface"
+      >
+        <span
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full"
+          style={{ backgroundColor: `color-mix(in srgb, ${colorPrimary} 18%, white)` }}
+        >
+          <CheckCircle2 size={20} style={{ color: colorPrimary }} aria-hidden="true" />
+        </span>
+        <p className="font-medium text-on-surface">{t("success.title")}</p>
+        <p className="text-on-surface-variant">{t("success.body", { amount: amountSummary })}</p>
+      </div>
+    );
+  }
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+      <div className="rounded-2xl border border-outline-variant bg-surface px-4 py-3 text-sm text-on-surface-variant">
+        <p className="text-on-surface">{t("summary.title", { amount: amountSummary })}</p>
+        <p className="mt-1 text-xs">{t("summary.subtitle")}</p>
+      </div>
+
+      <PaymentElement options={{ layout: "tabs" }} />
+
+      {error ? <p className="text-sm text-error">{error}</p> : null}
+
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={submitting || !stripe || !elements}
+        style={{ backgroundColor: colorPrimary, color: getReadableTextColor(colorPrimary) }}
+      >
+        {submitting ? (
+          <>
+            <LoaderCircle size={16} className="animate-spin" aria-hidden="true" />
+            {t("actions.paying")}
+          </>
+        ) : (
+          t("actions.pay", { amount: amountSummary })
+        )}
+      </Button>
+
+      <p className="text-center text-xs leading-5 text-on-surface-variant">{t("footnote")}</p>
+    </form>
+  );
+}
+
+function getReadableTextColor(hex: string): "#FFFFFF" | "#111827" {
+  const normalized = hex.replace("#", "");
+  const r = Number.parseInt(normalized.slice(0, 2), 16);
+  const g = Number.parseInt(normalized.slice(2, 4), 16);
+  const b = Number.parseInt(normalized.slice(4, 6), 16);
+  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return luminance > 0.6 ? "#111827" : "#FFFFFF";
+}

--- a/packages/web/src/components/campaigns/public-donation-payment-step.tsx
+++ b/packages/web/src/components/campaigns/public-donation-payment-step.tsx
@@ -2,7 +2,7 @@
 
 import { Elements, PaymentElement, useElements, useStripe } from "@stripe/react-stripe-js";
 import { loadStripe, type Stripe, type StripeElementsOptions } from "@stripe/stripe-js";
-import { CheckCircle2, FlaskConical, LoaderCircle } from "lucide-react";
+import { ArrowLeft, CheckCircle2, FlaskConical, LoaderCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { type FormEvent, useMemo, useState } from "react";
 
@@ -15,6 +15,14 @@ interface PublicDonationPaymentStepProps {
   colorPrimary: string;
   amountSummary: string;
   onPaid: () => void;
+  /**
+   * Return the donor to the identity/amount form. We don't cancel the
+   * orphaned PaymentIntent server-side — Stripe auto-cancels unconfirmed
+   * intents after ~7 days, and resubmitting creates a fresh one (each
+   * submit mints a new idempotency key). Acceptable for Phase 1; if the
+   * orphan rate becomes a concern, add a `paymentIntents.cancel` call here.
+   */
+  onBack: () => void;
 }
 
 /**
@@ -67,6 +75,7 @@ export function PublicDonationPaymentStep(props: PublicDonationPaymentStepProps)
         colorPrimary={props.colorPrimary}
         testMode={isTestModeKey(props.publishableKey)}
         onPaid={props.onPaid}
+        onBack={props.onBack}
       />
     </Elements>
   );
@@ -77,11 +86,13 @@ function PaymentForm({
   colorPrimary,
   testMode,
   onPaid,
+  onBack,
 }: {
   amountSummary: string;
   colorPrimary: string;
   testMode: boolean;
   onPaid: () => void;
+  onBack: () => void;
 }) {
   const t = useTranslations("publicDonationPage.payment");
   const stripe = useStripe();
@@ -145,6 +156,16 @@ function PaymentForm({
 
   return (
     <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+      <button
+        type="button"
+        onClick={onBack}
+        disabled={submitting}
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-on-surface-variant hover:text-on-surface disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <ArrowLeft size={16} aria-hidden="true" />
+        {t("actions.back")}
+      </button>
+
       <div className="rounded-2xl border border-outline-variant bg-surface px-4 py-3 text-sm text-on-surface-variant">
         <p className="text-on-surface">{t("summary.title", { amount: amountSummary })}</p>
         <p className="mt-1 text-xs">{t("summary.subtitle")}</p>

--- a/packages/web/src/components/campaigns/public-donation-payment-step.tsx
+++ b/packages/web/src/components/campaigns/public-donation-payment-step.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { type FormEvent, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { getReadableTextColor } from "@/lib/color";
 
 interface PublicDonationPaymentStepProps {
   clientSecret: string;
@@ -155,7 +156,12 @@ function PaymentForm({
   }
 
   return (
-    <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+    <form
+      className="space-y-4"
+      onSubmit={handleSubmit}
+      noValidate
+      aria-busy={submitting || undefined}
+    >
       <Button variant="ghost" size="sm" onClick={onBack} disabled={submitting}>
         <ArrowLeft size={16} aria-hidden="true" />
         {t("actions.back")}
@@ -167,9 +173,15 @@ function PaymentForm({
       </div>
 
       {testMode ? (
+        // role="status" + aria-live so AT users hear the test-mode disclosure
+        // when the banner mounts. Visually uses the `info` token family
+        // (matches the `Badge variant="info"` palette) — `tertiary` aliases
+        // to `--color-amber` in the design system, which would read as a
+        // warning rather than an informational note.
         <div
-          role="note"
-          className="flex items-start gap-3 rounded-2xl border border-tertiary bg-tertiary-container px-4 py-3 text-sm text-on-tertiary-container"
+          role="status"
+          aria-live="polite"
+          className="flex items-start gap-3 rounded-2xl border border-secondary bg-secondary-fixed px-4 py-3 text-sm text-on-secondary-fixed-variant"
         >
           <FlaskConical size={18} aria-hidden="true" className="mt-0.5 shrink-0" />
           <div className="space-y-1">
@@ -206,13 +218,4 @@ function PaymentForm({
       </Button>
     </form>
   );
-}
-
-function getReadableTextColor(hex: string): "#FFFFFF" | "#111827" {
-  const normalized = hex.replace("#", "");
-  const r = Number.parseInt(normalized.slice(0, 2), 16);
-  const g = Number.parseInt(normalized.slice(2, 4), 16);
-  const b = Number.parseInt(normalized.slice(4, 6), 16);
-  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
-  return luminance > 0.6 ? "#111827" : "#FFFFFF";
 }

--- a/packages/web/src/components/campaigns/public-donation-post-redirect.ts
+++ b/packages/web/src/components/campaigns/public-donation-post-redirect.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import { loadStripe } from "@stripe/stripe-js";
+
+/**
+ * Outcome of inspecting the URL after a Stripe redirect (typically a
+ * 3DS / SCA challenge that bounced the donor back to `return_url`).
+ *
+ * `null` = no redirect in progress, render the normal donor flow.
+ *
+ * Issue #197: without this handler, a donor whose card requires 3DS
+ * sees the page reset to an empty donation form after the bank challenge
+ * — they'd believe the payment failed, churn, or retry and create a
+ * duplicate intent. EU PSD2 mandates SCA on a non-trivial share of cards
+ * so this matters at scale.
+ */
+export type PostRedirectOutcome =
+  | {
+      kind: "succeeded";
+      amountCents: number;
+      currency: string;
+    }
+  | {
+      kind: "requires_action";
+      // Re-mounting the Payment Element against the same intent lets the
+      // donor pick a different card or retry without creating a new
+      // PaymentIntent (which would duplicate metadata + leak an extra
+      // application_fee on the connected account if they retry-succeed).
+      clientSecret: string;
+      amountCents: number;
+      currency: string;
+    }
+  | {
+      kind: "processing";
+    }
+  | {
+      kind: "failed";
+      // Donor-facing message lifted from `last_payment_error.message` —
+      // already localised by Stripe.js per the donor's locale.
+      message: string;
+    };
+
+interface RetrieveOptions {
+  publishableKey: string;
+  stripeAccountId: string;
+  /**
+   * In production read from `window.location.search`. Tests pass a string
+   * so we can drive the function deterministically without monkey-patching
+   * the global location.
+   */
+  search?: string;
+  /**
+   * Whether to strip the redirect query params from the URL bar after
+   * resolving — defaults to true so a refresh doesn't loop into the
+   * same retrieve. Tests pass `false` so the assertion can inspect the
+   * input that was parsed.
+   */
+  cleanUrl?: boolean;
+}
+
+/**
+ * Inspect the URL for Stripe's post-redirect query params and resolve
+ * them via `stripe.retrievePaymentIntent`. Returns `null` if the page
+ * was not loaded as a redirect target.
+ *
+ * Connect direct-charge note: the Stripe.js client must bind to the
+ * connected account (`stripeAccount`) — same constraint as the inline
+ * `confirmPayment` flow. Without it the retrieve 404s the intent.
+ */
+export async function retrievePostRedirectIntent(
+  options: RetrieveOptions,
+): Promise<PostRedirectOutcome | null> {
+  if (typeof window === "undefined") return null;
+
+  const search = options.search ?? window.location.search;
+  const params = new URLSearchParams(search);
+  const clientSecret = params.get("payment_intent_client_secret");
+  // `payment_intent` arrives alongside but we don't need it — clientSecret
+  // already binds to the specific intent on the connected account.
+  if (!clientSecret) return null;
+
+  const stripe = await loadStripe(options.publishableKey, {
+    stripeAccount: options.stripeAccountId,
+  });
+  if (!stripe) {
+    return { kind: "failed", message: "Stripe.js failed to load" };
+  }
+
+  const { paymentIntent, error } = await stripe.retrievePaymentIntent(clientSecret);
+
+  if (options.cleanUrl !== false) {
+    // Drop the redirect params so a refresh doesn't loop the retrieval.
+    // Use replaceState so we don't add a history entry.
+    const cleanUrl = new URL(window.location.href);
+    cleanUrl.searchParams.delete("payment_intent");
+    cleanUrl.searchParams.delete("payment_intent_client_secret");
+    cleanUrl.searchParams.delete("redirect_status");
+    window.history.replaceState({}, "", cleanUrl.toString());
+  }
+
+  if (error) {
+    return { kind: "failed", message: error.message ?? "Payment could not be confirmed." };
+  }
+  if (!paymentIntent) {
+    return { kind: "failed", message: "Payment could not be confirmed." };
+  }
+
+  switch (paymentIntent.status) {
+    case "succeeded":
+      return {
+        kind: "succeeded",
+        amountCents: paymentIntent.amount,
+        currency: (paymentIntent.currency ?? "eur").toUpperCase(),
+      };
+    case "processing":
+      return { kind: "processing" };
+    case "requires_payment_method":
+    case "requires_action":
+      return {
+        kind: "requires_action",
+        clientSecret,
+        amountCents: paymentIntent.amount,
+        currency: (paymentIntent.currency ?? "eur").toUpperCase(),
+      };
+    default:
+      return {
+        kind: "failed",
+        message: paymentIntent.last_payment_error?.message ?? "Payment did not complete.",
+      };
+  }
+}

--- a/packages/web/src/components/donations/donation-form.test.tsx
+++ b/packages/web/src/components/donations/donation-form.test.tsx
@@ -125,6 +125,7 @@ describe("DonationForm", () => {
           campaignId: null,
           paymentMethod: "wire",
           paymentRef: "WIRE-2026-0001",
+          status: "cleared",
           donatedAt: "2026-04-22T00:00:00.000Z",
           fiscalYear: 2026,
           createdAt: "2026-04-22T00:00:00.000Z",

--- a/packages/web/src/components/donations/refund-donation-button.tsx
+++ b/packages/web/src/components/donations/refund-donation-button.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Undo2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { DonationService } from "@/services/DonationService";
+
+interface RefundDonationButtonProps {
+  donationId: string;
+  /**
+   * Localised amount label interpolated into the confirm dialog
+   * ("Refund €50.00 to Jane Doe?"). Pre-formatted at the server layer
+   * so we don't re-derive it client-side.
+   */
+  amountLabel: string;
+  /** Donor display name; falls back to a generic copy when null. */
+  donorName: string | null;
+}
+
+/**
+ * Refund a Stripe donation via `POST /v1/donations/:id/refund`. Org-admin
+ * only — guarded both client-side (rendered behind `hasPermission(auth,
+ * "admin")` on the detail page) and server-side (`requireOrgAdmin`).
+ *
+ * On success we `router.refresh()` so the donation status badge flips
+ * to "refunded" without a full reload. The Stripe-side rollback of the
+ * application fee is handled by the route's `refund_application_fee:
+ * true` flag (issue #199 / docs/payments-overview.md).
+ */
+export function RefundDonationButton({
+  donationId,
+  amountLabel,
+  donorName,
+}: RefundDonationButtonProps) {
+  const router = useRouter();
+  const t = useTranslations("donations");
+  const tDetail = useTranslations("donations.detail.actions");
+  const [open, setOpen] = useState(false);
+  const [isRefunding, setIsRefunding] = useState(false);
+
+  async function confirmRefund() {
+    setIsRefunding(true);
+    try {
+      await DonationService.refundDonation(createClientApiClient(), donationId);
+      toast.success(t("success.refunded"));
+      setOpen(false);
+      router.refresh();
+    } catch (err) {
+      if (!(err instanceof ApiProblem)) console.error("donation.refund failed", err);
+      const message =
+        err instanceof ApiProblem
+          ? (err.detail ?? err.title ?? t("errors.refundGeneric"))
+          : t("errors.refundGeneric");
+      toast.error(message);
+    } finally {
+      setIsRefunding(false);
+    }
+  }
+
+  return (
+    <>
+      <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>
+        <Undo2 size={16} aria-hidden="true" />
+        {tDetail("refund")}
+      </Button>
+
+      <AlertDialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!isRefunding) setOpen(next);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("refundDialog.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {donorName
+                ? t("refundDialog.description", { amount: amountLabel, name: donorName })
+                : t("refundDialog.descriptionFallback", { amount: amountLabel })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <p className="px-6 pb-2 text-xs text-on-surface-variant">{t("refundDialog.hint")}</p>
+          <AlertDialogFooter>
+            <AlertDialogCancel asChild>
+              <Button variant="ghost" disabled={isRefunding}>
+                {t("refundDialog.cancel")}
+              </Button>
+            </AlertDialogCancel>
+            <Button variant="secondary" disabled={isRefunding} onClick={() => void confirmRefund()}>
+              {isRefunding ? t("refundDialog.refunding") : t("refundDialog.confirm")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/packages/web/src/components/settings/stripe-connect-panel.tsx
+++ b/packages/web/src/components/settings/stripe-connect-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CreditCard, ExternalLink, Lock } from "lucide-react";
+import { AlertTriangle, CreditCard, ExternalLink, Lock } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 
@@ -108,6 +108,10 @@ export function StripeConnectPanel({ canManageTenant }: StripeConnectPanelProps)
             </div>
           ) : null}
 
+          {status && status.accountId && !status.chargesEnabled ? (
+            <RequirementsList status={status} />
+          ) : null}
+
           {errorMessage ? <p className="mt-3 text-sm text-error">{errorMessage}</p> : null}
         </div>
 
@@ -164,4 +168,61 @@ function describeState(
   if (!status || !status.accountId) return "notConnected";
   if (status.chargesEnabled) return "connected";
   return "pending";
+}
+
+/**
+ * Render the remediation list when an account is onboarded but charges
+ * are disabled. Stripe gives us machine-readable requirement keys (e.g.
+ * `external_account`, `individual.id_number`); we translate them via
+ * i18n to human-readable labels and fall back to the raw key for
+ * requirement keys we haven't translated yet (so the operator at least
+ * sees what's missing rather than a localised "?"). Issue #201.
+ */
+function RequirementsList({ status }: { status: StripeConnectStatus }) {
+  const t = useTranslations("settings.stripeConnect.requirements");
+  const tFields = useTranslations("settings.stripeConnect.requirements.fields");
+
+  if (status.requirementsCurrentlyDue.length === 0 && !status.disabledReason) {
+    return null;
+  }
+
+  return (
+    // `tertiary` is the design-system's amber/warning tone — the right
+    // palette here precisely *because* this is a remediation state the
+    // operator needs to act on, contrast with the test-mode banner which
+    // is informational and uses `secondary-fixed`.
+    <div className="mt-4 rounded-2xl border border-tertiary bg-tertiary-container px-4 py-3 text-sm text-on-tertiary-container">
+      <div className="flex items-start gap-2">
+        <AlertTriangle size={16} aria-hidden="true" className="mt-0.5 shrink-0" />
+        <div className="space-y-2">
+          <p className="font-semibold">{t("title")}</p>
+          {status.requirementsCurrentlyDue.length > 0 ? (
+            <ul className="list-disc space-y-1 pl-5">
+              {status.requirementsCurrentlyDue.map((key) => {
+                // Translate known requirement keys; fall back to the raw key
+                // for ones we haven't covered yet (Stripe ships ~20 of them).
+                let label: string;
+                try {
+                  label = tFields(key as never);
+                } catch {
+                  label = key;
+                }
+                return (
+                  <li key={key}>
+                    <span>{label}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+          {status.disabledReason ? (
+            <p className="text-xs">
+              {t("disabledReason")}: <code>{status.disabledReason}</code>
+            </p>
+          ) : null}
+          <p className="text-xs">{t("hint")}</p>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/packages/web/src/components/settings/stripe-connect-panel.tsx
+++ b/packages/web/src/components/settings/stripe-connect-panel.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { CreditCard, ExternalLink, Lock } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { StripeConnectService, type StripeConnectStatus } from "@/services/StripeConnectService";
+
+interface StripeConnectPanelProps {
+  canManageTenant: boolean;
+}
+
+type Stage = "idle" | "loading" | "starting" | "error";
+
+function resolveErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiProblem) {
+    return error.detail ?? error.title ?? fallback;
+  }
+  return fallback;
+}
+
+export function StripeConnectPanel({ canManageTenant }: StripeConnectPanelProps) {
+  const t = useTranslations("settings.stripeConnect");
+  const [status, setStatus] = useState<StripeConnectStatus | null>(null);
+  const [stage, setStage] = useState<Stage>("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!canManageTenant) {
+      setStage("idle");
+      return;
+    }
+
+    let active = true;
+
+    async function load() {
+      try {
+        const next = await StripeConnectService.getStatus(createClientApiClient());
+        if (!active) return;
+        setStatus(next);
+        setStage("idle");
+      } catch (err) {
+        if (!active) return;
+        setErrorMessage(resolveErrorMessage(err, t("errors.load")));
+        setStage("error");
+      }
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [canManageTenant, t]);
+
+  async function handleStart() {
+    if (!canManageTenant || stage === "starting") return;
+    setStage("starting");
+    setErrorMessage(null);
+
+    try {
+      const here = window.location.href;
+      const link = await StripeConnectService.startOnboarding(createClientApiClient(), {
+        // Stripe loops back to `refreshUrl` if the operator abandons the
+        // hosted form, and to `returnUrl` after they finish (success or not —
+        // we re-fetch status to know which).
+        refreshUrl: here,
+        returnUrl: here,
+      });
+      // Open in the same tab — the GET status call on return reflects the
+      // new account state, so the operator sees the resolved badge without
+      // a manual reload.
+      window.location.assign(link.url);
+    } catch (err) {
+      const message = resolveErrorMessage(err, t("errors.start"));
+      setErrorMessage(message);
+      toast.error(message);
+      setStage("idle");
+    }
+  }
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <div className="inline-flex items-center gap-2 rounded-full bg-surface-container px-3 py-1 text-xs font-medium text-on-surface-variant">
+            <CreditCard size={12} aria-hidden="true" />
+            {t("badge")}
+          </div>
+          <h2 className="mt-4 font-heading text-2xl leading-tight text-on-surface">{t("title")}</h2>
+          <p className="mt-2 text-sm leading-6 text-on-surface-variant">{t("description")}</p>
+
+          {status ? (
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <StatusBadge status={status} t={t} />
+              {status.accountId ? (
+                <span className="font-mono text-xs text-on-surface-variant">
+                  {status.accountId}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+
+          {errorMessage ? <p className="mt-3 text-sm text-error">{errorMessage}</p> : null}
+        </div>
+
+        <div className="flex shrink-0 flex-col items-start gap-3">
+          {canManageTenant ? (
+            <Button onClick={handleStart} disabled={stage !== "idle" || !status}>
+              <ExternalLink size={16} aria-hidden="true" />
+              {stage === "starting"
+                ? t("actions.starting")
+                : status?.chargesEnabled
+                  ? t("actions.manage")
+                  : status?.accountId
+                    ? t("actions.continue")
+                    : t("actions.connect")}
+            </Button>
+          ) : (
+            <div className="inline-flex items-center gap-2 rounded-xl bg-surface-container px-4 py-3 text-sm text-on-surface-variant">
+              <Lock size={16} aria-hidden="true" />
+              <span>{t("adminOnly")}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StatusBadge({
+  status,
+  t,
+}: {
+  status: StripeConnectStatus;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  if (status.chargesEnabled) {
+    return <Badge variant="success">{t("status.connected")}</Badge>;
+  }
+  if (status.accountId) {
+    return <Badge variant="warning">{t("status.pending")}</Badge>;
+  }
+  return <Badge variant="neutral">{t("status.notConnected")}</Badge>;
+}

--- a/packages/web/src/components/settings/stripe-connect-panel.tsx
+++ b/packages/web/src/components/settings/stripe-connect-panel.tsx
@@ -93,7 +93,9 @@ export function StripeConnectPanel({ canManageTenant }: StripeConnectPanelProps)
             {t("badge")}
           </div>
           <h2 className="mt-4 font-heading text-2xl leading-tight text-on-surface">{t("title")}</h2>
-          <p className="mt-2 text-sm leading-6 text-on-surface-variant">{t("description")}</p>
+          <p className="mt-2 text-sm leading-6 text-on-surface-variant">
+            {t(`description.${describeState(status)}`)}
+          </p>
 
           {status ? (
             <div className="mt-4 flex flex-wrap items-center gap-2">
@@ -147,4 +149,19 @@ function StatusBadge({
     return <Badge variant="warning">{t("status.pending")}</Badge>;
   }
   return <Badge variant="neutral">{t("status.notConnected")}</Badge>;
+}
+
+/**
+ * Map the live status to the i18n key suffix that drives the descriptive
+ * copy. Falls back to the not-connected description while the status fetch
+ * is in flight — the operator sees the right call-to-action immediately
+ * rather than "loading…", and once the GET resolves the copy swaps to
+ * "Connected" if applicable. Issue #192 follow-up.
+ */
+function describeState(
+  status: StripeConnectStatus | null,
+): "notConnected" | "pending" | "connected" {
+  if (!status || !status.accountId) return "notConnected";
+  if (status.chargesEnabled) return "connected";
+  return "pending";
 }

--- a/packages/web/src/lib/color.ts
+++ b/packages/web/src/lib/color.ts
@@ -1,0 +1,19 @@
+/**
+ * Pick a readable text colour for a given hex background — used to render
+ * the donor's tenant-themed CTA buttons + suggested-amount chips legibly
+ * regardless of the operator's chosen `colorPrimary`.
+ *
+ * Returns `#FFFFFF` (white) for dark/saturated backgrounds and `#111827`
+ * (near-black) for light ones. Threshold tuned empirically to match what
+ * a donor would label as "readable" — formal WCAG 4.5:1 enforcement is
+ * the design system's responsibility on the static palette; this is the
+ * runtime fallback for the per-tenant override colour.
+ */
+export function getReadableTextColor(hex: string): "#FFFFFF" | "#111827" {
+  const normalized = hex.replace("#", "");
+  const r = Number.parseInt(normalized.slice(0, 2), 16);
+  const g = Number.parseInt(normalized.slice(2, 4), 16);
+  const b = Number.parseInt(normalized.slice(4, 6), 16);
+  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return luminance > 0.6 ? "#111827" : "#FFFFFF";
+}

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1462,7 +1462,6 @@
     "descriptionFallback": "Your donation directly helps fund this campaign and the next steps it unlocks in the field.",
     "metrics": {
       "goal": "Fundraising goal",
-      "goalFallback": "Goal coming soon",
       "trust": "Payment",
       "trustValue": "Secured by Stripe"
     },

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1457,7 +1457,6 @@
     }
   },
   "publicDonationPage": {
-    "backHome": "Givernance home",
     "badge": "Public fundraising",
     "eyebrow": "Support this work",
     "descriptionFallback": "Your donation directly helps fund this campaign and the next steps it unlocks in the field.",

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -892,7 +892,11 @@
     "stripeConnect": {
       "badge": "Payments",
       "title": "Stripe Connect",
-      "description": "Connect your Stripe account so donors can pay through campaign pages. Givernance never holds funds — payouts go directly to your account.",
+      "description": {
+        "notConnected": "Connect your Stripe account so donors can pay through campaign pages. Givernance never holds funds — payouts go directly to your account.",
+        "pending": "Your Stripe onboarding isn't complete. Until you finish it, donors can't pay you.",
+        "connected": "Your Stripe account is connected. Donations from campaign pages land directly in your Stripe balance, and Givernance collects its platform fee on each donation."
+      },
       "adminOnly": "Only organisation admins can manage payments.",
       "status": {
         "notConnected": "Not connected",

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1465,7 +1465,7 @@
       "goal": "Fundraising goal",
       "goalFallback": "Goal coming soon",
       "trust": "Payment",
-      "trustValue": "Stripe flow coming next"
+      "trustValue": "Secured by Stripe"
     },
     "form": {
       "eyebrow": "Online donation",
@@ -1521,7 +1521,11 @@
         "generic": "Payment could not be completed. Please try a different card or contact support.",
         "missingPublishableKey": "Stripe is not configured for this environment. Ask an admin to set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY."
       },
-      "footnote": "Test mode: use card 4242 4242 4242 4242 with any future expiry and any CVC."
+      "testMode": {
+        "title": "Test mode — no real charge",
+        "bodyBefore": "Use card",
+        "bodyAfter": "with any future expiry and any CVC. No money will move."
+      }
     }
   },
   "constituentForm": {

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1510,7 +1510,8 @@
       },
       "actions": {
         "pay": "Donate {amount}",
-        "paying": "Processing payment…"
+        "paying": "Processing payment…",
+        "back": "Edit my donation"
       },
       "success": {
         "title": "Thank you for your donation!",

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -888,6 +888,27 @@
       "errorGeneric": "Unable to download the export right now.",
       "errorProblem": "Export failed (HTTP {status}).",
       "lastDownloaded": "Last download: {value}"
+    },
+    "stripeConnect": {
+      "badge": "Payments",
+      "title": "Stripe Connect",
+      "description": "Connect your Stripe account so donors can pay through campaign pages. Givernance never holds funds — payouts go directly to your account.",
+      "adminOnly": "Only organisation admins can manage payments.",
+      "status": {
+        "notConnected": "Not connected",
+        "pending": "Onboarding incomplete",
+        "connected": "Connected"
+      },
+      "actions": {
+        "connect": "Connect Stripe",
+        "continue": "Continue onboarding",
+        "manage": "Re-open Stripe onboarding",
+        "starting": "Opening Stripe…"
+      },
+      "errors": {
+        "load": "Unable to load Stripe status right now.",
+        "start": "Unable to start Stripe onboarding right now."
+      }
     }
   },
   "profile": {
@@ -1473,11 +1494,30 @@
         "generic": "Something went wrong while preparing payment. Please try again."
       },
       "success": {
-        "intentCreated": "Your donation is ready. The Stripe payment step is the next integration.",
+        "intentCreated": "Donation prepared — enter your card details below.",
         "nextStepTitle": "Next step",
-        "nextStepBody": "A payment intent has been created successfully through the API. Redirecting to Stripe or rendering Elements will be added in the next increment."
+        "nextStepBody": "Use the card form to complete your donation securely with Stripe."
       },
-      "footnote": "Submitting this form prepares a secure payment. This version of the page does not charge the card yet."
+      "footnote": "Submitting this form prepares a secure payment. Your card will be charged on the next step."
+    },
+    "payment": {
+      "summary": {
+        "title": "You're donating {amount}",
+        "subtitle": "Powered by Stripe — your card details are sent directly to Stripe and never stored on our servers."
+      },
+      "actions": {
+        "pay": "Donate {amount}",
+        "paying": "Processing payment…"
+      },
+      "success": {
+        "title": "Thank you for your donation!",
+        "body": "We've received {amount}. A receipt is on its way to your inbox."
+      },
+      "errors": {
+        "generic": "Payment could not be completed. Please try a different card or contact support.",
+        "missingPublishableKey": "Stripe is not configured for this environment. Ask an admin to set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY."
+      },
+      "footnote": "Test mode: use card 4242 4242 4242 4242 with any future expiry and any CVC."
     }
   },
   "constituentForm": {

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -897,6 +897,35 @@
         "pending": "Your Stripe onboarding isn't complete. Until you finish it, donors can't pay you.",
         "connected": "Your Stripe account is connected. Donations from campaign pages land directly in your Stripe balance, and Givernance collects its platform fee on each donation."
       },
+      "requirements": {
+        "title": "Stripe needs more information before you can accept payments",
+        "disabledReason": "Reason",
+        "hint": "Click 'Continue onboarding' above to provide the missing information.",
+        "fields": {
+          "external_account": "Bank account for payouts",
+          "tos_acceptance.date": "Accept Stripe's Terms of Service",
+          "tos_acceptance.ip": "Accept Stripe's Terms of Service (IP)",
+          "individual.id_number": "Personal ID number",
+          "individual.dob.day": "Date of birth (day)",
+          "individual.dob.month": "Date of birth (month)",
+          "individual.dob.year": "Date of birth (year)",
+          "individual.first_name": "Legal first name",
+          "individual.last_name": "Legal last name",
+          "individual.email": "Email address",
+          "individual.phone": "Phone number",
+          "individual.address.line1": "Address (street)",
+          "individual.address.city": "Address (city)",
+          "individual.address.postal_code": "Address (postal code)",
+          "individual.address.country": "Address (country)",
+          "individual.verification.document": "ID verification document",
+          "business_profile.url": "Business website",
+          "business_profile.mcc": "Business category",
+          "business_type": "Business type",
+          "company.name": "Company name",
+          "company.tax_id": "Company tax ID",
+          "company.verification.document": "Company verification document"
+        }
+      },
       "adminOnly": "Only organisation admins can manage payments.",
       "status": {
         "notConnected": "Not connected",
@@ -1033,11 +1062,22 @@
       "confirm": "Delete donation",
       "deleting": "Deleting…"
     },
+    "refundDialog": {
+      "title": "Refund this donation?",
+      "description": "Refund {amount} back to {name}'s card via Stripe. This also rolls back the platform fee.",
+      "descriptionFallback": "Refund {amount} back to the donor's card via Stripe. This also rolls back the platform fee.",
+      "hint": "The donor's card will be credited within a few business days. This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Refund donation",
+      "refunding": "Processing refund…"
+    },
     "success": {
-      "deleted": "Donation deleted."
+      "deleted": "Donation deleted.",
+      "refunded": "Refund issued. The donor will see the credit within a few business days."
     },
     "errors": {
-      "deleteGeneric": "Something went wrong while deleting the donation. Please try again."
+      "deleteGeneric": "Something went wrong while deleting the donation. Please try again.",
+      "refundGeneric": "Something went wrong while processing the refund. Please try again."
     },
     "form": {
       "createTitle": "Record a donation",
@@ -1143,6 +1183,7 @@
         "back": "Back to donations",
         "edit": "Edit",
         "delete": "Delete",
+        "refund": "Refund",
         "previewReceipt": "Receipt preview",
         "generatingReceipt": "Generating receipt…"
       },
@@ -1462,6 +1503,9 @@
     "descriptionFallback": "Your donation directly helps fund this campaign and the next steps it unlocks in the field.",
     "metrics": {
       "goal": "Fundraising goal",
+      "raised": "Raised so far",
+      "goalSuffix": "of",
+      "donors": "{count, plural, =0 {No donors yet} one {# donor} other {# donors}}",
       "trust": "Payment",
       "trustValue": "Secured by Stripe"
     },
@@ -1519,6 +1563,12 @@
       "errors": {
         "generic": "Payment could not be completed. Please try a different card or contact support.",
         "missingPublishableKey": "Stripe is not configured for this environment. Ask an admin to set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY."
+      },
+      "postRedirect": {
+        "checking": "Verifying your payment with Stripe…",
+        "processing": "Your payment is being processed. You'll receive a confirmation email shortly.",
+        "requiresAction": "Your payment didn't complete. Try a different card below.",
+        "startOver": "Start a new donation"
       },
       "testMode": {
         "title": "Test mode — no real charge",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -897,6 +897,35 @@
         "pending": "L'onboarding Stripe n'est pas terminé. Tant que vous n'avez pas validé toutes les étapes, les donateurs ne peuvent pas payer.",
         "connected": "Votre compte Stripe est connecté. Les dons effectués depuis les pages de campagne arrivent directement sur votre solde Stripe ; Givernance prélève sa commission sur chaque don."
       },
+      "requirements": {
+        "title": "Stripe a besoin d'informations supplémentaires avant que vous puissiez accepter les paiements",
+        "disabledReason": "Raison",
+        "hint": "Cliquez sur « Reprendre l'onboarding » ci-dessus pour fournir les informations manquantes.",
+        "fields": {
+          "external_account": "Compte bancaire pour les versements",
+          "tos_acceptance.date": "Accepter les CGU de Stripe",
+          "tos_acceptance.ip": "Accepter les CGU de Stripe (IP)",
+          "individual.id_number": "Numéro de pièce d'identité",
+          "individual.dob.day": "Date de naissance (jour)",
+          "individual.dob.month": "Date de naissance (mois)",
+          "individual.dob.year": "Date de naissance (année)",
+          "individual.first_name": "Prénom légal",
+          "individual.last_name": "Nom légal",
+          "individual.email": "Adresse email",
+          "individual.phone": "Numéro de téléphone",
+          "individual.address.line1": "Adresse (rue)",
+          "individual.address.city": "Adresse (ville)",
+          "individual.address.postal_code": "Adresse (code postal)",
+          "individual.address.country": "Adresse (pays)",
+          "individual.verification.document": "Document d'identité",
+          "business_profile.url": "Site web de l'organisation",
+          "business_profile.mcc": "Catégorie d'activité",
+          "business_type": "Type d'entité",
+          "company.name": "Nom de l'organisation",
+          "company.tax_id": "Numéro fiscal",
+          "company.verification.document": "Document de vérification de l'organisation"
+        }
+      },
       "adminOnly": "Seuls les administrateurs de l'organisation peuvent gérer les paiements.",
       "status": {
         "notConnected": "Non connecté",
@@ -1033,11 +1062,22 @@
       "confirm": "Supprimer le don",
       "deleting": "Suppression…"
     },
+    "refundDialog": {
+      "title": "Rembourser ce don ?",
+      "description": "Rembourser {amount} sur la carte de {name} via Stripe. La commission de plateforme est également annulée.",
+      "descriptionFallback": "Rembourser {amount} sur la carte du donateur via Stripe. La commission de plateforme est également annulée.",
+      "hint": "Le donateur verra le crédit sur sa carte sous quelques jours ouvrés. Cette action est irréversible.",
+      "cancel": "Annuler",
+      "confirm": "Rembourser le don",
+      "refunding": "Traitement du remboursement…"
+    },
     "success": {
-      "deleted": "Don supprimé."
+      "deleted": "Don supprimé.",
+      "refunded": "Remboursement effectué. Le donateur verra le crédit sous quelques jours ouvrés."
     },
     "errors": {
-      "deleteGeneric": "Une erreur est survenue lors de la suppression du don. Réessayez."
+      "deleteGeneric": "Une erreur est survenue lors de la suppression du don. Réessayez.",
+      "refundGeneric": "Une erreur est survenue lors du traitement du remboursement. Réessayez."
     },
     "form": {
       "createTitle": "Enregistrer un don",
@@ -1143,6 +1183,7 @@
         "back": "Retour aux dons",
         "edit": "Modifier",
         "delete": "Supprimer",
+        "refund": "Rembourser",
         "previewReceipt": "Aperçu du reçu",
         "generatingReceipt": "Génération du reçu…"
       },
@@ -1462,6 +1503,9 @@
     "descriptionFallback": "Votre don aide directement à financer cette campagne et ses prochaines étapes sur le terrain.",
     "metrics": {
       "goal": "Objectif de collecte",
+      "raised": "Déjà collecté",
+      "goalSuffix": "sur",
+      "donors": "{count, plural, =0 {Aucun donateur pour l'instant} one {# donateur} other {# donateurs}}",
       "trust": "Paiement",
       "trustValue": "Sécurisé par Stripe"
     },
@@ -1519,6 +1563,12 @@
       "errors": {
         "generic": "Le paiement n'a pas pu aboutir. Essayez avec une autre carte ou contactez le support.",
         "missingPublishableKey": "Stripe n'est pas configuré sur cet environnement. Demandez à un administrateur de définir NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY."
+      },
+      "postRedirect": {
+        "checking": "Vérification du paiement auprès de Stripe…",
+        "processing": "Votre paiement est en cours de traitement. Vous recevrez un email de confirmation sous peu.",
+        "requiresAction": "Votre paiement n'a pas abouti. Essayez avec une autre carte ci-dessous.",
+        "startOver": "Recommencer un don"
       },
       "testMode": {
         "title": "Mode test — aucun débit réel",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1465,7 +1465,7 @@
       "goal": "Objectif de collecte",
       "goalFallback": "Objectif bientôt précisé",
       "trust": "Paiement",
-      "trustValue": "Flux Stripe à venir"
+      "trustValue": "Sécurisé par Stripe"
     },
     "form": {
       "eyebrow": "Don en ligne",
@@ -1521,7 +1521,11 @@
         "generic": "Le paiement n'a pas pu aboutir. Essayez avec une autre carte ou contactez le support.",
         "missingPublishableKey": "Stripe n'est pas configuré sur cet environnement. Demandez à un administrateur de définir NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY."
       },
-      "footnote": "Mode test : utilisez la carte 4242 4242 4242 4242 avec une date d'expiration future et n'importe quel CVC."
+      "testMode": {
+        "title": "Mode test — aucun débit réel",
+        "bodyBefore": "Utilisez la carte",
+        "bodyAfter": "avec une date d'expiration future et n'importe quel CVC. Aucun mouvement d'argent n'aura lieu."
+      }
     }
   },
   "constituentForm": {

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -892,7 +892,11 @@
     "stripeConnect": {
       "badge": "Paiements",
       "title": "Stripe Connect",
-      "description": "Connectez votre compte Stripe pour que les donateurs puissent payer depuis les pages de campagne. Givernance ne détient jamais les fonds — les paiements arrivent directement sur votre compte.",
+      "description": {
+        "notConnected": "Connectez votre compte Stripe pour que les donateurs puissent payer depuis les pages de campagne. Givernance ne détient jamais les fonds — les paiements arrivent directement sur votre compte.",
+        "pending": "L'onboarding Stripe n'est pas terminé. Tant que vous n'avez pas validé toutes les étapes, les donateurs ne peuvent pas payer.",
+        "connected": "Votre compte Stripe est connecté. Les dons effectués depuis les pages de campagne arrivent directement sur votre solde Stripe ; Givernance prélève sa commission sur chaque don."
+      },
       "adminOnly": "Seuls les administrateurs de l'organisation peuvent gérer les paiements.",
       "status": {
         "notConnected": "Non connecté",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -888,6 +888,27 @@
       "errorGeneric": "Impossible de télécharger l'export pour le moment.",
       "errorProblem": "L'export a échoué (HTTP {status}).",
       "lastDownloaded": "Dernier téléchargement : {value}"
+    },
+    "stripeConnect": {
+      "badge": "Paiements",
+      "title": "Stripe Connect",
+      "description": "Connectez votre compte Stripe pour que les donateurs puissent payer depuis les pages de campagne. Givernance ne détient jamais les fonds — les paiements arrivent directement sur votre compte.",
+      "adminOnly": "Seuls les administrateurs de l'organisation peuvent gérer les paiements.",
+      "status": {
+        "notConnected": "Non connecté",
+        "pending": "Onboarding incomplet",
+        "connected": "Connecté"
+      },
+      "actions": {
+        "connect": "Connecter Stripe",
+        "continue": "Reprendre l'onboarding",
+        "manage": "Rouvrir l'onboarding Stripe",
+        "starting": "Ouverture de Stripe…"
+      },
+      "errors": {
+        "load": "Impossible de charger le statut Stripe pour le moment.",
+        "start": "Impossible de démarrer l'onboarding Stripe pour le moment."
+      }
     }
   },
   "profile": {
@@ -1473,11 +1494,30 @@
         "generic": "Une erreur est survenue lors de la préparation du paiement. Réessayez."
       },
       "success": {
-        "intentCreated": "Votre don est prêt. L'étape de paiement Stripe est la prochaine intégration.",
+        "intentCreated": "Don préparé — saisissez vos informations de carte ci-dessous.",
         "nextStepTitle": "Étape suivante",
-        "nextStepBody": "Un intent de paiement a bien été créé côté API. La redirection ou le formulaire Stripe sera branché dans le prochain incrément."
+        "nextStepBody": "Utilisez le formulaire de carte pour finaliser votre don de manière sécurisée avec Stripe."
       },
-      "footnote": "En soumettant ce formulaire, vous préparez un paiement sécurisé. Le débit ne se fait pas encore sur cette version de la page."
+      "footnote": "En soumettant ce formulaire, vous préparez un paiement sécurisé. Votre carte sera débitée à l'étape suivante."
+    },
+    "payment": {
+      "summary": {
+        "title": "Vous donnez {amount}",
+        "subtitle": "Propulsé par Stripe — vos données de carte sont envoyées directement à Stripe et ne sont jamais stockées sur nos serveurs."
+      },
+      "actions": {
+        "pay": "Donner {amount}",
+        "paying": "Traitement du paiement…"
+      },
+      "success": {
+        "title": "Merci pour votre don !",
+        "body": "Nous avons bien reçu {amount}. Un reçu va arriver dans votre boîte mail."
+      },
+      "errors": {
+        "generic": "Le paiement n'a pas pu aboutir. Essayez avec une autre carte ou contactez le support.",
+        "missingPublishableKey": "Stripe n'est pas configuré sur cet environnement. Demandez à un administrateur de définir NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY."
+      },
+      "footnote": "Mode test : utilisez la carte 4242 4242 4242 4242 avec une date d'expiration future et n'importe quel CVC."
     }
   },
   "constituentForm": {

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1510,7 +1510,8 @@
       },
       "actions": {
         "pay": "Donner {amount}",
-        "paying": "Traitement du paiement…"
+        "paying": "Traitement du paiement…",
+        "back": "Modifier mon don"
       },
       "success": {
         "title": "Merci pour votre don !",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1462,7 +1462,6 @@
     "descriptionFallback": "Votre don aide directement à financer cette campagne et ses prochaines étapes sur le terrain.",
     "metrics": {
       "goal": "Objectif de collecte",
-      "goalFallback": "Objectif bientôt précisé",
       "trust": "Paiement",
       "trustValue": "Sécurisé par Stripe"
     },

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1457,7 +1457,6 @@
     }
   },
   "publicDonationPage": {
-    "backHome": "Accueil Givernance",
     "badge": "Collecte publique",
     "eyebrow": "Soutenez notre action",
     "descriptionFallback": "Votre don aide directement à financer cette campagne et ses prochaines étapes sur le terrain.",

--- a/packages/web/src/models/donation.ts
+++ b/packages/web/src/models/donation.ts
@@ -10,6 +10,12 @@ import type { Pagination } from "@/models/constituent";
 
 export type ReceiptStatus = "pending" | "generated" | "failed";
 
+/**
+ * Donation lifecycle status as exposed by `GET /v1/donations/:id`. Issue
+ * #199 — the refund button hides itself when status is already `refunded`.
+ */
+export type DonationStatus = "pending" | "cleared" | "refunded" | "failed";
+
 export interface Donation {
   id: string;
   orgId: string;
@@ -60,6 +66,8 @@ export interface DonationAllocationInput {
 }
 
 export interface DonationDetail extends Donation {
+  /** Lifecycle status — see `DonationStatus`. Drives the refund button. */
+  status: DonationStatus;
   constituent: {
     id: string;
     firstName: string;

--- a/packages/web/src/models/public-page.ts
+++ b/packages/web/src/models/public-page.ts
@@ -28,6 +28,12 @@ export interface PublishedCampaignPublicPage {
   colorPrimary: CampaignPublicPageColor | null;
   goalAmountCents: number | null;
   defaultCurrency: PublicDonationCurrency;
+  /** `acct_…` for the campaign's tenant; null when not yet onboarded. */
+  stripeAccountId: string | null;
+  /** Cumulative cleared donations in the tenant's base currency (issue #200). */
+  raisedCents: number;
+  /** Distinct donor count, cleared donations only (issue #200). */
+  donorCount: number;
 }
 
 export interface PublishedCampaignPublicPageResponse {

--- a/packages/web/src/models/public-page.ts
+++ b/packages/web/src/models/public-page.ts
@@ -52,6 +52,11 @@ export interface PublicDonationIntentInput {
 
 export interface PublicDonationIntent {
   clientSecret: string;
+  /**
+   * Connected account the PaymentIntent lives on. Stripe.js needs this when
+   * confirming a direct-charge intent — `loadStripe(pk, { stripeAccount })`.
+   */
+  stripeAccountId: string;
 }
 
 export interface PublicDonationIntentResponse {

--- a/packages/web/src/services/DonationService.ts
+++ b/packages/web/src/services/DonationService.ts
@@ -80,6 +80,19 @@ export const DonationService = {
     );
     return response.data.url;
   },
+
+  /**
+   * Refund a Stripe donation (issue #199). Returns the refunded id +
+   * status; the actual donation row is updated server-side both
+   * synchronously by this route AND asynchronously by the
+   * `charge.refunded` webhook (idempotent).
+   */
+  async refundDonation(client: ApiClient, id: string): Promise<{ id: string; status: "refunded" }> {
+    const response = await client.post<{ data: { id: string; status: "refunded" } }>(
+      `/v1/donations/${encodeURIComponent(id)}/refund`,
+    );
+    return response.data;
+  },
 };
 
 function mapDonationRow(raw: DonationListRow): DonationListRow {

--- a/packages/web/src/services/StripeConnectService.ts
+++ b/packages/web/src/services/StripeConnectService.ts
@@ -1,0 +1,36 @@
+import type { ApiClient } from "@/lib/api";
+
+export interface StripeConnectStatus {
+  accountId: string | null;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+}
+
+export interface StripeOnboardingLink {
+  url: string;
+  accountId: string;
+}
+
+export interface StripeOnboardingInput {
+  refreshUrl: string;
+  returnUrl: string;
+}
+
+export const StripeConnectService = {
+  async getStatus(client: ApiClient): Promise<StripeConnectStatus> {
+    const response = await client.get<{ data: StripeConnectStatus }>("/v1/admin/stripe-connect");
+    return response.data;
+  },
+
+  async startOnboarding(
+    client: ApiClient,
+    input: StripeOnboardingInput,
+  ): Promise<StripeOnboardingLink> {
+    const response = await client.post<{ data: StripeOnboardingLink }>(
+      "/v1/admin/stripe-connect",
+      input,
+    );
+    return response.data;
+  },
+};

--- a/packages/web/src/services/StripeConnectService.ts
+++ b/packages/web/src/services/StripeConnectService.ts
@@ -1,10 +1,26 @@
 import type { ApiClient } from "@/lib/api";
 
+export type StripeCapabilityStatus = "active" | "pending" | "inactive" | "unrequested";
+
 export interface StripeConnectStatus {
   accountId: string | null;
   chargesEnabled: boolean;
   payoutsEnabled: boolean;
   detailsSubmitted: boolean;
+  /**
+   * Stripe-emitted requirement keys (e.g. `external_account`,
+   * `individual.id_number`) the operator must satisfy before
+   * `chargesEnabled` flips on. Empty when fully onboarded. Drives the
+   * Settings panel's remediation list (issue #201).
+   */
+  requirementsCurrentlyDue: string[];
+  /** Stripe's reason for `chargesEnabled: false` (e.g. `requirements.past_due`). */
+  disabledReason: string | null;
+  capabilities: {
+    cardPayments: StripeCapabilityStatus;
+    transfers: StripeCapabilityStatus;
+    linkPayments: StripeCapabilityStatus;
+  };
 }
 
 export interface StripeOnboardingLink {

--- a/packages/worker/src/processors/stripe-webhook.ts
+++ b/packages/worker/src/processors/stripe-webhook.ts
@@ -11,7 +11,7 @@ import {
   webhookEvents,
 } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { env } from "../env.js";
 import { db, withWorkerContext } from "../lib/db.js";
 import { jobLogger } from "../lib/logger.js";
@@ -188,13 +188,20 @@ async function handlePaymentIntentSucceeded(
     const donationId = donation.id;
 
     if (campaignId) {
+      // Defence-in-depth: `campaignId` came from PaymentIntent metadata, which
+      // the platform sets server-side today but is technically attacker-tainted
+      // (a hand-crafted PI created via Stripe dashboard on the same connected
+      // account could carry a `metadata.campaign_id` for a campaign on a
+      // different tenant). RLS catches it via `withWorkerContext(orgId)`, but
+      // the explicit `org_id` filter makes the query refuse to write across
+      // tenants even if the RLS context were ever wrong.
       await tx
         .update(campaigns)
         .set({
           platformFeesCents: sql`${campaigns.platformFeesCents} + ${platformFeeCents}`,
           updatedAt: new Date(),
         })
-        .where(eq(campaigns.id, campaignId));
+        .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
     }
 
     // Emit DonationCreated domain event atomically

--- a/packages/worker/src/processors/stripe-webhook.ts
+++ b/packages/worker/src/processors/stripe-webhook.ts
@@ -12,9 +12,36 @@ import {
 } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
 import { and, eq, sql } from "drizzle-orm";
+import type Stripe from "stripe";
 import { env } from "../env.js";
 import { db, withWorkerContext } from "../lib/db.js";
 import { jobLogger } from "../lib/logger.js";
+
+/**
+ * Type-safe coercion of the BullMQ-serialised payload back into a Stripe
+ * resource shape. The wire format is `Record<string, unknown>` (BullMQ
+ * doesn't preserve class types), but every event Stripe sends carries a
+ * documented shape — we cast through `unknown` and validate the fields we
+ * actually read so a malformed event DLQs loudly instead of silently
+ * inserting a €0 donation.
+ */
+function asPaymentIntent(payload: Record<string, unknown>): Stripe.PaymentIntent {
+  if (typeof payload.id !== "string" || typeof payload.amount !== "number") {
+    throw new Error(
+      `Malformed payment_intent payload: id=${typeof payload.id}, amount=${typeof payload.amount}`,
+    );
+  }
+  return payload as unknown as Stripe.PaymentIntent;
+}
+
+function asCharge(payload: Record<string, unknown>): Stripe.Charge {
+  if (typeof payload.id !== "string" || typeof payload.payment_intent !== "string") {
+    throw new Error(
+      `Malformed charge payload: id=${typeof payload.id}, payment_intent=${typeof payload.payment_intent}`,
+    );
+  }
+  return payload as unknown as Stripe.Charge;
+}
 
 /** Look up the tenant associated with a Stripe connected account ID */
 async function findTenantByStripeAccount(stripeAccountId: string) {
@@ -28,8 +55,10 @@ async function findTenantByStripeAccount(stripeAccountId: string) {
 
 /**
  * Process a Stripe webhook event.
- * Currently handles: payment_intent.succeeded
- * Designed to be extended for additional event types (e.g. Mollie).
+ * Handles: payment_intent.succeeded, charge.refunded.
+ * Other event types are acknowledged + marked completed without action so the
+ * `webhook_events` row carries an audit trail of "we saw it" without forcing
+ * a retry storm; extend the routing block below to handle new types.
  */
 export async function processStripeWebhook(
   job: Job<ProcessStripeWebhookJob["data"]>,
@@ -47,7 +76,9 @@ export async function processStripeWebhook(
 
   try {
     if (eventType === "payment_intent.succeeded") {
-      await handlePaymentIntentSucceeded(accountId, payload, log);
+      await handlePaymentIntentSucceeded(accountId, asPaymentIntent(payload), log);
+    } else if (eventType === "charge.refunded") {
+      await handleChargeRefunded(accountId, asCharge(payload), log);
     } else {
       log.info({ eventType }, "Unhandled Stripe event type, marking completed");
     }
@@ -77,7 +108,7 @@ export async function processStripeWebhook(
  */
 async function handlePaymentIntentSucceeded(
   accountId: string | null,
-  payload: Record<string, unknown>,
+  intent: Stripe.PaymentIntent,
   log: ReturnType<typeof jobLogger>,
 ): Promise<void> {
   if (!accountId) {
@@ -92,16 +123,15 @@ async function handlePaymentIntentSucceeded(
   }
 
   const orgId = tenant.id;
-  const amountCents = (payload.amount as number) ?? 0;
-  const currency = ((payload.currency as string) ?? "eur").toUpperCase();
-  const paymentIntentId = payload.id as string;
-  const metadata = (payload.metadata as Record<string, string>) ?? {};
-  const constituentEmail =
-    (payload.receipt_email as string | undefined) || metadata.constituent_email;
+  const amountCents = intent.amount;
+  const currency = (intent.currency ?? "eur").toUpperCase();
+  const paymentIntentId = intent.id;
+  const metadata = intent.metadata ?? {};
+  const constituentEmail = intent.receipt_email ?? metadata.constituent_email ?? undefined;
   const constituentFirstName = metadata.constituent_first_name ?? "Anonymous";
   const constituentLastName = metadata.constituent_last_name ?? "Donor";
   const campaignId = metadata.campaign_id || null;
-  const platformFeeCents = Number((payload.application_fee_amount as number | null) ?? 0);
+  const platformFeeCents = intent.application_fee_amount ?? 0;
 
   await withWorkerContext(orgId, async (tx) => {
     const exchangeRateService = new ExchangeRateService({
@@ -230,6 +260,101 @@ async function handlePaymentIntentSucceeded(
         amountCents,
       },
       "Donation created from Stripe payment_intent.succeeded",
+    );
+  });
+}
+
+/**
+ * Handle charge.refunded — flip the donation status to `refunded` and roll
+ * back the platform-fee accumulator on the campaign. Stripe's default on
+ * direct charges is to refund the application fee alongside the charge
+ * when our `refunds.create` call passes `refund_application_fee: true`
+ * (see donations refund route), so the platform fee returns to the NPO's
+ * balance and we mirror that on our side.
+ *
+ * Idempotent against retries: if the donation is already `refunded`,
+ * the update is a no-op (filter on `status != 'refunded'` for the campaign
+ * fee decrement so we don't double-decrement on a webhook replay).
+ */
+async function handleChargeRefunded(
+  accountId: string | null,
+  charge: Stripe.Charge,
+  log: ReturnType<typeof jobLogger>,
+): Promise<void> {
+  if (!accountId) {
+    log.warn("charge.refunded without account_id, skipping");
+    return;
+  }
+
+  const tenant = await findTenantByStripeAccount(accountId);
+  if (!tenant) {
+    throw new Error(`No tenant found for Stripe account ${accountId}`);
+  }
+  const orgId = tenant.id;
+
+  const paymentIntentId =
+    typeof charge.payment_intent === "string" ? charge.payment_intent : charge.payment_intent?.id;
+  if (!paymentIntentId) {
+    log.warn({ chargeId: charge.id }, "charge.refunded without payment_intent, skipping");
+    return;
+  }
+
+  await withWorkerContext(orgId, async (tx) => {
+    // Resolve the donation we recorded on the original `payment_intent.succeeded`.
+    // Filtering by orgId is belt-and-braces under RLS — same defence-in-depth
+    // pattern as the campaign update on the success path.
+    const [donation] = await tx
+      .select({
+        id: donations.id,
+        status: donations.status,
+        campaignId: donations.campaignId,
+        platformFeeCents: donations.platformFeeCents,
+      })
+      .from(donations)
+      .where(and(eq(donations.paymentRef, paymentIntentId), eq(donations.orgId, orgId)));
+
+    if (!donation) {
+      log.warn(
+        { paymentIntentId },
+        "charge.refunded for unknown payment_intent, skipping (Stripe-only charge?)",
+      );
+      return;
+    }
+
+    if (donation.status === "refunded") {
+      log.info({ donationId: donation.id }, "Donation already marked refunded, skipping");
+      return;
+    }
+
+    await tx
+      .update(donations)
+      .set({ status: "refunded" })
+      .where(and(eq(donations.id, donation.id), eq(donations.orgId, orgId)));
+
+    if (donation.campaignId && donation.platformFeeCents > 0) {
+      await tx
+        .update(campaigns)
+        .set({
+          platformFeesCents: sql`GREATEST(${campaigns.platformFeesCents} - ${donation.platformFeeCents}, 0)`,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(campaigns.id, donation.campaignId), eq(campaigns.orgId, orgId)));
+    }
+
+    // Emit DonationRefunded domain event so receipts / reporting can react.
+    await tx.insert(outboxEvents).values({
+      tenantId: orgId,
+      type: "donation.refunded",
+      payload: {
+        donationId: donation.id,
+        paymentRef: paymentIntentId,
+        source: "stripe_webhook",
+      },
+    });
+
+    log.info(
+      { donationId: donation.id, paymentIntentId, chargeId: charge.id },
+      "Donation refunded from Stripe charge.refunded",
     );
   });
 }

--- a/packages/worker/src/processors/stripe-webhook.ts
+++ b/packages/worker/src/processors/stripe-webhook.ts
@@ -3,6 +3,7 @@
 import { ExchangeRateService } from "@givernance/shared";
 import type { ProcessStripeWebhookJob } from "@givernance/shared/jobs";
 import {
+  auditLogs,
   campaigns,
   constituents,
   donations,
@@ -349,6 +350,28 @@ async function handleChargeRefunded(
         donationId: donation.id,
         paymentRef: paymentIntentId,
         source: "stripe_webhook",
+      },
+    });
+
+    // Audit trail (PR #193 review, finding #9). The API plugin already
+    // logs the operator who hit POST /v1/donations/:id/refund — but a
+    // refund initiated from the NPO's Stripe dashboard skips that path
+    // entirely, and the worker-side state change had no audit trace.
+    // `userId` / `actorId` null = system-initiated; the previous +
+    // resulting status are recorded so a forensic reader can reconstruct
+    // who-flipped-what without joining against the original API request.
+    await tx.insert(auditLogs).values({
+      orgId,
+      userId: null,
+      actorId: null,
+      action: "WEBHOOK:charge.refunded",
+      resourceType: "donations",
+      resourceId: donation.id,
+      oldValues: { status: "cleared" },
+      newValues: {
+        status: "refunded",
+        chargeId: charge.id,
+        paymentIntentId,
       },
     });
 

--- a/packages/worker/src/tests/integration/stripe-webhook.test.ts
+++ b/packages/worker/src/tests/integration/stripe-webhook.test.ts
@@ -294,4 +294,171 @@ describe("processStripeWebhook", () => {
     expect(donation?.exchangeRate).toBe("150.00000000");
     expect(donation?.amountBaseCents).toBe(375000);
   });
+
+  // ─── #198: malformed payload rejected, not silently inserted as €0 ──────
+
+  it("DLQs (throws) when payment_intent payload is missing required fields", async () => {
+    // Insert a webhook_events row so the processor has somewhere to write
+    // its `failed` status update.
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000ee",
+      stripeEventId: "evt_test_malformed_pi",
+      eventType: "payment_intent.succeeded",
+      accountId: STRIPE_ACCOUNT_ID,
+      payload: {},
+      status: "pending",
+    });
+
+    const job = makeMockJob({
+      webhookEventId: "00000000-0000-0000-0000-0000000000ee",
+      stripeEventId: "evt_test_malformed_pi",
+      eventType: "payment_intent.succeeded",
+      accountId: STRIPE_ACCOUNT_ID,
+      payload: {
+        // Missing `id` and `amount` — would have silently inserted a €0
+        // donation under the previous `as number ?? 0` casts.
+        currency: "eur",
+      },
+    });
+
+    await expect(processStripeWebhook(job)).rejects.toThrow(/Malformed payment_intent/);
+
+    // No donation row written
+    const matches = await db
+      .select()
+      .from(donations)
+      .where(and(eq(donations.orgId, ORG_ID), eq(donations.paymentRef, "evt_test_malformed_pi")));
+    expect(matches).toHaveLength(0);
+
+    // webhook_events flipped to failed (so the BullMQ retry chain has a record)
+    const [event] = await db
+      .select({ status: webhookEvents.status, error: webhookEvents.error })
+      .from(webhookEvents)
+      .where(eq(webhookEvents.id, "00000000-0000-0000-0000-0000000000ee"));
+    expect(event?.status).toBe("failed");
+    expect(event?.error).toContain("Malformed payment_intent");
+  });
+
+  // ─── #199: charge.refunded marks donation refunded + decrements campaign fee ──
+
+  it("charge.refunded flips status to refunded + decrements campaign platform fee", async () => {
+    // First seed a cleared Stripe donation we can refund.
+    const paymentRef = "pi_test_refund_target";
+    await db.execute(
+      sql`INSERT INTO constituents (id, org_id, first_name, last_name, type)
+          VALUES ('00000000-0000-0000-0000-0000000000c1', ${ORG_ID}, 'Refund', 'Target', 'donor')
+          ON CONFLICT (id) DO NOTHING`,
+    );
+    await db.execute(
+      sql`INSERT INTO campaigns (id, org_id, name, type, platform_fees_cents)
+          VALUES ('00000000-0000-0000-0000-0000000000c2', ${ORG_ID}, 'Refund Campaign', 'digital', 105)
+          ON CONFLICT (id) DO UPDATE SET platform_fees_cents = 105`,
+    );
+    await db.execute(
+      sql`INSERT INTO donations
+          (org_id, constituent_id, amount_cents, currency, exchange_rate, amount_base_cents,
+           campaign_id, status, platform_fee_cents, payment_method, payment_ref, donated_at, fiscal_year)
+          VALUES (${ORG_ID}, '00000000-0000-0000-0000-0000000000c1', 5000, 'EUR', '1', 5000,
+                  '00000000-0000-0000-0000-0000000000c2', 'cleared', 105, 'stripe', ${paymentRef}, now(), 2026)
+          ON CONFLICT DO NOTHING`,
+    );
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000ef",
+      stripeEventId: "evt_test_refund_1",
+      eventType: "charge.refunded",
+      accountId: STRIPE_ACCOUNT_ID,
+      payload: {},
+      status: "pending",
+    });
+
+    const job = makeMockJob({
+      webhookEventId: "00000000-0000-0000-0000-0000000000ef",
+      stripeEventId: "evt_test_refund_1",
+      eventType: "charge.refunded",
+      accountId: STRIPE_ACCOUNT_ID,
+      payload: {
+        id: "ch_test_refund_1",
+        payment_intent: paymentRef,
+      },
+    });
+
+    await processStripeWebhook(job);
+
+    const [donation] = await db
+      .select({ status: donations.status })
+      .from(donations)
+      .where(and(eq(donations.orgId, ORG_ID), eq(donations.paymentRef, paymentRef)));
+    expect(donation?.status).toBe("refunded");
+
+    // Campaign platform-fee accumulator rolled back
+    const campaignResult = await db.execute(
+      sql`SELECT platform_fees_cents FROM campaigns WHERE id = '00000000-0000-0000-0000-0000000000c2'`,
+    );
+    const campaignRows = (
+      campaignResult as unknown as { rows: { platform_fees_cents: string | number }[] }
+    ).rows;
+    // Postgres `bigint` (or numeric-summed) columns can come back as strings
+    // through node-pg; normalise before asserting.
+    expect(Number(campaignRows[0]?.platform_fees_cents ?? -1)).toBe(0);
+
+    // donation.refunded outbox event emitted
+    const events = await db
+      .select({ type: outboxEvents.type, payload: outboxEvents.payload })
+      .from(outboxEvents)
+      .where(and(eq(outboxEvents.tenantId, ORG_ID), eq(outboxEvents.type, "donation.refunded")));
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it("charge.refunded is idempotent on already-refunded donations", async () => {
+    // Donation seeded as already refunded — handler should short-circuit
+    // (no second outbox event, no second decrement).
+    const paymentRef = "pi_test_refund_idempotent";
+    await db.execute(
+      sql`INSERT INTO constituents (id, org_id, first_name, last_name, type)
+          VALUES ('00000000-0000-0000-0000-0000000000d1', ${ORG_ID}, 'Refund', 'Idempotent', 'donor')
+          ON CONFLICT (id) DO NOTHING`,
+    );
+    await db.execute(
+      sql`INSERT INTO donations
+          (org_id, constituent_id, amount_cents, currency, exchange_rate, amount_base_cents,
+           status, platform_fee_cents, payment_method, payment_ref, donated_at, fiscal_year)
+          VALUES (${ORG_ID}, '00000000-0000-0000-0000-0000000000d1', 5000, 'EUR', '1', 5000,
+                  'refunded', 105, 'stripe', ${paymentRef}, now(), 2026)
+          ON CONFLICT DO NOTHING`,
+    );
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000ea",
+      stripeEventId: "evt_test_refund_idempotent",
+      eventType: "charge.refunded",
+      accountId: STRIPE_ACCOUNT_ID,
+      payload: {},
+      status: "pending",
+    });
+
+    const job = makeMockJob({
+      webhookEventId: "00000000-0000-0000-0000-0000000000ea",
+      stripeEventId: "evt_test_refund_idempotent",
+      eventType: "charge.refunded",
+      accountId: STRIPE_ACCOUNT_ID,
+      payload: {
+        id: "ch_test_refund_idempotent",
+        payment_intent: paymentRef,
+      },
+    });
+
+    // Should NOT throw — short-circuits on already-refunded.
+    await processStripeWebhook(job);
+
+    // Only one (or zero) refunded outbox event for this paymentRef — the
+    // first refund route call already emitted one in seeded data; the
+    // webhook handler must NOT emit a second.
+    const events = await db
+      .select({ payload: outboxEvents.payload })
+      .from(outboxEvents)
+      .where(and(eq(outboxEvents.tenantId, ORG_ID), eq(outboxEvents.type, "donation.refunded")));
+    const matchingPayloads = events.filter(
+      (e) => (e.payload as { paymentRef?: string }).paymentRef === paymentRef,
+    );
+    expect(matchingPayloads.length).toBeLessThanOrEqual(1);
+  });
 });

--- a/packages/worker/src/tests/integration/stripe-webhook.test.ts
+++ b/packages/worker/src/tests/integration/stripe-webhook.test.ts
@@ -407,6 +407,31 @@ describe("processStripeWebhook", () => {
       .from(outboxEvents)
       .where(and(eq(outboxEvents.tenantId, ORG_ID), eq(outboxEvents.type, "donation.refunded")));
     expect(events.length).toBeGreaterThan(0);
+
+    // Audit log row written by the worker (PR #193 finding #9). The API
+    // refund route is captured by the audit plugin via `onResponse`, but
+    // a refund initiated from the NPO's Stripe dashboard skips that path
+    // entirely — the worker is the only place we can record the state
+    // change in that case.
+    const auditRows = await db.execute(
+      sql`SELECT user_id, actor_id, action, resource_type, resource_id, old_values, new_values
+          FROM audit_logs
+          WHERE org_id = ${ORG_ID}
+            AND action = 'WEBHOOK:charge.refunded'
+            AND resource_id = (SELECT id::text FROM donations WHERE org_id = ${ORG_ID} AND payment_ref = ${paymentRef})`,
+    );
+    const auditRow = (auditRows as unknown as { rows: Record<string, unknown>[] }).rows[0];
+    expect(auditRow).toBeDefined();
+    // System-initiated → both null. Forensic readers compute "who did
+    // this" via COALESCE(actor_id, user_id, 'system').
+    expect(auditRow?.user_id).toBeNull();
+    expect(auditRow?.actor_id).toBeNull();
+    expect(auditRow?.resource_type).toBe("donations");
+    expect(auditRow?.old_values).toMatchObject({ status: "cleared" });
+    expect(auditRow?.new_values).toMatchObject({
+      status: "refunded",
+      paymentIntentId: paymentRef,
+    });
   });
 
   it("charge.refunded is idempotent on already-refunded donations", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,12 @@ importers:
       '@sinclair/typebox':
         specifier: ^0.34.12
         version: 0.34.49
+      '@stripe/react-stripe-js':
+        specifier: ^6.3.0
+        version: 6.3.0(@stripe/stripe-js@9.3.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@stripe/stripe-js':
+        specifier: ^9.3.1
+        version: 9.3.1
       '@tanstack/react-query':
         specifier: ^5.99.0
         version: 5.99.0(react@19.2.5)
@@ -2455,6 +2461,17 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@stripe/react-stripe-js@6.3.0':
+    resolution: {integrity: sha512-N1FTRNCMKySElDz1lAsf/m6Oy5vcl6LRVXcW29t0Y3U3HYOAqCBlk6nuDsR2x7SAuaXkVCjnpCqrNbA/7l74jg==}
+    peerDependencies:
+      '@stripe/stripe-js': '>=9.3.1 <10.0.0'
+      react: '>=16.8.0 <20.0.0'
+      react-dom: '>=16.8.0 <20.0.0'
+
+  '@stripe/stripe-js@9.3.1':
+    resolution: {integrity: sha512-oWpAEENuVg8aw4W2OUAM9WxRDtIV2YTLr2nr6qHT+D8tHPW7bya61ufinPpUespyRNUVXqesnHo+jQdUNsGywA==}
+    engines: {node: '>=12.16'}
+
   '@swc/core-darwin-arm64@1.15.26':
     resolution: {integrity: sha512-OmcP96CFsNOwa65tamQayRcfqhNlcQ3YCWOq+0Wb+CAM4uB7kOMrXY41Gj4atthxrGhLQ9pg7Vk26iApb88idA==}
     engines: {node: '>=10'}
@@ -3566,6 +3583,10 @@ packages:
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -3902,6 +3923,9 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3924,6 +3948,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -6603,6 +6630,15 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@stripe/react-stripe-js@6.3.0(@stripe/stripe-js@9.3.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@stripe/stripe-js': 9.3.1
+      prop-types: 15.8.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@stripe/stripe-js@9.3.1': {}
+
   '@swc/core-darwin-arm64@1.15.26':
     optional: true
 
@@ -7678,6 +7714,10 @@ snapshots:
 
   lodash.isarguments@3.1.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -7993,6 +8033,12 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   punycode@2.3.1: {}
 
   qrcode@1.5.4:
@@ -8011,6 +8057,8 @@ snapshots:
   react-hook-form@7.72.1(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 


### PR DESCRIPTION
## Summary

- Adds the Settings UI to onboard a tenant onto Stripe Connect (the API endpoint already existed, no UI was wired up).
- Adds the Stripe Payment Element to the public donation page so donors can actually pay — previously the form created a PaymentIntent and stopped.
- Adds `GET /v1/admin/stripe-connect` returning live capability flags from `accounts.retrieve` so the panel can show **Connected** / **Onboarding incomplete** / **Not connected** without a separate 404 path.
- Adds a step-by-step local-dev guide ([docs/dev/stripe-local-setup.md](https://github.com/purposestack/givernance/blob/feat/stripe-connect-settings-and-payment-element/docs/dev/stripe-local-setup.md)) covering Stripe signup, Connect platform setup, CLI install, `.env` wiring, `stripe listen`, onboarding, and a first test donation. Test cards + troubleshooting included.
- Repo hygiene: consolidates the Stripe-installer's three duplicate skill trees (`.agents/skills/`, `skills/` → both symlinks → `.claude/skills/`) into a single canonical `.claude/skills/` matching the existing `.claude/agents/` convention.
- Multi-agent review pass + fixes from 5 specialists (payment, security, QA, design, API contract).
- Final round: integrates **all** review follow-ups in-PR rather than deferring — post-3DS handler, webhook payload validation, refund flow, raised/donor aggregates on hero, Stripe Connect requirements remediation UI.

close #192
close #197
close #198
close #199
close #200
close #201

## Direct-charge wiring note

The PaymentIntent lives on the connected account (`requestOptions.stripeAccount` in `createDonationIntent`). Stripe.js must bind to the same account or `confirmPayment` 404s the intent — that's why the donate response returns `stripeAccountId` and the public-page response also exposes it (for the post-3DS retrieve, where the donor lands back on the page with no session). Memoised by `(publishableKey, stripeAccountId)` so we don't reload Stripe.js per render. `redirect: 'if_required'` keeps cards in-page; 3DS/wallets fall back to the redirect, which is now properly handled.

## CI pipeline (per CLAUDE.md)

- `pnpm install` — up to date
- `pnpm build` — Done
- `pnpm run format` — Biome auto-fixed
- `pnpm run lint` — exit 0 (12 pre-existing warnings, none introduced)
- `pnpm typecheck` — Done across all 5 packages
- `pnpm test` — 639 passing across 54 files (was 616 at start of review pass — 23 new tests)

## Manual acceptance checklist

Reviewer should be able to merge after walking the test plan below.

### Local Stripe setup (one-time, ~15 min)
- [ ] Follow [docs/dev/stripe-local-setup.md](https://github.com/purposestack/givernance/blob/feat/stripe-connect-settings-and-payment-element/docs/dev/stripe-local-setup.md) steps 1–7.

### Settings UI (`/settings`)
- [ ] Org admin sees a **Stripe Connect** panel between **Organisation settings** and **Data export**.
- [ ] Initial state shows the **Not connected** badge and a **Connect Stripe** button.
- [ ] Click → redirects to Stripe-hosted Express onboarding.
- [ ] Abandon onboarding → return to settings → badge reads **Onboarding incomplete** **and** a remediation list shows what's missing (e.g. "Bank account for payouts", "Date of birth").
- [ ] Complete onboarding with test data → return to settings → badge reads **Connected**, account ID is shown in monospace, requirements list is gone.
- [ ] Non-admin users (`viewer`, `user`) see a **lock** state instead of the action button.

### Donor flow (`/p/[campaignId]`)
- [ ] Filling the form and clicking **Continue to payment** replaces the donor-details form with the Stripe **Payment Element**.
- [ ] Card `4242 4242 4242 4242` + any future expiry + any CVC succeeds in-page (no redirect).
- [ ] Test mode banner is visible above the Payment Element (only when `pk_test_*`).
- [ ] **Modifier mon don** button returns to the form with values preserved.
- [ ] Worker terminal logs **Donation created from Stripe payment_intent.succeeded**.
- [ ] Donor sees the **Thank you for your donation!** confirmation.
- [ ] In the admin app, the new donation appears in **Donations** with the constituent matched/created from the donor email.
- [ ] **Hero shows progress bar + donor count** once at least one cleared donation exists.

### Refund flow (new in this PR)
- [ ] Open a Stripe-sourced cleared donation as org_admin.
- [ ] **Refund** button visible. Click → confirm dialog explains the platform-fee rollback.
- [ ] Confirm → Stripe issues the refund, donation status flips to **refunded** in the UI.
- [ ] Stripe dashboard shows the refund + the application fee returned to the connected account.

### Post-3DS handling
- [ ] Use Stripe test card `4000 0027 6000 3184` (3DS required) on the donor flow.
- [ ] Donor is redirected to Stripe's challenge, completes it, lands back on the page.
- [ ] Page shows **Thank you for your donation!** without re-rendering the donor-details form.
- [ ] URL bar no longer contains `payment_intent_client_secret`.

### i18n
- [ ] Switch the org locale to `fr` → settings panel + donor flow + refund dialog + remediation list render in French.

🤖 Generated with [Claude Code](https://claude.com/claude-code)