### PR TITLE
perf(staging): cut deploy time ~50% via build cache, kamal deploy, and gated Keycloak chain

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,13 @@ dist
 .env.*
 !.env.example
 .pnpm-store
+# `setup-kamal-secrets` writes plaintext secrets to `.kamal/secrets`
+# on the runner CWD before the build, and the Dockerfile's `COPY . .`
+# would otherwise ingest that file into a layer. With `builder.cache:
+# mode=max` (config/deploy-staging.yml) those layers also get pushed
+# to the GHCR build-cache image, widening the blast radius if a
+# secret ever leaks into the build context. Kamal filters `.kamal/`
+# from the context itself today, but that's an upstream-tool
+# implementation detail — explicit `.dockerignore` is the durable
+# defense. Per @Onigam's review on PR #208.
+.kamal

--- a/.github/actions/reboot-kamal-accessory/action.yml
+++ b/.github/actions/reboot-kamal-accessory/action.yml
@@ -1,0 +1,42 @@
+name: Reboot Kamal Accessory
+description: >
+  Reboot a Kamal accessory and dump its container logs on failure.
+  Single source of truth for the reboot procedure: deploy-staging.yml
+  invokes it after a kamal deploy when accessory config changed (so
+  port-mapping / image-bump / env edits actually take effect on the
+  running container — `kamal setup` is a noop on already-running
+  accessories), and staging-accessory-reboot.yml invokes it for
+  out-of-band secret rotations (MINIO_KMS_SECRET_KEY etc) where no
+  file changed but the running env is now stale.
+
+  Caller responsibilities (must run before this action): the SSH agent
+  is configured against the staging VPS, ruby + kamal are installed,
+  and `.kamal/secrets` is on disk. The two callers both get there via
+  the same setup-kamal-secrets composite action.
+
+inputs:
+  accessory:
+    description: Accessory name, must match `accessories.<name>` in the kamal config.
+    required: true
+  config:
+    description: Path to the kamal config file.
+    required: false
+    default: config/deploy-staging.yml
+
+runs:
+  using: composite
+  steps:
+    - name: Reboot accessory
+      id: reboot
+      shell: bash
+      run: kamal accessory reboot "${{ inputs.accessory }}" -c "${{ inputs.config }}"
+
+    # Scoped to "the reboot itself failed" rather than `if: failure()`,
+    # which would also fire on any earlier failure in the parent job and
+    # produce confusing logs from an accessory we never tried to touch.
+    - name: Dump accessory logs on reboot failure
+      if: steps.reboot.conclusion == 'failure'
+      shell: bash
+      run: |
+        kamal server exec -c "${{ inputs.config }}" \
+          "docker logs givernance-${{ inputs.accessory }} --tail 100" || true

--- a/.github/actions/reboot-kamal-accessory/action.yml
+++ b/.github/actions/reboot-kamal-accessory/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Reboot accessory
       id: reboot
       shell: bash
-      run: kamal accessory reboot "${{ inputs.accessory }}" -c "${{ inputs.config }}"
+      run: bundle exec kamal accessory reboot "${{ inputs.accessory }}" -c "${{ inputs.config }}"
 
     # Scoped to "the reboot itself failed" rather than `if: failure()`,
     # which would also fire on any earlier failure in the parent job and
@@ -38,5 +38,5 @@ runs:
       if: steps.reboot.conclusion == 'failure'
       shell: bash
       run: |
-        kamal server exec -c "${{ inputs.config }}" \
+        bundle exec kamal server exec -c "${{ inputs.config }}" \
           "docker logs givernance-${{ inputs.accessory }} --tail 100" || true

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -175,12 +175,17 @@ jobs:
       # `kamal setup` only re-creates accessories that aren't already
       # running, so accessory-config changes (port mappings, env vars,
       # image bumps) on an existing instance are silent no-ops. Reboot
-      # MinIO unconditionally so port-mapping or KMS-key changes in
-      # `config/deploy-staging.yml` actually take effect on the running
-      # container — issue #214 dropped the public `port: 9000` mapping
-      # and previously that change would have only landed on a fresh
-      # VPS. Idempotent: noop on a steady-state deploy.
+      # MinIO when `config/deploy-staging.yml` changed so port-mapping
+      # or image-bump edits actually take effect on the running container
+      # — issue #214 dropped the public `port: 9000` mapping and that
+      # change would have only landed on a fresh VPS otherwise. Gated
+      # on the same `kamal_config` filter as the auto-detector below,
+      # so a typical no-config push skips the ~30-60s reboot. Out-of-band
+      # secret rotations (MINIO_KMS_SECRET_KEY etc) use the dedicated
+      # `staging-accessory-reboot.yml` workflow — they don't need this
+      # gate because no file changed to trigger paths-filter.
       - name: Reboot MinIO to apply accessory config changes
+        if: steps.changes.outputs.kamal_config == 'true' || github.event_name == 'workflow_dispatch'
         run: kamal accessory reboot minio -c config/deploy-staging.yml
 
       - name: Wait for Keycloak realm to be ready

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -168,25 +168,30 @@ jobs:
       # The realm JSON is mounted into the keycloak accessory via Kamal's `files:`.
       # Rebooting the accessory re-copies the file and triggers a re-import under
       # KC_IMPORT_STRATEGY=OVERWRITE_EXISTING (set in config/deploy-staging.yml).
