### PR TITLE
fix(deploy): reconcile loginTheme + i18n in sync script so staging uses the custom KC login theme

### DIFF
--- a/scripts/keycloak-sync-realm.sh
+++ b/scripts/keycloak-sync-realm.sh
@@ -96,35 +96,66 @@ else
   log "User profile already permissive — no change."
 fi
 
-# 1.b Reconcile the realm-level `passwordPolicy`. The realm JSON declares
-#     `length(12) and notUsername` to match the API-side `minLength: 12` and
-#     prevent a future direct-admin path from setting trivial passwords.
-#     Two reasons to reconcile at runtime as well:
-#       - `--import-realm` skips fields on existing realms (IGNORE_EXISTING),
-#         so the JSON change alone never reaches a dev's running container.
-#       - The PR #143 review caught a JS-template-literal accident
-#         (`notUsername(undefined)`) that landed in the imported realm and
-#         silently degraded the policy. Reconciling here means the policy
-#         state on disk is the source of truth even when the import was
-#         lossy or the operator hand-edited it via the admin console.
+# 1.b Reconcile realm-level fields that `--import-realm` silently skips
+#     when the realm already exists. Despite `KC_IMPORT_STRATEGY=
+#     OVERWRITE_EXISTING` being set in the env, the start-time import
+#     path still uses IGNORE_EXISTING (the env var only takes effect via
+#     the dedicated `kc.sh import` command). Confirmed in KC 26.6.1
+#     boot logs:
+#       "Realm 'givernance' already exists. Import skipped"
+#       "Strategy: IGNORE_EXISTING"
+#
+#     Reconciling here means the realm JSON stays the source of truth
+#     for these fields even when the start-time import was lossy or the
+#     operator hand-edited them via the admin console:
+#       - passwordPolicy → matches API-side `minLength: 12` and prevents
+#         a future direct-admin path from setting trivial passwords.
+#         (PR #143 review also caught a `notUsername(undefined)` accident
+#         that this same reconciliation block now repairs.)
+#       - loginTheme → required for the custom Givernance theme to
+#         render; without it KC silently falls back to `keycloak.v2`.
+#       - internationalizationEnabled / supportedLocales / defaultLocale
+#         → drive the locale picker and the per-locale message bundles
+#         (issue #153 / locale-resolution flows).
 DESIRED_PASSWORD_POLICY="${KEYCLOAK_PASSWORD_POLICY:-length(12) and notUsername}"
 realm_repr=$(curl -sS "${auth[@]}" "${KC_URL}/admin/realms/${REALM}")
