### PR TITLE
fix(ci): repair MINIO_KMS fallback + add accessory-reboot workflow

### DIFF
--- a/.github/actions/setup-kamal-secrets/action.yml
+++ b/.github/actions/setup-kamal-secrets/action.yml
@@ -1,0 +1,77 @@
+name: Setup Kamal Secrets
+description: >
+  Build the `.kamal/secrets` file the staging deploy + accessory-reboot
+  workflows hand to Kamal. Reads the resolved secret values from environment
+  variables the caller workflow exports (so the GH `secrets.*` lookups stay
+  scoped to the caller, which knows its `environment:`). Validates that
+  `MINIO_KMS_SECRET_KEY` decodes to exactly 32 bytes — MinIO refuses to boot
+  on any other length, and a bad fallback masquerading as a valid secret was
+  the root cause of the 2026-04-29 staging incident (issue #211).
+
+  Single source of truth for the secrets bag: deploy-staging.yml and
+  staging-accessory-reboot.yml both `uses: ./.github/actions/setup-kamal-secrets`,
+  so a future change to the bag (new var, rotation policy) lands in one place.
+
+runs:
+  using: composite
+  steps:
+    - name: Build .kamal/secrets and validate MINIO_KMS
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p .kamal
+
+        # Apply non-load-bearing fallbacks for staging-only credentials so
+        # a fresh fork or accidentally-deleted secret doesn't block the
+        # deploy. These match the values the local docker-compose stack
+        # uses; production must override every one of them via a real
+        # secret.
+        PG_PASS="${POSTGRES_PASSWORD:-staging_postgres_123}"
+        REDIS_PASS="${REDIS_PASSWORD:-staging_redis_123}"
+        MINIO_PASS="${MINIO_ROOT_PASSWORD:-staging_minio_123}"
+        KC_PASS="${KEYCLOAK_ADMIN_PASSWORD:-staging_keycloak_123}"
+        KC_CLIENT_SECRET="${KEYCLOAK_ADMIN_CLIENT_SECRET:-staging_keycloak_client_secret_123}"
+        SESSION_SEC="${SESSION_SECRET:-staging_session_secret_123}"
+        # Resend API key — required because deploy-staging.yml sets
+        # EMAIL_PROVIDER=resend; missing key crashes the worker on first
+        # send. No fallback: an unset secret here is a deploy bug.
+        RESEND_KEY="${RESEND_API_KEY:-}"
+        # Stripe — empty fallback intentionally surfaces the user-facing
+        # "Stripe is not configured" message instead of silently no-op'ing
+        # the route. Set via `gh secret set --env staging`
+        # (see docs/dev/stripe-local-setup.md → Staging deployment).
+        STRIPE_SECRET="${STRIPE_SECRET_KEY:-}"
+        STRIPE_WEBHOOK_SEC="${STRIPE_WEBHOOK_SECRET:-}"
+        # MinIO server-side AES256 encryption key. Format
+        # `<key-name>:<base64-32-byte-secret>`; generate with
+        # `openssl rand -base64 32`. The base64 portion MUST decode to
+        # *exactly* 32 bytes — the validation step below enforces this so
+        # a future maintainer who edits the fallback can't silently
+        # reproduce the 2026-04-29 outage (issue #211).
+        MINIO_KMS="${MINIO_KMS_SECRET_KEY:-staging-kms:p3wiREaVf4VXPFYGTbdyrk5kVzqCrd9jEpw1EgEl/Qg=}"
+
+        KMS_BASE64="${MINIO_KMS#*:}"
+        KMS_LEN=$(printf '%s' "$KMS_BASE64" | base64 -d 2>/dev/null | wc -c | tr -d ' ')
+        if [ "$KMS_LEN" != "32" ]; then
+          echo "::error::MINIO_KMS_SECRET_KEY base64 portion decodes to $KMS_LEN bytes, MinIO requires exactly 32. Regenerate with 'openssl rand -base64 32' and update the GH secret (or the fallback in this action)." >&2
+          exit 1
+        fi
+
+        cat <<EOF > .kamal/secrets
+        GITHUB_TOKEN=${GITHUB_TOKEN}
+        POSTGRES_PASSWORD=$PG_PASS
+        REDIS_PASSWORD=$REDIS_PASS
+        MINIO_ROOT_PASSWORD=$MINIO_PASS
+        MINIO_KMS_SECRET_KEY=$MINIO_KMS
+        KEYCLOAK_ADMIN_PASSWORD=$KC_PASS
+        SESSION_SECRET=$SESSION_SEC
+        KC_DB_PASSWORD=$PG_PASS
+        DATABASE_URL=postgres://givernance:$PG_PASS@givernance-postgres:5432/givernance_staging
+        DATABASE_URL_APP=postgres://givernance:$PG_PASS@givernance-postgres:5432/givernance_staging
+        REDIS_URL=redis://:$REDIS_PASS@givernance-redis:6379
+        S3_SECRET_ACCESS_KEY=$MINIO_PASS
+        KEYCLOAK_ADMIN_CLIENT_SECRET=$KC_CLIENT_SECRET
+        RESEND_API_KEY=$RESEND_KEY
+        STRIPE_SECRET_KEY=$STRIPE_SECRET
+        STRIPE_WEBHOOK_SECRET=$STRIPE_WEBHOOK_SEC
+        EOF

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,49 +53,23 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
+      # Resolve every secret via `staging` env first (with fallbacks for
+      # non-load-bearing values) and hand them to the composite action,
+      # which writes `.kamal/secrets` and validates MINIO_KMS_SECRET_KEY.
+      # Same setup is reused by .github/workflows/staging-accessory-reboot.yml.
       - name: Setup Kamal Secrets
-        run: |
-          mkdir -p .kamal
-          PG_PASS="${{ secrets.POSTGRES_PASSWORD || 'staging_postgres_123' }}"
-          REDIS_PASS="${{ secrets.REDIS_PASSWORD || 'staging_redis_123' }}"
-          MINIO_PASS="${{ secrets.MINIO_ROOT_PASSWORD || 'staging_minio_123' }}"
-          KC_PASS="${{ secrets.KEYCLOAK_ADMIN_PASSWORD || 'staging_keycloak_123' }}"
-          KC_CLIENT_SECRET="${{ secrets.KEYCLOAK_ADMIN_CLIENT_SECRET || 'staging_keycloak_client_secret_123' }}"
-          SESSION_SEC="${{ secrets.SESSION_SECRET || 'staging_session_secret_123' }}"
-          # Resend API key — required because deploy-staging.yml sets
-          # EMAIL_PROVIDER=resend; missing key crashes the worker on first
-          # send. No fallback: an unset secret here is a deploy bug.
-          RESEND_KEY="${{ secrets.RESEND_API_KEY }}"
-          # Stripe — empty fallback intentionally surfaces the user-facing
-          # "Stripe is not configured" message instead of silently no-op'ing
-          # the route. Set the actual values via `gh secret set --env staging`
-          # (see docs/dev/stripe-local-setup.md → Staging deployment).
-          STRIPE_SECRET="${{ secrets.STRIPE_SECRET_KEY || '' }}"
-          STRIPE_WEBHOOK_SEC="${{ secrets.STRIPE_WEBHOOK_SECRET || '' }}"
-          # MinIO server-side AES256 encryption key. Format
-          # `<key-name>:<base64-32-byte-secret>`; generate with
-          # `openssl rand -base64 32`. Without this the worker DLQs every
-          # receipt PDF upload (issue #193 follow-up).
-          MINIO_KMS="${{ secrets.MINIO_KMS_SECRET_KEY || 'staging-kms:c3RhZ2luZy1taW5pby1rbXMtZmFsbGJhY2stMzItYnl0ZXM=' }}"
-
-          cat <<EOF > .kamal/secrets
-          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          POSTGRES_PASSWORD=$PG_PASS
-          REDIS_PASSWORD=$REDIS_PASS
-          MINIO_ROOT_PASSWORD=$MINIO_PASS
-          MINIO_KMS_SECRET_KEY=$MINIO_KMS
-          KEYCLOAK_ADMIN_PASSWORD=$KC_PASS
-          SESSION_SECRET=$SESSION_SEC
-          KC_DB_PASSWORD=$PG_PASS
-          DATABASE_URL=postgres://givernance:$PG_PASS@givernance-postgres:5432/givernance_staging
-          DATABASE_URL_APP=postgres://givernance:$PG_PASS@givernance-postgres:5432/givernance_staging
-          REDIS_URL=redis://:$REDIS_PASS@givernance-redis:6379
-          S3_SECRET_ACCESS_KEY=$MINIO_PASS
-          KEYCLOAK_ADMIN_CLIENT_SECRET=$KC_CLIENT_SECRET
-          RESEND_API_KEY=$RESEND_KEY
-          STRIPE_SECRET_KEY=$STRIPE_SECRET
-          STRIPE_WEBHOOK_SECRET=$STRIPE_WEBHOOK_SEC
-          EOF
+        uses: ./.github/actions/setup-kamal-secrets
+        env:
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+          KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD }}
+          KEYCLOAK_ADMIN_CLIENT_SECRET: ${{ secrets.KEYCLOAK_ADMIN_CLIENT_SECRET }}
+          SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          MINIO_KMS_SECRET_KEY: ${{ secrets.MINIO_KMS_SECRET_KEY }}
 
       - name: Build and push Keycloak image
         run: |