+      # Reboot procedure shared with staging-accessory-reboot.yml via the
+      # composite action.
       - name: Reboot Keycloak to re-import realm JSON
         if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'
-        run: kamal accessory reboot keycloak -c config/deploy-staging.yml
+        uses: ./.github/actions/reboot-kamal-accessory
+        with:
+          accessory: keycloak
 
       # `kamal setup` only re-creates accessories that aren't already
-      # running, so accessory-config changes (port mappings, env vars,
-      # image bumps) on an existing instance are silent no-ops. Reboot
-      # MinIO when `config/deploy-staging.yml` changed so port-mapping
-      # or image-bump edits actually take effect on the running container
-      # — issue #214 dropped the public `port: 9000` mapping and that
-      # change would have only landed on a fresh VPS otherwise. Gated
-      # on the same `kamal_config` filter as the auto-detector below,
-      # so a typical no-config push skips the ~30-60s reboot. Out-of-band
-      # secret rotations (MINIO_KMS_SECRET_KEY etc) use the dedicated
-      # `staging-accessory-reboot.yml` workflow — they don't need this
-      # gate because no file changed to trigger paths-filter.
+      # running, so accessory-config changes (port mappings, image bumps,
+      # env edits) on an existing instance are silent no-ops. Reboot
+      # MinIO when `config/deploy-staging.yml` changed so those edits
+      # actually take effect on the running container — issue #214
+      # dropped the public `port: 9000` mapping and that change would
+      # have only landed on a fresh VPS otherwise. A typical no-config
+      # push skips this ~30-60s reboot. Out-of-band secret rotations
+      # (MINIO_KMS_SECRET_KEY etc) use staging-accessory-reboot.yml —
+      # they don't need this gate because no file changed to trigger
+      # paths-filter.
       - name: Reboot MinIO to apply accessory config changes
         if: steps.changes.outputs.kamal_config == 'true' || github.event_name == 'workflow_dispatch'
-        run: kamal accessory reboot minio -c config/deploy-staging.yml
+        uses: ./.github/actions/reboot-kamal-accessory
+        with:
+          accessory: minio
 
       - name: Wait for Keycloak realm to be ready
         if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -54,22 +54,117 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Detect whether this push touched Keycloak — gates the slow chain
-      # (image build → accessory reboot → realm-ready wait → realm sync,
-      # ~85s combined). On workflow_dispatch we always run the chain so a
-      # manual button-click means "full deploy" by default. paths-filter
-      # uses the GitHub API and works with default (shallow) checkouts.
+      # Detect whether this push touched Keycloak source files (the realm
+      # JSON, the sync script) — combined with `gates.outputs.keycloak_changed`
+      # below to drive the slow chain (image build → reboot → realm-ready
+      # wait → realm sync, ~85s combined). On workflow_dispatch we always
+      # run the chain so a manual button-click means "full deploy" by
+      # default. paths-filter uses the GitHub API and works with default
+      # (shallow) checkouts.
+      #
+      # `.github/workflows/deploy-staging.yml` is intentionally NOT in the
+      # `keycloak` filter — workflow tweaks (comment edits, runner bumps,
+      # editing this filter list) shouldn't trigger the ~85s Keycloak chain.
+      # Real Keycloak-relevant changes are caught either by `infra/keycloak/**`
+      # / the sync script (here) or by `gates.outputs.keycloak_changed`
+      # (when `accessories.keycloak` in `config/deploy-staging.yml`
+      # changes — image bumps, env tweaks).
+      #
+      # Pinned to a commit SHA per @Onigam's review — the workflow runs
+      # with `packages: write`, so a third-party action gets a SHA pin
+      # instead of a moving tag. SHA below is `dorny/paths-filter@v3`
+      # at 2026-04-30; bump intentionally when upgrading.
       - name: Detect changed paths
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         with:
           filters: |
             keycloak:
               - 'infra/keycloak/**'
               - 'scripts/keycloak-sync-realm.sh'
-              - '.github/workflows/deploy-staging.yml'
             kamal_config:
               - 'config/deploy-staging.yml'
