### PR TITLE
fix(web): nest Stripe Connect requirement keys to satisfy next-intl

### DIFF
--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -903,27 +903,43 @@
         "hint": "Click 'Continue onboarding' above to provide the missing information.",
         "fields": {
           "external_account": "Bank account for payouts",
-          "tos_acceptance.date": "Accept Stripe's Terms of Service",
-          "tos_acceptance.ip": "Accept Stripe's Terms of Service (IP)",
-          "individual.id_number": "Personal ID number",
-          "individual.dob.day": "Date of birth (day)",
-          "individual.dob.month": "Date of birth (month)",
-          "individual.dob.year": "Date of birth (year)",
-          "individual.first_name": "Legal first name",
-          "individual.last_name": "Legal last name",
-          "individual.email": "Email address",
-          "individual.phone": "Phone number",
-          "individual.address.line1": "Address (street)",
-          "individual.address.city": "Address (city)",
-          "individual.address.postal_code": "Address (postal code)",
-          "individual.address.country": "Address (country)",
-          "individual.verification.document": "ID verification document",
-          "business_profile.url": "Business website",
-          "business_profile.mcc": "Business category",
           "business_type": "Business type",
-          "company.name": "Company name",
-          "company.tax_id": "Company tax ID",
-          "company.verification.document": "Company verification document"
+          "tos_acceptance": {
+            "date": "Accept Stripe's Terms of Service",
+            "ip": "Accept Stripe's Terms of Service (IP)"
+          },
+          "individual": {
+            "id_number": "Personal ID number",
+            "first_name": "Legal first name",
+            "last_name": "Legal last name",
+            "email": "Email address",
+            "phone": "Phone number",
+            "dob": {
+              "day": "Date of birth (day)",
+              "month": "Date of birth (month)",
+              "year": "Date of birth (year)"
+            },
+            "address": {
+              "line1": "Address (street)",
+              "city": "Address (city)",
+              "postal_code": "Address (postal code)",
+              "country": "Address (country)"
+            },
+            "verification": {
+              "document": "ID verification document"
+            }
+          },
+          "business_profile": {
+            "url": "Business website",
+            "mcc": "Business category"
+          },
+          "company": {
+            "name": "Company name",
+            "tax_id": "Company tax ID",
+            "verification": {
+              "document": "Company verification document"
+            }
+          }
         }
       },
       "adminOnly": "Only organisation admins can manage payments.",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -903,27 +903,43 @@
         "hint": "Cliquez sur « Reprendre l'onboarding » ci-dessus pour fournir les informations manquantes.",
         "fields": {
           "external_account": "Compte bancaire pour les versements",
-          "tos_acceptance.date": "Accepter les CGU de Stripe",
-          "tos_acceptance.ip": "Accepter les CGU de Stripe (IP)",
-          "individual.id_number": "Numéro de pièce d'identité",
-          "individual.dob.day": "Date de naissance (jour)",
-          "individual.dob.month": "Date de naissance (mois)",
-          "individual.dob.year": "Date de naissance (année)",
-          "individual.first_name": "Prénom légal",
-          "individual.last_name": "Nom légal",
-          "individual.email": "Adresse email",
-          "individual.phone": "Numéro de téléphone",
-          "individual.address.line1": "Adresse (rue)",
-          "individual.address.city": "Adresse (ville)",
-          "individual.address.postal_code": "Adresse (code postal)",
-          "individual.address.country": "Adresse (pays)",
-          "individual.verification.document": "Document d'identité",
-          "business_profile.url": "Site web de l'organisation",
-          "business_profile.mcc": "Catégorie d'activité",
           "business_type": "Type d'entité",
-          "company.name": "Nom de l'organisation",
-          "company.tax_id": "Numéro fiscal",
-          "company.verification.document": "Document de vérification de l'organisation"
+          "tos_acceptance": {
+            "date": "Accepter les CGU de Stripe",
+            "ip": "Accepter les CGU de Stripe (IP)"
+          },
+          "individual": {
+            "id_number": "Numéro de pièce d'identité",
+            "first_name": "Prénom légal",
+            "last_name": "Nom légal",
+            "email": "Adresse email",
+            "phone": "Numéro de téléphone",
+            "dob": {
+              "day": "Date de naissance (jour)",
+              "month": "Date de naissance (mois)",
+              "year": "Date de naissance (année)"
+            },
+            "address": {
+              "line1": "Adresse (rue)",
+              "city": "Adresse (ville)",
+              "postal_code": "Adresse (code postal)",
+              "country": "Adresse (pays)"
+            },
+            "verification": {
+              "document": "Document d'identité"
+            }
+          },
+          "business_profile": {
+            "url": "Site web de l'organisation",
+            "mcc": "Catégorie d'activité"
+          },
+          "company": {
+            "name": "Nom de l'organisation",
+            "tax_id": "Numéro fiscal",
+            "verification": {
+              "document": "Document de vérification de l'organisation"
+            }
+          }
         }
       },
       "adminOnly": "Seuls les administrateurs de l'organisation peuvent gérer les paiements.",


### PR DESCRIPTION
## Summary

Runtime error on every page through `NextIntlClientProvider` (`src/app/layout.tsx:52`):

```
INVALID_KEY: Namespace keys cannot contain the character "." as this is used to express nesting.
Invalid keys: tos_acceptance.date, tos_acceptance.ip, individual.id_number,
individual.dob.day, individual.dob.month, individual.dob.year, individual.first_name,
individual.last_name, individual.email, individual.phone, individual.address.line1,
individual.address.city, individual.address.postal_code, individual.address.country,
individual.verification.document, business_profile.url, business_profile.mcc,
company.name, company.tax_id, company.verification.document
(at settings.stripeConnect.requirements.fields)
```

`next-intl` uses `.` as the message-namespace separator on lookup and refuses to load any catalog containing literal `.` in keys. The Stripe Connect requirements block in both [`messages/en.json`](packages/web/src/messages/en.json) and [`messages/fr.json`](packages/web/src/messages/fr.json) had been keyed by raw Stripe field paths (`tos_acceptance.date`, `individual.dob.day`, etc.) which Stripe returns verbatim from its API.

## Fix

Restructure `settings.stripeConnect.requirements.fields` to nest by the natural Stripe field path:

```json
"fields": {
  "external_account": "...",
  "business_type": "...",
  "tos_acceptance": { "date": "...", "ip": "..." },
  "individual": {
    "id_number": "...",
    "dob": { "day": "...", "month": "...", "year": "..." },
    "address": { "line1": "...", "city": "...", "postal_code": "...", "country": "..." },
    ...
  },
  "business_profile": { "url": "...", "mcc": "..." },
  "company": { "name": "...", "tax_id": "...", "verification": { "document": "..." } }
}
```

## Why the consumer code didn't change

[`stripe-connect-panel.tsx:206`](packages/web/src/components/settings/stripe-connect-panel.tsx#L206) does `tFields(key as never)` where `key` is whatever Stripe returns (e.g. `"individual.dob.day"`). Since `.` IS the lookup-path separator in `next-intl`, that call now walks the nested tree correctly without any code change.

## Test plan

- [ ] Reload the dev server (`pnpm --filter @givernance/web dev`) — runtime error gone on every page.
- [ ] Connect Stripe in test mode for an org without an external account, observe the requirements list on `/settings/payments` shows correctly translated labels.
- [ ] French locale: same screen renders the FR translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)