--- a/.github/workflows/staging-accessory-reboot.yml
+++ b/.github/workflows/staging-accessory-reboot.yml
@@ -1,0 +1,103 @@
+name: Reboot Staging Accessory
+
+# Manually-triggered workaround for accessory env-var changes that the
+# per-push `Deploy to Staging` flow doesn't cover. `kamal deploy` only
+# rolls app containers (web, api, worker, relay); accessories
+# (postgres, redis, minio, keycloak) keep running with whatever env
+# they were last booted with. So when an accessory secret rotates
+# (e.g. MINIO_KMS_SECRET_KEY, KEYCLOAK_ADMIN_PASSWORD) or its image
+# bumps for a CVE patch, this workflow re-boots the named accessory
+# with the *current* GH secret values — without forcing a slow
+# `kamal setup` or an out-of-band `docker run` on the VPS that drifts
+# Kamal's view of the world (issue #212; see incident on 2026-04-29).
+
+on:
+  workflow_dispatch:
+    inputs:
+      accessory:
+        description: Accessory to reboot
+        required: true
+        type: choice
+        options:
+          - minio
+          - redis
+          - postgres
+          - keycloak
+      confirm:
+        description: >
+          Type the accessory name again to confirm (extra-click guard,
+          since rebooting an accessory drops every connection it was
+          serving).
+        required: true
+        type: string
+
+jobs:
+  reboot:
+    name: Reboot ${{ inputs.accessory }}
+    runs-on: ubuntu-latest
+    # Same `staging` GitHub Environment as deploy-staging.yml so the
+    # secrets bag resolves identically. Approval gates / branch policies
+    # added later attach here automatically.
+    environment: staging
+    concurrency:
+      # Share the deploy-staging concurrency group so a reboot can't
+      # collide with an in-flight `kamal setup` (both touch the same
+      # Kamal lock).
+      group: deploy-staging
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: read
+    env:
+      STAGING_VPS_IP: ${{ secrets.VPS_IP }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Validate confirm input
+        run: |
+          if [ "${{ inputs.confirm }}" != "${{ inputs.accessory }}" ]; then
+            echo "::error::Confirm input '${{ inputs.confirm }}' does not match accessory '${{ inputs.accessory }}'. Re-run and type the accessory name in the confirm field." >&2
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby (for Kamal)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Install Kamal
+        run: gem install kamal
+
+      - name: Configure SSH Auth Sock
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      # Same secrets bag as deploy-staging.yml — single source of truth
+      # in .github/actions/setup-kamal-secrets/action.yml. Any future
+      # rotation / new var lands once and propagates to both flows.
+      - name: Setup Kamal Secrets
+        uses: ./.github/actions/setup-kamal-secrets
+        env:
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+          KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD }}
+          KEYCLOAK_ADMIN_CLIENT_SECRET: ${{ secrets.KEYCLOAK_ADMIN_CLIENT_SECRET }}
+          SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          MINIO_KMS_SECRET_KEY: ${{ secrets.MINIO_KMS_SECRET_KEY }}
+
+      - name: Reboot accessory
+        run: kamal accessory reboot "${{ inputs.accessory }}" -c config/deploy-staging.yml
+
+      - name: Dump accessory logs on failure
+        if: failure()
+        run: |
+          kamal server exec -c config/deploy-staging.yml \
+            "docker logs givernance-${{ inputs.accessory }} --tail 100" || true

