### PR TITLE
feat(auth): enable password reset on the givernance Keycloak realm

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -144,6 +144,17 @@ jobs:
           # from the backend authenticate cleanly. Same value Kamal injects
           # into the API container.
           KEYCLOAK_ADMIN_CLIENT_SECRET: ${{ secrets.KEYCLOAK_ADMIN_CLIENT_SECRET || 'staging_keycloak_client_secret_123' }}
+          # SMTP — Keycloak sends password-reset emails via Resend's SMTP relay.
+          # Reuses the same API key as the app worker (issue #190) so the
+          # secret surface stays small. KC_SMTP_PASSWORD is a GitHub secret.
+          KC_SMTP_HOST: smtp.resend.com
+          KC_SMTP_PORT: "587"
+          KC_SMTP_FROM: "noreply@givernance.org"
+          KC_SMTP_FROM_DISPLAY_NAME: "Givernance"
+          KC_SMTP_STARTTLS: "true"
+          KC_SMTP_AUTH: "true"
+          KC_SMTP_USERNAME: resend
+          KC_SMTP_PASSWORD: ${{ secrets.RESEND_API_KEY }}
         run: bash scripts/keycloak-sync-realm.sh
 
       - name: Dump Keycloak logs on failure

--- a/infra/keycloak/realm-givernance.json
+++ b/infra/keycloak/realm-givernance.json
@@ -12,7 +12,7 @@
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,
-  "resetPasswordAllowed": false,
+  "resetPasswordAllowed": true,
   "editUsernameAllowed": false,
   "bruteForceProtected": true,
   "passwordPolicy": "length(12) and notUsername",

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -106,7 +106,14 @@ until curl -sf -o /dev/null "${KC_URL}/realms/${REALM_NAME}/.well-known/openid-c
 done
 
 echo "Syncing Keycloak realm state (idempotent)..."
-KEYCLOAK_URL="$KC_URL" "$SCRIPT_DIR/keycloak-sync-realm.sh"
+KC_SMTP_HOST=mailpit \
+  KC_SMTP_PORT=1025 \
+  KC_SMTP_FROM="noreply@givernance.org" \
+  KC_SMTP_FROM_DISPLAY_NAME="Givernance" \
+  KC_SMTP_SSL=false \
+  KC_SMTP_STARTTLS=false \
+  KC_SMTP_AUTH=false \
+  KEYCLOAK_URL="$KC_URL" "$SCRIPT_DIR/keycloak-sync-realm.sh"
 
 echo "Running Keycloak smoke test (issue #114 acceptance criterion)..."
 # Fail-fast: a broken realm (missing org_id claim, missing membership,

--- a/scripts/keycloak-sync-realm.sh
+++ b/scripts/keycloak-sync-realm.sh
@@ -127,6 +127,7 @@ desired_login_theme = "givernance"
 desired_i18n = True
 desired_locales = ["en", "fr"]
 desired_default_locale = "en"
+desired_reset_password = True
 
 changes = []
 if d.get("passwordPolicy") != desired_policy:
@@ -144,6 +145,9 @@ if sorted(d.get("supportedLocales") or []) != sorted(desired_locales):
 if d.get("defaultLocale") != desired_default_locale:
     d["defaultLocale"] = desired_default_locale
     changes.append("defaultLocale")
+if d.get("resetPasswordAllowed") != desired_reset_password:
+    d["resetPasswordAllowed"] = desired_reset_password
+    changes.append("resetPasswordAllowed")
 
 print(json.dumps({"changes": changes, "realm": d}))
 ')
