### PR TITLE
feat(dashboard): real-data StatCard trends + i18n table-filter fixes

### DIFF
--- a/packages/api/src/modules/campaigns/routes.ts
+++ b/packages/api/src/modules/campaigns/routes.ts
@@ -144,7 +144,8 @@ const CampaignRoiResponse = Type.Object({
 const ListQuery = Type.Intersect([
   PaginationQuery,
   Type.Object({
-    search: Type.Optional(Type.String()),
+    search: Type.Optional(Type.String({ maxLength: 200 })),
+    status: Type.Optional(CampaignStatusSchema),
   }),
 ]);
 
@@ -166,11 +167,17 @@ export async function campaignRoutes(app: FastifyInstance) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
 
-      const query = request.query as { page?: number; perPage?: number; search?: string };
+      const query = request.query as {
+        page?: number;
+        perPage?: number;
+        search?: string;
+        status?: "draft" | "active" | "closed";
+      };
       const result = await listCampaigns(orgId, {
         page: query.page ?? 1,
         perPage: query.perPage ?? 20,
         search: query.search,
+        status: query.status,
       });
 
       return { data: result.data, pagination: result.pagination };

--- a/packages/api/src/modules/campaigns/routes.ts
+++ b/packages/api/src/modules/campaigns/routes.ts
@@ -69,7 +69,8 @@ const CampaignCreateBody = Type.Object({
   type: CampaignTypeSchema,
   defaultCurrency: Type.Optional(CampaignDefaultCurrencySchema),
   parentId: Type.Optional(Type.Union([UuidSchema, Type.Null()])),
-  operationalCostCents: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+  operationalCostCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
+  goalAmountCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
   fundIds: Type.Optional(Type.Array(UuidSchema)),
 });
 
@@ -82,7 +83,8 @@ const CampaignUpdateBody = Type.Object(
       Type.Union([Type.Literal("draft"), Type.Literal("active"), Type.Literal("closed")]),
     ),
     parentId: Type.Optional(Type.Union([UuidSchema, Type.Null()])),
-    operationalCostCents: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+    operationalCostCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
+    goalAmountCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
     fundIds: Type.Optional(Type.Array(UuidSchema)),
   },
   { minProperties: 1 },
@@ -216,6 +218,7 @@ export async function campaignRoutes(app: FastifyInstance) {
         defaultCurrency?: "EUR" | "GBP" | "CHF";
         parentId?: string | null;
         operationalCostCents?: number | null;
+        goalAmountCents?: number | null;
         fundIds?: string[];
       };
       try {
@@ -307,6 +310,7 @@ export async function campaignRoutes(app: FastifyInstance) {
         status?: "draft" | "active" | "closed";
         parentId?: string | null;
         operationalCostCents?: number | null;
+        goalAmountCents?: number | null;
         fundIds?: string[];
       };
 

--- a/packages/api/src/modules/campaigns/service.ts
+++ b/packages/api/src/modules/campaigns/service.ts
@@ -19,6 +19,7 @@ export interface CreateCampaignInput {
   defaultCurrency?: "EUR" | "GBP" | "CHF";
   parentId?: string | null;
   operationalCostCents?: number | null;
+  goalAmountCents?: number | null;
   fundIds?: string[];
 }
 
@@ -29,6 +30,7 @@ export interface UpdateCampaignInput {
   status?: "draft" | "active" | "closed";
   parentId?: string | null;
   operationalCostCents?: number | null;
+  goalAmountCents?: number | null;
   fundIds?: string[];
 }
 
@@ -127,6 +129,43 @@ async function syncCampaignFunds(
   );
 }
 
+/**
+ * Persist the campaign-level fundraising goal. Stored on
+ * `campaign_public_pages.goalAmountCents` (cf. ADR-pending) so it can also
+ * back the public page widget. When no public_pages row exists yet (the
+ * org hasn't opened the public-page editor), bootstrap a draft row whose
+ * title mirrors the campaign name — the org can override every other
+ * field later from `/campaigns/[id]/public-page`.
+ */
+async function upsertCampaignGoal(
+  tx: Parameters<Parameters<typeof withTenantContext>[1]>[0],
+  orgId: string,
+  campaignId: string,
+  campaignName: string,
+  goalAmountCents: number | null,
+) {
+  const [existing] = await tx
+    .select({ id: campaignPublicPages.id })
+    .from(campaignPublicPages)
+    .where(eq(campaignPublicPages.campaignId, campaignId));
+
+  if (existing) {
+    await tx
+      .update(campaignPublicPages)
+      .set({ goalAmountCents, updatedAt: new Date() })
+      .where(eq(campaignPublicPages.id, existing.id));
+    return;
+  }
+
+  await tx.insert(campaignPublicPages).values({
+    orgId,
+    campaignId,
+    title: campaignName,
+    status: "draft",
+    goalAmountCents,
+  });
+}
+
 /** List campaigns for an organization with pagination */
 export async function listCampaigns(orgId: string, query: ListCampaignsQuery) {
   const { page, perPage, search, status } = query;
@@ -209,6 +248,11 @@ export async function createCampaign(orgId: string, input: CreateCampaignInput, 
     if (input.fundIds !== undefined) {
       // biome-ignore lint/style/noNonNullAssertion: insert().returning() always returns one row
       await syncCampaignFunds(tx, orgId, campaign!.id, input.fundIds);
+    }
+
+    if (input.goalAmountCents !== undefined) {
+      // biome-ignore lint/style/noNonNullAssertion: insert().returning() always returns one row
+      await upsertCampaignGoal(tx, orgId, campaign!.id, input.name, input.goalAmountCents);
     }
 
     await tx.insert(outboxEvents).values({
@@ -303,6 +347,10 @@ export async function updateCampaign(
 
     if (input.fundIds !== undefined) {
       await syncCampaignFunds(tx, orgId, id, input.fundIds);
+    }
+
+    if (input.goalAmountCents !== undefined) {
+      await upsertCampaignGoal(tx, orgId, id, input.name ?? existing.name, input.goalAmountCents);
     }
 
     const [updated] = await tx

--- a/packages/api/src/modules/campaigns/service.ts
+++ b/packages/api/src/modules/campaigns/service.ts
@@ -36,6 +36,7 @@ export interface ListCampaignsQuery {
   page: number;
   perPage: number;
   search?: string;
+  status?: "draft" | "active" | "closed";
 }
 
 function campaignSelectFields() {
@@ -128,7 +129,7 @@ async function syncCampaignFunds(
 
 /** List campaigns for an organization with pagination */
 export async function listCampaigns(orgId: string, query: ListCampaignsQuery) {
-  const { page, perPage, search } = query;
+  const { page, perPage, search, status } = query;
   const offset = (page - 1) * perPage;
 
   return withTenantContext(orgId, async (tx) => {
@@ -136,6 +137,10 @@ export async function listCampaigns(orgId: string, query: ListCampaignsQuery) {
 
     if (search) {
       conditions.push(ilike(campaigns.name, `%${search}%`));
+    }
+
+    if (status) {
+      conditions.push(eq(campaigns.status, status));
     }
 
     const where = and(...conditions);

--- a/packages/api/src/modules/constituents/routes.ts
+++ b/packages/api/src/modules/constituents/routes.ts
@@ -67,7 +67,7 @@ const ConstituentUpdateBody = Type.Object(
 const ListQuery = Type.Intersect([
   PaginationQuery,
   Type.Object({
-    search: Type.Optional(Type.String()),
+    search: Type.Optional(Type.String({ maxLength: 200 })),
     tags: Type.Optional(Type.Union([Type.Array(Type.String()), Type.String()])),
     type: Type.Optional(ConstituentTypeEnum),
     includeDeleted: Type.Optional(Type.Boolean({ default: false })),

--- a/packages/api/src/modules/dashboard/routes.ts
+++ b/packages/api/src/modules/dashboard/routes.ts
@@ -1,0 +1,42 @@
+/** Dashboard routes — month-over-month KPI aggregates for the home screen */
+
+import { Type } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
+import { requireAuth } from "../../lib/guards.js";
+import { DataResponse, ErrorResponses, problemDetail } from "../../lib/schemas.js";
+import { getDashboardStats } from "./service.js";
+
+const PeriodSchema = Type.Object({
+  current: Type.Integer({ minimum: 0 }),
+  previous: Type.Integer({ minimum: 0 }),
+});
+
+const DashboardStatsSchema = Type.Object({
+  totalRaisedCents: PeriodSchema,
+  newDonors: PeriodSchema,
+  newActiveCampaigns: PeriodSchema,
+});
+
+export async function dashboardRoutes(app: FastifyInstance) {
+  app.get(
+    "/dashboard/stats",
+    {
+      preHandler: requireAuth,
+      schema: {
+        tags: ["Dashboard"],
+        response: {
+          200: DataResponse(DashboardStatsSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const data = await getDashboardStats(orgId);
+      return { data };
+    },
+  );
+}

--- a/packages/api/src/modules/dashboard/service.ts
+++ b/packages/api/src/modules/dashboard/service.ts
@@ -1,0 +1,104 @@
+/** Dashboard service — month-over-month KPI aggregates */
+
+import { campaigns, constituents, donations } from "@givernance/shared/schema";
+import { and, eq, gte, lt, sql } from "drizzle-orm";
+import { withTenantContext } from "../../lib/db.js";
+
+export interface DashboardPeriod {
+  current: number;
+  previous: number;
+}
+
+export interface DashboardStats {
+  totalRaisedCents: DashboardPeriod;
+  newDonors: DashboardPeriod;
+  newActiveCampaigns: DashboardPeriod;
+}
+
+interface MonthRanges {
+  current: { start: Date; end: Date };
+  previous: { start: Date; end: Date };
+}
+
+/**
+ * Half-open calendar-month windows in UTC.
+ * `current` is the running month (1st 00:00 UTC → next 1st 00:00 UTC).
+ * `previous` is the full prior month.
+ */
+export function monthRanges(now: Date = new Date()): MonthRanges {
+  const currentStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const currentEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+  const previousStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+  return {
+    current: { start: currentStart, end: currentEnd },
+    previous: { start: previousStart, end: currentStart },
+  };
+}
+
+export async function getDashboardStats(
+  orgId: string,
+  now: Date = new Date(),
+): Promise<DashboardStats> {
+  const ranges = monthRanges(now);
+
+  return withTenantContext(orgId, async (tx) => {
+    const [donationsAgg] = await tx
+      .select({
+        currentSum: sql<string>`COALESCE(SUM(${donations.amountCents}) FILTER (WHERE ${donations.donatedAt} >= ${ranges.current.start} AND ${donations.donatedAt} < ${ranges.current.end}), 0)`,
+        previousSum: sql<string>`COALESCE(SUM(${donations.amountCents}) FILTER (WHERE ${donations.donatedAt} >= ${ranges.previous.start} AND ${donations.donatedAt} < ${ranges.previous.end}), 0)`,
+      })
+      .from(donations)
+      .where(
+        and(
+          eq(donations.orgId, orgId),
+          gte(donations.donatedAt, ranges.previous.start),
+          lt(donations.donatedAt, ranges.current.end),
+        ),
+      );
+
+    const [donorsAgg] = await tx
+      .select({
+        currentCount: sql<string>`COUNT(*) FILTER (WHERE ${constituents.createdAt} >= ${ranges.current.start} AND ${constituents.createdAt} < ${ranges.current.end})`,
+        previousCount: sql<string>`COUNT(*) FILTER (WHERE ${constituents.createdAt} >= ${ranges.previous.start} AND ${constituents.createdAt} < ${ranges.previous.end})`,
+      })
+      .from(constituents)
+      .where(
+        and(
+          eq(constituents.orgId, orgId),
+          eq(constituents.type, "donor"),
+          gte(constituents.createdAt, ranges.previous.start),
+          lt(constituents.createdAt, ranges.current.end),
+        ),
+      );
+
+    const [campaignsAgg] = await tx
+      .select({
+        currentCount: sql<string>`COUNT(*) FILTER (WHERE ${campaigns.createdAt} >= ${ranges.current.start} AND ${campaigns.createdAt} < ${ranges.current.end})`,
+        previousCount: sql<string>`COUNT(*) FILTER (WHERE ${campaigns.createdAt} >= ${ranges.previous.start} AND ${campaigns.createdAt} < ${ranges.previous.end})`,
+      })
+      .from(campaigns)
+      .where(
+        and(
+          eq(campaigns.orgId, orgId),
+          eq(campaigns.status, "active"),
+          gte(campaigns.createdAt, ranges.previous.start),
+          lt(campaigns.createdAt, ranges.current.end),
+        ),
+      );
+
+    return {
+      totalRaisedCents: {
+        current: Number(donationsAgg?.currentSum ?? 0),
+        previous: Number(donationsAgg?.previousSum ?? 0),
+      },
+      newDonors: {
+        current: Number(donorsAgg?.currentCount ?? 0),
+        previous: Number(donorsAgg?.previousCount ?? 0),
+      },
+      newActiveCampaigns: {
+        current: Number(campaignsAgg?.currentCount ?? 0),
+        previous: Number(campaignsAgg?.previousCount ?? 0),
+      },
+    };
+  });
+}

--- a/packages/api/src/modules/donations/routes.ts
+++ b/packages/api/src/modules/donations/routes.ts
@@ -26,16 +26,23 @@ import {
   updateDonation,
 } from "./service.js";
 
+const ReceiptStatusSchema = Type.Union([
+  Type.Literal("pending"),
+  Type.Literal("generated"),
+  Type.Literal("failed"),
+]);
+
 const ListQuery = Type.Intersect([
   PaginationQuery,
   Type.Object({
-    search: Type.Optional(Type.String()),
+    search: Type.Optional(Type.String({ maxLength: 200 })),
     dateFrom: Type.Optional(Type.String({ format: "date" })),
     dateTo: Type.Optional(Type.String({ format: "date" })),
     amountMin: Type.Optional(Type.Integer({ minimum: 0 })),
     amountMax: Type.Optional(Type.Integer({ minimum: 0 })),
     constituentId: Type.Optional(UuidSchema),
     campaignId: Type.Optional(UuidSchema),
+    receiptStatus: Type.Optional(ReceiptStatusSchema),
   }),
 ]);
 
@@ -195,6 +202,7 @@ export async function donationRoutes(app: FastifyInstance) {
         amountMax?: number;
         constituentId?: string;
         campaignId?: string;
+        receiptStatus?: "pending" | "generated" | "failed";
       };
 
       const result = await listDonations(orgId, {
@@ -207,6 +215,7 @@ export async function donationRoutes(app: FastifyInstance) {
         amountMax: query.amountMax,
         constituentId: query.constituentId,
         campaignId: query.campaignId,
+        receiptStatus: query.receiptStatus,
       });
 
       return { data: result.data, pagination: result.pagination };

--- a/packages/api/src/modules/donations/service.ts
+++ b/packages/api/src/modules/donations/service.ts
@@ -11,8 +11,8 @@ import {
   tenants,
 } from "@givernance/shared/schema";
 import type { Pagination } from "@givernance/shared/types";
-import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
-import { withTenantContext } from "../../lib/db.js";
+import { and, desc, eq, gte, ilike, inArray, lte, or, sql } from "drizzle-orm";
+import { db, withTenantContext } from "../../lib/db.js";
 import { ExchangeRateService } from "../finance/exchange-rate-service.js";
 
 /** Thrown when allocation amounts don't sum to the donation total */
@@ -81,6 +81,7 @@ export interface ListDonationsQuery {
   amountMax?: number;
   constituentId?: string;
   campaignId?: string;
+  receiptStatus?: "pending" | "generated" | "failed";
 }
 
 export interface DonationInput {
@@ -169,15 +170,35 @@ async function replaceDonationAllocations(
 
 /** Build the SQL conditions for a list-donations query */
 function listDonationsConditions(orgId: string, query: ListDonationsQuery) {
-  const { search, dateFrom, dateTo, amountMin, amountMax, constituentId, campaignId } = query;
+  const {
+    search,
+    dateFrom,
+    dateTo,
+    amountMin,
+    amountMax,
+    constituentId,
+    campaignId,
+    receiptStatus,
+  } = query;
   const conditions = [eq(donations.orgId, orgId)];
 
   if (search) {
     const pattern = `%${search}%`;
+    // Subquery: constituents matching the term. RLS on `constituents`
+    // already scopes to the current org, so no need to re-filter org_id here.
     conditions.push(
       inArray(
         donations.constituentId,
-        sql`(SELECT id FROM constituents WHERE org_id = ${orgId} AND (first_name ILIKE ${pattern} OR last_name ILIKE ${pattern} OR email ILIKE ${pattern}))`,
+        db
+          .select({ id: constituents.id })
+          .from(constituents)
+          .where(
+            or(
+              ilike(constituents.firstName, pattern),
+              ilike(constituents.lastName, pattern),
+              ilike(constituents.email, pattern),
+            ),
+          ),
       ),
     );
   }
@@ -188,6 +209,20 @@ function listDonationsConditions(orgId: string, query: ListDonationsQuery) {
   if (amountMax !== undefined) conditions.push(lte(donations.amountCents, amountMax));
   if (constituentId) conditions.push(eq(donations.constituentId, constituentId));
   if (campaignId) conditions.push(eq(donations.campaignId, campaignId));
+  if (receiptStatus) {
+    // Donations whose latest receipt has the requested status. Only one
+    // receipt per donation is produced today (cf. enrichDonationRows), so
+    // an EXISTS-style subquery is sufficient and avoids a window function.
+    conditions.push(
+      inArray(
+        donations.id,
+        db
+          .select({ id: receipts.donationId })
+          .from(receipts)
+          .where(eq(receipts.status, receiptStatus)),
+      ),
+    );
+  }
 
   return and(...conditions);
 }

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -15,6 +15,7 @@ import { impersonationRoutes } from "./modules/admin/impersonation-routes.js";
 import { auditRoutes } from "./modules/audit/routes.js";
 import { campaignRoutes } from "./modules/campaigns/routes.js";
 import { constituentRoutes } from "./modules/constituents/routes.js";
+import { dashboardRoutes } from "./modules/dashboard/routes.js";
 import { disputeRoutes } from "./modules/disputes/routes.js";
 import { donationRoutes } from "./modules/donations/routes.js";
 import { fundRoutes } from "./modules/funds/routes.js";
@@ -163,6 +164,7 @@ export async function createServer(opts: CreateServerOpts = {}): Promise<Fastify
   await app.register(tenantAdminRoutes, { prefix: "/v1" });
   await app.register(sessionRoutes, { prefix: "/v1" });
   await app.register(disputeRoutes, { prefix: "/v1" });
+  await app.register(dashboardRoutes, { prefix: "/v1" });
 
   return app;
 }

--- a/packages/api/src/tests/integration/campaigns.test.ts
+++ b/packages/api/src/tests/integration/campaigns.test.ts
@@ -578,9 +578,13 @@ describe("Campaign pagination", () => {
     expect(res.statusCode).toBe(200);
     const body = res.json<{
       data: unknown[];
-      pagination: { total: number };
+      pagination: { page: number; perPage: number; total: number; totalPages: number };
     }>();
     expect(body.data).toHaveLength(2);
+    expect(body.pagination.page).toBe(1);
+    expect(body.pagination.perPage).toBe(2);
+    expect(body.pagination.totalPages).toBeGreaterThanOrEqual(1);
+    expect(body.pagination.total).toBeGreaterThanOrEqual(2);
   });
 
   it("GET /v1/campaigns supports search filter", async () => {
@@ -607,6 +611,57 @@ describe("Campaign pagination", () => {
     const body = res.json<{ data: unknown[]; pagination: { page: number; total: number } }>();
     expect(body.data.length).toBe(0);
     expect(body.pagination.page).toBe(9999);
+  });
+
+  it("GET /v1/campaigns?status=active returns only active campaigns", async () => {
+    const token = signToken(app);
+    // Seed: ensure at least one active and one draft
+    const draftRes = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(token),
+      payload: { name: "Status filter draft", type: "digital", defaultCurrency: "EUR" },
+    });
+    expect(draftRes.statusCode).toBe(201);
+    const activeRes = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(token),
+      payload: { name: "Status filter active", type: "digital", defaultCurrency: "EUR" },
+    });
+    expect(activeRes.statusCode).toBe(201);
+    const activeId = activeRes.json<{ data: { id: string } }>().data.id;
+    await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${activeId}`,
+      headers: authHeader(token),
+      payload: { status: "active" },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/campaigns?status=active&perPage=100",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { name: string; status: "draft" | "active" | "closed" }[];
+    }>();
+    expect(body.data.length).toBeGreaterThan(0);
+    for (const c of body.data) {
+      expect(c.status).toBe("active");
+    }
+    expect(body.data.map((c) => c.name)).not.toContain("Status filter draft");
+  });
+
+  it("GET /v1/campaigns?status=invalid returns 400", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/campaigns?status=bogus",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(400);
   });
 });
 

--- a/packages/api/src/tests/integration/campaigns.test.ts
+++ b/packages/api/src/tests/integration/campaigns.test.ts
@@ -116,6 +116,72 @@ describe("Campaigns CRUD", () => {
     expect(body.data.operationalCostCents).toBe(50000);
   });
 
+  it("POST /v1/campaigns persists goalAmountCents and reads it back on the campaign", async () => {
+    const token = signToken(app);
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(token),
+      payload: {
+        name: "Goal Campaign",
+        type: "digital",
+        goalAmountCents: 1_000_000,
+      },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const created = createRes.json<{ data: { id: string; goalAmountCents: number | null } }>();
+    expect(created.data.goalAmountCents).toBe(1_000_000);
+
+    const getRes = await app.inject({
+      method: "GET",
+      url: `/v1/campaigns/${created.data.id}`,
+      headers: authHeader(token),
+    });
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json<{ data: { goalAmountCents: number | null } }>().data.goalAmountCents).toBe(
+      1_000_000,
+    );
+  });
+
+  it("PATCH /v1/campaigns/:id updates goalAmountCents (and supports clearing it)", async () => {
+    const token = signToken(app);
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(token),
+      payload: { name: "Goal Update", type: "digital" },
+    });
+    const id = createRes.json<{ data: { id: string } }>().data.id;
+
+    const setRes = await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${id}`,
+      headers: authHeader(token),
+      payload: { goalAmountCents: 500_000 },
+    });
+    expect(setRes.statusCode).toBe(200);
+    expect(setRes.json<{ data: { goalAmountCents: number | null } }>().data.goalAmountCents).toBe(
+      500_000,
+    );
+
+    const clearRes = await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${id}`,
+      headers: authHeader(token),
+      payload: { goalAmountCents: null },
+    });
+    expect(clearRes.statusCode).toBe(200);
+    // Verify the DB row directly — clearer signal than the API response in
+    // case fast-json-stringify ever mis-serializes the union[integer, null].
+    const { rows: dbRows } = await db.execute<{ goal_amount_cents: number | null }>(
+      sql`SELECT goal_amount_cents FROM campaign_public_pages WHERE campaign_id = ${id}`,
+    );
+    expect(dbRows[0]?.goal_amount_cents).toBeNull();
+    expect(
+      clearRes.json<{ data: { goalAmountCents: number | null } }>().data.goalAmountCents,
+    ).toBeNull();
+  });
+
   it("POST /v1/campaigns rejects non-existent parent UUID", async () => {
     const token = signToken(app);
     const res = await app.inject({

--- a/packages/api/src/tests/integration/dashboard-stats.test.ts
+++ b/packages/api/src/tests/integration/dashboard-stats.test.ts
@@ -1,0 +1,154 @@
+import { sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { getDashboardStats, monthRanges } from "../../modules/dashboard/service.js";
+import { createServer } from "../../server.js";
+import { authHeader, ensureTestTenants, seedTenantUser, signToken } from "../helpers/auth.js";
+
+let app: FastifyInstance;
+const DASHBOARD_ORG = "00000000-0000-0000-0000-000000000125";
+const OTHER_ORG = "00000000-0000-0000-0000-000000000126";
+const DASHBOARD_USER = "00000000-0000-0000-0000-0000000d0101";
+const OTHER_USER = "00000000-0000-0000-0000-0000000d0102";
+
+const ranges = monthRanges();
+const inCurrent = new Date(ranges.current.start.getTime() + 86_400_000);
+const inPrevious = new Date(ranges.previous.start.getTime() + 86_400_000);
+const beforePrevious = new Date(ranges.previous.start.getTime() - 86_400_000);
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+
+  for (const orgId of [DASHBOARD_ORG, OTHER_ORG]) {
+    await db.execute(sql`DELETE FROM outbox_events WHERE tenant_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM donations WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM campaigns WHERE org_id = ${orgId}`);
+    await db.execute(sql`DELETE FROM constituents WHERE org_id = ${orgId}`);
+    await db.execute(
+      sql`INSERT INTO tenants (id, name, slug, base_currency)
+          VALUES (${orgId}, 'Dashboard Org', ${`dashboard-${orgId.slice(-3)}`}, 'EUR')
+          ON CONFLICT (id) DO UPDATE SET base_currency = 'EUR'`,
+    );
+  }
+  // Distinct subs so seedTenantUser's derived rowId doesn't collide
+  // (it slices the orgId — orgs sharing a tail would overwrite each other).
+  await seedTenantUser(DASHBOARD_ORG, { sub: DASHBOARD_USER, email: "dashboard@example.org" });
+  await seedTenantUser(OTHER_ORG, { sub: OTHER_USER, email: "other@example.org" });
+
+  // DASHBOARD_ORG fixtures — known counts/sums per period
+  // Donors: 2 in current, 3 in previous, 1 before (must NOT be counted)
+  await db.execute(sql`
+    INSERT INTO constituents (org_id, first_name, last_name, type, created_at, updated_at)
+    VALUES
+      (${DASHBOARD_ORG}, 'D1', 'Cur', 'donor', ${inCurrent.toISOString()}, ${inCurrent.toISOString()}),
+      (${DASHBOARD_ORG}, 'D2', 'Cur', 'donor', ${inCurrent.toISOString()}, ${inCurrent.toISOString()}),
+      (${DASHBOARD_ORG}, 'D3', 'Prev', 'donor', ${inPrevious.toISOString()}, ${inPrevious.toISOString()}),
+      (${DASHBOARD_ORG}, 'D4', 'Prev', 'donor', ${inPrevious.toISOString()}, ${inPrevious.toISOString()}),
+      (${DASHBOARD_ORG}, 'D5', 'Prev', 'donor', ${inPrevious.toISOString()}, ${inPrevious.toISOString()}),
+      (${DASHBOARD_ORG}, 'D6', 'Old', 'donor', ${beforePrevious.toISOString()}, ${beforePrevious.toISOString()}),
+      (${DASHBOARD_ORG}, 'V1', 'Vol', 'volunteer', ${inCurrent.toISOString()}, ${inCurrent.toISOString()})
+  `);
+
+  // Pick one constituent for donation FK
+  const { rows: donorRows } = await db.execute<{ id: string }>(
+    sql`SELECT id FROM constituents WHERE org_id = ${DASHBOARD_ORG} AND first_name = 'D1' LIMIT 1`,
+  );
+  const donorId = donorRows[0]?.id;
+  if (!donorId) throw new Error("Test setup: D1 donor not found");
+
+  // Donations: 12000 cents total in current (5000 + 7000), 3000 in previous, 999 before
+  await db.execute(sql`
+    INSERT INTO donations (
+      org_id, constituent_id, amount_cents, currency, exchange_rate, amount_base_cents, donated_at
+    )
+    VALUES
+      (${DASHBOARD_ORG}, ${donorId}, 5000, 'EUR', 1.00000000, 5000, ${inCurrent.toISOString()}::timestamptz),
+      (${DASHBOARD_ORG}, ${donorId}, 7000, 'EUR', 1.00000000, 7000, ${inCurrent.toISOString()}::timestamptz),
+      (${DASHBOARD_ORG}, ${donorId}, 3000, 'EUR', 1.00000000, 3000, ${inPrevious.toISOString()}::timestamptz),
+      (${DASHBOARD_ORG}, ${donorId}, 999, 'EUR', 1.00000000, 999, ${beforePrevious.toISOString()}::timestamptz)
+  `);
+
+  // Campaigns: 1 active in current, 2 active in previous, 1 draft in current (must NOT count)
+  await db.execute(sql`
+    INSERT INTO campaigns (org_id, name, type, status, default_currency, created_at, updated_at)
+    VALUES
+      (${DASHBOARD_ORG}, 'C-cur-active', 'digital', 'active', 'EUR', ${inCurrent.toISOString()}, ${inCurrent.toISOString()}),
+      (${DASHBOARD_ORG}, 'C-cur-draft', 'digital', 'draft', 'EUR', ${inCurrent.toISOString()}, ${inCurrent.toISOString()}),
+      (${DASHBOARD_ORG}, 'C-prev-1', 'digital', 'active', 'EUR', ${inPrevious.toISOString()}, ${inPrevious.toISOString()}),
+      (${DASHBOARD_ORG}, 'C-prev-2', 'digital', 'active', 'EUR', ${inPrevious.toISOString()}, ${inPrevious.toISOString()})
+  `);
+
+  // OTHER_ORG fixture — must not leak into DASHBOARD_ORG totals
+  await db.execute(sql`
+    INSERT INTO constituents (org_id, first_name, last_name, type, created_at, updated_at)
+    VALUES (${OTHER_ORG}, 'X1', 'Other', 'donor', ${inCurrent.toISOString()}, ${inCurrent.toISOString()})
+  `);
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe("Dashboard stats — service", () => {
+  it("buckets donations, donors, and active campaigns by current/previous month", async () => {
+    const stats = await getDashboardStats(DASHBOARD_ORG);
+    expect(stats.totalRaisedCents).toEqual({ current: 12000, previous: 3000 });
+    expect(stats.newDonors).toEqual({ current: 2, previous: 3 });
+    expect(stats.newActiveCampaigns).toEqual({ current: 1, previous: 2 });
+  });
+
+  it("isolates tenants — OTHER_ORG donor does not show up in DASHBOARD_ORG stats", async () => {
+    const stats = await getDashboardStats(OTHER_ORG);
+    expect(stats.totalRaisedCents).toEqual({ current: 0, previous: 0 });
+    expect(stats.newDonors.current).toBe(1);
+    expect(stats.newActiveCampaigns).toEqual({ current: 0, previous: 0 });
+  });
+});
+
+describe("Dashboard stats — route", () => {
+  it("GET /v1/dashboard/stats returns the same shape as the service", async () => {
+    const token = signToken(app, { org_id: DASHBOARD_ORG, sub: DASHBOARD_USER });
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/dashboard/stats",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        totalRaisedCents: { current: number; previous: number };
+        newDonors: { current: number; previous: number };
+        newActiveCampaigns: { current: number; previous: number };
+      };
+    }>();
+    expect(body.data.totalRaisedCents).toEqual({ current: 12000, previous: 3000 });
+    expect(body.data.newDonors).toEqual({ current: 2, previous: 3 });
+    expect(body.data.newActiveCampaigns).toEqual({ current: 1, previous: 2 });
+  });
+
+  it("GET /v1/dashboard/stats without auth returns 401", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/dashboard/stats",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("GET /v1/dashboard/stats from another tenant returns that tenant's data", async () => {
+    const token = signToken(app, { org_id: OTHER_ORG, sub: OTHER_USER });
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/dashboard/stats",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { totalRaisedCents: { current: number; previous: number } };
+    }>();
+    expect(body.data.totalRaisedCents).toEqual({ current: 0, previous: 0 });
+  });
+});

--- a/packages/api/src/tests/integration/donations.test.ts
+++ b/packages/api/src/tests/integration/donations.test.ts
@@ -221,6 +221,66 @@ describe("Donations CRUD", () => {
     expect(res.json().data).toBeInstanceOf(Array);
   });
 
+  it("GET /v1/donations?receiptStatus=generated returns only donations with a generated receipt", async () => {
+    const tokenA = signToken(app);
+    // Create a donation, then directly insert a 'generated' receipt for it
+    const donRes = await app.inject({
+      method: "POST",
+      url: "/v1/donations",
+      headers: authHeader(tokenA),
+      payload: {
+        constituentId: constituentIdA,
+        amountCents: 4242,
+        currency: "EUR",
+      },
+    });
+    expect(donRes.statusCode).toBe(201);
+    const seededDonationId = donRes.json<{ data: { id: string } }>().data.id;
+    // Receipt numbers are unique per (org, fiscal_year) — derive from the
+    // donation ID so re-runs against a persistent DB don't collide.
+    const receiptNumber = `TEST-FILTER-${seededDonationId.slice(0, 8)}`;
+    await db.execute(sql`
+      INSERT INTO receipts (org_id, donation_id, receipt_number, fiscal_year, s3_path, status)
+      VALUES (${ORG_A}, ${seededDonationId}, ${receiptNumber}, 2026, 's3://test/path', 'generated')
+    `);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/donations?receiptStatus=generated&perPage=100",
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { id: string; receiptStatus: "generated" | "pending" | "failed" | null }[];
+    }>();
+    expect(body.data.length).toBeGreaterThan(0);
+    for (const d of body.data) {
+      expect(d.receiptStatus).toBe("generated");
+    }
+    expect(body.data.map((d) => d.id)).toContain(seededDonationId);
+  });
+
+  it("GET /v1/donations?receiptStatus=invalid returns 400", async () => {
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/donations?receiptStatus=bogus",
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("GET /v1/donations?search=<201 chars> returns 400", async () => {
+    const tokenA = signToken(app);
+    const longSearch = "a".repeat(201);
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/donations?search=${longSearch}`,
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
   it("GET /v1/donations/:id returns donation with constituent and allocations", async () => {
     const tokenA = signToken(app);
     const res = await app.inject({

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -144,7 +144,11 @@ export const CampaignCreateSchema = Type.Object({
   ]),
   defaultCurrency: Type.Optional(MultiCurrencySchema),
   parentId: Type.Optional(Type.Union([Type.String({ format: "uuid" }), Type.Null()])),
-  operationalCostCents: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+  // Type.Null() comes first in the union: AJV otherwise coerces JSON `null`
+  // into 0 when validating the body, which silently turns "clear the value"
+  // into "set it to zero" (cf. PR #204 review).
+  operationalCostCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
+  goalAmountCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
 });
 
 /** Schema for updating a campaign (all fields optional) */

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, CircleHelp, Gift, Globe, Pencil } from "lucide-react";
+import { ArrowLeft, CircleHelp, Gift, Globe, Pencil, Trophy } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
@@ -216,16 +216,27 @@ async function StatsCard({
       </CardHeader>
       <CardContent className="space-y-4">
         <dl className="space-y-4">
-          <StatRow
-            label={t("stats.raised")}
-            value={formatCurrency(roiMetrics.rawRaisedCents, locale)}
-            hint={t("stats.goalHint", {
-              goal:
-                campaign.goalAmountCents !== null
-                  ? formatCurrency(campaign.goalAmountCents, locale)
-                  : t("stats.noGoal"),
-            })}
-          />
+          {campaign.goalAmountCents && campaign.goalAmountCents > 0 ? (
+            <GoalProgressRow
+              raisedCents={roiMetrics.rawRaisedCents}
+              goalCents={campaign.goalAmountCents}
+              locale={locale}
+              labels={{
+                raised: t("stats.raised"),
+                progressLabel: t("stats.goalProgressLabel"),
+                caption: (progress, goal) => t("stats.goalProgressCaption", { progress, goal }),
+                aria: (raised, goal) => t("stats.goalProgressAria", { raised, goal }),
+                remaining: (amount) => t("stats.goalRemaining", { amount }),
+                reached: t("stats.goalReached"),
+              }}
+            />
+          ) : (
+            <StatRow
+              label={t("stats.raised")}
+              value={formatCurrency(roiMetrics.rawRaisedCents, locale)}
+              hint={t("stats.goalHint", { goal: t("stats.noGoal") })}
+            />
+          )}
           <StatRow
             label={t("stats.donors")}
             value={formatNumber(stats.uniqueDonors, locale)}
@@ -241,6 +252,75 @@ async function StatsCard({
         </dl>
       </CardContent>
     </Card>
+  );
+}
+
+interface GoalProgressLabels {
+  raised: string;
+  progressLabel: string;
+  caption: (progress: number, goal: string) => string;
+  aria: (raised: string, goal: string) => string;
+  remaining: (amount: string) => string;
+  reached: string;
+}
+
+function GoalProgressRow({
+  raisedCents,
+  goalCents,
+  locale,
+  labels,
+}: {
+  raisedCents: number;
+  goalCents: number;
+  locale: string;
+  labels: GoalProgressLabels;
+}) {
+  const ratio = raisedCents / goalCents;
+  const progress = Math.round(ratio * 100);
+  const cappedProgress = Math.min(progress, 100);
+  const remainingCents = Math.max(goalCents - raisedCents, 0);
+  const reached = raisedCents >= goalCents;
+  const raisedFormatted = formatCurrency(raisedCents, locale);
+  const goalFormatted = formatCurrency(goalCents, locale);
+
+  return (
+    <div className="rounded-xl bg-surface-container p-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <dt className="text-sm text-on-surface-variant">{labels.raised}</dt>
+        {reached ? (
+          <Badge variant="success" className="gap-1 text-[10px] uppercase tracking-wide">
+            <Trophy size={12} aria-hidden="true" />
+            {labels.reached}
+          </Badge>
+        ) : null}
+      </div>
+      <dd className="mt-1 font-mono text-2xl font-semibold tabular-nums text-on-surface">
+        {raisedFormatted}
+      </dd>
+      <div
+        className="mt-3 h-2 overflow-hidden rounded-md bg-surface-container-highest"
+        role="progressbar"
+        aria-valuenow={cappedProgress}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={labels.aria(raisedFormatted, goalFormatted)}
+      >
+        <div
+          className={`h-full rounded-md transition-all duration-500 ease-out ${
+            reached ? "bg-success" : "bg-secondary"
+          }`}
+          style={{ width: `${cappedProgress}%` }}
+        />
+      </div>
+      <p className="mt-2 flex items-center justify-between gap-2 text-xs text-on-surface-variant">
+        <span>{labels.caption(progress, goalFormatted)}</span>
+        {!reached ? (
+          <span className="font-mono tabular-nums">
+            {labels.remaining(formatCurrency(remainingCents, locale))}
+          </span>
+        ) : null}
+      </p>
+    </div>
   );
 }
 

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, CircleHelp, Gift, Globe, Pencil, Trophy } from "lucide-react";
+import { ArrowLeft, Gift, Globe, Pencil, Trophy } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
@@ -6,11 +6,11 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { CampaignRoiChart } from "@/components/campaigns/campaign-roi-chart";
 import { CampaignStatusActions } from "@/components/campaigns/campaign-status-actions";
 import { EmptyState } from "@/components/shared/empty-state";
+import { InfoTooltipButton } from "@/components/shared/info-tooltip-button";
 import { PageHeader } from "@/components/shared/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { hasPermission, requireAuth } from "@/lib/auth/guards";
@@ -348,22 +348,10 @@ async function CostBreakdownCard({
         <CardHeader className="gap-2">
           <div className="flex items-center gap-2">
             <CardTitle>{t("roi.breakdownTitle")}</CardTitle>
-            <TooltipProvider delayDuration={150}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    className="inline-flex size-7 items-center justify-center rounded-full text-on-surface-variant transition-colors hover:bg-surface-container hover:text-on-surface"
-                    aria-label={t("roi.breakdownTooltipLabel")}
-                  >
-                    <CircleHelp size={16} aria-hidden="true" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="max-w-72 text-sm leading-relaxed">
-                  {t("roi.breakdownTooltip")}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <InfoTooltipButton
+              ariaLabel={t("roi.breakdownTooltipLabel")}
+              content={t("roi.breakdownTooltip")}
+            />
           </div>
           <CardDescription>{t("roi.breakdownSubtitle")}</CardDescription>
         </CardHeader>

--- a/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
+++ b/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
@@ -102,15 +102,20 @@ export function CampaignsTable({
   const tFilters = useTranslations("campaigns.filters");
   const [closeTarget, setCloseTarget] = useState<Campaign | null>(null);
   const [isClosing, setIsClosing] = useState(false);
-  const [searchTerm, setSearchTerm] = useState(() => searchParams.get("search") ?? "");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const initialSearch = searchParams.get("search") ?? "";
+  const initialStatus = searchParams.get("status") ?? "all";
+  const [searchTerm, setSearchTerm] = useState(initialSearch);
 
+  // Server-side search: debounce keystrokes then push the new ?search= param
+  // to the URL so the page re-fetches with consistent server pagination.
+  // Excluding `searchParams` from deps is intentional — re-running on every
+  // navigation would queue redundant timers; the input value is the only
+  // signal that should restart the debounce.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
   useEffect(() => {
+    if (searchTerm === initialSearch) return;
     const timer = setTimeout(() => {
       const params = new URLSearchParams(searchParams.toString());
-      const currentSearch = params.get("search") ?? "";
-      if (searchTerm === currentSearch) return;
-
       if (searchTerm) {
         params.set("search", searchTerm);
       } else {
@@ -121,14 +126,22 @@ export function CampaignsTable({
       router.push(query ? `${pathname}?${query}` : pathname);
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchTerm, pathname, router, searchParams]);
+  }, [searchTerm]);
 
-  const filteredCampaigns = useMemo(() => {
-    return campaigns.filter((c) => {
-      const matchesStatus = statusFilter === "all" || c.campaign.status === statusFilter;
-      return matchesStatus;
-    });
-  }, [campaigns, statusFilter]);
+  const updateStatus = useCallback(
+    (next: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next && next !== "all") {
+        params.set("status", next);
+      } else {
+        params.delete("status");
+      }
+      params.delete("page");
+      const query = params.toString();
+      router.push(query ? `${pathname}?${query}` : pathname);
+    },
+    [pathname, router, searchParams],
+  );
 
   const navigateToPage = useCallback(
     (page: number) => {
@@ -306,13 +319,14 @@ export function CampaignsTable({
           />
           <Input
             placeholder={tFilters("searchPlaceholder")}
+            aria-label={tFilters("searchPlaceholder")}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="pl-9"
           />
         </div>
-        <Select value={statusFilter} onValueChange={setStatusFilter}>
-          <SelectTrigger className="w-full sm:w-[180px]">
+        <Select value={initialStatus} onValueChange={updateStatus}>
+          <SelectTrigger className="w-full sm:w-[180px]" aria-label={tFilters("statusLabel")}>
             <SelectValue placeholder={tFilters("allStatuses")} />
           </SelectTrigger>
           <SelectContent>
@@ -327,7 +341,7 @@ export function CampaignsTable({
       <div className="transition-opacity duration-normal">
         <DataTable
           columns={columns}
-          data={filteredCampaigns}
+          data={campaigns}
           pagination={pagination}
           onPageChange={navigateToPage}
           onRowClick={(row) => router.push(`/campaigns/${row.original.campaign.id}`)}

--- a/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
+++ b/packages/web/src/app/(app)/campaigns/campaigns-table.tsx
@@ -98,6 +98,8 @@ export function CampaignsTable({
   const searchParams = useSearchParams();
   const locale = useLocale();
   const t = useTranslations("campaigns");
+  const tStatus = useTranslations("campaigns.status");
+  const tFilters = useTranslations("campaigns.filters");
   const [closeTarget, setCloseTarget] = useState<Campaign | null>(null);
   const [isClosing, setIsClosing] = useState(false);
   const [searchTerm, setSearchTerm] = useState(() => searchParams.get("search") ?? "");
@@ -303,7 +305,7 @@ export function CampaignsTable({
             size={16}
           />
           <Input
-            placeholder="Rechercher une campagne..."
+            placeholder={tFilters("searchPlaceholder")}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="pl-9"
@@ -311,13 +313,13 @@ export function CampaignsTable({
         </div>
         <Select value={statusFilter} onValueChange={setStatusFilter}>
           <SelectTrigger className="w-full sm:w-[180px]">
-            <SelectValue placeholder="Tous les statuts" />
+            <SelectValue placeholder={tFilters("allStatuses")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Tous les statuts</SelectItem>
-            <SelectItem value="draft">Brouillon</SelectItem>
-            <SelectItem value="active">Actif</SelectItem>
-            <SelectItem value="closed">Fermé</SelectItem>
+            <SelectItem value="all">{tFilters("allStatuses")}</SelectItem>
+            <SelectItem value="draft">{tStatus("draft")}</SelectItem>
+            <SelectItem value="active">{tStatus("active")}</SelectItem>
+            <SelectItem value="closed">{tStatus("closed")}</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/packages/web/src/app/(app)/campaigns/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/page.tsx
@@ -37,6 +37,11 @@ export default async function CampaignsPage({ searchParams }: CampaignsPageProps
   const page = parsePositiveInt(params.page, 1);
   const perPage = parsePositiveInt(params.perPage, DEFAULT_PER_PAGE, MAX_PER_PAGE);
   const searchValue = Array.isArray(params.search) ? params.search[0] : params.search;
+  const rawStatus = Array.isArray(params.status) ? params.status[0] : params.status;
+  const statusValue =
+    rawStatus === "draft" || rawStatus === "active" || rawStatus === "closed"
+      ? rawStatus
+      : undefined;
 
   const client = await createServerApiClient();
 
@@ -46,6 +51,7 @@ export default async function CampaignsPage({ searchParams }: CampaignsPageProps
       page,
       perPage,
       search: searchValue,
+      status: statusValue,
     });
   } catch (err) {
     if (err instanceof ApiProblem && (err.status === 401 || err.status === 403)) {

--- a/packages/web/src/app/(app)/constituents/constituents-table.tsx
+++ b/packages/web/src/app/(app)/constituents/constituents-table.tsx
@@ -93,15 +93,17 @@ export function ConstituentsTable({
   const tFilters = useTranslations("constituents.filters");
   const [deleteTarget, setDeleteTarget] = useState<Constituent | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [searchTerm, setSearchTerm] = useState(() => searchParams.get("search") ?? "");
-  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const initialSearch = searchParams.get("search") ?? "";
+  const initialType = searchParams.get("type") ?? "all";
+  const [searchTerm, setSearchTerm] = useState(initialSearch);
 
+  // Server-side search: see campaigns-table.tsx for the rationale on why
+  // `searchParams` is excluded from the deps.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
   useEffect(() => {
+    if (searchTerm === initialSearch) return;
     const timer = setTimeout(() => {
       const params = new URLSearchParams(searchParams.toString());
-      const currentSearch = params.get("search") ?? "";
-      if (searchTerm === currentSearch) return;
-
       if (searchTerm) {
         params.set("search", searchTerm);
       } else {
@@ -112,14 +114,22 @@ export function ConstituentsTable({
       router.push(query ? `${pathname}?${query}` : pathname);
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchTerm, pathname, router, searchParams]);
+  }, [searchTerm]);
 
-  const filteredConstituents = useMemo(() => {
-    return constituents.filter((c) => {
-      const matchesType = typeFilter === "all" || c.type === typeFilter;
-      return matchesType;
-    });
-  }, [constituents, typeFilter]);
+  const updateType = useCallback(
+    (next: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next && next !== "all") {
+        params.set("type", next);
+      } else {
+        params.delete("type");
+      }
+      params.delete("page");
+      const query = params.toString();
+      router.push(query ? `${pathname}?${query}` : pathname);
+    },
+    [pathname, router, searchParams],
+  );
 
   const navigateToPage = useCallback(
     (page: number) => {
@@ -262,13 +272,14 @@ export function ConstituentsTable({
           />
           <Input
             placeholder={tFilters("searchPlaceholder")}
+            aria-label={tFilters("searchPlaceholder")}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="pl-9"
           />
         </div>
-        <Select value={typeFilter} onValueChange={setTypeFilter}>
-          <SelectTrigger className="w-full sm:w-[180px]">
+        <Select value={initialType} onValueChange={updateType}>
+          <SelectTrigger className="w-full sm:w-[180px]" aria-label={tFilters("typeLabel")}>
             <SelectValue placeholder={tFilters("allTypes")} />
           </SelectTrigger>
           <SelectContent>
@@ -285,7 +296,7 @@ export function ConstituentsTable({
       <div className="transition-opacity duration-normal">
         <DataTable
           columns={columns}
-          data={filteredConstituents}
+          data={constituents}
           pagination={pagination}
           onPageChange={navigateToPage}
           onRowClick={(row) => router.push(`/constituents/${row.original.id}`)}

--- a/packages/web/src/app/(app)/constituents/constituents-table.tsx
+++ b/packages/web/src/app/(app)/constituents/constituents-table.tsx
@@ -90,6 +90,7 @@ export function ConstituentsTable({
   const searchParams = useSearchParams();
   const t = useTranslations("constituents");
   const tType = useTranslations("constituents.types");
+  const tFilters = useTranslations("constituents.filters");
   const [deleteTarget, setDeleteTarget] = useState<Constituent | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [searchTerm, setSearchTerm] = useState(() => searchParams.get("search") ?? "");
@@ -200,7 +201,7 @@ export function ConstituentsTable({
       {
         id: "tags",
         accessorKey: "tags",
-        header: () => t("columns.tags") || "Tags",
+        header: () => t("columns.tags"),
         enableSorting: false,
         cell: ({ row }) => {
           const tags = row.original.tags;
@@ -260,7 +261,7 @@ export function ConstituentsTable({
             size={16}
           />
           <Input
-            placeholder="Rechercher un contact..."
+            placeholder={tFilters("searchPlaceholder")}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="pl-9"
@@ -268,15 +269,15 @@ export function ConstituentsTable({
         </div>
         <Select value={typeFilter} onValueChange={setTypeFilter}>
           <SelectTrigger className="w-full sm:w-[180px]">
-            <SelectValue placeholder="Tous les types" />
+            <SelectValue placeholder={tFilters("allTypes")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Tous les types</SelectItem>
-            <SelectItem value="donor">Donateur</SelectItem>
-            <SelectItem value="volunteer">Bénévole</SelectItem>
-            <SelectItem value="member">Membre</SelectItem>
-            <SelectItem value="beneficiary">Bénéficiaire</SelectItem>
-            <SelectItem value="partner">Partenaire</SelectItem>
+            <SelectItem value="all">{tFilters("allTypes")}</SelectItem>
+            <SelectItem value="donor">{tType("donor")}</SelectItem>
+            <SelectItem value="volunteer">{tType("volunteer")}</SelectItem>
+            <SelectItem value="member">{tType("member")}</SelectItem>
+            <SelectItem value="beneficiary">{tType("beneficiary")}</SelectItem>
+            <SelectItem value="partner">{tType("partner")}</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/packages/web/src/app/(app)/constituents/page.tsx
+++ b/packages/web/src/app/(app)/constituents/page.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { hasPermission, requireAuth } from "@/lib/auth/guards";
-import type { ConstituentListResponse } from "@/models/constituent";
+import type { ConstituentListResponse, ConstituentType } from "@/models/constituent";
 import { ConstituentService } from "@/services/ConstituentService";
 
 import { ConstituentsTable } from "./constituents-table";
@@ -38,6 +38,15 @@ export default async function ConstituentsPage({ searchParams }: ConstituentsPag
   const page = parsePositiveInt(params.page, 1);
   const perPage = parsePositiveInt(params.perPage, DEFAULT_PER_PAGE, MAX_PER_PAGE);
   const searchValue = Array.isArray(params.search) ? params.search[0] : params.search;
+  const rawType = Array.isArray(params.type) ? params.type[0] : params.type;
+  const ALLOWED_TYPES: readonly ConstituentType[] = [
+    "donor",
+    "volunteer",
+    "member",
+    "beneficiary",
+    "partner",
+  ];
+  const typeValue = ALLOWED_TYPES.find((t) => t === rawType);
 
   const client = await createServerApiClient();
 
@@ -47,6 +56,7 @@ export default async function ConstituentsPage({ searchParams }: ConstituentsPag
       page,
       perPage,
       search: searchValue,
+      type: typeValue,
     });
   } catch (err) {
     if (err instanceof ApiProblem && (err.status === 401 || err.status === 403)) {

--- a/packages/web/src/app/(app)/dashboard/page.tsx
+++ b/packages/web/src/app/(app)/dashboard/page.tsx
@@ -12,19 +12,20 @@ import {
 import Link from "next/link";
 import { getLocale, getTranslations } from "next-intl/server";
 
+import { StatCardTrend } from "@/components/dashboard/stat-card-trend";
 import { EmptyState } from "@/components/shared/empty-state";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { hasPermission, requireAuth } from "@/lib/auth/guards";
 import { formatCurrency, formatDate, formatNumber } from "@/lib/format";
 import type { Campaign, CampaignStats } from "@/models/campaign";
-import type { ConstituentListResponse } from "@/models/constituent";
+import type { DashboardPeriod } from "@/models/dashboard";
 import type { DonationListRow } from "@/models/donation";
 import { donationDonorName } from "@/models/donation";
 import { CampaignService } from "@/services/CampaignService";
 import { ConstituentService } from "@/services/ConstituentService";
+import { DashboardService } from "@/services/DashboardService";
 import { DonationService } from "@/services/DonationService";
 
 const RECENT_DONATIONS_LIMIT = 5;
@@ -53,7 +54,7 @@ export default async function DashboardPage() {
   const locale = await getLocale();
   const client = await createServerApiClient();
 
-  const [recentDonations, kpiDonations, donorResult, activeCampaigns] = await Promise.all([
+  const [recentDonations, kpiDonations, donorResult, activeCampaigns, stats] = await Promise.all([
     getSafeData(() =>
       DonationService.listDonations(client, { page: 1, perPage: RECENT_DONATIONS_LIMIT }),
     ),
@@ -70,16 +71,22 @@ export default async function DashboardPage() {
     getSafeData(() =>
       CampaignService.listCampaigns(client, { page: 1, perPage: 5, status: "active" }),
     ),
+    getSafeData(() => DashboardService.getStats(client)),
   ]);
 
   const activeCampaignStats = await getActiveCampaignStats(activeCampaigns?.data ?? []);
-  const totalRaisedCents = (kpiDonations?.data ?? []).reduce(
-    (sum, donation) => sum + donation.amountCents,
-    0,
-  );
+  const totalRaisedCents = stats?.totalRaisedCents.current ?? 0;
   const primaryCurrency = kpiDonations?.data[0]?.currency ?? "EUR";
-  const newDonorsThisMonth = countCreatedThisMonth(donorResult?.data ?? []);
+  const newDonorsThisMonth = stats?.newDonors.current ?? 0;
   const activeCampaignCount = activeCampaigns?.pagination.total ?? 0;
+  const trendLabel = t("stats.trendLabel");
+  const trendRaised = buildTrend(stats?.totalRaisedCents, trendLabel, (cents) =>
+    formatCurrency(cents, locale, primaryCurrency),
+  );
+  const trendCampaigns = buildTrend(stats?.newActiveCampaigns, trendLabel, (n) =>
+    formatNumber(n, locale),
+  );
+  const trendDonors = buildTrend(stats?.newDonors, trendLabel, (n) => formatNumber(n, locale));
 
   return (
     <div className="space-y-6 sm:space-y-8">
@@ -103,7 +110,7 @@ export default async function DashboardPage() {
           valueClassName="font-mono"
           icon={Banknote}
           color="primary"
-          trend={{ value: 14, label: "vs mois précédent" }}
+          trend={trendRaised}
         />
         <StatCard
           label={t("stats.activeCampaigns")}
@@ -111,7 +118,7 @@ export default async function DashboardPage() {
           description={t("stats.activeCampaignsHint")}
           icon={Megaphone}
           color="secondary"
-          trend={{ value: 5, label: "vs mois précédent" }}
+          trend={trendCampaigns}
         />
         <StatCard
           label={t("stats.donors")}
@@ -119,7 +126,7 @@ export default async function DashboardPage() {
           description={t("stats.newDonorsThisMonth", { count: newDonorsThisMonth })}
           icon={Users}
           color="tertiary"
-          trend={{ value: 2, label: "vs mois précédent" }}
+          trend={trendDonors}
         />
         <StatCard
           label={t("stats.grantDeadlines")}
@@ -246,10 +253,24 @@ async function getSafeData<T>(loader: () => Promise<T>): Promise<T | null> {
   }
 }
 
-function countCreatedThisMonth(constituents: ConstituentListResponse["data"]) {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), now.getMonth(), 1);
-  return constituents.filter((constituent) => new Date(constituent.createdAt) >= start).length;
+function buildTrend(
+  period: DashboardPeriod | undefined,
+  label: string,
+  format: (n: number) => string,
+): TrendProp | undefined {
+  if (!period || period.previous === 0) return undefined;
+  const value = Math.round(((period.current - period.previous) / period.previous) * 100);
+  return {
+    value,
+    label,
+    detail: { current: format(period.current), previous: format(period.previous) },
+  };
+}
+
+interface TrendProp {
+  value: number;
+  label: string;
+  detail: { current: string; previous: string };
 }
 
 function SectionHeader({
@@ -293,7 +314,7 @@ function StatCard({
   valueClassName?: string;
   icon?: React.ElementType;
   color?: "primary" | "secondary" | "tertiary" | "neutral";
-  trend?: { value: number; label: string };
+  trend?: TrendProp;
 }) {
   const colorStyles = {
     primary: "bg-primary-fixed text-on-primary-fixed-variant",
@@ -308,15 +329,7 @@ function StatCard({
         <p className="text-sm font-medium text-on-surface-variant">{label}</p>
         <div className="flex items-center gap-2">
           {trend ? (
-            <div title={trend.label}>
-              <Badge
-                variant={trend.value >= 0 ? "success" : "error"}
-                className="text-[10px] px-1.5 py-0 h-5"
-              >
-                {trend.value > 0 ? "+" : ""}
-                {trend.value}%
-              </Badge>
-            </div>
+            <StatCardTrend value={trend.value} label={trend.label} detail={trend.detail} />
           ) : null}
           {Icon ? (
             <div

--- a/packages/web/src/app/(app)/dashboard/page.tsx
+++ b/packages/web/src/app/(app)/dashboard/page.tsx
@@ -324,7 +324,7 @@ function StatCard({
   };
 
   return (
-    <article className="min-h-36 rounded-2xl bg-surface-container-lowest p-5 shadow-card group">
+    <article className="min-h-36 rounded-2xl bg-surface-container-lowest p-5 shadow-card">
       <div className="flex items-center justify-between">
         <p className="text-sm font-medium text-on-surface-variant">{label}</p>
         <div className="flex items-center gap-2">
@@ -333,7 +333,7 @@ function StatCard({
           ) : null}
           {Icon ? (
             <div
-              className={`flex h-10 w-10 items-center justify-center rounded-xl transition-transform group-hover:scale-105 ${colorStyles[color]}`}
+              className={`flex h-10 w-10 items-center justify-center rounded-xl ${colorStyles[color]}`}
             >
               <Icon size={20} aria-hidden="true" />
             </div>

--- a/packages/web/src/app/(app)/donations/donations-table.tsx
+++ b/packages/web/src/app/(app)/donations/donations-table.tsx
@@ -67,6 +67,8 @@ export function DonationsTable({
   const searchParams = useSearchParams();
   const locale = useLocale();
   const t = useTranslations("donations");
+  const tReceipt = useTranslations("donations.receiptStatus");
+  const tFilters = useTranslations("donations.filters");
   const [donationToDelete, setDonationToDelete] = useState<DonationListRow | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [searchTerm, setSearchTerm] = useState(() => searchParams.get("search") ?? "");
@@ -238,7 +240,7 @@ export function DonationsTable({
             size={16}
           />
           <Input
-            placeholder="Rechercher un donateur..."
+            placeholder={tFilters("searchPlaceholder")}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="pl-9"
@@ -246,13 +248,13 @@ export function DonationsTable({
         </div>
         <Select value={receiptFilter} onValueChange={setReceiptFilter}>
           <SelectTrigger className="w-full sm:w-[180px]">
-            <SelectValue placeholder="Reçus" />
+            <SelectValue placeholder={tFilters("receiptLabel")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Tous les reçus</SelectItem>
-            <SelectItem value="generated">Générés</SelectItem>
-            <SelectItem value="pending">En attente</SelectItem>
-            <SelectItem value="failed">En erreur</SelectItem>
+            <SelectItem value="all">{tFilters("allReceipts")}</SelectItem>
+            <SelectItem value="generated">{tReceipt("generated")}</SelectItem>
+            <SelectItem value="pending">{tReceipt("pending")}</SelectItem>
+            <SelectItem value="failed">{tReceipt("failed")}</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/packages/web/src/app/(app)/donations/donations-table.tsx
+++ b/packages/web/src/app/(app)/donations/donations-table.tsx
@@ -71,15 +71,17 @@ export function DonationsTable({
   const tFilters = useTranslations("donations.filters");
   const [donationToDelete, setDonationToDelete] = useState<DonationListRow | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [searchTerm, setSearchTerm] = useState(() => searchParams.get("search") ?? "");
-  const [receiptFilter, setReceiptFilter] = useState<string>("all");
+  const initialSearch = searchParams.get("search") ?? "";
+  const initialReceipt = searchParams.get("receiptStatus") ?? "all";
+  const [searchTerm, setSearchTerm] = useState(initialSearch);
 
+  // Server-side search: see campaigns-table.tsx for the rationale on why
+  // `searchParams` is excluded from the deps.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
   useEffect(() => {
+    if (searchTerm === initialSearch) return;
     const timer = setTimeout(() => {
       const params = new URLSearchParams(searchParams.toString());
-      const currentSearch = params.get("search") ?? "";
-      if (searchTerm === currentSearch) return;
-
       if (searchTerm) {
         params.set("search", searchTerm);
       } else {
@@ -90,14 +92,22 @@ export function DonationsTable({
       router.push(query ? `${pathname}?${query}` : pathname);
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchTerm, pathname, router, searchParams]);
+  }, [searchTerm]);
 
-  const filteredDonations = useMemo(() => {
-    return donations.filter((d) => {
-      const matchesReceipt = receiptFilter === "all" || d.receiptStatus === receiptFilter;
-      return matchesReceipt;
-    });
-  }, [donations, receiptFilter]);
+  const updateReceipt = useCallback(
+    (next: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next && next !== "all") {
+        params.set("receiptStatus", next);
+      } else {
+        params.delete("receiptStatus");
+      }
+      params.delete("page");
+      const query = params.toString();
+      router.push(query ? `${pathname}?${query}` : pathname);
+    },
+    [pathname, router, searchParams],
+  );
 
   const navigateToPage = useCallback(
     (page: number) => {
@@ -241,13 +251,14 @@ export function DonationsTable({
           />
           <Input
             placeholder={tFilters("searchPlaceholder")}
+            aria-label={tFilters("searchPlaceholder")}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="pl-9"
           />
         </div>
-        <Select value={receiptFilter} onValueChange={setReceiptFilter}>
-          <SelectTrigger className="w-full sm:w-[180px]">
+        <Select value={initialReceipt} onValueChange={updateReceipt}>
+          <SelectTrigger className="w-full sm:w-[180px]" aria-label={tFilters("receiptLabel")}>
             <SelectValue placeholder={tFilters("receiptLabel")} />
           </SelectTrigger>
           <SelectContent>
@@ -262,7 +273,7 @@ export function DonationsTable({
       <div className="transition-opacity duration-normal">
         <DataTable
           columns={columns}
-          data={filteredDonations}
+          data={donations}
           pagination={pagination}
           onPageChange={navigateToPage}
           onRowClick={(row) => router.push(`/donations/${row.original.id}`)}

--- a/packages/web/src/app/(app)/donations/page.tsx
+++ b/packages/web/src/app/(app)/donations/page.tsx
@@ -55,6 +55,13 @@ export default async function DonationsPage({ searchParams }: DonationsPageProps
   const dateTo = parseIsoDate(params.dateTo);
   const campaignId = parseUuid(params.campaignId);
   const constituentId = parseUuid(params.constituentId);
+  const rawReceipt = Array.isArray(params.receiptStatus)
+    ? params.receiptStatus[0]
+    : params.receiptStatus;
+  const receiptStatusValue =
+    rawReceipt === "pending" || rawReceipt === "generated" || rawReceipt === "failed"
+      ? rawReceipt
+      : undefined;
 
   const client = await createServerApiClient();
 
@@ -68,6 +75,7 @@ export default async function DonationsPage({ searchParams }: DonationsPageProps
       dateTo,
       campaignId,
       constituentId,
+      receiptStatus: receiptStatusValue,
     });
   } catch (err) {
     if (err instanceof ApiProblem && (err.status === 401 || err.status === 403)) {

--- a/packages/web/src/components/dashboard/stat-card-trend.tsx
+++ b/packages/web/src/components/dashboard/stat-card-trend.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+export interface StatCardTrendProps {
+  /** Rounded percentage change between current and previous period. */
+  value: number;
+  /** Short label shown in the tooltip (e.g. "vs previous month"). */
+  label: string;
+  /** Formatted current and previous values displayed in the tooltip. */
+  detail?: { current: string; previous: string };
+}
+
+export function StatCardTrend({ value, label, detail }: StatCardTrendProps) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            aria-label={`${value > 0 ? "+" : ""}${value}% — ${label}`}
+          >
+            <Badge
+              variant={value >= 0 ? "success" : "error"}
+              className="text-[10px] px-1.5 py-0 h-5"
+            >
+              {value > 0 ? "+" : ""}
+              {value}%
+            </Badge>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-64 text-xs leading-relaxed">
+          <p className="font-medium">{label}</p>
+          {detail ? (
+            <p className="mt-1 font-mono tabular-nums opacity-80">
+              {detail.previous} → {detail.current}
+            </p>
+          ) : null}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/packages/web/src/components/shared/info-tooltip-button.tsx
+++ b/packages/web/src/components/shared/info-tooltip-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { CircleHelp } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+export interface InfoTooltipButtonProps {
+  /** Accessible name for the trigger (e.g. "Explain campaign cost breakdown"). */
+  ariaLabel: string;
+  /** Tooltip body text rendered on hover / focus. */
+  content: string;
+}
+
+/**
+ * Small "i" helper rendered next to a heading. Wraps Radix Tooltip in a
+ * client component so it can be safely embedded inside an async Server
+ * Component without triggering a hydration mismatch on the Radix-generated
+ * `contentId` / `data-state` / event-handler attributes.
+ */
+export function InfoTooltipButton({ ariaLabel, content }: InfoTooltipButtonProps) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex size-7 items-center justify-center rounded-full text-on-surface-variant transition-colors hover:bg-surface-container hover:text-on-surface"
+            aria-label={ariaLabel}
+          >
+            <CircleHelp size={16} aria-hidden="true" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-72 text-sm leading-relaxed">
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1385,6 +1385,11 @@
         "created": "Created",
         "noGoal": "No goal",
         "goalHint": "Goal: {goal}",
+        "goalProgressLabel": "Progress to goal",
+        "goalProgressCaption": "{progress}% of {goal}",
+        "goalProgressAria": "{raised} raised of {goal}",
+        "goalRemaining": "{amount} left to reach the goal",
+        "goalReached": "Goal reached",
         "donationsHint": "{count, plural, =0 {No donations yet} one {# donation recorded} other {# donations recorded}}",
         "updatedHint": "Updated {date}"
       },

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -381,7 +381,7 @@
           "createdAt": "Created at",
           "updatedAt": "Last updated",
           "actions": "Actions",
-      "tags": "Tags"
+          "tags": "Tags"
         },
         "statuses": {
           "active": "Active",
@@ -658,7 +658,7 @@
         "createdAt": "Invited",
         "joinedAt": "Joined",
         "actions": "Actions",
-      "tags": "Tags"
+        "tags": "Tags"
       },
       "roles": {
         "org_admin": "Admin",
@@ -781,7 +781,7 @@
         "description": "Description",
         "createdAt": "Created",
         "actions": "Actions",
-      "tags": "Tags"
+        "tags": "Tags"
       },
       "actions": {
         "new": "New fund",
@@ -931,7 +931,8 @@
       "newDonorsThisMonth": "{count, plural, =0 {No new donors this month} one {# new donor this month} other {# new donors this month}}",
       "grantDeadlines": "Grant deadlines",
       "noGrantDeadlinesValue": "0",
-      "noGrantDeadlinesHint": "Grant tracking is coming in a later sprint."
+      "noGrantDeadlinesHint": "Grant tracking is coming in a later sprint.",
+      "trendLabel": "vs previous month"
     },
     "recentDonations": {
       "title": "Recent donations",
@@ -992,7 +993,10 @@
     },
     "filters": {
       "dateFrom": "From",
-      "dateTo": "To"
+      "dateTo": "To",
+      "searchPlaceholder": "Search a donor…",
+      "receiptLabel": "Receipts",
+      "allReceipts": "All receipts"
     },
     "actions": {
       "new": "New donation",
@@ -1153,6 +1157,11 @@
       "beneficiary": "Beneficiary",
       "partner": "Partner"
     },
+    "filters": {
+      "searchPlaceholder": "Search a contact…",
+      "typeLabel": "Type",
+      "allTypes": "All types"
+    },
     "actions": {
       "new": "New constituent",
       "menu": "Open actions for {name}",
@@ -1202,6 +1211,11 @@
       "nominative_postal": "Nominative postal",
       "door_drop": "Door drop",
       "digital": "Digital"
+    },
+    "filters": {
+      "searchPlaceholder": "Search a campaign…",
+      "statusLabel": "Status",
+      "allStatuses": "All statuses"
     },
     "actions": {
       "new": "New Campaign",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -381,7 +381,7 @@
           "createdAt": "Créé le",
           "updatedAt": "Dernière mise à jour",
           "actions": "Actions",
-      "tags": "Tags"
+          "tags": "Tags"
         },
         "statuses": {
           "active": "Actif",
@@ -658,7 +658,7 @@
         "createdAt": "Invité·e le",
         "joinedAt": "A rejoint le",
         "actions": "Actions",
-      "tags": "Tags"
+        "tags": "Tags"
       },
       "roles": {
         "org_admin": "Administration",
@@ -781,7 +781,7 @@
         "description": "Description",
         "createdAt": "Créé le",
         "actions": "Actions",
-      "tags": "Tags"
+        "tags": "Tags"
       },
       "actions": {
         "new": "Nouveau fonds",
@@ -931,7 +931,8 @@
       "newDonorsThisMonth": "{count, plural, =0 {Aucun nouveau donateur ce mois-ci} one {# nouveau donateur ce mois-ci} other {# nouveaux donateurs ce mois-ci}}",
       "grantDeadlines": "Échéances de subventions",
       "noGrantDeadlinesValue": "0",
-      "noGrantDeadlinesHint": "Le suivi des subventions arrivera dans un sprint ultérieur."
+      "noGrantDeadlinesHint": "Le suivi des subventions arrivera dans un sprint ultérieur.",
+      "trendLabel": "vs mois précédent"
     },
     "recentDonations": {
       "title": "Dons récents",
@@ -992,7 +993,10 @@
     },
     "filters": {
       "dateFrom": "Du",
-      "dateTo": "Au"
+      "dateTo": "Au",
+      "searchPlaceholder": "Rechercher un donateur…",
+      "receiptLabel": "Reçus",
+      "allReceipts": "Tous les reçus"
     },
     "actions": {
       "new": "Nouveau don",
@@ -1153,6 +1157,11 @@
       "beneficiary": "Bénéficiaire",
       "partner": "Partenaire"
     },
+    "filters": {
+      "searchPlaceholder": "Rechercher un contact…",
+      "typeLabel": "Type",
+      "allTypes": "Tous les types"
+    },
     "actions": {
       "new": "Nouveau constituant",
       "menu": "Ouvrir les actions pour {name}",
@@ -1202,6 +1211,11 @@
       "nominative_postal": "Postal nominatif",
       "door_drop": "Boîtage",
       "digital": "Digital"
+    },
+    "filters": {
+      "searchPlaceholder": "Rechercher une campagne…",
+      "statusLabel": "Statut",
+      "allStatuses": "Tous les statuts"
     },
     "actions": {
       "new": "Nouvelle campagne",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1385,6 +1385,11 @@
         "created": "Créée",
         "noGoal": "Aucun objectif",
         "goalHint": "Objectif : {goal}",
+        "goalProgressLabel": "Progression vers l'objectif",
+        "goalProgressCaption": "{progress}% de {goal}",
+        "goalProgressAria": "{raised} collecté sur {goal}",
+        "goalRemaining": "{amount} restants pour atteindre l'objectif",
+        "goalReached": "Objectif atteint",
         "donationsHint": "{count, plural, =0 {Aucun don pour l'instant} one {# don enregistré} other {# dons enregistrés}}",
         "updatedHint": "Mise à jour {date}"
       },

--- a/packages/web/src/models/campaign.ts
+++ b/packages/web/src/models/campaign.ts
@@ -66,6 +66,7 @@ export interface CampaignCreateInput {
   defaultCurrency?: CampaignCurrency;
   parentId?: string | null;
   operationalCostCents?: number | null;
+  goalAmountCents?: number | null;
   fundIds?: string[];
 }
 

--- a/packages/web/src/models/dashboard.ts
+++ b/packages/web/src/models/dashboard.ts
@@ -1,0 +1,14 @@
+export interface DashboardPeriod {
+  current: number;
+  previous: number;
+}
+
+export interface DashboardStats {
+  totalRaisedCents: DashboardPeriod;
+  newDonors: DashboardPeriod;
+  newActiveCampaigns: DashboardPeriod;
+}
+
+export interface DashboardStatsResponse {
+  data: DashboardStats;
+}

--- a/packages/web/src/models/donation.ts
+++ b/packages/web/src/models/donation.ts
@@ -45,6 +45,7 @@ export interface DonationListQuery {
   dateTo?: string;
   amountMin?: number;
   amountMax?: number;
+  receiptStatus?: "pending" | "generated" | "failed";
 }
 
 export interface DonationAllocation {

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -115,6 +115,9 @@ function toRequestBody(input: CampaignCreateInput | CampaignUpdateInput): Record
   if (input.operationalCostCents !== undefined) {
     body.operationalCostCents = input.operationalCostCents;
   }
+  if (input.goalAmountCents !== undefined) {
+    body.goalAmountCents = input.goalAmountCents;
+  }
   if (input.fundIds !== undefined) body.fundIds = input.fundIds;
 
   return body;

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -13,13 +13,7 @@ import type {
 } from "@/models/campaign";
 import type { Fund } from "@/models/fund";
 
-/**
- * CampaignService — ADR-011 Layer 2 (services).
- *
- * The API list endpoint does not expose a status query yet. Keep status
- * filtering in this web adapter for dashboard reads until the API contract
- * grows that filter.
- */
+/** CampaignService — ADR-011 Layer 2 (services). */
 export const CampaignService = {
   async listCampaigns(
     client: ApiClient,
@@ -27,29 +21,12 @@ export const CampaignService = {
   ): Promise<CampaignListResponse> {
     const page = query.page ?? 1;
     const perPage = query.perPage ?? 20;
-    const requestPerPage = query.status ? Math.max(perPage, 100) : perPage;
 
     const response = await client.get<CampaignListResponse>("/v1/campaigns", {
-      params: { page, perPage: requestPerPage, search: query.search },
+      params: { page, perPage, search: query.search, status: query.status },
     });
 
-    const data = response.data.map(mapCampaign);
-
-    if (!query.status) {
-      return { data, pagination: response.pagination };
-    }
-
-    const filtered = data.filter((campaign) => campaign.status === query.status);
-
-    return {
-      data: filtered.slice(0, perPage),
-      pagination: {
-        page,
-        perPage,
-        total: filtered.length,
-        totalPages: Math.ceil(filtered.length / perPage),
-      },
-    };
+    return { data: response.data.map(mapCampaign), pagination: response.pagination };
   },
 
   async getCampaignStats(client: ApiClient, id: string): Promise<CampaignStats> {

--- a/packages/web/src/services/DashboardService.ts
+++ b/packages/web/src/services/DashboardService.ts
@@ -1,0 +1,9 @@
+import type { ApiClient } from "@/lib/api";
+import type { DashboardStats, DashboardStatsResponse } from "@/models/dashboard";
+
+export const DashboardService = {
+  async getStats(client: ApiClient): Promise<DashboardStats> {
+    const response = await client.get<DashboardStatsResponse>("/v1/dashboard/stats");
+    return response.data;
+  },
+};

--- a/packages/web/src/services/DonationService.ts
+++ b/packages/web/src/services/DonationService.ts
@@ -33,6 +33,7 @@ export const DonationService = {
       dateTo: query.dateTo,
       amountMin: query.amountMin,
       amountMax: query.amountMax,
+      receiptStatus: query.receiptStatus,
     };
 
     const response = await client.get<DonationListResponse>("/v1/donations", { params });


### PR DESCRIPTION
## Summary

- **Dashboard StatCard trends** now compute their percentage from a new `GET /v1/dashboard/stats` endpoint returning current/previous-month aggregates (total raised, new donors, new active campaigns) instead of the hardcoded `14% / 5% / 2%` mock values that shipped in #196. The trend badge is wrapped in a Tooltip that reveals the period label and `previous → current` values on hover or keyboard focus, and is hidden when the previous period is zero (no division-by-zero).
- **i18n cleanup** for the table filters added in #196: search placeholders and Select options that were hardcoded in French (`"Rechercher une campagne..."`, `"Brouillon"`, `"Donateur"`, `"En attente"`, etc.) now go through `t()` and reuse the existing `campaigns.status.*`, `constituents.types.*`, `donations.receiptStatus.*` namespaces. New `*.filters.*` keys added in both `en.json` and `fr.json`.
- Misindented `tags` entries in three super-admin tables blocks fixed.

## Notes

- The `stats` endpoint is a single tenant-scoped call (3 aggregate queries) gated by `requireAuth`. RLS context is set via `withTenantContext`.
- `monthRanges()` uses half-open UTC calendar months to avoid double-counting on the 1st.
- Trend semantics: total raised compares donation sums by `donatedAt`; donors and active campaigns compare new rows by `createdAt` (filtered by `type = 'donor'` and `status = 'active'` respectively).

## Test plan

- [x] `pnpm typecheck` (all 6 packages)
- [x] `pnpm run lint` (no new warnings)
- [x] `pnpm --filter @givernance/api test` (541/541; 5 new tests in `dashboard-stats.test.ts` cover bucketing, tenant isolation, route shape, and 401)
- [x] `pnpm --filter @givernance/web test` (57/57)
- [x] `pnpm build`
- [ ] Smoke-test the dashboard locally and confirm trend badges only show when there's previous-month data
- [ ] Hover/focus a trend badge and confirm the tooltip shows the formatted previous → current values

🤖 Generated with [Claude Code](https://claude.com/claude-code)