-patched_realm=$(printf '%s' "$realm_repr" | DESIRED="$DESIRED_PASSWORD_POLICY" python3 -c '
+patched_realm=$(printf '%s' "$realm_repr" | DESIRED_POLICY="$DESIRED_PASSWORD_POLICY" python3 -c '
 import json, os, sys
 d = json.load(sys.stdin)
-desired = os.environ["DESIRED"]
-changed = d.get("passwordPolicy") != desired
-d["passwordPolicy"] = desired
-print(json.dumps({"changed": changed, "realm": d}))
+desired_policy = os.environ["DESIRED_POLICY"]
+desired_login_theme = "givernance"
+desired_i18n = True
+desired_locales = ["en", "fr"]
+desired_default_locale = "en"
+
+changes = []
+if d.get("passwordPolicy") != desired_policy:
+    d["passwordPolicy"] = desired_policy
+    changes.append("passwordPolicy")
+if d.get("loginTheme") != desired_login_theme:
+    d["loginTheme"] = desired_login_theme
+    changes.append("loginTheme")
+if d.get("internationalizationEnabled") != desired_i18n:
+    d["internationalizationEnabled"] = desired_i18n
+    changes.append("internationalizationEnabled")
+if sorted(d.get("supportedLocales") or []) != sorted(desired_locales):
+    d["supportedLocales"] = desired_locales
+    changes.append("supportedLocales")
+if d.get("defaultLocale") != desired_default_locale:
+    d["defaultLocale"] = desired_default_locale
+    changes.append("defaultLocale")
+
+print(json.dumps({"changes": changes, "realm": d}))
 ')
-if printf '%s' "$patched_realm" | python3 -c 'import json,sys;sys.exit(0 if json.load(sys.stdin)["changed"] else 1)'; then
+realm_changes=$(printf '%s' "$patched_realm" | python3 -c 'import json,sys; print(",".join(json.load(sys.stdin)["changes"]))')
+if [ -n "$realm_changes" ]; then
   new_realm=$(printf '%s' "$patched_realm" | python3 -c 'import json,sys;print(json.dumps(json.load(sys.stdin)["realm"]))')
-  curl -sS -o /dev/null -w 'realm passwordPolicy update: HTTP %{http_code}\n' \
+  curl -sS -o /dev/null -w 'realm fields update: HTTP %{http_code}\n' \
     -X PUT "${KC_URL}/admin/realms/${REALM}" \
     "${auth[@]}" -H "Content-Type: application/json" -d "$new_realm"
-  log "Reconciled passwordPolicy on realm '${REALM}' to '${DESIRED_PASSWORD_POLICY}'."
+  log "Reconciled realm fields on '${REALM}': ${realm_changes}"
 else
-  log "passwordPolicy already matches '${DESIRED_PASSWORD_POLICY}' — no change."
+  log "Realm fields (passwordPolicy, loginTheme, i18n, locales) already match — no change."
 fi
 
 # 2. Ensure the `organization` client scope is the single home for all


### PR DESCRIPTION
## Summary

The custom Givernance Keycloak login theme renders fine in local
Compose but never showed up on staging — every login screen fell
back to the default `keycloak.v2`. Confirmed root cause: the live
staging realm has `loginTheme: null` and
`internationalizationEnabled: false`, even though the realm JSON
declares both.

## Why the JSON values weren't applied

Keycloak's `start-dev --import-realm` path silently uses the
`IGNORE_EXISTING` strategy when the realm already exists, regardless
of what `KC_IMPORT_STRATEGY` is set to in the environment — that env
var only takes effect via the dedicated `kc.sh import` subcommand.
The boot log on staging:

```
Importing from directory /opt/keycloak/bin/../data/import
Realm 'givernance' already exists. Import skipped
Full model import requested. Strategy: IGNORE_EXISTING
```

`scripts/keycloak-sync-realm.sh` already worked around this for
`passwordPolicy`. This PR extends the same reconciliation block to
cover the four fields the custom theme + locale picker depend on:

- `loginTheme = "givernance"`
- `internationalizationEnabled = true`
- `supportedLocales = ["en", "fr"]`
- `defaultLocale = "en"`

Implemented as a single batched PUT (one round-trip for all five
fields including `passwordPolicy`), idempotent — the script logs
only the diff and stays a no-op once the realm is reconciled.

The custom KC image (`infra/keycloak/Dockerfile`) already bakes the
theme files into `/opt/keycloak/themes/givernance` — no change
needed there. Verified the files are present on the running staging
container. The bug was purely realm-state: the theme files existed,
KC just wasn't told to use them.

## Test plan

- [ ] Trigger Deploy to Staging on this branch
- [ ] Watch the "Sync Keycloak realm" step log line
      `Reconciled realm fields on 'givernance': ...,loginTheme,...`
- [ ] Hit `https://auth.staging.givernance.org/realms/givernance/protocol/openid-connect/auth?...` and confirm the HTML references `/login/givernance/css/givernance.css`, not `keycloak.v2`
- [ ] Open the staging login page in a browser and confirm the
      Givernance branding renders (Inter/Newsreader fonts, custom
      hero, locale picker)
- [ ] Re-run the deploy a second time and confirm the sync step now
      logs "no change" (idempotency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)