+
+      # Per-accessory subtree diff of `config/deploy-staging.yml`. The
+      # file-level `kamal_config` filter above tells us "the file was
+      # edited"; this step tells us "the `accessories.minio` subtree
+      # changed" or "the `accessories.keycloak` subtree changed", so we
+      # only reboot the accessories whose config actually moved instead
+      # of every accessory whenever the file is touched (e.g., a
+      # top-level `env.clear` edit).
+      #
+      # Outputs:
+      #   minio_changed       — `accessories.minio` subtree differs vs BEFORE_SHA
+      #   keycloak_changed    — `accessories.keycloak` subtree differs vs BEFORE_SHA
+      #   run_keycloak        — combined gate for the Keycloak chain
+      #                         (file-paths OR subtree OR workflow_dispatch)
+      #   run_minio_reboot    — combined gate for the MinIO accessory reboot
+      #                         (subtree OR workflow_dispatch)
+      #
+      # Conservative on edge cases: workflow_dispatch (no diff base) and
+      # missing-parent (force push, first push to a new branch) both
+      # treat every accessory as changed. False positive cost is one
+      # extra ~30-60s reboot on a rare push; false negative cost is a
+      # silently-skipped config sync, which we won't accept.
+      - name: Detect per-accessory config changes & compute gates
+        id: gates
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          KAMAL_CONFIG_CHANGED: ${{ steps.changes.outputs.kamal_config }}
+          KEYCLOAK_FILES_CHANGED: ${{ steps.changes.outputs.keycloak }}
+        run: |
+          set -euo pipefail
+          minio_changed=false
+          keycloak_changed=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            minio_changed=true
+            keycloak_changed=true
+          elif [ "$KAMAL_CONFIG_CHANGED" = "true" ]; then
+            OLD=$(mktemp)
+            if git show "${BEFORE_SHA}:config/deploy-staging.yml" > "$OLD" 2>/dev/null; then
+              for acc in minio keycloak; do
+                OLD_HASH=$(yq ".accessories.${acc}" "$OLD" 2>/dev/null | sha256sum | cut -d' ' -f1)
+                NEW_HASH=$(yq ".accessories.${acc}" config/deploy-staging.yml 2>/dev/null | sha256sum | cut -d' ' -f1)
+                if [ "$OLD_HASH" != "$NEW_HASH" ]; then
+                  eval "${acc}_changed=true"
+                  echo "accessories.${acc} subtree changed"
+                fi
+              done
+              rm -f "$OLD"
+            else
+              # Force push, first-push to branch, or BEFORE_SHA gone — be conservative.
+              minio_changed=true
+              keycloak_changed=true
+              echo "BEFORE_SHA=${BEFORE_SHA} unavailable — assuming all accessory subtrees changed"
+            fi
+          fi
+
+          run_keycloak=false
+          if [ "$KEYCLOAK_FILES_CHANGED" = "true" ] || [ "$keycloak_changed" = "true" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            run_keycloak=true
+          fi
+
+          run_minio_reboot=false
+          if [ "$minio_changed" = "true" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            run_minio_reboot=true
+          fi
+
+          {
+            echo "minio_changed=${minio_changed}"
+            echo "keycloak_changed=${keycloak_changed}"
+            echo "run_keycloak=${run_keycloak}"
+            echo "run_minio_reboot=${run_minio_reboot}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::group::Computed deploy gates"
+          echo "  keycloak files changed (paths-filter):    ${KEYCLOAK_FILES_CHANGED}"
+          echo "  accessories.keycloak subtree changed:     ${keycloak_changed}"
+          echo "  accessories.minio subtree changed:        ${minio_changed}"
+          echo "  → run_keycloak (chain):                   ${run_keycloak}"
+          echo "  → run_minio_reboot:                       ${run_minio_reboot}"
+          echo "::endgroup::"
 
       - name: Set up Ruby (for Kamal)
         uses: ruby/setup-ruby@v1
@@ -104,7 +199,7 @@ jobs:
           MINIO_KMS_SECRET_KEY: ${{ secrets.MINIO_KMS_SECRET_KEY }}
 
       - name: Build and push Keycloak image
-        if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.gates.outputs.run_keycloak == 'true'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker build \
@@ -171,7 +266,7 @@ jobs:
       # Reboot procedure shared with staging-accessory-reboot.yml via the
       # composite action.
       - name: Reboot Keycloak to re-import realm JSON
-        if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.gates.outputs.run_keycloak == 'true'
         uses: ./.github/actions/reboot-kamal-accessory
         with:
           accessory: keycloak
@@ -188,13 +283,13 @@ jobs:
       # they don't need this gate because no file changed to trigger
       # paths-filter.
       - name: Reboot MinIO to apply accessory config changes
-        if: steps.changes.outputs.kamal_config == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.gates.outputs.run_minio_reboot == 'true'
         uses: ./.github/actions/reboot-kamal-accessory
         with:
           accessory: minio
 
       - name: Wait for Keycloak realm to be ready
-        if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.gates.outputs.run_keycloak == 'true'
         run: |
           for i in $(seq 1 60); do
             code=$(curl -s -o /dev/null -w '%{http_code}' \
@@ -250,7 +345,7 @@ jobs:
       # are all native to ubuntu-latest, so we don't have to ship them in the
       # production image just to satisfy `kamal app exec`.
       - name: Sync Keycloak realm
-        if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.gates.outputs.run_keycloak == 'true'
         env:
           KEYCLOAK_URL: https://auth.staging.givernance.org
           KEYCLOAK_ADMIN: admin

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,6 +2,19 @@ name: Deploy to Staging
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: |
+          Kamal command to run. `deploy` is the per-push fast path (only
+          rolls the app containers). `setup` does a full bootstrap —
+          pick this after editing `accessories:` in
+          `config/deploy-staging.yml` (new accessory, new env var on an
+          existing accessory) so the changes actually land on the VPS.
+        type: choice
+        options:
+          - deploy
+          - setup
+        default: deploy
   push:
     branches:
       - main
@@ -83,16 +96,24 @@ jobs:
       - name: Release Deploy Lock
         run: kamal lock release -c config/deploy-staging.yml || true
 
+      # Per-push runs use `kamal deploy` (only rolls app containers) — `setup`
+      # additionally re-installs Docker, recreates the kamal network, and
+      # re-registers every accessory, all of which is wasted work on an
+      # already-bootstrapped VPS. Trigger `setup` manually via the
+      # workflow_dispatch `mode: setup` input after editing `accessories:`
+      # in `config/deploy-staging.yml`.
       - name: Deploy with Kamal
+        env:
+          KAMAL_CMD: ${{ github.event.inputs.mode || 'deploy' }}
         run: |
           attempt=1
           max_attempts=3
-          until kamal setup -c config/deploy-staging.yml; do
+          until kamal "$KAMAL_CMD" -c config/deploy-staging.yml; do
             if [ "$attempt" -ge "$max_attempts" ]; then
-              echo "kamal setup failed after $max_attempts attempts" >&2
+              echo "kamal $KAMAL_CMD failed after $max_attempts attempts" >&2
               exit 1
             fi
-            echo "kamal setup failed (attempt $attempt/$max_attempts) — releasing lock and retrying"
+            echo "kamal $KAMAL_CMD failed (attempt $attempt/$max_attempts) — releasing lock and retrying"
             kamal lock release -c config/deploy-staging.yml || true
             attempt=$((attempt + 1))
             sleep 5

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -52,6 +52,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Detect whether this push touched Keycloak — gates the slow chain
+      # (image build → accessory reboot → realm-ready wait → realm sync,
+      # ~85s combined). On workflow_dispatch we always run the chain so a
+      # manual button-click means "full deploy" by default. paths-filter
+      # uses the GitHub API and works with default (shallow) checkouts.
+      - name: Detect changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            keycloak:
+              - 'infra/keycloak/**'
+              - 'scripts/keycloak-sync-realm.sh'
+              - '.github/workflows/deploy-staging.yml'
+
       - name: Set up Ruby (for Kamal)
         uses: ruby/setup-ruby@v1
         with:
@@ -85,6 +100,7 @@ jobs:
           MINIO_KMS_SECRET_KEY: ${{ secrets.MINIO_KMS_SECRET_KEY }}
 
       - name: Build and push Keycloak image
+        if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker build \
@@ -123,6 +139,7 @@ jobs:
       # Rebooting the accessory re-copies the file and triggers a re-import under
       # KC_IMPORT_STRATEGY=OVERWRITE_EXISTING (set in config/deploy-staging.yml).
       - name: Reboot Keycloak to re-import realm JSON
+        if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'
         run: kamal accessory reboot keycloak -c config/deploy-staging.yml
 
       # `kamal setup` only re-creates accessories that aren't already
@@ -137,6 +154,7 @@ jobs:
         run: kamal accessory reboot minio -c config/deploy-staging.yml
 
       - name: Wait for Keycloak realm to be ready
+        if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           for i in $(seq 1 60); do
             code=$(curl -s -o /dev/null -w '%{http_code}' \
@@ -192,6 +210,7 @@ jobs:
       # are all native to ubuntu-latest, so we don't have to ship them in the
       # production image just to satisfy `kamal app exec`.
       - name: Sync Keycloak realm
+        if: steps.changes.outputs.keycloak == 'true' || github.event_name == 'workflow_dispatch'
         env:
           KEYCLOAK_URL: https://auth.staging.givernance.org
           KEYCLOAK_ADMIN: admin

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,16 +5,18 @@ on:
     inputs:
       mode:
         description: |
-          Kamal command to run. `deploy` is the per-push fast path (only
-          rolls the app containers). `setup` does a full bootstrap —
-          pick this after editing `accessories:` in
-          `config/deploy-staging.yml` (new accessory, new env var on an
-          existing accessory) so the changes actually land on the VPS.
+          Kamal command override. `auto` (default) inspects the diff — if
+          `config/deploy-staging.yml` changed (accessories, proxy, env,
+          builder), runs `kamal setup`; otherwise runs `kamal deploy`.
+          Pick `setup` to force a full bootstrap, or `deploy` to skip
+          bootstrap even if config changed (only if you're sure the
+          change has no accessory side-effects).
         type: choice
         options:
+          - auto
           - deploy
           - setup
-        default: deploy
+        default: auto
   push:
     branches:
       - main
@@ -66,6 +68,8 @@ jobs:
               - 'infra/keycloak/**'
               - 'scripts/keycloak-sync-realm.sh'
               - '.github/workflows/deploy-staging.yml'
+            kamal_config:
+              - 'config/deploy-staging.yml'
 
       - name: Set up Ruby (for Kamal)
         uses: ruby/setup-ruby@v1
@@ -115,12 +119,38 @@ jobs:
       # Per-push runs use `kamal deploy` (only rolls app containers) — `setup`
       # additionally re-installs Docker, recreates the kamal network, and
       # re-registers every accessory, all of which is wasted work on an
-      # already-bootstrapped VPS. Trigger `setup` manually via the
-      # workflow_dispatch `mode: setup` input after editing `accessories:`
-      # in `config/deploy-staging.yml`.
+      # already-bootstrapped VPS. We auto-fall-back to `setup` whenever
+      # `config/deploy-staging.yml` is modified, so accessory edits land
+      # on the VPS without anyone having to remember to flip a switch.
+      # Manual override available via the `mode` workflow_dispatch input.
+      - name: Resolve Kamal command
+        id: kamal_cmd
+        env:
+          INPUT_MODE: ${{ github.event.inputs.mode || 'auto' }}
+          KAMAL_CONFIG_CHANGED: ${{ steps.changes.outputs.kamal_config }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$INPUT_MODE" = "setup" ] || [ "$INPUT_MODE" = "deploy" ]; then
+            CMD="$INPUT_MODE"
+            echo "Manual override (workflow_dispatch mode=$INPUT_MODE) — running kamal $CMD"
+          elif [ "$KAMAL_CONFIG_CHANGED" = "true" ]; then
+            CMD="setup"
+            echo "config/deploy-staging.yml changed in this push — running kamal setup (full bootstrap, accessory-safe)"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # Manual trigger + mode=auto: paths-filter has no reliable diff
+            # to compare against (no parent push), so default to the safe
+            # full-bootstrap path. Mirrors the keycloak-chain default.
+            CMD="setup"
+            echo "Manual trigger with mode=auto — defaulting to kamal setup"
+          else
+            CMD="deploy"
+            echo "Routine push, no config change — running kamal deploy (fast path)"
+          fi
+          echo "cmd=$CMD" >> "$GITHUB_OUTPUT"
+
       - name: Deploy with Kamal
         env:
-          KAMAL_CMD: ${{ github.event.inputs.mode || 'deploy' }}
+          KAMAL_CMD: ${{ steps.kamal_cmd.outputs.cmd }}
         run: |
           attempt=1
           max_attempts=3

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -166,14 +166,16 @@ jobs:
           echo "  → run_minio_reboot:                       ${run_minio_reboot}"
           echo "::endgroup::"
 
+      # `bundler-cache: true` reads `Gemfile.lock` at the repo root and
+      # caches `vendor/bundle` keyed on that file's hash, so a no-Gemfile-
+      # change push reuses the previous run's installed gems instead of
+      # paying ~10-15s for `gem install kamal`. Cache hit/miss is logged
+      # by the action.
       - name: Set up Ruby (for Kamal)
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
-
-      - name: Install Kamal
-        run: gem install kamal
 
       - name: Configure SSH Auth Sock
         uses: webfactory/ssh-agent@v0.9.0
@@ -209,7 +211,7 @@ jobs:
           docker push ghcr.io/purposestack/givernance-keycloak:latest
 
       - name: Release Deploy Lock
-        run: kamal lock release -c config/deploy-staging.yml || true
+        run: bundle exec kamal lock release -c config/deploy-staging.yml || true
 
       # Per-push runs use `kamal deploy` (only rolls app containers) — `setup`
       # additionally re-installs Docker, recreates the kamal network, and
@@ -249,13 +251,13 @@ jobs:
         run: |
           attempt=1
           max_attempts=3
-          until kamal "$KAMAL_CMD" -c config/deploy-staging.yml; do
+          until bundle exec kamal "$KAMAL_CMD" -c config/deploy-staging.yml; do
             if [ "$attempt" -ge "$max_attempts" ]; then
               echo "kamal $KAMAL_CMD failed after $max_attempts attempts" >&2
               exit 1
             fi
             echo "kamal $KAMAL_CMD failed (attempt $attempt/$max_attempts) — releasing lock and retrying"
-            kamal lock release -c config/deploy-staging.yml || true
+            bundle exec kamal lock release -c config/deploy-staging.yml || true
             attempt=$((attempt + 1))
             sleep 5
           done
@@ -305,10 +307,10 @@ jobs:
           exit 1
 
       - name: Run DB Migrations
-        run: kamal app exec -c config/deploy-staging.yml --reuse "pnpm --filter @givernance/api run db:migrate"
+        run: bundle exec kamal app exec -c config/deploy-staging.yml --reuse "pnpm --filter @givernance/api run db:migrate"
 
       - name: Run DB Seed
-        run: kamal app exec -c config/deploy-staging.yml --reuse "pnpm --filter @givernance/api run db:seed"
+        run: bundle exec kamal app exec -c config/deploy-staging.yml --reuse "pnpm --filter @givernance/api run db:seed"
 
       # Ensure the MinIO buckets the worker writes receipt + campaign PDFs
       # to actually exist (issue #193 follow-up). Mirrors the local
@@ -337,7 +339,7 @@ jobs:
                 && mc mb --ignore-existing local/${S3_RECEIPTS_BUCKET} \
                 && mc mb --ignore-existing local/${S3_CAMPAIGNS_BUCKET} \
                 && echo MinIO buckets ready: ${S3_RECEIPTS_BUCKET}, ${S3_CAMPAIGNS_BUCKET}'"
-          kamal server exec -c config/deploy-staging.yml "$REMOTE_CMD"
+          bundle exec kamal server exec -c config/deploy-staging.yml "$REMOTE_CMD"
 
       # The sync script reconciles the live realm (mappers, scopes, role
       # assignments) against the source-of-truth in scripts/keycloak-sync-realm.sh.
@@ -371,11 +373,11 @@ jobs:
       - name: Dump Keycloak logs on failure
         if: failure()
         run: |
-          kamal server exec -c config/deploy-staging.yml \
+          bundle exec kamal server exec -c config/deploy-staging.yml \
             "docker logs givernance-keycloak --tail 200" || true
 
       - name: Dump API logs on failure
         if: failure()
         run: |
-          kamal server exec -c config/deploy-staging.yml \
+          bundle exec kamal server exec -c config/deploy-staging.yml \
             "docker ps -a --filter name=givernance-api -q | head -n 1 | xargs -I {} docker logs --tail 200 {}" || true

--- a/.github/workflows/staging-accessory-reboot.yml
+++ b/.github/workflows/staging-accessory-reboot.yml
@@ -93,11 +93,10 @@ jobs:
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           MINIO_KMS_SECRET_KEY: ${{ secrets.MINIO_KMS_SECRET_KEY }}
 
+      # Same reboot procedure used by deploy-staging.yml when accessory
+      # config (kamal yml subtree) changed. Single source of truth in
+      # .github/actions/reboot-kamal-accessory/action.yml.
       - name: Reboot accessory
-        run: kamal accessory reboot "${{ inputs.accessory }}" -c config/deploy-staging.yml
-
-      - name: Dump accessory logs on failure
-        if: failure()
-        run: |
-          kamal server exec -c config/deploy-staging.yml \
-            "docker logs givernance-${{ inputs.accessory }} --tail 100" || true
+        uses: ./.github/actions/reboot-kamal-accessory
+        with:
+          accessory: ${{ inputs.accessory }}

--- a/.github/workflows/staging-accessory-reboot.yml
+++ b/.github/workflows/staging-accessory-reboot.yml
@@ -62,14 +62,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # `bundler-cache: true` reads the repo-root Gemfile.lock and caches
+      # `vendor/bundle` between runs (same setup as deploy-staging.yml so
+      # both flows share the cache). Bumping Kamal: edit the version in
+      # the Gemfile, run `bundle update kamal`, commit both files.
       - name: Set up Ruby (for Kamal)
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
-
-      - name: Install Kamal
-        run: gem install kamal
 
       - name: Configure SSH Auth Sock
         uses: webfactory/ssh-agent@v0.9.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,17 @@
+# Pin Kamal so the staging deploy doesn't pull a fresh `latest` on every
+# CI run — without this file, `gem install kamal` cost ~10-15s per push
+# and an unrelated upstream Kamal release could change deploy behavior
+# without a corresponding PR.
+#
+# This Gemfile is consumed by:
+#   .github/workflows/deploy-staging.yml          (Deploy to Staging)
+#   .github/workflows/staging-accessory-reboot.yml (Reboot Staging Accessory)
+#
+# Both invoke `ruby/setup-ruby@v1` with `bundler-cache: true`, which keys
+# on `Gemfile.lock` and caches `vendor/bundle` between runs. Bumping
+# Kamal: edit the version below, run `bundle update kamal`, commit both
+# files. The action takes care of the rest.
+
+source "https://rubygems.org"
+
+gem "kamal", "~> 2.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,77 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    bcrypt_pbkdf (1.1.2)
+    bcrypt_pbkdf (1.1.2-arm64-darwin)
+    bcrypt_pbkdf (1.1.2-x86_64-darwin)
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    dotenv (3.2.0)
+    drb (2.2.3)
+    ed25519 (1.4.0)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    json (2.19.4)
+    kamal (2.11.0)
+      activesupport (>= 7.0)
+      base64 (~> 0.2)
+      bcrypt_pbkdf (~> 1.0)
+      concurrent-ruby (~> 1.2)
+      dotenv (~> 3.1)
+      ed25519 (~> 1.4)
+      net-ssh (~> 7.3)
+      sshkit (>= 1.23.0, < 2.0)
+      thor (~> 1.3)
+      zeitwerk (>= 2.6.18, < 3.0)
+    logger (1.7.0)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-ssh (7.3.2)
+    ostruct (0.6.3)
+    prism (1.9.0)
+    securerandom (0.4.1)
+    sshkit (1.25.0)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    thor (1.5.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.1.1)
+    zeitwerk (2.7.5)
+
+PLATFORMS
+  aarch64-linux
+  arm64-darwin
+  ruby
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  kamal (~> 2.11)
+
+BUNDLED WITH
+   2.5.22

--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -120,9 +120,15 @@ builder:
   # intermediate layers (not just the final ones) for better hit rates;
   # the existing `packages: write` permission on the deploy workflow covers
   # the cache image push.
+  #
+  # IMPORTANT: `image:` is the path RELATIVE TO `registry.server` above.
+  # Kamal joins them at build time, so do NOT include `ghcr.io/` here —
+  # an earlier version of this PR did, which produced a cache image at
+  # `ghcr.io/ghcr.io/purposestack/givernance-build-cache` (doubled host).
+  # Fully-qualified resolved ref: `ghcr.io/purposestack/givernance-build-cache`.
   cache:
     type: registry
-    image: ghcr.io/purposestack/givernance-build-cache
+    image: purposestack/givernance-build-cache
     options: mode=max
   args:
     # The Next.js rewrite destination is baked into routes-manifest.json

--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -112,6 +112,18 @@ env:
 builder:
   arch: amd64
   dockerfile: Dockerfile
+  # Registry-backed BuildKit cache — without this, the `kamal-local-docker-container`
+  # buildx builder is recreated from scratch on every CI run, losing the pnpm
+  # store mount cache and forcing a full `pnpm install` + `pnpm -r build`
+  # (~76s of the deploy). Storing the cache as a sibling tag in GHCR lets
+  # subsequent runs reuse the install/build layers. `mode=max` exports
+  # intermediate layers (not just the final ones) for better hit rates;
+  # the existing `packages: write` permission on the deploy workflow covers
+  # the cache image push.
+  cache:
+    type: registry
+    image: ghcr.io/purposestack/givernance-build-cache
+    options: mode=max
   args:
     # The Next.js rewrite destination is baked into routes-manifest.json
     # at build time (see Dockerfile ARG API_URL comment). `env.clear`

--- a/docs/infra/README.md
+++ b/docs/infra/README.md
@@ -212,6 +212,19 @@ Production self-hosted deployments should add:
 - Redis persistence configuration
 - MinIO replication for storage durability
 
+### Staging build cache (GHCR)
+
+The staging deploy ([`.github/workflows/deploy-staging.yml`](../../.github/workflows/deploy-staging.yml)) uses a registry-backed BuildKit cache (`ghcr.io/purposestack/givernance-build-cache`, `mode=max`) so the pnpm-store mount and `pnpm -r build` outputs survive across runs. Without retention, manifests accumulate as untagged blobs over time.
+
+GHCR doesn't auto-prune untagged manifests. Suggested policy:
+
+- Retain only the **latest 5 untagged manifests** of `givernance-build-cache` — `mode=max` rewrites the cache image on every cache-warm push, and only the latest manifest is read on the next build.
+- Worst case (a corrupt cache push) is one slow rebuild; older manifests are not used as fallbacks. Keeping 5 covers the rare case of needing to roll back.
+
+Apply via the **package settings** UI on `ghcr.io/purposestack/givernance-build-cache` → "Manage versions" → set retention rule, or via a small scheduled workflow using `actions/delete-package-versions`. Either approach is fine — pick the one that fits your operational cadence. The cache image is **safe to delete entirely** at any time; the next push reseeds it (one slow run, then back to fast).
+
+`docker run ghcr.io/purposestack/givernance-build-cache` won't work — these are BuildKit cache manifests, not runnable images. Inspect with `docker buildx imagetools inspect ghcr.io/purposestack/givernance-build-cache` if you need to see what's there.
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Multi-pass perf PR on the staging deploy. Profiling baseline [run 25120027073](https://github.com/purposestack/givernance/actions/runs/25120027073) was 5 min 8 s; main has since added an unconditional MinIO reboot (`b6a735b`, ~+30 s) so today's effective baseline is **~5 min 38 s**.

Each change is its own commit and individually revertable. Touching only `.github/workflows/deploy-staging.yml`, `config/deploy-staging.yml`, two composite actions, the repo-root `Gemfile`, `.dockerignore`, and `docs/infra/README.md`.

| # | Change | Where | Expected savings |
|---|--------|-------|------------------|
| 1 | Registry-backed BuildKit cache for the app image | [`config/deploy-staging.yml`](config/deploy-staging.yml) `builder.cache` | 30–50 s on cache-warm pushes |
| 2 | `kamal deploy` per push, `kamal setup` reserved for `workflow_dispatch` (or auto-detected from config diff) | [`.github/workflows/deploy-staging.yml`](.github/workflows/deploy-staging.yml) | 30–60 s |
| 3 | Gate Keycloak chain on `dorny/paths-filter@v3` + per-accessory subtree diff | [`.github/workflows/deploy-staging.yml`](.github/workflows/deploy-staging.yml) | ~85 s on >90% of pushes |
| 4 | Auto-detect `kamal setup` vs `kamal deploy` from the diff | [`.github/workflows/deploy-staging.yml`](.github/workflows/deploy-staging.yml) | Removes manual-handshake risk |
| 5 | Gate MinIO reboot on actual `accessories.minio` subtree change | [`.github/workflows/deploy-staging.yml`](.github/workflows/deploy-staging.yml) | ~30–60 s on >90% of pushes |
| 6 | Extract `kamal accessory reboot` into a composite action | [`.github/actions/reboot-kamal-accessory/`](.github/actions/reboot-kamal-accessory/action.yml) | DRY between deploy + manual-reboot flows; correctly-scoped failure dumps |
| 7 | Per-accessory subtree diff via `yq` (file-level → key-level gating) | [`.github/workflows/deploy-staging.yml`](.github/workflows/deploy-staging.yml) `gates` step | Reboot only the accessory whose config moved |
| 8 | Cache `kamal` install via `Gemfile` + `bundler-cache: true` | [`Gemfile`](Gemfile) + workflow `bundle exec kamal` | ~10–15 s per push |
| 9 | `.kamal` in `.dockerignore` — close the `mode=max` cache-export hole | [`.dockerignore`](.dockerignore) | (security) |
| 10 | GHCR build-cache retention policy documented | [`docs/infra/README.md`](docs/infra/README.md) | (operational) |

## Updated savings

| Edit type | Before this PR | After this PR |
|---|---:|---:|
| No-config-change push (90%+ of pushes) | ~5 min 38 s | **~2 min flat** |
| `infra/keycloak/realm-givernance.json` only | ~5 min 38 s | ~3 min 30 s |
| `accessories.minio` subtree only | ~5 min 38 s | ~3 min |
| `accessories.keycloak` subtree only | (latent bug — image bump was never propagated to the running container) | ~3 min 30 s |
| `env.clear` only (e.g. `EMAIL_FROM`) | ~5 min 38 s | ~2 min 30 s |
| First post-merge run (cache-miss) | ~5 min 38 s | ~3 min 30 s |

## How `KAMAL_CMD` is resolved

Decision order in the **Resolve Kamal command** step:

1. `workflow_dispatch` with `mode: setup` or `mode: deploy` → that command (manual override)
2. `config/deploy-staging.yml` was modified in the pushed commits → `setup` (full bootstrap, accessory-safe)
3. `workflow_dispatch` with `mode: auto` (default) → `setup` (no reliable diff to inspect on a manual button-click)
4. Routine push, no config change → `deploy` (fast path)

The `mode` input is `auto` (default) / `deploy` / `setup`. Manual overrides remain available for "I know this env-only config edit is accessory-safe, give me the fast path" or "force a bootstrap on a no-config push."

## How accessory reboots are resolved

**Per-accessory subtree diff** (new in commit 7) drives the reboot gates instead of the file-level `kamal_config` flag:

- `accessories.minio` subtree changed → reboot MinIO
- `accessories.keycloak` subtree changed → run the full Keycloak chain (build image / reboot / wait / sync)
- `infra/keycloak/**` or `scripts/keycloak-sync-realm.sh` changed → run the full Keycloak chain
- workflow_dispatch → all of the above (manual = "redeploy everything")
- Out-of-band secret rotation (`MINIO_KMS_SECRET_KEY` etc) → use [`staging-accessory-reboot.yml`](.github/workflows/staging-accessory-reboot.yml) (no file changed, paths-filter wouldn't catch it)

The reboot procedure itself (`kamal accessory reboot X` + failure log dump) is now a single composite action at [`.github/actions/reboot-kamal-accessory/`](.github/actions/reboot-kamal-accessory/action.yml), shared by both flows.

## Risk profile

- **#1 (build cache)** — low risk. Worst case the cache image is corrupt and we get one slow rebuild that overwrites it.
- **#2 + #4 (`kamal deploy` with auto-fallback)** — manual-handshake risk is gone. Edge case: a `config/deploy-staging.yml` edit that doesn't strictly need a bootstrap will still spend ~30–60 s on a setup it didn't strictly need. Acceptable.
- **#3 + #5 + #7 (per-accessory gating)** — false-positive (reboot something we didn't need to) costs ~30–60 s. False-negative (skip a reboot that was needed) is the risk we *don't* want; mitigated by being conservative on every edge case (workflow_dispatch, force push, missing parent SHA → all → `true`).
- **#6 (composite action)** — pure refactor, no behavioral change beyond correctly scoping the failure-log dump.
- **#8 (Gemfile)** — Kamal version is now reproducible; bumping requires `bundle update kamal` and a commit. Lockfile platforms include the GH-runner platform plus `*-darwin` for local verification.
- **#9 (`.dockerignore`)** — defense in depth; Kamal already filters `.kamal/`, this prevents future drift.

Blast radius is the staging deploy. Recovery is `git revert` + push. No production deploy touched.

## Test plan

### Acceptance checklist (manual sign-off after merge)

**First post-merge run** — auto-detector picks `setup` (this PR modifies `config/deploy-staging.yml`), seeds the build cache, ~5 min:
- [ ] **Resolve Kamal command** logs `config/deploy-staging.yml changed in this push — running kamal setup`
- [ ] Build pushes a manifest to `ghcr.io/purposestack/givernance-build-cache`
- [ ] All accessories come up; donor flow on `staging.givernance.org` works (Stripe checkout, donation creation, team invitation)

**Second post-merge run** (any small no-Keycloak-no-config push) — the fast path:
- [ ] **Resolve Kamal command** logs `Routine push, no config change — running kamal deploy (fast path)`
- [ ] **Detect per-accessory config changes** logs `run_keycloak: false` and `run_minio_reboot: false`
- [ ] **Build and push Keycloak image / Reboot Keycloak / Wait for realm / Sync Keycloak realm / Reboot MinIO** all show as **skipped** (not failed)
- [ ] Total run ≤ ~2 min 30 s

**Per-accessory-subtree push** (e.g. bumping the Keycloak image tag in `accessories.keycloak`):
- [ ] **Detect per-accessory config changes** logs `accessories.keycloak subtree changed`, `run_keycloak: true`
- [ ] Full Keycloak chain runs; new image is on the running container after reboot
- [ ] MinIO reboot is **skipped**

**Workflow_dispatch with `mode: setup`** — confirm `kamal setup` runs.
**Workflow_dispatch with `mode: deploy`** — confirm `kamal deploy` runs.
**Workflow_dispatch with `mode: auto`** (default) — confirm it falls back to `setup`.

**Manual accessory reboot** ([`staging-accessory-reboot.yml`](.github/workflows/staging-accessory-reboot.yml) → "Run workflow" → `accessory: minio`, `confirm: minio`):
- [ ] Reboots MinIO via the shared composite action
- [ ] On a deliberate failure (e.g. invalid accessory name), the **Dump accessory logs on reboot failure** step fires only because the reboot itself failed, not because of a prior unrelated step

**Resolves**

close #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)