@@ -858,3 +862,88 @@ print("yes" if any(m.get("id") == wanted for m in json.load(sys.stdin)) else "no
       log "Added user '${SEED_USERNAME}' as member of '${SEED_ORG_ALIAS}'."
     fi
   fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Configure Keycloak realm SMTP so password-reset emails can be sent.
+#
+#    resetPasswordAllowed is now true in realm-givernance.json (and reconciled
+#    by section 1.b above). Without SMTP the KC "Forgot password?" flow shows
+#    a generic error immediately after the user submits the reset form — the
+#    realm has no MTA to deliver the token.
+#
+#    Configuration is driven by env vars so each environment supplies its own
+#    mail backend without touching the realm JSON:
+#
+#      Local dev  →  KC_SMTP_HOST=mailpit  KC_SMTP_PORT=1025  (no auth, no TLS)
+#                    Mailpit is running in docker-compose and captures every mail
+#                    at http://localhost:${MAILPIT_HTTP_PORT:-8025}.
+#      Staging    →  KC_SMTP_HOST=smtp.resend.com  KC_SMTP_PORT=587
+#                    KC_SMTP_AUTH=true  KC_SMTP_STARTTLS=true
+#                    KC_SMTP_USERNAME=resend  KC_SMTP_PASSWORD=<RESEND_API_KEY>
+#                    Resend is already the app worker's email backend (issue #190).
+#                    Using the same API key for KC keeps the secret surface small.
+#
+#    The section is idempotent: it reads the current smtpServer from the realm,
+#    compares it to the desired state, and only calls PUT when a field differs.
+#    When KC_SMTP_HOST is unset the section is skipped entirely (allows running
+#    the sync script in read-only environments where email is not needed).
+# ─────────────────────────────────────────────────────────────────────────────
+
+if [ -z "${KC_SMTP_HOST:-}" ]; then
+  log "KC_SMTP_HOST not set — skipping SMTP configuration (password-reset emails will not work until configured)."
+else
+  log "Reconciling realm SMTP configuration (host=${KC_SMTP_HOST}, port=${KC_SMTP_PORT:-25})..."
+
+  current_realm_for_smtp=$(curl -sS "${auth[@]}" "${KC_URL}/admin/realms/${REALM}")
+
+  smtp_patch=$(printf '%s' "$current_realm_for_smtp" | \
+    KC_SMTP_HOST="${KC_SMTP_HOST}" \
+    KC_SMTP_PORT="${KC_SMTP_PORT:-25}" \
+    KC_SMTP_FROM="${KC_SMTP_FROM:-noreply@givernance.org}" \
+    KC_SMTP_FROM_DISPLAY_NAME="${KC_SMTP_FROM_DISPLAY_NAME:-Givernance}" \
+    KC_SMTP_REPLY_TO="${KC_SMTP_REPLY_TO:-}" \
+    KC_SMTP_SSL="${KC_SMTP_SSL:-false}" \
+    KC_SMTP_STARTTLS="${KC_SMTP_STARTTLS:-false}" \
+    KC_SMTP_AUTH="${KC_SMTP_AUTH:-false}" \
+    KC_SMTP_USERNAME="${KC_SMTP_USERNAME:-}" \
+    KC_SMTP_PASSWORD="${KC_SMTP_PASSWORD:-}" \
+    python3 -c '
+import json, os, sys
+
+d = json.load(sys.stdin)
+desired = {
+    "host":            os.environ["KC_SMTP_HOST"],
+    "port":            os.environ["KC_SMTP_PORT"],
+    "from":            os.environ["KC_SMTP_FROM"],
+    "fromDisplayName": os.environ["KC_SMTP_FROM_DISPLAY_NAME"],
+    "replyTo":         os.environ["KC_SMTP_REPLY_TO"],
+    "ssl":             os.environ["KC_SMTP_SSL"],
+    "starttls":        os.environ["KC_SMTP_STARTTLS"],
+    "auth":            os.environ["KC_SMTP_AUTH"],
+    "user":            os.environ["KC_SMTP_USERNAME"],
+    "password":        os.environ["KC_SMTP_PASSWORD"],
+}
+# Strip empty optional fields to avoid sending empty strings to KC
+desired = {k: v for k, v in desired.items() if v != "" or k in ("host", "port", "from")}
+
+current = d.get("smtpServer") or {}
+# Compare only the keys we manage (ignore KC-internal extras like "envelopeFrom")
+needs_update = any(current.get(k) != v for k, v in desired.items())
+if needs_update:
+    d["smtpServer"] = {**current, **desired}
+    print(json.dumps({"update": True, "realm": d}))
+else:
+    print(json.dumps({"update": False}))
+')
+
+  smtp_needs_update=$(printf '%s' "$smtp_patch" | python3 -c 'import json,sys; print(json.load(sys.stdin)["update"])')
+  if [ "$smtp_needs_update" = "True" ]; then
+    new_realm_smtp=$(printf '%s' "$smtp_patch" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["realm"]))')
+    curl -sS -o /dev/null -w 'realm smtp update: HTTP %{http_code}\n' \
+      -X PUT "${KC_URL}/admin/realms/${REALM}" \
+      "${auth[@]}" -H "Content-Type: application/json" -d "$new_realm_smtp"
+    log "SMTP configured on realm '${REALM}' (host=${KC_SMTP_HOST}:${KC_SMTP_PORT:-25})."
+  else
+    log "Realm SMTP already matches desired config — no change."
+  fi
+fi


### PR DESCRIPTION
## Summary

- **`realm-givernance.json`**: `resetPasswordAllowed: true`. The "Forgot password?" link in `login.ftl` is already guarded by `<#if realm.resetPasswordAllowed>`, and `login-reset-password.ftl` / `login-update-password.ftl` are already in the theme — no template changes needed.
- **`keycloak-sync-realm.sh` §1.b**: adds `resetPasswordAllowed` to the existing realm-level field reconciliation (GET → merge → PUT) so the flag is enforced even when Keycloak skips the JSON import on an already-existing realm.
- **`keycloak-sync-realm.sh` §6 (new)**: idempotent SMTP section. Reads `KC_SMTP_*` env vars, compares against current realm `smtpServer`, and PATCHes via `PUT /admin/realms/{realm}` only when a field differs. Skipped entirely when `KC_SMTP_HOST` is unset (safe for CI environments where email isn't needed).
- **`scripts/dev-up.sh`**: passes Mailpit SMTP vars (`host=mailpit`, `port=1025`, no auth/TLS) to the sync script. Mailpit is already running in `docker-compose` and captures all outbound mail at `http://localhost:8025`.
- **`.github/workflows/deploy-staging.yml`**: passes Resend SMTP vars to the staging sync step (`smtp.resend.com:587`, STARTTLS, `KC_SMTP_PASSWORD=${{ secrets.RESEND_API_KEY }}`). Reuses the existing `RESEND_API_KEY` secret — no new secret needed.

## Test plan

- [ ] Local dev: `./scripts/dev-up.sh` → Keycloak sync logs `SMTP configured on realm 'givernance' (host=mailpit:1025)` → open `http://localhost:8080`, click "Forgot password?", enter `admin@givernance.org`, submit → Mailpit at `http://localhost:8025` receives the reset email
- [ ] Local dev: re-run `dev-up.sh` → sync logs `Realm SMTP already matches desired config — no change` (idempotent)
- [ ] Local dev: `resetPasswordAllowed` survives a Keycloak container restart (sync reconciles it on next `dev-up.sh`)
- [ ] Staging: deploy pipeline logs `realm smtp update: HTTP 204` on first deploy, then `no change` on subsequent runs
- [ ] Staging: full password-reset flow delivers email via Resend

close #197