--- a/docs/dev/stripe-local-setup.md
+++ b/docs/dev/stripe-local-setup.md
@@ -300,6 +300,18 @@ After deploy, smoke-test by:
 - **Stripe keys**: regenerate in the dashboard, update both `gh secret set …` values, redeploy.
 - **MINIO_KMS_SECRET_KEY**: generate a new value, update the secret, redeploy. **Existing receipts encrypted with the old key won't be readable** — staging data is non-load-bearing so this is acceptable; production rotation will need MinIO's `MINIO_KMS_AUTO_ENCRYPTION` config to keep both keys mounted.
 
+  The `Deploy to Staging` workflow validates that the resolved value (secret OR fallback) decodes to exactly 32 bytes; a mismatch fails the deploy with `MINIO_KMS_SECRET_KEY base64 portion decodes to N bytes, MinIO requires exactly 32`. Catches both a botched fallback edit and a malformed `gh secret set` value (issue #211).
+
+### Rotating an accessory env var without a full setup
+
+`kamal deploy` (the per-push staging flow) only rolls app containers — `web`, `api`, `worker`, `relay`. Accessories (`postgres`, `redis`, `minio`, `keycloak`) keep running with whatever env they were last booted with. So when you rotate an accessory secret (e.g. `MINIO_KMS_SECRET_KEY`, `KEYCLOAK_ADMIN_PASSWORD`) or bump an accessory image for a CVE patch, the per-push deploy will *not* pick it up.
+
+Use **`Reboot Staging Accessory`** (`.github/workflows/staging-accessory-reboot.yml`) — `Actions → Reboot Staging Accessory → Run workflow`, pick the accessory, type its name into the confirm field. The workflow reuses the same secrets bag as the deploy (single source of truth in `.github/actions/setup-kamal-secrets/action.yml`), then runs `kamal accessory reboot <name>`. This is the path that would have closed the 2026-04-29 incident in one click instead of an SSH session (issue #212).
+
+When NOT to use it:
+- **Accessory schema/topology change** (new port mapping, new mounted file, new env var added in `config/deploy-staging.yml`). Kamal needs to re-render the Compose config — use `workflow_dispatch` on the regular `Deploy to Staging` workflow, which runs `kamal setup` (slower, full bootstrap).
+- **App container restart** (web, api, worker, relay). Push to `main` or re-run the deploy workflow; `kamal deploy` already covers these.
+
 ---
 
 ## What's not covered yet


### PR DESCRIPTION
## Summary

Two CI/infra follow-ups to the 2026-04-29 staging incident chain.

- **#211** — The fallback for `MINIO_KMS_SECRET_KEY` in `.github/workflows/deploy-staging.yml` decoded to **35 bytes** instead of 32 (the literal `staging-minio-kms-fallback-32-bytes`). Any deploy without the GitHub secret set hit the fallback → MinIO refused to boot → every receipt PDF upload DLQ'd silently. Replaced with a fresh `openssl rand -base64 32` value and added a CI guard that fails the deploy fast if the resolved value (secret OR fallback) doesn't decode to exactly 32 bytes.
- **#212** — Added `.github/workflows/staging-accessory-reboot.yml`, a manually-triggered workflow for accessory env-var changes that the per-push `kamal deploy` doesn't pick up (the per-push flow only rolls app containers — `web`, `api`, `worker`, `relay`). Same secrets bag as the deploy, single source of truth via a new composite action at `.github/actions/setup-kamal-secrets`. Choice input + free-text confirm guards against accidental clicks.

The 2026-04-29 hotfix had to bypass Kamal entirely with an SSH `docker run` on the VPS. With this workflow available, the same kind of incident gets a 1-click fix instead.

## Test plan

- [x] `actionlint` passes on all three YAML files
- [x] Composite action's KMS validation simulated for three paths: unset secret + fallback (passes), valid 32-byte secret (passes), the previously-broken 35-byte string (correctly rejected)
- [x] `pnpm build` / `pnpm typecheck` / `pnpm lint` / `pnpm test` (681 tests) all green
- [ ] Smoke-test post-merge: trigger `Reboot Staging Accessory` workflow with `accessory=minio`, `confirm=minio`, then `docker inspect givernance-minio` on the VPS and verify `MINIO_KMS_SECRET_KEY` env appears
- [ ] Verify next push-to-main deploy still works end-to-end (composite-action refactor of the secrets-write step is the only behavior-affecting change there)
- [ ] Confirm running deploy with `MINIO_KMS_SECRET_KEY` GH secret unset → MinIO accessory boots cleanly with the new fallback

close #211
close #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)