### PR TITLE
feat(payments): Mollie gateway + Stripe account.updated (#62)

### DIFF
--- a/docs/dev/mollie-local-setup.md
+++ b/docs/dev/mollie-local-setup.md
@@ -1,0 +1,289 @@
+# Mollie — Local Development Setup
+
+This guide walks through wiring Mollie into your local Givernance dev environment, end-to-end, so you can run a full donor-pays-NPO flow against the real Mollie API **in test mode** (no money moves, no NPO verification needed).
+
+The first time you do this you'll spend about 15 minutes. After that, the only step that needs to be running between sessions is the public tunnel that fronts your local API for Mollie's webhook to reach.
+
+> **Audience.** Engineers running the stack via `pnpm dev` + Docker Compose, who already have Stripe local dev set up (see [stripe-local-setup.md](stripe-local-setup.md)). The two providers coexist — you don't need to tear down Stripe to add Mollie.
+>
+> **Why two payment providers.** ADR-010 (`docs/20-payment-strategy.md` §4) selects Stripe Connect as the primary gateway and Mollie as **co-primary for FR/BE/NL** because Mollie's NPO program offers simpler verification + native EU residency. The architecture is per-tenant: each org chooses one provider in Settings → Payment gateway. This doc gets you to the point where you can test the Mollie path locally with the same dev DB you use for Stripe testing.
+
+---
+
+## Prerequisites
+
+- Repo cloned and `pnpm install` run.
+- Docker Compose stack up (`./scripts/dev-up.sh`).
+- API + worker + web running (`pnpm dev`).
+- A way to expose `http://localhost:4000` to the public internet — Mollie's webhook is a real HTTP POST from Mollie's servers and **cannot reach `localhost`**. Recommended:
+  - **Cloudflare Tunnel** (free, no signup-time-of-day limits): `brew install cloudflared`
+  - **ngrok** as fallback: `brew install ngrok`
+
+---
+
+## Step 1 — Create a Mollie account (test mode only)
+
+1. Go to https://my.mollie.com/dashboard/signup.
+2. Sign up with your work email. Pick **non-profit** as the organisation type — that path stays in test mode without asking for the verification documents Mollie needs to enable live payments. (For real NPO onboarding, Mollie's NPO programme requires a few documents; it's still simpler than Stripe's KYB.)
+3. Confirm your email; the dashboard loads in **test mode** by default. The toggle is the round badge in the top-right of every dashboard page — keep it on **Test mode** for everything in this guide. Test-mode payments never move money and never trigger payouts.
+4. **No NPO verification is required for test mode.** You can run the full local donor flow today.
+
+---
+
+## Step 2 — Copy your Mollie test API key
+
+1. Open **Developers → API keys** (https://my.mollie.com/dashboard/developers/api-keys).
+2. You'll see two keys:
+   - **Test API key** — starts with `test_…`. **This is the one you want.**
+   - **Live API key** — starts with `live_…`. Don't touch this for local dev.
+3. Click the **eye** icon next to the test key to reveal it, then copy.
+
+> **One key per Mollie account, not per tenant.** Unlike Stripe Connect (where the platform creates a separate connected account per NPO), Mollie's Phase 1 model gives each NPO their own Mollie account and they paste their own test/live key into Givernance Settings. For local dev, you're playing both roles — your Mollie test key represents "the NPO's Mollie account" in Step 6.
+
+---
+
+## Step 3 — Mint the platform webhook signing secret
+
+The `X-Mollie-Signature` HMAC verification on `POST /v1/donations/mollie-webhook` uses a **platform-level** signing secret (one per Givernance deployment), distinct from the per-tenant API key. Mollie generates this when you register a webhook endpoint.
+
+For local dev, we don't register a permanent endpoint — we use the per-payment `webhookUrl` field that Mollie reads off each `payments.create` call. That field doesn't have its own signing secret yet (Mollie's "next-gen webhooks" signing is opt-in per endpoint), so for **local development we generate a synthetic secret** and configure Givernance to verify against it. The Mollie CLI (or a `curl` request that signs the body identically) can then drive the worker through the full webhook flow.
+
+Generate a random 32-byte secret:
+
+```sh
+openssl rand -hex 32
+# → 7f3a8b…  (copy this)
+```
+
+You'll paste it into `.env` in Step 5 and use it again in Step 7 when crafting test webhook requests.
+
+> **Why synthetic in dev.** Mollie production tenants register the endpoint under **Developers → Webhooks → New endpoint** and Mollie issues a `whsec`-style secret bound to that endpoint. We deliberately avoid that for local dev because (a) the endpoint URL changes every tunnel restart and (b) Mollie webhooks can be replayed manually from the dashboard, so a synthetic secret + the same HMAC algorithm gives full coverage without dashboard juggling. See `docs/20-payment-strategy.md` §5.3 for the production registration flow.
+
+---
+
+## Step 4 — Start a public tunnel to your local API
+
+Mollie's webhook is a server-to-server POST from Mollie's data centre. It must hit a publicly resolvable hostname.
+
+**Option A — Cloudflare Tunnel (recommended):**
+
+In a terminal you'll keep running for the rest of your session:
+
+```sh
+cloudflared tunnel --url http://localhost:4000
+```
+
+After 5–10 seconds, the output prints:
+
+```
+Your quick Tunnel has been created! Visit it at:
+  https://random-words-here.trycloudflare.com
+```
+
+Copy that hostname. Your local API is now reachable at `https://random-words-here.trycloudflare.com/v1/donations/mollie-webhook`.
+
+**Option B — ngrok:**
+
+```sh
+ngrok http 4000
+```
+
+Copy the `https://….ngrok-free.app` URL from the output.
+
+> **Cloudflare Tunnel vs ngrok.** Cloudflare Tunnel issues a fresh hostname per session with no time limit and no account needed. ngrok's free tier is also fine but rate-limits more aggressively and requires sign-up after the first few minutes. Either works.
+
+The tunnel terminal must stay open the whole time you're testing — closing it kills the URL and Mollie webhook delivery breaks.
+
+---
+
+## Step 5 — Wire Mollie into `.env`
+
+Open the repo's root `.env` (copy from `.env.example` if it doesn't exist yet). Add a **Mollie** block:
+
+```sh
+# Platform-level webhook signing secret (Step 3). HMAC-SHA256 of the
+# raw request body, hex-encoded, in the X-Mollie-Signature header.
+MOLLIE_WEBHOOK_SECRET=7f3a8b…  # the openssl rand -hex 32 output
+
+# Public hostname Mollie can reach. Used by the donate endpoint to set
+# webhookUrl on every payments.create call. Leave APP_URL alone if you
+# don't have any public-tunnel-aware code path beyond the donor flow.
+APP_URL=https://random-words-here.trycloudflare.com  # the tunnel URL
+```
+
+> **`APP_URL` does double duty.** It's the canonical public URL for the API and is used for two things in the Mollie path: (1) it's the prefix for the donor `redirectUrl` (`${APP_URL}/p/<campaignId>`) — Mollie sends donors here after checkout, (2) it's the prefix for `webhookUrl` (`${APP_URL}/v1/donations/mollie-webhook`) — Mollie POSTs status changes here. The donor redirect would technically work even with `APP_URL=http://localhost:3000` because the donor's browser does the navigation, but the webhook MUST be a real public URL or every donation stays stuck in `open` status.
+
+Restart `pnpm dev` so the API + worker pick up the new env. Both services read `.env` once at boot and don't watch it.
+
+---
+
+## Step 6 — Onboard your tenant via the Settings UI
+
+The org-admin Settings page now has a **Payment gateway** panel that lets you switch between Stripe / Mollie / Manual.
+
+1. Sign in to `http://localhost:3000` as an org admin (use the seeded admin from `pnpm db:seed:local` — see `scripts/dev-up.sh`).
+2. Navigate to **Settings → Payment gateway**.
+3. The Mollie option is **disabled by default**. To enable it for your test tenant, you need to flip the `ff.payments.mollie` feature flag on the tenant row. There's no admin UI for the flag yet (doc-18 will add one) — do it directly in Postgres:
+    ```sh
+    docker compose exec postgres psql -U givernance -d givernance -c \
+      "UPDATE tenants SET feature_flags = '{\"ff.payments.mollie\": true}'::jsonb WHERE slug = 'givernance';"
+    ```
+    (Replace `'givernance'` with whatever slug your seeded admin tenant uses.)
+4. Refresh the Settings page. The **Mollie** option in the dropdown is now selectable.
+5. Pick **Mollie**, paste your `test_…` API key from Step 2 into the **Mollie API key** field, and click **Save changes**.
+6. The panel re-fetches state and shows **Active: Mollie** + a **Mollie key configured** badge. The tenant's `payment_gateway` column is now `'mollie'` and `mollie_api_key` holds the test key.
+
+The API key is stored as plaintext VARCHAR for the FR/BE/NL pilot — KMS encryption is a Phase 2 follow-up (issue #223). The Settings response NEVER echoes the stored key back; only a `mollieConfigured` boolean. The Pino redact paths cover the request body so the key can't leak into Loki on a 4xx/5xx.
+
+> **No NPO-side onboarding form.** This is the biggest UX difference from Stripe Connect: Mollie tenants paste a key they got from their own Mollie dashboard, end of story. No hosted onboarding flow, no `accounts.create` round-trip, no `account.updated` webhook to wait for. The trade-off is that Mollie tenants must already have a Mollie account; Stripe tenants get created on the fly during onboarding.
+
+---
+
+## Step 7 — Test a real donation from the public campaign page
+
+1. Make sure you have a published campaign with a public page. If not, in the app: **Campaigns → New**, then on the campaign detail page open **Public page**, fill the title/description, set status to **Published**.
+2. Open the public URL: `http://localhost:3000/p/<campaign-id>` (the campaign page exposes a copy-link button).
+3. Fill the donor details: name, email, amount (`50` is fine), currency (EUR).
+4. Click **Continue to payment**. The browser navigates AWAY from Givernance to a Mollie-hosted checkout URL like `https://www.mollie.com/checkout/test/2-tr_xxx…`.
+5. Mollie's test-mode checkout doesn't ask for real card / IBAN data. You see a **status picker**:
+    - **Paid** — simulates a successful donation
+    - **Failed** — simulates a card decline / IBAN reject
+    - **Canceled** — simulates donor abandoning at the bank
+    - **Expired** — simulates a SEPA / iDEAL session timing out
+    - (and a few more — see https://docs.mollie.com/overview/testing)
+6. Pick **Paid**.
+7. Mollie redirects the donor back to `${APP_URL}/p/<campaign-id>` (the URL set on `redirectUrl`). The donor sees the campaign page render normally — no in-page confirmation yet (that's a polish follow-up; the donation is already credited server-side).
+
+While this is happening, watch your terminals:
+
+- **Cloudflare Tunnel terminal** prints `POST /v1/donations/mollie-webhook → 200`
+- **API terminal** prints `Mollie webhook event queued` with `molliePaymentId: tr_…`
+- **Worker terminal** prints `Donation created from Mollie payment.paid` with the donation ID
+
+Switch back to the app:
+
+- In **Donations** (admin), the new gift appears with `payment_method: ideal` (or `bancontact`, `creditcard`, etc. — whatever Mollie picked for test mode), `payment_ref: tr_…`, and a constituent matched/created from the donor email.
+- The campaign's `platform_fees_cents` is **not** incremented — Mollie has no Stripe-Connect-equivalent fee mechanism in Phase 1, so Mollie donations record `platform_fee_cents = 0` (see ADR-010 follow-up #224 for the planned monetisation path).
+
+> **The webhook fires multiple times per payment.** Mollie sends a webhook on every status transition (`open → pending → paid` / `failed` / etc.). Givernance's worker fetches the payment via `payments.get` to learn the actual status; the `webhook_events` row gets re-keyed from `tr_xxx` to `tr_xxx-paid` so each transition is processed exactly once but a true retry on the same status is deduped. Look at the worker logs — you may see two `Mollie webhook event queued` entries for a single donation, which is normal.
+
+---
+
+## Test methods reference
+
+Mollie test mode lets you pick the resulting status directly in the checkout UI — there are no "test card numbers" because the donor never enters card data on the Mollie test page. The status picker covers:
+
+| Picker option | Worker outcome |
+| --- | --- |
+| **Paid** | `donations` row inserted, `donation.created` outbox event |
+| **Pending** | No row yet — wait for the next webhook to fire `paid` or `failed` |
+| **Authorized** | No row yet — `authorized` is a pre-capture hold for "pay later" methods like Klarna; we wait for the capture flow's own `paid` webhook |
+| **Failed** | No row inserted, status logged |
+| **Canceled** / **Expired** | No row inserted, status logged |
+
+For automated testing (`packages/worker/src/tests/integration/mollie-webhook.test.ts`), the Mollie SDK is mocked at the module boundary so we can synthesise any of these without hitting Mollie. See that file for the test pattern.
+
+Full list of Mollie test scenarios: https://docs.mollie.com/overview/testing.
+
+---
+
+## Troubleshooting
+
+**Settings → Payment gateway shows Mollie greyed out**
+The `ff.payments.mollie` flag isn't set on the tenant. Run the `UPDATE tenants SET feature_flags = …` query from Step 6, then hard-refresh the Settings page (the panel reads the flag from the API on every load).
+
+**`POST /v1/admin/payment-gateway → 400 Mollie API key is required when switching gateway to mollie`**
+You picked **Mollie** in the dropdown but the **Mollie API key** field was empty. The API refuses to enable the gateway without a key (we don't want a tenant whose `payment_gateway = 'mollie'` but no key — the donor flow would 502). Paste a `test_…` key.
+
+**`POST /v1/donations/mollie-webhook → 400 Signature verification failed`**
+Either `MOLLIE_WEBHOOK_SECRET` doesn't match the secret you signed the test request with, or you restarted `pnpm dev` without re-reading `.env`. The signing algorithm is HMAC-SHA256 over the raw form-encoded body, hex-encoded, in the `X-Mollie-Signature` header (with optional `sha256=` prefix). To craft a manual test:
+```sh
+SECRET=$(grep MOLLIE_WEBHOOK_SECRET .env | cut -d= -f2)
+BODY="id=tr_test_manual_$$"
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
+curl -X POST https://your-tunnel.trycloudflare.com/v1/donations/mollie-webhook \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "X-Mollie-Signature: $SIG" \
+  -d "$BODY"
+```
+
+**Webhook arrives but donation never appears**
+Check the worker terminal for `No Mollie tenant claimed this payment — skipping`. This means `processMollieWebhook` iterated every Mollie-enabled tenant's API key calling `payments.get(<id>)` and got 404 from all of them. Cause: the test payment id you sent isn't owned by the API key in `tenants.mollie_api_key`. If you crafted the request manually with a synthetic id, this is expected — only payments Mollie actually issued under your test key will resolve.
+
+**Donor redirected back to the app but the page doesn't show the donation immediately**
+Eventual consistency. The webhook fires asynchronously after the donor's redirect; depending on tunnel latency this can lag the redirect by 1–2 seconds. Refresh and the donation appears under **Donations**. If it doesn't appear after 10s, check the worker logs.
+
+**`Cannot connect to Mollie API` errors in the worker**
+The per-tenant `mollie_api_key` is wrong or expired. Mollie test keys don't expire on a fixed schedule but they do get invalidated if you regenerate them in the dashboard. Re-paste a fresh key in Settings.
+
+**Tunnel URL changed and `APP_URL` is stale**
+Cloudflare Tunnel issues a fresh URL on every restart. After restarting the tunnel, update `APP_URL` in `.env` and `pnpm dev` to pick up the new URL — otherwise existing payments use a stale `webhookUrl` and Mollie's delivery retries land on a defunct hostname. (For longer sessions, register a named Cloudflare Tunnel — `cloudflared tunnel create givernance-dev` — which gives you a stable URL across restarts.)
+
+---
+
+## Differences from Stripe (fee model + marketplace)
+
+If you're already familiar with the Stripe flow from `stripe-local-setup.md`, these are the differences that affect onboarding, fee collection, and operations.
+
+### 1. Marketplace / "platform" model
+
+| | Stripe Connect | Mollie (Phase 1) |
+| --- | --- | --- |
+| Givernance's role | **Platform** in Stripe's marketplace model. Owns a single Stripe platform account; each NPO is a **connected account** (`acct_…`) created on-demand via Express onboarding. | **Not a marketplace operator.** Givernance is just a relay: it stores the NPO's own Mollie API key and uses it server-side. The NPO has their own Mollie account, signed up directly with Mollie. |
+| NPO onboarding | Hosted Express form on `connect.stripe.com`. Givernance's API calls `accounts.create` + `accountLinks.create`; the NPO never logs into Stripe directly — KYB is collected by Stripe and verified out-of-band. | NPO signs up at `my.mollie.com`, completes Mollie's NPO verification (separately from Givernance), copies their `live_…` API key, pastes it into Givernance Settings → Payment gateway. |
+| Identity proof | Stripe's KYB (typically 2–5 business days for live mode). Test mode is instant. | Mollie's NPO programme (faster than Stripe per ADR-010, but still a few days). Test keys work immediately without verification. |
+| Single source of truth for "is this account chargeable?" | `account.updated` webhook → `tenants.stripe_charges_enabled` cached in our DB (PR #222). | The presence of a `live_…` key in `tenants.mollie_api_key` IS the readiness signal — there's no equivalent webhook because Givernance isn't the operator of the Mollie account. |
+
+**Operational implication.** Stripe lets us ship a single signup flow that takes a tenant from "no payments" to "donor can donate" without leaving the Givernance UI. Mollie's Phase 1 flow is a two-step ritual: NPO signs up with Mollie themselves, then comes back to Givernance to paste a key. Filed as follow-up #224 — Mollie Connect / OAuth would close that gap.
+
+### 2. Platform fee collection (this is the most important difference)
+
+| | Stripe Connect | Mollie (Phase 1) |
+| --- | --- | --- |
+| How Givernance gets paid | `application_fee_amount` on every PaymentIntent → Stripe automatically routes that fraction to the platform balance, the rest to the NPO's connected account balance, in **a single charge**. | **No equivalent mechanism.** Mollie has no platform-fee facility for non-Connect accounts. 100% of the donation lands on the NPO's Mollie balance. |
+| Today's behaviour in code | `packages/api/src/lib/payments/stripe-gateway.ts` passes `application_fee_amount: applicationFeeAmountCents` (1.5% + 30¢, computed in `packages/api/src/modules/public/service.ts:calculatePlatformFee`). The `payment_intent.succeeded` worker logs that fee on `donations.platform_fee_cents` and accumulates it on `campaigns.platform_fees_cents`. | `packages/worker/src/processors/mollie-webhook.ts:handleMolliePaid` hardcodes `platformFeeCents = 0` and skips the campaign accumulator update entirely. The `application_fee_cents` field IS still written to Mollie metadata for audit traceability but the worker doesn't read it — Mollie doesn't actually deduct anything. |
+| Refund handling | `refunds.create` with `refund_application_fee: true` returns the application fee to the NPO's balance alongside the donor refund — the platform's books reverse cleanly. | The refund route currently bypasses Mollie entirely (it's still Stripe-only — see follow-up #225). Once gateway-aware, Mollie refunds simply move the full donation amount back from the NPO's Mollie balance — there's no platform-fee reversal because there was no platform fee to begin with. |
+| Cash-flow timing | Stripe pays out the NPO's balance on its rolling Stripe schedule (default daily, T+2 to T+7 in EU); the platform fee shows up in Givernance's Stripe balance immediately. | Mollie pays out the NPO's full donation balance on its own schedule. Givernance receives nothing automatically — we'd have to invoice the NPO for our SaaS subscription separately. |
+
+**Operational implication.** Today, Stripe-tenant donations finance Givernance's platform automatically. Mollie-tenant donations don't — we currently rely on Mollie tenants paying their Givernance subscription out-of-band. **Don't roll Mollie out to a tenant who isn't on a paid Givernance plan**, otherwise we're processing donations for them at zero revenue.
+
+The two paths to fix this in Phase 2:
+
+1. **Mollie Connect (preferred)** — same model as Stripe Connect, where Mollie is aware of Givernance as a platform and supports a payout split. Filed as follow-up #224.
+2. **Stripe-billed platform fee** — keep Mollie for the donor checkout, but bill the NPO a periodic Givernance subscription fee via Stripe Billing. Decoupled from per-donation flow but adds a moving part. Discussed in `docs/20-payment-strategy.md` §10 future work.
+
+### 3. Webhook contract
+
+| | Stripe | Mollie |
+| --- | --- | --- |
+| Body | Signed JSON envelope (`event.data.object` is the resource). | Form-encoded `id=tr_…` only — you fetch the payment via the API to learn the actual status. |
+| Signature | `Stripe-Signature: t=<unix>,v1=<hex>` plus an optional secondary `v0=` value — verified by `stripe.webhooks.constructEvent`, which handles both signing methods + a 5-minute replay window. | `X-Mollie-Signature: <hex>` (or `sha256=<hex>` with optional prefix) — HMAC-SHA256 of the raw body, no timestamp / replay window. We re-implement verification in `packages/api/src/lib/payments/mollie-gateway.ts` using Node's `crypto.createHmac` because the `@mollie/api-client@4.x` SDK doesn't ship with a verifier helper. |
+| Replay protection | Stripe's signature includes a timestamp; the SDK rejects events older than 5 minutes by default. | None — Mollie's signature is content-only. Replay attacks are mitigated by the `(provider, provider_event_id)` unique index on `webhook_events`: a duplicate webhook for the same status transition is rejected at insert time. |
+| Local development tooling | `stripe listen` forwards live events to localhost + issues a per-session signing secret. | No CLI equivalent. You need a public tunnel (Cloudflare Tunnel / ngrok) and a synthetic `MOLLIE_WEBHOOK_SECRET` you sign requests with manually. |
+| Unique event id | `evt_…` per webhook — Stripe never sends the same `evt_id` twice. | None. Mollie sends the resource id (`tr_…`) which can repeat across status transitions (open → pending → paid, all carry the same `tr_…`). The worker re-keys the `webhook_events` row to `${id}-${status}` to give each transition its own row. |
+| Cross-account events | Stripe lets the platform subscribe to events on connected accounts via the **"Listen to events on Connected accounts"** toggle on the dashboard webhook endpoint. Without this toggle, donations on connected accounts fire events to *the connected account's* own webhooks, not the platform's. | N/A — there's no platform/connected-account distinction in Mollie's Phase 1 model, so all events are direct. |
+
+### 4. Donor UX
+
+| | Stripe | Mollie |
+| --- | --- | --- |
+| Where the donor enters payment data | In-page **Stripe Payment Element** iframe — the donor never leaves Givernance. PCI SAQ A scope (no card data on our servers). | Mollie-hosted checkout page — the donor is redirected away from Givernance to `https://www.mollie.com/checkout/…` and back. The donor experience is two more clicks but Givernance never sees card / IBAN data. |
+| Payment methods supported | Cards, SEPA Direct Debit, Apple Pay, Google Pay, Stripe Link (one-click), iDEAL/Bancontact/EPS via Payment Element. | iDEAL, Bancontact, SOFORT, KBC, Belfius, ING Home'Pay, cards, SEPA Direct Debit, Apple Pay, Klarna, PayPal — Mollie's NL/BE coverage is the strongest argument for offering it. |
+| Granular payment-method tracking | We store `payment_method = 'stripe'` on every donation. Stripe-side data identifies the actual method but we don't denormalise it. | We store `payment_method = 'ideal' | 'bancontact' | 'creditcard' | 'sepadirectdebit' | …` from `payment.method` on the Mollie Payment object. Belgian/Dutch reporting cares about this distinction; SEPA DD reconciliation queries key on `'sepadirectdebit'`. |
+| Test-mode flow | Stripe Payment Element accepts `4242 4242 4242 4242` → success, `4000 0025 0000 3155` → 3DS challenge, `4000 0000 0000 0002` → declined. | Mollie's test checkout shows a status picker (Paid / Failed / Canceled / Expired / Authorized). No card numbers needed. |
+
+### 5. Refunds (current state)
+
+The refund route at `POST /v1/donations/:id/refund` is **Stripe-only today** and bypasses the gateway abstraction (see `packages/api/src/modules/donations/routes.ts:refundDonation`). Trying to refund a Mollie donation through that endpoint returns `kind: "not_stripe"`. Filed as follow-up #225 — gateway-aware refunds need: (a) a `refund` method on the `PaymentGateway` interface (already in ADR-010 §5.1, just unimplemented), (b) Mollie-side refund handling via `client.payment_refunds.create`, and (c) a Mollie webhook handler for `refund.paid` to mirror the donation status flip we already do for `charge.refunded` on Stripe.
+
+---
+
+## What's not covered yet
+
+- **Mollie Connect / OAuth flow** — the platform-fee mechanism and the smoother NPO onboarding flow are both unlocked by this. Tracked in [issue #224](https://github.com/purposestack/givernance/issues/224).
+- **Mollie API key encryption at rest** — plaintext today; KMS / pgcrypto follow-up in [issue #223](https://github.com/purposestack/givernance/issues/223).
+- **Gateway-aware refund flow** — Stripe-only today; Mollie refund support tracked in [issue #225](https://github.com/purposestack/givernance/issues/225).
+- **Production webhook endpoint registration** — the `MOLLIE_WEBHOOK_SECRET` flow described above is local-dev-shaped (synthetic secret + manual sign). Production registers a real endpoint via **Developers → Webhooks** and binds the secret to that endpoint URL. Documented separately when the staging deployment story for Mollie lands.
+- **Staging deployment** — once the Mollie pilot moves to staging, this guide's "Staging deployment" section (mirroring the Stripe section in `stripe-local-setup.md`) gets written.
+
+If you hit a snag this guide doesn't cover, file an issue with the `payments` label and link the failing log line.

--- a/packages/api/migrations/0033_mollie_gateway.sql
+++ b/packages/api/migrations/0033_mollie_gateway.sql
@@ -1,0 +1,93 @@
+-- Migration: 0033_mollie_gateway
+-- Sprint 5 / issue #62 — Mollie co-primary gateway + Stripe account.updated lifecycle.
+--
+-- Adds:
+--   * tenants.payment_gateway          — per-tenant gateway selection ('stripe' | 'mollie' | 'manual')
+--   * tenants.mollie_api_key           — per-tenant Mollie API key (each NPO brings its own; out-of-scope: KMS-encrypt at rest)
+--   * tenants.feature_flags            — JSONB store for `ff.*` overrides (minimal MVP ahead of doc-18 full system)
+--   * tenants.stripe_charges_enabled   — cached from `account.updated`; "live mode" = charges_enabled=true
+--   * tenants.stripe_payouts_enabled   — cached from `account.updated`
+--   * tenants.stripe_details_submitted — cached from `account.updated`
+--   * tenants.stripe_account_state_at  — last time the cached fields above were refreshed by a webhook
+--
+-- Renames:
+--   * webhook_events.stripe_event_id → webhook_events.provider_event_id
+--   * adds webhook_events.provider with default 'stripe' (backfill existing rows)
+--   * unique constraint becomes (provider, provider_event_id) so Stripe + Mollie + future
+--     gateways share the table without ID-namespace collisions.
+--
+-- ADR-010: payment_gateway enum is `stripe | mollie | manual`. Mollie is gated per-tenant by
+-- the `ff.payments.mollie` feature flag — the gateway selector enforces this in the API layer.
+
+-- ─── Tenants: payment-gateway selection + Mollie key + flags ───────────────
+
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS payment_gateway VARCHAR(20) NOT NULL DEFAULT 'stripe';
+
+ALTER TABLE tenants
+  ADD CONSTRAINT tenants_payment_gateway_check
+  CHECK (payment_gateway IN ('stripe', 'mollie', 'manual'));
+
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS mollie_api_key VARCHAR(255);
+
+-- Minimal feature-flag store ahead of the full doc-18 system. Holds per-tenant boolean
+-- overrides keyed by flag id (e.g. `{"ff.payments.mollie": true}`). Defaults to '{}'::jsonb
+-- so the helper can read the column unconditionally without NULL-checks. The full
+-- doc-18 plan layers Redis caching + a `tenant_flag_overrides` table on top of this;
+-- migrating to that future schema means moving keys out of this column, not changing
+-- the helper signature.
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS feature_flags JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Cached Stripe Connect state, populated by the `account.updated` webhook handler.
+-- Keeping this on the tenant row (rather than a separate `stripe_account_states`
+-- table) lets the donor flow read live-mode in a single SELECT and matches the
+-- 1:1 cardinality between tenant and connected account. `stripe_account_state_at`
+-- is informational — drives the Settings UI's "last refreshed" hint.
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS stripe_charges_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS stripe_payouts_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS stripe_details_submitted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS stripe_account_state_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS tenants_payment_gateway_idx ON tenants (payment_gateway);
+
+-- ─── Webhook events: multi-gateway support ─────────────────────────────────
+
+-- Add `provider` first; backfill existing Stripe rows; then enforce NOT NULL.
+ALTER TABLE webhook_events ADD COLUMN IF NOT EXISTS provider VARCHAR(20);
+
+UPDATE webhook_events SET provider = 'stripe' WHERE provider IS NULL;
+
+ALTER TABLE webhook_events ALTER COLUMN provider SET NOT NULL;
+ALTER TABLE webhook_events ALTER COLUMN provider SET DEFAULT 'stripe';
+ALTER TABLE webhook_events
+  ADD CONSTRAINT webhook_events_provider_check
+  CHECK (provider IN ('stripe', 'mollie'));
+
+-- Rename stripe_event_id → provider_event_id, then re-create the index/uniq. The old
+-- index + UNIQUE constraint move with the column under PostgreSQL's `RENAME COLUMN`
+-- semantics, but Drizzle Kit names them after the column — we rename them too so
+-- pg_dump output matches what `drizzle-kit generate` would emit.
+ALTER TABLE webhook_events RENAME COLUMN stripe_event_id TO provider_event_id;
+
+ALTER TABLE webhook_events
+  DROP CONSTRAINT IF EXISTS webhook_events_stripe_event_id_key;
+DROP INDEX IF EXISTS webhook_events_stripe_event_id_idx;
+
+-- Composite uniqueness so Mollie payment ids can repeat Stripe event ids without conflict.
+CREATE UNIQUE INDEX IF NOT EXISTS webhook_events_provider_event_uniq
+  ON webhook_events (provider, provider_event_id);
+
+CREATE INDEX IF NOT EXISTS webhook_events_provider_event_id_idx
+  ON webhook_events (provider_event_id);
+
+-- ─── Permissions for the app role ──────────────────────────────────────────
+
+-- Grants on tenants are inherited from the existing role bootstrap; new columns
+-- are visible automatically. webhook_events grants from migration 0017 cover the
+-- renamed column without an explicit re-grant.

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1777366800000,
       "tag": "0032_user_soft_delete",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1777392000000,
+      "tag": "0033_mollie_gateway",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,6 +25,7 @@
     "@fastify/swagger": "^9.4.2",
     "@fastify/swagger-ui": "^5.2.1",
     "@givernance/shared": "workspace:*",
+    "@mollie/api-client": "^4.5.0",
     "@sinclair/typebox": "^0.34.12",
     "bullmq": "^5.31.0",
     "drizzle-orm": "^0.36.4",

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -67,6 +67,17 @@ const EnvSchema = Type.Object({
   STRIPE_SECRET_KEY: Type.Optional(Type.String({ minLength: 1 })),
   /** Stripe webhook endpoint secret (whsec_...) */
   STRIPE_WEBHOOK_SECRET: Type.Optional(Type.String({ minLength: 1 })),
+  /**
+   * Mollie webhook signing secret (issue #62). Verifies the
+   * `X-Mollie-Signature` HMAC-SHA256 header on inbound Mollie webhooks
+   * (`/v1/donations/mollie-webhook`). Platform-level — one secret per
+   * Givernance deployment, configured in the Mollie dashboard. Distinct
+   * from the per-tenant `tenants.mollie_api_key`, which authenticates
+   * outbound API calls per NPO. Optional in dev so a workspace without
+   * Mollie configured still boots; required in production once any
+   * tenant has `payment_gateway = 'mollie'`.
+   */
+  MOLLIE_WEBHOOK_SECRET: Type.Optional(Type.String({ minLength: 1 })),
   /** ExchangeRate-API key used for currency conversion refreshes */
   EXCHANGE_RATE_API_KEY: Type.Optional(Type.String({ minLength: 1 })),
 });

--- a/packages/api/src/lib/feature-flags.test.ts
+++ b/packages/api/src/lib/feature-flags.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the minimal feature-flag resolver (issue #62).
+ *
+ * The resolver is the linchpin for both the gateway factory's
+ * `mollie_flag_off` rejection and the org-admin PATCH route's
+ * "Mollie is not enabled" 400 — pinning its behaviour at the unit
+ * level catches regressions that would otherwise only surface via
+ * integration paths.
+ */
+
+import { describe, expect, it } from "vitest";
+import { hasFeatureFlag } from "./feature-flags.js";
+
+describe("hasFeatureFlag", () => {
+  it("returns false when featureFlags is an empty object", () => {
+    expect(hasFeatureFlag({ featureFlags: {} }, "ff.payments.mollie")).toBe(false);
+  });
+
+  it("returns true when the key is explicitly true", () => {
+    expect(
+      hasFeatureFlag({ featureFlags: { "ff.payments.mollie": true } }, "ff.payments.mollie"),
+    ).toBe(true);
+  });
+
+  it("returns false when the key is explicitly false", () => {
+    expect(
+      hasFeatureFlag({ featureFlags: { "ff.payments.mollie": false } }, "ff.payments.mollie"),
+    ).toBe(false);
+  });
+
+  it("returns false for non-strict-true values (defends against string coercion)", () => {
+    // JSONB columns can occasionally end up with string values from a
+    // hand-crafted UPDATE statement. The strict `=== true` check is the
+    // last line of defence — `"true"`, `1`, `[true]` must NOT activate
+    // the gate.
+    const cases: unknown[] = ["true", 1, "1", [true], { value: true }];
+    for (const value of cases) {
+      const tenant = {
+        featureFlags: { "ff.payments.mollie": value } as unknown as Partial<
+          Record<"ff.payments.mollie", boolean>
+        >,
+      };
+      expect(hasFeatureFlag(tenant, "ff.payments.mollie")).toBe(false);
+    }
+  });
+
+  it("returns false when featureFlags is null/undefined (defensive)", () => {
+    // Drizzle types it as non-null (DB default `'{}'::jsonb`), but the
+    // helper accepts the broader shape so a partial test fixture or a
+    // `SELECT` that omits the column doesn't crash.
+    expect(
+      hasFeatureFlag(
+        { featureFlags: null as unknown as Partial<Record<"ff.payments.mollie", boolean>> },
+        "ff.payments.mollie",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/api/src/lib/feature-flags.ts
+++ b/packages/api/src/lib/feature-flags.ts
@@ -1,0 +1,50 @@
+/**
+ * Minimal feature-flag resolver (issue #62 / preview of doc-18).
+ *
+ * Flags are stored as a JSONB column on `tenants.feature_flags`, keyed by
+ * the flag id (e.g. `"ff.payments.mollie": true`). Missing keys resolve to
+ * `false` so the column can stay sparse — only tenants that flipped a
+ * flag carry an entry. The full doc-18 system layers a Redis cache + a
+ * `tenant_flag_overrides` table on top of this, but #62 only needs to
+ * gate Mollie and we keep the surface minimal.
+ *
+ * Why a separate file (vs. inlined into the factory): the helper is also
+ * used by the org-admin Settings PATCH route to refuse switching to
+ * `payment_gateway = 'mollie'` when the flag is off. Keeping the resolver
+ * call site small and centralised makes it easy to swap in the Redis-backed
+ * resolver later without re-finding consumers.
+ */
+
+import type { FEATURE_FLAG_KEYS, FeatureFlagKey, tenants } from "@givernance/shared/schema";
+import type { InferSelectModel } from "drizzle-orm";
+
+type TenantRow = InferSelectModel<typeof tenants>;
+
+/** Subset of `tenants` row the resolver needs. */
+export type FeatureFlagTenant = Pick<TenantRow, "featureFlags">;
+
+/**
+ * Resolve a single feature flag for a tenant. Returns `false` when the key
+ * is missing from the JSONB column or its value is not strictly `true`.
+ *
+ * The strict `=== true` check defends against a JSONB row that ended up
+ * with `{"ff.payments.mollie": "true"}` (string) — that should NOT
+ * activate the gateway by accident. Only the explicit boolean unlocks it.
+ */
+export function hasFeatureFlag(tenant: FeatureFlagTenant, key: FeatureFlagKey): boolean {
+  const flags = tenant.featureFlags ?? {};
+  return flags[key] === true;
+}
+
+/**
+ * Type guard so the Settings PATCH route can validate the body without
+ * pulling the full doc-18 registry of allowed flag keys. Re-exported from
+ * `@givernance/shared/schema` so consumers don't import the runtime list
+ * (`FEATURE_FLAG_KEYS`) just to reach the type.
+ */
+export function isFeatureFlagKey(
+  candidate: string,
+  registry: typeof FEATURE_FLAG_KEYS,
+): candidate is FeatureFlagKey {
+  return (registry as readonly string[]).includes(candidate);
+}

--- a/packages/api/src/lib/payments/gateway-factory.ts
+++ b/packages/api/src/lib/payments/gateway-factory.ts
@@ -1,0 +1,103 @@
+/**
+ * Payment gateway factory (issue #62).
+ *
+ * `getGatewayForTenant` is the only call site that should know about the
+ * `tenant.payment_gateway` value — the rest of the API holds a
+ * `PaymentGateway` reference. The factory enforces the
+ * `ff.payments.mollie` feature flag: a tenant whose `payment_gateway` is
+ * `'mollie'` but whose flag is off raises a 502-equivalent error so a
+ * mis-flipped DB state can't sneak past the gate.
+ */
+
+import type { tenants } from "@givernance/shared/schema";
+import type { InferSelectModel } from "drizzle-orm";
+import { hasFeatureFlag } from "../feature-flags.js";
+import type { PaymentGateway, TenantPaymentContext } from "./gateway.interface.js";
+import { MollieGateway } from "./mollie-gateway.js";
+import { StripeGateway } from "./stripe-gateway.js";
+
+type TenantRow = InferSelectModel<typeof tenants>;
+
+/** Subset of `tenants` row the factory needs — accepts both partial mocks and full rows. */
+export type TenantGatewaySelector = Pick<
+  TenantRow,
+  "id" | "paymentGateway" | "stripeAccountId" | "mollieApiKey" | "featureFlags"
+>;
+
+export class PaymentGatewayUnavailableError extends Error {
+  readonly reason:
+    | "manual_gateway"
+    | "mollie_flag_off"
+    | "mollie_not_configured"
+    | "stripe_not_onboarded";
+
+  constructor(
+    reason: "manual_gateway" | "mollie_flag_off" | "mollie_not_configured" | "stripe_not_onboarded",
+    message: string,
+  ) {
+    super(message);
+    this.name = "PaymentGatewayUnavailableError";
+    this.reason = reason;
+  }
+}
+
+export function getGatewayForTenant(tenant: TenantGatewaySelector): PaymentGateway {
+  const ctx: TenantPaymentContext = {
+    orgId: tenant.id,
+    stripeAccountId: tenant.stripeAccountId ?? null,
+    mollieApiKey: tenant.mollieApiKey ?? null,
+  };
+
+  switch (tenant.paymentGateway) {
+    case "stripe":
+      if (!tenant.stripeAccountId) {
+        throw new PaymentGatewayUnavailableError(
+          "stripe_not_onboarded",
+          "Stripe Connect onboarding is not complete for this tenant",
+        );
+      }
+      return new StripeGateway(ctx);
+    case "mollie":
+      if (!hasFeatureFlag(tenant, "ff.payments.mollie")) {
+        throw new PaymentGatewayUnavailableError(
+          "mollie_flag_off",
+          "Mollie is not enabled for this tenant",
+        );
+      }
+      if (!tenant.mollieApiKey) {
+        throw new PaymentGatewayUnavailableError(
+          "mollie_not_configured",
+          "Mollie API key is not configured for this tenant",
+        );
+      }
+      return new MollieGateway(ctx);
+    case "manual":
+      throw new PaymentGatewayUnavailableError(
+        "manual_gateway",
+        "Tenant uses manual reconciliation — no online donations supported",
+      );
+    default: {
+      // Defence-in-depth — the CHECK constraint on tenants.payment_gateway
+      // covers the DB side, this guards against an in-process row that
+      // bypassed validation (e.g., a service test seeding directly).
+      const exhaustive: never = tenant.paymentGateway as never;
+      throw new Error(`Unsupported payment_gateway value: ${String(exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Standalone Mollie gateway instantiation for the platform-side webhook
+ * route, which doesn't have a tenant in context yet (the route receives
+ * the body, signs the payload with `MOLLIE_WEBHOOK_SECRET`, and resolves
+ * the tenant only after the worker has fetched the payment). Pass an
+ * orgId of empty string — the gateway only uses the api key for outbound
+ * calls, which the route doesn't make.
+ */
+export function getMollieWebhookVerifier(): MollieGateway {
+  return new MollieGateway({
+    orgId: "",
+    stripeAccountId: null,
+    mollieApiKey: null,
+  });
+}

--- a/packages/api/src/lib/payments/gateway.interface.ts
+++ b/packages/api/src/lib/payments/gateway.interface.ts
@@ -28,6 +28,14 @@ export interface CreateDonationIntentParams {
   campaignId: string;
   /** ISO 4217 (uppercase) — the donor's chosen currency. */
   currency: string;
+  /**
+   * Campaign's configured default currency (`campaigns.default_currency`).
+   * Threaded into gateway-side metadata as a reconciliation breadcrumb
+   * between the donor-chosen currency and the campaign's books — a donor
+   * giving GBP to a EUR-denominated campaign carries this on the
+   * PaymentIntent for downstream finance reports.
+   */
+  campaignDefaultCurrency: string;
   amountCents: number;
   /** `applicationFeeAmount` for Stripe; not currently surfaced for Mollie. */
   applicationFeeAmountCents: number;
@@ -61,6 +69,15 @@ export type CreateDonationIntentResult =
       provider: "stripe";
       clientSecret: string;
       stripeAccountId: string;
+      /**
+       * The created PaymentIntent id (`pi_…`). Returned alongside the
+       * client secret so the orphan-PI observability log line in
+       * `public/service.ts` can join API-side intent creation against the
+       * `payment_intent.succeeded` webhook for donor abandon-rate metrics.
+       * Stripe documents `pi_…` ids as not secret (they appear in the
+       * post-3DS redirect URL).
+       */
+      paymentIntentId: string;
     }
   | {
       provider: "mollie";

--- a/packages/api/src/lib/payments/gateway.interface.ts
+++ b/packages/api/src/lib/payments/gateway.interface.ts
@@ -1,0 +1,105 @@
+/**
+ * Payment gateway abstraction (ADR-010 / issue #62).
+ *
+ * The donor flow, refund flow, and webhook ingestion all dispatch through
+ * this interface so the rest of the API never imports Stripe or Mollie SDK
+ * types directly. Adding a new gateway (Saferpay, Mangopay) is implementing
+ * `PaymentGateway`, registering it in `gateway-factory.ts`, and extending
+ * the `PAYMENT_GATEWAY_VALUES` enum — no other module changes.
+ *
+ * Why an interface and not a discriminated union of services: a discriminated
+ * union puts gateway-specific code in every consumer (each route would
+ * `switch (gateway.kind)`). An interface lets each consumer call the same
+ * methods and the implementation handles the provider-specific shape.
+ */
+
+/** Per-tenant context the factory passes through to each gateway. */
+export interface TenantPaymentContext {
+  /** Org id (UUID) — used as `metadata.org_id` and for log correlation. */
+  orgId: string;
+  /** `acct_…` (Stripe) — null when the tenant uses Mollie or hasn't onboarded. */
+  stripeAccountId: string | null;
+  /** Per-tenant Mollie API key — null when the tenant uses Stripe. */
+  mollieApiKey: string | null;
+}
+
+/** Common params for the donor `POST /v1/public/campaigns/:id/donate` route. */
+export interface CreateDonationIntentParams {
+  campaignId: string;
+  /** ISO 4217 (uppercase) — the donor's chosen currency. */
+  currency: string;
+  amountCents: number;
+  /** `applicationFeeAmount` for Stripe; not currently surfaced for Mollie. */
+  applicationFeeAmountCents: number;
+  /** Donor identity threaded as gateway-side metadata for the webhook to recover. */
+  donor: {
+    email: string;
+    firstName: string;
+    lastName: string;
+  };
+  /**
+   * Idempotency key supplied by the browser (`Idempotency-Key` header). Forwarded
+   * to the gateway's own idempotency mechanism — Stripe dedupes server-side via
+   * the same key; Mollie doesn't have a request-level idempotency header so the
+   * key is folded into the payment description for after-the-fact reconciliation.
+   */
+  idempotencyKey?: string;
+  /** Browser-side return URL after the donor finishes / abandons the gateway flow. */
+  returnUrl: string;
+  /** Public webhook URL Mollie will POST to once the payment status changes. */
+  webhookUrl: string;
+}
+
+/**
+ * Discriminated union returned to the donor's browser. The frontend renders
+ * Stripe Elements when `provider === 'stripe'` and a redirect button when
+ * `provider === 'mollie'` — anything else is a programming error caught by
+ * the route's TypeBox response schema.
+ */
+export type CreateDonationIntentResult =
+  | {
+      provider: "stripe";
+      clientSecret: string;
+      stripeAccountId: string;
+    }
+  | {
+      provider: "mollie";
+      checkoutUrl: string;
+      molliePaymentId: string;
+    };
+
+/**
+ * Webhook signature verification. Implementations throw on invalid signature;
+ * the route turns that into a 400 with a sanitised body so the gateway error
+ * detail (which can leak internals) never reaches the client.
+ *
+ * Returns the parsed event in a provider-agnostic envelope. The
+ * `providerEventId` field is what feeds `webhook_events.provider_event_id`
+ * for idempotency — Mollie doesn't emit unique event ids, so the gateway
+ * synthesises `${paymentId}-${status}` to keep one row per status transition.
+ */
+export interface VerifiedWebhookEvent {
+  providerEventId: string;
+  eventType: string;
+  /** Stripe connected-account id; null for Mollie events. */
+  accountId: string | null;
+  /** Provider-side livemode flag — Stripe carries it natively, Mollie's payment id prefix indicates it. */
+  livemode: boolean;
+  payload: Record<string, unknown>;
+}
+
+export interface PaymentGateway {
+  /** Stable kind discriminator — used in logs and the enqueued job's name. */
+  readonly kind: "stripe" | "mollie";
+  /**
+   * Create a payment intent / Mollie payment. Returns a discriminated union
+   * the donor frontend uses to decide which UI to render.
+   */
+  createDonationIntent(params: CreateDonationIntentParams): Promise<CreateDonationIntentResult>;
+  /**
+   * Verify a webhook signature and parse the body into a provider-agnostic
+   * envelope. Throws on invalid signature; the caller must NOT echo the
+   * thrown error message verbatim to the wire.
+   */
+  verifyWebhook(rawBody: Buffer, signature: string): Promise<VerifiedWebhookEvent>;
+}

--- a/packages/api/src/lib/payments/mollie-gateway.ts
+++ b/packages/api/src/lib/payments/mollie-gateway.ts
@@ -1,0 +1,167 @@
+/**
+ * Mollie gateway implementation (issue #62).
+ *
+ * Mollie's onboarding model differs from Stripe Connect: each NPO signs up
+ * with Mollie directly and pastes their API key (`test_…` / `live_…`) into
+ * Settings → Payments. The gateway uses that per-tenant key to create
+ * payments and fetch them back on webhook receipt. There is no
+ * equivalent of Stripe's "connected account id" — a single API key
+ * authenticates an entire organisation's Mollie account.
+ *
+ * Webhook signature verification is platform-side: Mollie signs every
+ * request with the platform's `MOLLIE_WEBHOOK_SECRET` (configured in
+ * the Mollie dashboard once per Givernance deployment), HMAC-SHA256
+ * of the raw body, hex-encoded, in the `X-Mollie-Signature` header
+ * (optionally prefixed `sha256=`). See
+ * https://github.com/mollie/mollie-api-typescript SignatureValidator
+ * for the canonical algorithm — we re-implement here against
+ * Node's `crypto` to avoid pulling the TS-only SDK package
+ * (which doesn't ship in `@mollie/api-client@4.x`).
+ *
+ * Idempotency note: Mollie's webhook contract sends only the payment id
+ * and current status — the same payment can fire multiple webhooks as
+ * its status transitions (`open` → `pending` → `paid` / `failed`). The
+ * worker fetches the payment via the API to learn the status, then
+ * inserts a `webhook_events` row keyed on `(provider, "${id}-${status}")`
+ * so each transition is processed exactly once but a true retry of the
+ * same transition is deduped.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import createMollieClient, { type MollieClient } from "@mollie/api-client";
+import { env } from "../../env.js";
+import type {
+  CreateDonationIntentParams,
+  CreateDonationIntentResult,
+  PaymentGateway,
+  TenantPaymentContext,
+  VerifiedWebhookEvent,
+} from "./gateway.interface.js";
+
+const SIGNATURE_PREFIX = "sha256=";
+
+export class MollieGateway implements PaymentGateway {
+  readonly kind = "mollie" as const;
+
+  private clientCache: MollieClient | null = null;
+
+  constructor(private readonly tenant: TenantPaymentContext) {}
+
+  private getClient(): MollieClient {
+    if (!this.tenant.mollieApiKey) {
+      throw new Error(
+        "Organization has not configured Mollie — set tenants.mollie_api_key in Settings",
+      );
+    }
+    if (!this.clientCache) {
+      this.clientCache = createMollieClient({ apiKey: this.tenant.mollieApiKey });
+    }
+    return this.clientCache;
+  }
+
+  async createDonationIntent(
+    params: CreateDonationIntentParams,
+  ): Promise<CreateDonationIntentResult> {
+    const client = this.getClient();
+
+    // Mollie expects the amount as a string with two decimals (e.g. "12.50"),
+    // not minor units. Currency must be uppercase ISO 4217.
+    const amountValue = (params.amountCents / 100).toFixed(2);
+
+    // Mollie's API doesn't have a request-level idempotency header, so we
+    // fold the donor's idempotency key into the payment description for
+    // after-the-fact reconciliation. A repeat submit from the same browser
+    // creates a fresh Mollie payment — it's the donor's call to abandon
+    // the orphan, similar to how Stripe handles intent abandonment after
+    // 7 days. Filing donor-side dedupe as a follow-up to keep #62 scoped.
+    const description = `Donation to campaign ${params.campaignId}`;
+
+    const payment = await client.payments.create({
+      amount: { value: amountValue, currency: params.currency.toUpperCase() },
+      description,
+      redirectUrl: params.returnUrl,
+      webhookUrl: params.webhookUrl,
+      metadata: {
+        campaign_id: params.campaignId,
+        org_id: this.tenant.orgId,
+        constituent_first_name: params.donor.firstName,
+        constituent_last_name: params.donor.lastName,
+        constituent_email: params.donor.email,
+        application_fee_cents: params.applicationFeeAmountCents,
+        ...(params.idempotencyKey ? { idempotency_key: params.idempotencyKey } : {}),
+      },
+    });
+
+    const checkoutUrl = payment._links?.checkout?.href;
+    if (!checkoutUrl) {
+      throw new Error("Mollie returned a payment without a checkout URL");
+    }
+
+    return {
+      provider: "mollie",
+      checkoutUrl,
+      molliePaymentId: payment.id,
+    };
+  }
+
+  /**
+   * Verify the `X-Mollie-Signature` HMAC over the raw form-encoded body.
+   *
+   * Mollie's webhook body is `application/x-www-form-urlencoded` with
+   * a single `id=tr_…` field — we decode it here so the route handler
+   * can keep the request handling minimal. The signature is computed
+   * over the raw body exactly as received (Mollie's TS SDK stringifies
+   * the buffer with `payload.toString()`; we mirror that with `utf8`).
+   */
+  async verifyWebhook(rawBody: Buffer, signature: string): Promise<VerifiedWebhookEvent> {
+    if (!env.MOLLIE_WEBHOOK_SECRET) {
+      throw new Error("MOLLIE_WEBHOOK_SECRET is not configured");
+    }
+
+    const provided = signature.startsWith(SIGNATURE_PREFIX)
+      ? signature.slice(SIGNATURE_PREFIX.length)
+      : signature;
+
+    const expected = createHmac("sha256", env.MOLLIE_WEBHOOK_SECRET).update(rawBody).digest("hex");
+
+    // `timingSafeEqual` requires equal-length buffers — pad-or-fail by
+    // comparing buffer lengths first so a malformed (e.g. base64) signature
+    // doesn't throw a length-mismatch on us.
+    const providedBuf = Buffer.from(provided, "hex");
+    const expectedBuf = Buffer.from(expected, "hex");
+    if (providedBuf.length !== expectedBuf.length || !timingSafeEqual(providedBuf, expectedBuf)) {
+      throw new Error("Invalid Mollie webhook signature");
+    }
+
+    const params = new URLSearchParams(rawBody.toString("utf8"));
+    const paymentId = params.get("id");
+    if (!paymentId) {
+      throw new Error("Mollie webhook missing 'id' field");
+    }
+
+    return {
+      // Status is unknown until the worker fetches the payment from Mollie;
+      // the worker re-keys the `webhook_events` row with `${id}-${status}`
+      // before insert. At route time we use just the payment id — this
+      // accepts a duplicate webhook within the same status transition only
+      // if the worker hasn't begun processing it yet, which is fine since
+      // the worker re-keys on its side and the unique index will reject.
+      providerEventId: paymentId,
+      eventType: "payment.notification",
+      accountId: null,
+      livemode: paymentId.startsWith("tr_"),
+      payload: { id: paymentId },
+    };
+  }
+
+  /**
+   * Worker-side helper to fetch the full payment. Exposed on the gateway
+   * so the worker can construct a Mollie client without re-implementing
+   * the per-tenant key lookup. Returns the raw SDK Payment shape — the
+   * worker maps it to a domain donation row.
+   */
+  async getPayment(paymentId: string) {
+    const client = this.getClient();
+    return client.payments.get(paymentId);
+  }
+}

--- a/packages/api/src/lib/payments/stripe-gateway.ts
+++ b/packages/api/src/lib/payments/stripe-gateway.ts
@@ -52,6 +52,10 @@ export class StripeGateway implements PaymentGateway {
       metadata: {
         campaign_id: params.campaignId,
         org_id: this.tenant.orgId,
+        // Reconciliation breadcrumb — the campaign's books currency
+        // alongside the donor's chosen currency. Survives the round-trip
+        // to the `payment_intent.succeeded` webhook for finance reports.
+        campaign_default_currency: params.campaignDefaultCurrency,
         constituent_first_name: params.donor.firstName,
         constituent_last_name: params.donor.lastName,
       },
@@ -75,6 +79,7 @@ export class StripeGateway implements PaymentGateway {
       provider: "stripe",
       clientSecret: intent.client_secret,
       stripeAccountId: this.tenant.stripeAccountId,
+      paymentIntentId: intent.id,
     };
   }
 

--- a/packages/api/src/lib/payments/stripe-gateway.ts
+++ b/packages/api/src/lib/payments/stripe-gateway.ts
@@ -1,0 +1,97 @@
+/**
+ * Stripe gateway implementation (ADR-010).
+ *
+ * Wraps the singleton `Stripe` client created in `modules/payments/service.ts`
+ * — the actual SDK init lives there because a bunch of pre-#62 code paths
+ * (refunds, account.retrieve in `getStripeConnectStatus`, account-link
+ * onboarding) call `getStripe()` directly. Centralising those callers behind
+ * the gateway interface is out of scope for #62; for now this file is the
+ * `PaymentGateway`-facing facade and the rest stays where it is.
+ */
+
+import { env } from "../../env.js";
+import { getStripe } from "../../modules/payments/service.js";
+import type {
+  CreateDonationIntentParams,
+  CreateDonationIntentResult,
+  PaymentGateway,
+  TenantPaymentContext,
+  VerifiedWebhookEvent,
+} from "./gateway.interface.js";
+
+export class StripeGateway implements PaymentGateway {
+  readonly kind = "stripe" as const;
+
+  constructor(private readonly tenant: TenantPaymentContext) {}
+
+  async createDonationIntent(
+    params: CreateDonationIntentParams,
+  ): Promise<CreateDonationIntentResult> {
+    if (!this.tenant.stripeAccountId) {
+      throw new Error("Organization has not completed Stripe onboarding");
+    }
+
+    const stripe = getStripe();
+
+    // Live retrieve to short-circuit donations against accounts that aren't
+    // chargeable yet — keeps the existing pre-#62 behaviour. Once
+    // `tenants.stripe_charges_enabled` is broadly populated by the
+    // `account.updated` webhook (also #62), this check can read the cached
+    // column and skip the round-trip; until then the live retrieve is the
+    // safety belt against a stale cache.
+    const account = await stripe.accounts.retrieve(this.tenant.stripeAccountId);
+    if (!account.charges_enabled) {
+      throw new Error("Organization Stripe account is not fully onboarded");
+    }
+
+    const intentParams: Parameters<typeof stripe.paymentIntents.create>[0] = {
+      amount: params.amountCents,
+      currency: params.currency.toLowerCase(),
+      application_fee_amount: params.applicationFeeAmountCents,
+      receipt_email: params.donor.email,
+      metadata: {
+        campaign_id: params.campaignId,
+        org_id: this.tenant.orgId,
+        constituent_first_name: params.donor.firstName,
+        constituent_last_name: params.donor.lastName,
+      },
+    };
+
+    const requestOptions: Parameters<typeof stripe.paymentIntents.create>[1] = {
+      stripeAccount: this.tenant.stripeAccountId,
+    };
+
+    if (params.idempotencyKey) {
+      requestOptions.idempotencyKey = params.idempotencyKey;
+    }
+
+    const intent = await stripe.paymentIntents.create(intentParams, requestOptions);
+
+    if (!intent.client_secret) {
+      throw new Error("Stripe returned a PaymentIntent without a client_secret");
+    }
+
+    return {
+      provider: "stripe",
+      clientSecret: intent.client_secret,
+      stripeAccountId: this.tenant.stripeAccountId,
+    };
+  }
+
+  async verifyWebhook(rawBody: Buffer, signature: string): Promise<VerifiedWebhookEvent> {
+    if (!env.STRIPE_WEBHOOK_SECRET) {
+      throw new Error("STRIPE_WEBHOOK_SECRET is not configured");
+    }
+
+    const stripe = getStripe();
+    const event = stripe.webhooks.constructEvent(rawBody, signature, env.STRIPE_WEBHOOK_SECRET);
+
+    return {
+      providerEventId: event.id,
+      eventType: event.type,
+      accountId: event.account ?? null,
+      livemode: event.livemode,
+      payload: event.data.object as unknown as Record<string, unknown>,
+    };
+  }
+}

--- a/packages/api/src/modules/payments/routes.ts
+++ b/packages/api/src/modules/payments/routes.ts
@@ -1,11 +1,16 @@
-/** Payment routes — Stripe Connect onboarding and webhook handler */
+/** Payment routes — Stripe Connect onboarding, Stripe + Mollie webhook handlers, gateway settings */
 
 import rateLimit from "@fastify/rate-limit";
 import { QUEUE_NAMES } from "@givernance/shared/jobs";
+import { FEATURE_FLAG_KEYS, PAYMENT_GATEWAY_VALUES, tenants } from "@givernance/shared/schema";
 import { Type } from "@sinclair/typebox";
 import { Queue } from "bullmq";
+import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
+import { db } from "../../lib/db.js";
+import { hasFeatureFlag } from "../../lib/feature-flags.js";
 import { requireOrgAdmin } from "../../lib/guards.js";
+import { getMollieWebhookVerifier } from "../../lib/payments/gateway-factory.js";
 import { redis } from "../../lib/redis.js";
 import {
   DataResponse,
@@ -227,7 +232,14 @@ export async function stripeWebhookRoute(app: FastifyInstance) {
       }
 
       // Atomic insert with ON CONFLICT — handles both first-seen and duplicate events
-      const record = await createWebhookEvent(event);
+      const record = await createWebhookEvent({
+        provider: "stripe",
+        providerEventId: event.id,
+        eventType: event.type,
+        accountId: event.account ?? null,
+        payload: event.data.object as unknown as Record<string, unknown>,
+        livemode: event.livemode,
+      });
       if (!record) {
         request.log.info({ stripeEventId: event.id }, "Duplicate webhook event, skipping");
         return reply.status(200).send({ received: true });
@@ -251,3 +263,277 @@ export async function stripeWebhookRoute(app: FastifyInstance) {
     },
   );
 }
+
+/**
+ * Mollie webhook route (issue #62). Mirrors the Stripe webhook in shape:
+ * raw-body parser → signature verify → idempotent persist → enqueue async
+ * processing. Differences:
+ *   - body is `application/x-www-form-urlencoded`, not JSON;
+ *   - signature header is `X-Mollie-Signature` (HMAC-SHA256 hex, optional
+ *     `sha256=` prefix);
+ *   - `provider_event_id` is the Mollie payment id (`tr_…`) at route time;
+ *     the worker re-keys subsequent rows with `${id}-${status}` once the
+ *     status transition is known.
+ */
+export async function mollieWebhookRoute(app: FastifyInstance) {
+  await app.register(rateLimit, {
+    max: 300,
+    timeWindow: "1 minute",
+    redis,
+  });
+
+  // Mollie sends form-encoded bodies; we parse the raw buffer ourselves to
+  // both verify the signature and pull out `id`. The default Fastify
+  // urlencoded parser would drop the raw bytes which we need for HMAC.
+  app.addContentTypeParser(
+    "application/x-www-form-urlencoded",
+    { parseAs: "buffer" },
+    (_req, body, done) => {
+      done(null, body);
+    },
+  );
+
+  const mollieGateway = getMollieWebhookVerifier();
+
+  app.post(
+    "/donations/mollie-webhook",
+    {
+      schema: {
+        tags: ["Payments"],
+        hide: true,
+      },
+    },
+    async (request, reply) => {
+      const signature = request.headers["x-mollie-signature"] as string | undefined;
+      if (!signature) {
+        return reply
+          .status(400)
+          .send(problemDetail(400, "Bad Request", "Missing x-mollie-signature"));
+      }
+
+      const rawBody = request.body as Buffer;
+
+      let event: Awaited<ReturnType<typeof mollieGateway.verifyWebhook>>;
+      try {
+        event = await mollieGateway.verifyWebhook(rawBody, signature);
+      } catch {
+        request.log.warn("Mollie webhook signature verification failed");
+        return reply
+          .status(400)
+          .send(problemDetail(400, "Bad Request", "Signature verification failed"));
+      }
+
+      const record = await createWebhookEvent({
+        provider: "mollie",
+        providerEventId: event.providerEventId,
+        eventType: event.eventType,
+        accountId: null,
+        payload: event.payload,
+        livemode: event.livemode,
+      });
+      if (!record) {
+        request.log.info(
+          { molliePaymentId: event.providerEventId },
+          "Duplicate Mollie webhook, skipping",
+        );
+        return reply.status(200).send({ received: true });
+      }
+
+      await webhooksQueue.add(
+        "process-mollie-webhook",
+        {
+          webhookEventId: record.id,
+          providerEventId: event.providerEventId,
+          molliePaymentId: event.providerEventId,
+          eventType: event.eventType,
+          payload: event.payload,
+        },
+        { jobId: `mollie-${event.providerEventId}` },
+      );
+
+      request.log.info({ molliePaymentId: event.providerEventId }, "Mollie webhook event queued");
+      return reply.status(200).send({ received: true });
+    },
+  );
+}
+
+// ─── Org-admin payment-gateway settings ───────────────────────────────────
+
+const PaymentGatewaySettingsBody = Type.Object({
+  paymentGateway: Type.Union(PAYMENT_GATEWAY_VALUES.map((v) => Type.Literal(v))),
+  /**
+   * Mollie API key (`test_…` / `live_…`). Required when switching the
+   * gateway to `'mollie'`; ignored otherwise. Sending an empty string
+   * clears the stored key — useful when an org rotates their Mollie
+   * credentials.
+   */
+  mollieApiKey: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+});
+
+const PaymentGatewaySettingsResponse = Type.Object({
+  paymentGateway: Type.Union(PAYMENT_GATEWAY_VALUES.map((v) => Type.Literal(v))),
+  /** Returns whether a Mollie key is currently set; the value itself is never sent back. */
+  mollieConfigured: Type.Boolean(),
+  flags: Type.Object({
+    "ff.payments.mollie": Type.Boolean(),
+  }),
+});
+
+export async function paymentGatewaySettingsRoute(app: FastifyInstance) {
+  /**
+   * Read the current org-admin gateway selection. Returns the payment
+   * gateway, whether a Mollie key is configured (boolean — never the
+   * key itself), and the relevant feature-flag state so the Settings
+   * UI can show / hide the Mollie option without round-tripping.
+   */
+  app.get(
+    "/admin/payment-gateway",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Payments"],
+        response: {
+          200: DataResponse(PaymentGatewaySettingsResponse),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const [tenant] = await db
+        .select({
+          paymentGateway: tenants.paymentGateway,
+          mollieApiKey: tenants.mollieApiKey,
+          featureFlags: tenants.featureFlags,
+        })
+        .from(tenants)
+        .where(eq(tenants.id, orgId));
+      if (!tenant) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Tenant not found"));
+      }
+      return {
+        data: {
+          paymentGateway: tenant.paymentGateway,
+          mollieConfigured: Boolean(tenant.mollieApiKey),
+          flags: {
+            "ff.payments.mollie": hasFeatureFlag(tenant, "ff.payments.mollie"),
+          },
+        },
+      };
+    },
+  );
+
+  /**
+   * Switch the org's payment gateway. Refuses `'mollie'` when the
+   * `ff.payments.mollie` flag is off — flag flip is a super-admin
+   * concern (no org-admin endpoint to flip flags here, by design;
+   * doc-18 will own that surface).
+   *
+   * Mollie key is stored as-is in `tenants.mollie_api_key`. The
+   * production-readiness note on encryption is in the schema comment;
+   * this route does not encrypt either, deliberately, to keep #62
+   * scoped to functional plumbing.
+   */
+  app.patch(
+    "/admin/payment-gateway",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Payments"],
+        body: PaymentGatewaySettingsBody,
+        response: {
+          200: DataResponse(PaymentGatewaySettingsResponse),
+          400: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const body = request.body as {
+        paymentGateway: (typeof PAYMENT_GATEWAY_VALUES)[number];
+        mollieApiKey?: string | null;
+      };
+
+      const [existing] = await db
+        .select({
+          paymentGateway: tenants.paymentGateway,
+          mollieApiKey: tenants.mollieApiKey,
+          featureFlags: tenants.featureFlags,
+        })
+        .from(tenants)
+        .where(eq(tenants.id, orgId));
+      if (!existing) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Tenant not found"));
+      }
+
+      if (body.paymentGateway === "mollie" && !hasFeatureFlag(existing, "ff.payments.mollie")) {
+        return reply
+          .status(400)
+          .send(problemDetail(400, "Bad Request", "Mollie is not enabled for this organization"));
+      }
+
+      // Compute the next Mollie API key:
+      //   - undefined: keep existing
+      //   - null or empty string: clear
+      //   - non-empty string: replace
+      let nextMollieKey: string | null;
+      if (body.mollieApiKey === undefined) {
+        nextMollieKey = existing.mollieApiKey;
+      } else if (body.mollieApiKey === null || body.mollieApiKey === "") {
+        nextMollieKey = null;
+      } else {
+        nextMollieKey = body.mollieApiKey;
+      }
+
+      if (body.paymentGateway === "mollie" && !nextMollieKey) {
+        return reply
+          .status(400)
+          .send(
+            problemDetail(
+              400,
+              "Bad Request",
+              "Mollie API key is required when switching gateway to mollie",
+            ),
+          );
+      }
+
+      const [updated] = await db
+        .update(tenants)
+        .set({
+          paymentGateway: body.paymentGateway,
+          mollieApiKey: nextMollieKey,
+          updatedAt: new Date(),
+        })
+        .where(eq(tenants.id, orgId))
+        .returning({
+          paymentGateway: tenants.paymentGateway,
+          mollieApiKey: tenants.mollieApiKey,
+          featureFlags: tenants.featureFlags,
+        });
+      if (!updated) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Tenant not found"));
+      }
+
+      return {
+        data: {
+          paymentGateway: updated.paymentGateway,
+          mollieConfigured: Boolean(updated.mollieApiKey),
+          flags: {
+            "ff.payments.mollie": hasFeatureFlag(updated, "ff.payments.mollie"),
+          },
+        },
+      };
+    },
+  );
+}
+
+// FEATURE_FLAG_KEYS is intentionally re-exported so tests can iterate
+// over the registry without importing from `@givernance/shared/schema`.
+export { FEATURE_FLAG_KEYS };

--- a/packages/api/src/modules/payments/service.ts
+++ b/packages/api/src/modules/payments/service.ts
@@ -119,22 +119,36 @@ export async function startStripeOnboarding(
 
 /**
  * Persist a webhook event with status 'pending' for async processing.
- * Stores only event.data.object (not the full Stripe envelope) to avoid
- * persisting unnecessary PII. Uses ON CONFLICT to handle race conditions.
+ * Stores only the gateway resource object (not the full envelope) to avoid
+ * persisting unnecessary PII. Uses ON CONFLICT on `(provider, provider_event_id)`
+ * to handle race conditions across BullMQ retries and gateway-side retries.
  * Returns the created record, or null if a duplicate was detected.
+ *
+ * Provider-agnostic since migration 0033 (issue #62) — accepts any of the
+ * `PaymentGatewayKey` values that emit webhooks (`stripe` | `mollie`). The
+ * route handler converts the gateway-specific `Stripe.Event` /
+ * `VerifiedWebhookEvent` envelope into this shape before calling.
  */
-export async function createWebhookEvent(event: Stripe.Event) {
+export async function createWebhookEvent(input: {
+  provider: "stripe" | "mollie";
+  providerEventId: string;
+  eventType: string;
+  accountId: string | null;
+  payload: Record<string, unknown>;
+  livemode: boolean;
+}) {
   const [record] = await db
     .insert(webhookEvents)
     .values({
-      stripeEventId: event.id,
-      eventType: event.type,
-      accountId: event.account ?? null,
-      payload: event.data.object as unknown as Record<string, unknown>,
+      provider: input.provider,
+      providerEventId: input.providerEventId,
+      eventType: input.eventType,
+      accountId: input.accountId,
+      payload: input.payload,
       status: "pending",
-      livemode: event.livemode,
+      livemode: input.livemode,
     })
-    .onConflictDoNothing({ target: webhookEvents.stripeEventId })
+    .onConflictDoNothing({ target: [webhookEvents.provider, webhookEvents.providerEventId] })
     .returning();
 
   return record ?? null;

--- a/packages/api/src/modules/public/routes.ts
+++ b/packages/api/src/modules/public/routes.ts
@@ -106,6 +106,7 @@ const DonateResponse = Type.Union([
     provider: Type.Literal("stripe"),
     clientSecret: Type.String(),
     stripeAccountId: Type.String(),
+    paymentIntentId: Type.String(),
   }),
   Type.Object({
     provider: Type.Literal("mollie"),

--- a/packages/api/src/modules/public/routes.ts
+++ b/packages/api/src/modules/public/routes.ts
@@ -1,8 +1,10 @@
 /** Public donation routes — unauthenticated endpoints for embeddable donation pages */
 
+import { PAYMENT_GATEWAY_VALUES } from "@givernance/shared/schema";
 import { CampaignPublicPageSchema } from "@givernance/shared/validators";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
+import { env } from "../../env.js";
 import { requireOrgAdmin } from "../../lib/guards.js";
 import {
   DataResponse,
@@ -34,6 +36,8 @@ const PublicDonationCurrencySchema = Type.Union([
   Type.Literal("CHF"),
 ]);
 
+const PaymentGatewaySchema = Type.Union(PAYMENT_GATEWAY_VALUES.map((v) => Type.Literal(v)));
+
 const PublicPageResponse = Type.Object({
   id: UuidSchema,
   campaignId: UuidSchema,
@@ -43,9 +47,15 @@ const PublicPageResponse = Type.Object({
   goalAmountCents: Type.Union([Type.Integer(), Type.Null()]),
   defaultCurrency: PublicDonationCurrencySchema,
   /**
+   * Tenant's selected payment gateway (issue #62). Drives donor-frontend
+   * branching: Stripe Elements for `'stripe'`, redirect to Mollie checkout
+   * for `'mollie'`, "donate offline" message for `'manual'`.
+   */
+  paymentGateway: PaymentGatewaySchema,
+  /**
    * Connected account id for the campaign's tenant. Null when the tenant
-   * hasn't onboarded with Stripe yet (donor flow blocks at the donate step
-   * with a 502 in that case). Public per Stripe docs — donor's Stripe.js
+   * hasn't onboarded with Stripe yet, or when the tenant uses a non-Stripe
+   * gateway (Mollie / manual). Public per Stripe docs — donor's Stripe.js
    * binds to it for both intent confirmation and 3DS post-redirect retrieve.
    */
   stripeAccountId: Type.Union([Type.String(), Type.Null()]),
@@ -85,10 +95,24 @@ const DonateHeaders = Type.Object({
   "idempotency-key": Type.Optional(Type.String({ minLength: 1, maxLength: 255 })),
 });
 
-const DonateResponse = Type.Object({
-  clientSecret: Type.String(),
-  stripeAccountId: Type.String(),
-});
+/**
+ * Discriminated union returned by `/donate` so the donor frontend renders
+ * Stripe Elements (`provider === 'stripe'`) or a Mollie checkout redirect
+ * (`provider === 'mollie'`). Adding a new gateway adds a new branch here +
+ * a new `PaymentGateway` implementation; route handler stays unchanged.
+ */
+const DonateResponse = Type.Union([
+  Type.Object({
+    provider: Type.Literal("stripe"),
+    clientSecret: Type.String(),
+    stripeAccountId: Type.String(),
+  }),
+  Type.Object({
+    provider: Type.Literal("mollie"),
+    checkoutUrl: Type.String(),
+    molliePaymentId: Type.String(),
+  }),
+]);
 
 const PublicPageCreateBody = CampaignPublicPageSchema;
 
@@ -224,7 +248,11 @@ export async function publicDonationRoutes(app: FastifyInstance) {
         headers: DonateHeaders,
         body: DonateBody,
         response: {
-          200: DataResponse(DonateResponse),
+          // Inline `data` wrapper because the response is a discriminated
+          // union and the shared `DataResponse(...)` helper accepts only a
+          // `TObject`. Keeping the type information at the call site is fine
+          // here — only this route returns a union shape today.
+          200: Type.Object({ data: DonateResponse }),
           400: ProblemDetailSchema,
           404: ProblemDetailSchema,
           429: ProblemDetailSchema,
@@ -254,15 +282,47 @@ export async function publicDonationRoutes(app: FastifyInstance) {
       }
 
       try {
-        const result = await createDonationIntent(id, body, idempotencyKey);
-        if (!result) {
-          // `createDonationIntent` returns `null` for several distinct reasons
-          // (invalid uuid, no public page found, no campaign row) — collapsing
-          // to a single 404 is deliberate so an enumerator can't distinguish
-          // "campaign exists but unpublished" from "campaign doesn't exist".
+        // Mollie needs a redirect URL (donor lands here post-checkout) and a
+        // webhook URL (Mollie POSTs status changes here). Both are derived
+        // from the API's configured `APP_URL` so a Cloudflare-tunnelled dev
+        // environment, staging, and prod each emit the right hostnames
+        // without per-tenant config. Stripe ignores both.
+        const returnUrl = `${env.APP_URL}/p/${id}`;
+        const webhookUrl = `${env.APP_URL.replace(/\/+$/, "")}/v1/donations/mollie-webhook`;
+
+        const outcome = await createDonationIntent(id, body, {
+          idempotencyKey,
+          returnUrl,
+          webhookUrl,
+        });
+        if (outcome.kind === "not_found") {
+          // The service collapses several distinct null reasons (invalid uuid,
+          // no public page, no campaign row) to a single 404 so an enumerator
+          // can't distinguish "campaign exists but unpublished" from "campaign
+          // doesn't exist".
           return reply.status(404).send(problemDetail(404, "Not Found", "Campaign not found"));
         }
-        return { data: result };
+        if (outcome.kind === "gateway_unavailable") {
+          // Map structured reasons to specific donor-facing messages so the
+          // Settings panel UI can show the right hint. Donors hit a 502 in
+          // every case — they shouldn't be able to distinguish "Stripe not
+          // onboarded" from "Mollie key missing"; both are operator errors
+          // on the NPO side that the donor cannot work around.
+          const detailByReason: Record<typeof outcome.reason, string> = {
+            stripe_not_onboarded: "Payment provider is not configured",
+            mollie_flag_off: "Payment provider is not configured",
+            mollie_not_configured: "Payment provider is not configured",
+            manual_gateway: "This organization accepts donations offline only",
+          };
+          request.log.warn(
+            { campaignId: id, reason: outcome.reason },
+            "Donate request rejected — gateway unavailable",
+          );
+          return reply
+            .status(502)
+            .send(problemDetail(502, "Bad Gateway", detailByReason[outcome.reason]));
+        }
+        return { data: outcome.result };
       } catch (err) {
         // Sanitised log: drop the raw Stripe Error object — it carries
         // `requestId`, `payment_intent.id`, and possibly the connected

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -1,17 +1,22 @@
-/** Public donations service — unauthenticated campaign page lookups and Stripe intent creation */
+/** Public donations service — unauthenticated campaign page lookups and gateway-dispatched intent creation */
 
 import {
   campaignPublicPages,
   campaignQrCodes,
   campaigns,
   donations,
+  type PaymentGatewayKey,
   tenants,
 } from "@givernance/shared/schema";
 import { and, eq, sql } from "drizzle-orm";
 import { db, withTenantContext } from "../../lib/db.js";
+import type { CreateDonationIntentResult } from "../../lib/payments/gateway.interface.js";
+import {
+  getGatewayForTenant,
+  PaymentGatewayUnavailableError,
+} from "../../lib/payments/gateway-factory.js";
 import { redis } from "../../lib/redis.js";
 import { isUuid } from "../../lib/schemas.js";
-import { getStripe } from "../payments/service.js";
 
 /**
  * 30s Redis cache for the public-page payload (issue #193 review,
@@ -131,11 +136,20 @@ async function loadPublicPage(campaignId: string) {
         colorPrimary: campaignPublicPages.colorPrimary,
         goalAmountCents: campaignPublicPages.goalAmountCents,
         defaultCurrency: campaigns.defaultCurrency,
+        /**
+         * Tenant's selected gateway. The donor frontend branches on this
+         * to render Stripe Elements (`'stripe'`), a Mollie redirect button
+         * (`'mollie'`), or a "this org takes offline donations" fallback
+         * (`'manual'`). Returned on the public page so the form can
+         * differentiate before the donor submits.
+         */
+        paymentGateway: tenants.paymentGateway,
         // Connect direct-charge requires the browser SDK to bind to the
         // connected account — exposed on this public endpoint so the donor
         // page can both (a) initialise Stripe.js and (b) handle 3DS
         // post-redirect retrieves without round-tripping to the donate
         // endpoint first. `acct_…` ids are public per Stripe docs (issue #197).
+        // Null when the tenant uses Mollie or has not onboarded yet.
         stripeAccountId: tenants.stripeAccountId,
       })
       .from(campaignPublicPages)
@@ -195,7 +209,29 @@ function calculatePlatformFee(amountCents: number): number {
   return Math.round(amountCents * 0.015 + 30);
 }
 
-/** Create a Stripe PaymentIntent on the tenant's connected account for a public donation */
+export type CreateDonationIntentOutcome =
+  | { kind: "ok"; result: CreateDonationIntentResult }
+  | { kind: "not_found" }
+  | { kind: "gateway_unavailable"; reason: PaymentGatewayUnavailableError["reason"] };
+
+/**
+ * Create a payment intent on the tenant's selected gateway (issue #62).
+ *
+ * Dispatch flow:
+ *   1. Resolve the public page → tenant
+ *   2. Build a `PaymentGateway` via `getGatewayForTenant` (which checks
+ *      the `ff.payments.mollie` flag for Mollie tenants, the
+ *      `stripeAccountId` for Stripe, etc.)
+ *   3. Delegate to `gateway.createDonationIntent(...)` with the donor
+ *      details + URLs the gateway needs (Mollie wants `webhookUrl` and
+ *      `redirectUrl`; Stripe doesn't, but the interface stays uniform).
+ *
+ * The return shape is the discriminated union the gateway emits — the
+ * route turns this into the donor-frontend response. `gateway_unavailable`
+ * surfaces the structured reason so the route can map to a specific
+ * problem-detail message ("Mollie not configured" vs. "Stripe not
+ * onboarded" vs. "Org uses manual reconciliation").
+ */
 export async function createDonationIntent(
   campaignId: string,
   body: {
@@ -205,13 +241,17 @@ export async function createDonationIntent(
     firstName: string;
     lastName: string;
   },
-  idempotencyKey?: string,
-) {
+  options: {
+    idempotencyKey?: string;
+    /** Public donor-page URL — Mollie redirects donors back here after checkout. */
+    returnUrl: string;
+    /** Public webhook URL Mollie POSTs to on payment status changes. */
+    webhookUrl: string;
+  },
+): Promise<CreateDonationIntentOutcome> {
   if (!isUuid(campaignId)) {
-    return null;
+    return { kind: "not_found" };
   }
-
-  const stripe = getStripe();
 
   // Find the orgId from the public page (readable without RLS)
   const [publicPage] = await db
@@ -219,9 +259,9 @@ export async function createDonationIntent(
     .from(campaignPublicPages)
     .where(eq(campaignPublicPages.campaignId, campaignId));
 
-  if (!publicPage) return null;
+  if (!publicPage) return { kind: "not_found" };
 
-  return withTenantContext(publicPage.orgId, async (tx) => {
+  return withTenantContext(publicPage.orgId, async (tx): Promise<CreateDonationIntentOutcome> => {
     // Look up the campaign to find the default currency (requires RLS context)
     const [campaign] = await tx
       .select({
@@ -232,22 +272,32 @@ export async function createDonationIntent(
       .from(campaigns)
       .where(eq(campaigns.id, campaignId));
 
-    if (!campaign) return null;
+    if (!campaign) return { kind: "not_found" };
 
-    // Look up the tenant's Stripe account
+    // Look up the tenant's gateway selection + per-gateway credentials.
     const [tenant] = await tx
-      .select({ id: tenants.id, stripeAccountId: tenants.stripeAccountId })
+      .select({
+        id: tenants.id,
+        paymentGateway: tenants.paymentGateway,
+        stripeAccountId: tenants.stripeAccountId,
+        mollieApiKey: tenants.mollieApiKey,
+        featureFlags: tenants.featureFlags,
+      })
       .from(tenants)
       .where(eq(tenants.id, campaign.orgId));
 
-    if (!tenant?.stripeAccountId) {
-      throw new Error("Organization has not completed Stripe onboarding");
+    if (!tenant) return { kind: "not_found" };
+
+    let gateway: ReturnType<typeof getGatewayForTenant>;
+    try {
+      gateway = getGatewayForTenant(tenant);
+    } catch (err) {
+      if (err instanceof PaymentGatewayUnavailableError) {
+        return { kind: "gateway_unavailable", reason: err.reason };
+      }
+      throw err;
     }
 
-    const stripeAccountDetails = await stripe.accounts.retrieve(tenant.stripeAccountId);
-    if (!stripeAccountDetails.charges_enabled) {
-      throw new Error("Organization Stripe account is not fully onboarded");
-    }
     // Platform fee. NOTE for the future refund handler: Stripe's default on
     // direct charges is to keep the application fee on refund — the platform
     // pockets the 1.5%+30¢ even when the donor is fully refunded. To match
@@ -256,67 +306,46 @@ export async function createDonationIntent(
     // refund-flow follow-up issue.
     const applicationFeeAmount = calculatePlatformFee(body.amountCents);
 
-    const intentParams: Parameters<typeof stripe.paymentIntents.create>[0] = {
-      amount: body.amountCents,
-      currency: body.currency.toLowerCase(),
-      application_fee_amount: applicationFeeAmount,
-      receipt_email: body.email,
-      metadata: {
-        campaign_id: campaignId,
-        org_id: campaign.orgId,
-        campaign_default_currency: campaign.defaultCurrency,
-        constituent_first_name: body.firstName,
-        constituent_last_name: body.lastName,
+    const result = await gateway.createDonationIntent({
+      campaignId,
+      currency: body.currency,
+      amountCents: body.amountCents,
+      applicationFeeAmountCents: applicationFeeAmount,
+      donor: {
+        email: body.email,
+        firstName: body.firstName,
+        lastName: body.lastName,
       },
-    };
+      idempotencyKey: options.idempotencyKey,
+      returnUrl: options.returnUrl,
+      webhookUrl: options.webhookUrl,
+    });
 
-    const requestOptions: Parameters<typeof stripe.paymentIntents.create>[1] = {
-      stripeAccount: tenant.stripeAccountId,
-    };
-
-    if (idempotencyKey) {
-      requestOptions.idempotencyKey = idempotencyKey;
-    }
-
-    const intent = await stripe.paymentIntents.create(intentParams, requestOptions);
-
-    if (!intent.client_secret) {
-      throw new Error("Stripe returned a PaymentIntent without a client_secret");
-    }
-
-    // Orphan-PI observability hook (PR #193 review, finding #10): emit a
-    // structured `donation_intent.created` log line per PI creation so
-    // an ops query of the form
-    //   donation_intent.created events without a matching
-    //   payment_intent.succeeded webhook within 24h
-    // surfaces the donor abandon rate. A donor who closes the tab
-    // between `paymentIntents.create` and `confirmPayment` leaves the
-    // intent in `requires_payment_method` — Stripe auto-cancels after
-    // 7 days, but in the meantime we have no signal to reconcile.
-    //
-    // Not implemented here: a cleanup worker that explicitly calls
-    // `paymentIntents.cancel` on orphans (24h+ stale, no match in our
-    // `donations` table). The platform-finance dashboard (#206) is the
-    // natural home for the abandon metric and the cleanup job; both are
-    // tracked there, deliberately not bundled into this PR.
+    // Orphan observability hook (PR #193 review, finding #10): one structured
+    // line per intent creation so an ops query of the form
+    //   donation_intent.created events without a matching gateway-success
+    //   webhook within 24h
+    // surfaces the donor abandon rate, regardless of which gateway was used.
     //
     // biome-ignore lint/suspicious/noConsole: structured ops log; pino is request-scoped, not in this code path
     console.info(
       JSON.stringify({
         event: "donation_intent.created",
-        paymentIntentId: intent.id,
-        stripeAccountId: tenant.stripeAccountId,
+        provider: result.provider,
         campaignId,
         ts: new Date().toISOString(),
+        ...(result.provider === "stripe"
+          ? { stripeAccountId: result.stripeAccountId }
+          : { molliePaymentId: result.molliePaymentId }),
       }),
     );
 
-    return {
-      clientSecret: intent.client_secret,
-      stripeAccountId: tenant.stripeAccountId,
-    };
+    return { kind: "ok", result };
   });
 }
+
+/** Re-export the discriminated union so the route + frontend share a single source of truth. */
+export type { CreateDonationIntentResult, PaymentGatewayKey };
 
 /** Upsert a public page configuration for a campaign (admin) */
 export async function upsertPublicPage(

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -309,6 +309,7 @@ export async function createDonationIntent(
     const result = await gateway.createDonationIntent({
       campaignId,
       currency: body.currency,
+      campaignDefaultCurrency: campaign.defaultCurrency,
       amountCents: body.amountCents,
       applicationFeeAmountCents: applicationFeeAmount,
       donor: {
@@ -326,6 +327,8 @@ export async function createDonationIntent(
     //   donation_intent.created events without a matching gateway-success
     //   webhook within 24h
     // surfaces the donor abandon rate, regardless of which gateway was used.
+    // The Stripe branch carries `paymentIntentId` so the join key against
+    // `payment_intent.succeeded` matches the original (pre-#62) log shape.
     //
     // biome-ignore lint/suspicious/noConsole: structured ops log; pino is request-scoped, not in this code path
     console.info(
@@ -335,7 +338,10 @@ export async function createDonationIntent(
         campaignId,
         ts: new Date().toISOString(),
         ...(result.provider === "stripe"
-          ? { stripeAccountId: result.stripeAccountId }
+          ? {
+              paymentIntentId: result.paymentIntentId,
+              stripeAccountId: result.stripeAccountId,
+            }
           : { molliePaymentId: result.molliePaymentId }),
       }),
     );

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -21,7 +21,12 @@ import { donationRoutes } from "./modules/donations/routes.js";
 import { fundRoutes } from "./modules/funds/routes.js";
 import { healthRoutes } from "./modules/health/routes.js";
 import { invitationRoutes } from "./modules/invitations/routes.js";
-import { paymentRoutes, stripeWebhookRoute } from "./modules/payments/routes.js";
+import {
+  mollieWebhookRoute,
+  paymentGatewaySettingsRoute,
+  paymentRoutes,
+  stripeWebhookRoute,
+} from "./modules/payments/routes.js";
 import { pledgeRoutes } from "./modules/pledges/routes.js";
 import { publicDonationRoutes } from "./modules/public/routes.js";
 import { reportsRoutes } from "./modules/reports/routes.js";
@@ -163,7 +168,9 @@ export async function createServer(opts: CreateServerOpts = {}): Promise<Fastify
   await app.register(pledgeRoutes, { prefix: "/v1" });
   await app.register(campaignRoutes, { prefix: "/v1" });
   await app.register(paymentRoutes, { prefix: "/v1" });
+  await app.register(paymentGatewaySettingsRoute, { prefix: "/v1" });
   await app.register(stripeWebhookRoute, { prefix: "/v1" });
+  await app.register(mollieWebhookRoute, { prefix: "/v1" });
   await app.register(publicDonationRoutes, { prefix: "/v1" });
   await app.register(signupRoutes, { prefix: "/v1" });
   await app.register(reportsRoutes, { prefix: "/v1" });

--- a/packages/api/src/tests/integration/mollie-payments.test.ts
+++ b/packages/api/src/tests/integration/mollie-payments.test.ts
@@ -24,14 +24,40 @@ import {
   signTokenB,
 } from "../helpers/auth.js";
 
-const { mockQueueAdd } = vi.hoisted(() => ({
-  mockQueueAdd: vi.fn().mockResolvedValue({ id: "mock-job-id" }),
-}));
+const { mockQueueAdd, mockMolliePaymentsCreate, mockCreateMollieClient } = vi.hoisted(() => {
+  const mockMolliePaymentsCreate = vi.fn();
+  const mockCreateMollieClient = vi.fn().mockImplementation(() => ({
+    payments: { create: mockMolliePaymentsCreate, get: vi.fn() },
+  }));
+  return {
+    mockQueueAdd: vi.fn().mockResolvedValue({ id: "mock-job-id" }),
+    mockMolliePaymentsCreate,
+    mockCreateMollieClient,
+  };
+});
 
 vi.mock("bullmq", () => ({
   Queue: vi.fn().mockImplementation(() => ({
     add: mockQueueAdd,
   })),
+}));
+
+// Mock the Mollie SDK at the module boundary so the donor-flow test below
+// can exercise the route → factory → MollieGateway path without making a
+// live Mollie API call. Stripe is NOT mocked here — the donor-flow Mollie
+// test sets ORG_A's gateway to `'mollie'` so the factory never reaches
+// Stripe, and the existing tests in this file don't touch the donate route.
+vi.mock("@mollie/api-client", () => ({
+  default: mockCreateMollieClient,
+  PaymentStatus: {
+    open: "open",
+    canceled: "canceled",
+    pending: "pending",
+    authorized: "authorized",
+    expired: "expired",
+    failed: "failed",
+    paid: "paid",
+  },
 }));
 
 // Must match the value set in `src/tests/setup.ts` so the route's env-loaded
@@ -48,12 +74,21 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await db.execute(sql`DELETE FROM webhook_events WHERE provider_event_id LIKE 'tr_test_%'`);
-  // Reset gateway selection on the test tenants so other test files start
-  // from a known state.
+  await db.execute(sql`DELETE FROM campaign_public_pages WHERE org_id = ${ORG_A}`);
+  await db.execute(
+    sql`DELETE FROM campaigns WHERE org_id = ${ORG_A} AND name LIKE 'Mollie Donate Test%'`,
+  );
+  // Reset gateway selection on BOTH test tenants so the next test file
+  // starts from a known state regardless of which test in this file ran
+  // last (the "isolates the PATCH" test mutates ORG_B to `manual`).
   await db
     .update(tenants)
     .set({ paymentGateway: "stripe", mollieApiKey: null, featureFlags: {} })
     .where(eq(tenants.id, ORG_A));
+  await db
+    .update(tenants)
+    .set({ paymentGateway: "stripe", mollieApiKey: null, featureFlags: {} })
+    .where(eq(tenants.id, ORG_B));
   await app.close();
 });
 
@@ -229,7 +264,7 @@ describe("GET /v1/admin/payment-gateway", () => {
 });
 
 describe("PATCH /v1/admin/payment-gateway", () => {
-  it("rejects switching to mollie when ff.payments.mollie is off (400)", async () => {
+  it("rejects switching to mollie when ff.payments.mollie is off (400 + RFC 9457 body)", async () => {
     await db
       .update(tenants)
       .set({ paymentGateway: "stripe", mollieApiKey: null, featureFlags: {} })
@@ -243,7 +278,13 @@ describe("PATCH /v1/admin/payment-gateway", () => {
       payload: { paymentGateway: "mollie", mollieApiKey: "test_xxx" },
     });
     expect(res.statusCode).toBe(400);
-    const body = res.json<{ detail: string }>();
+    // Lock the full RFC 9457 envelope on at least one PATCH 400 path so a
+    // regression to a plain-string body or a `{error}` shape doesn't slip
+    // through (memory: feedback_lock_rfc9457_body_in_tests.md).
+    const body = res.json<{ type: string; title: string; status: number; detail: string }>();
+    expect(body.type).toBe("https://httpproblems.com/http-status/400");
+    expect(body.title).toBe("Bad Request");
+    expect(body.status).toBe(400);
     expect(body.detail).toContain("Mollie is not enabled");
   });
 
@@ -339,5 +380,87 @@ describe("PATCH /v1/admin/payment-gateway", () => {
       .where(eq(tenants.id, ORG_A));
     expect(orgA?.paymentGateway).toBe("stripe");
     expect(orgA?.mollieApiKey).toBe("preserved");
+  });
+});
+
+// ─── End-to-end donor flow on the Mollie path ──────────────────────────────
+
+describe("POST /v1/public/campaigns/:id/donate (Mollie path)", () => {
+  it("returns the Mollie response shape when the tenant is on Mollie", async () => {
+    // 1. Switch ORG_A onto the Mollie gateway with the flag on + an API key.
+    await db
+      .update(tenants)
+      .set({
+        paymentGateway: "mollie",
+        mollieApiKey: "test_xxx_mollie_donor",
+        featureFlags: { "ff.payments.mollie": true },
+      })
+      .where(eq(tenants.id, ORG_A));
+
+    // 2. Create a campaign + published public page on ORG_A.
+    const adminToken = signToken(app);
+    const campaignRes = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(adminToken),
+      payload: { name: "Mollie Donate Test", type: "digital" },
+    });
+    const campaignId = campaignRes.json<{ data: { id: string } }>().data.id;
+    await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaignId}/public-page`,
+      headers: authHeader(adminToken),
+      payload: { title: "Help us", status: "published" },
+    });
+
+    // 3. Stub Mollie's `payments.create` to return a synthetic checkout URL.
+    mockMolliePaymentsCreate.mockResolvedValueOnce({
+      id: "tr_test_donate_e2e",
+      _links: { checkout: { href: "https://www.mollie.com/checkout/test/tr_test_donate_e2e" } },
+    });
+
+    // 4. POST the donate endpoint as a donor (unauthenticated).
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/public/campaigns/${campaignId}/donate`,
+      payload: {
+        amountCents: 5000,
+        currency: "EUR",
+        email: "donor@example.org",
+        firstName: "Mollie",
+        lastName: "Donor",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data:
+        | {
+            provider: "stripe";
+            clientSecret: string;
+            stripeAccountId: string;
+            paymentIntentId: string;
+          }
+        | { provider: "mollie"; checkoutUrl: string; molliePaymentId: string };
+    }>();
+    // Discriminated union — the donor frontend branches on this.
+    expect(body.data.provider).toBe("mollie");
+    if (body.data.provider !== "mollie") throw new Error("unreachable");
+    expect(body.data.checkoutUrl).toBe("https://www.mollie.com/checkout/test/tr_test_donate_e2e");
+    expect(body.data.molliePaymentId).toBe("tr_test_donate_e2e");
+
+    // The Mollie SDK's `payments.create` was called with the donor + campaign
+    // metadata so the worker can recover them on webhook receipt.
+    expect(mockMolliePaymentsCreate).toHaveBeenCalledTimes(1);
+    const createCall = mockMolliePaymentsCreate.mock.calls[0]?.[0] as {
+      amount: { value: string; currency: string };
+      metadata: Record<string, unknown>;
+      webhookUrl: string;
+      redirectUrl: string;
+    };
+    expect(createCall.amount).toEqual({ value: "50.00", currency: "EUR" });
+    expect(createCall.metadata.org_id).toBe(ORG_A);
+    expect(createCall.metadata.campaign_id).toBe(campaignId);
+    expect(createCall.webhookUrl).toContain("/v1/donations/mollie-webhook");
   });
 });

--- a/packages/api/src/tests/integration/mollie-payments.test.ts
+++ b/packages/api/src/tests/integration/mollie-payments.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Mollie webhook + payment-gateway settings tests (issue #62).
+ *
+ * Mirrors `payments.test.ts` but for the Mollie surface: HMAC signature
+ * verification, idempotent persistence, and the org-admin
+ * GET/PATCH `/admin/payment-gateway` route. The Mollie API client is
+ * NOT mocked at the SDK level — only the route layer is exercised here,
+ * so no live Mollie traffic.
+ */
+
+import { createHmac } from "node:crypto";
+import { tenants, webhookEvents } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { db } from "../../lib/db.js";
+import { createServer } from "../../server.js";
+import {
+  authHeader,
+  ensureTestTenants,
+  ORG_A,
+  ORG_B,
+  signToken,
+  signTokenB,
+} from "../helpers/auth.js";
+
+const { mockQueueAdd } = vi.hoisted(() => ({
+  mockQueueAdd: vi.fn().mockResolvedValue({ id: "mock-job-id" }),
+}));
+
+vi.mock("bullmq", () => ({
+  Queue: vi.fn().mockImplementation(() => ({
+    add: mockQueueAdd,
+  })),
+}));
+
+// Must match the value set in `src/tests/setup.ts` so the route's env-loaded
+// secret matches the bytes we sign with in this file.
+const TEST_MOLLIE_WEBHOOK_SECRET = "test-mollie-secret";
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+});
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM webhook_events WHERE provider_event_id LIKE 'tr_test_%'`);
+  // Reset gateway selection on the test tenants so other test files start
+  // from a known state.
+  await db
+    .update(tenants)
+    .set({ paymentGateway: "stripe", mollieApiKey: null, featureFlags: {} })
+    .where(eq(tenants.id, ORG_A));
+  await app.close();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function signMollieBody(body: string): string {
+  return createHmac("sha256", TEST_MOLLIE_WEBHOOK_SECRET).update(body).digest("hex");
+}
+
+// ─── Mollie webhook ────────────────────────────────────────────────────────
+
+describe("POST /v1/donations/mollie-webhook", () => {
+  it("returns 400 without x-mollie-signature header", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/donations/mollie-webhook",
+      payload: "id=tr_test_unauth",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toHaveProperty("detail", "Missing x-mollie-signature");
+  });
+
+  it("returns 400 for invalid signature", async () => {
+    const body = "id=tr_test_invalidsig";
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/donations/mollie-webhook",
+      payload: body,
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-mollie-signature": "deadbeef",
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toHaveProperty("detail", "Signature verification failed");
+  });
+
+  it("accepts a valid signature, persists the event, and enqueues a Mollie job", async () => {
+    const paymentId = `tr_test_${Date.now()}`;
+    const body = `id=${paymentId}`;
+    const signature = signMollieBody(body);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/donations/mollie-webhook",
+      payload: body,
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-mollie-signature": signature,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ received: true });
+
+    const [persisted] = await db
+      .select()
+      .from(webhookEvents)
+      .where(eq(webhookEvents.providerEventId, paymentId));
+    expect(persisted).toBeTruthy();
+    expect(persisted?.provider).toBe("mollie");
+    expect(persisted?.eventType).toBe("payment.notification");
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      "process-mollie-webhook",
+      expect.objectContaining({ molliePaymentId: paymentId }),
+      expect.any(Object),
+    );
+  });
+
+  it("accepts the sha256= prefix on the signature header", async () => {
+    const paymentId = `tr_test_prefix_${Date.now()}`;
+    const body = `id=${paymentId}`;
+    const signature = `sha256=${signMollieBody(body)}`;
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/donations/mollie-webhook",
+      payload: body,
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-mollie-signature": signature,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 200 for a duplicate event (idempotency)", async () => {
+    const paymentId = `tr_test_dup_${Date.now()}`;
+    const body = `id=${paymentId}`;
+    const signature = signMollieBody(body);
+
+    const res1 = await app.inject({
+      method: "POST",
+      url: "/v1/donations/mollie-webhook",
+      payload: body,
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-mollie-signature": signature,
+      },
+    });
+    expect(res1.statusCode).toBe(200);
+    expect(mockQueueAdd).toHaveBeenCalledTimes(1);
+
+    const res2 = await app.inject({
+      method: "POST",
+      url: "/v1/donations/mollie-webhook",
+      payload: body,
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-mollie-signature": signature,
+      },
+    });
+    expect(res2.statusCode).toBe(200);
+    expect(res2.json()).toEqual({ received: true });
+    // Duplicate must NOT enqueue a second job
+    expect(mockQueueAdd).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Org-admin gateway settings ────────────────────────────────────────────
+
+describe("GET /v1/admin/payment-gateway", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "GET", url: "/v1/admin/payment-gateway" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it.each([
+    { role: "viewer" as const },
+    { role: "user" as const },
+  ])("returns 403 for role $role", async ({ role }) => {
+    const token = signToken(app, { role });
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/payment-gateway",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(403);
+    const body = res.json<{ type: string; status: number }>();
+    expect(body.type).toBe("https://httpproblems.com/http-status/403");
+    expect(body.status).toBe(403);
+  });
+
+  it("returns the current gateway state", async () => {
+    await db
+      .update(tenants)
+      .set({ paymentGateway: "stripe", mollieApiKey: null, featureFlags: {} })
+      .where(eq(tenants.id, ORG_A));
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/payment-gateway",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        paymentGateway: string;
+        mollieConfigured: boolean;
+        flags: { "ff.payments.mollie": boolean };
+      };
+    }>();
+    expect(body.data.paymentGateway).toBe("stripe");
+    expect(body.data.mollieConfigured).toBe(false);
+    expect(body.data.flags["ff.payments.mollie"]).toBe(false);
+  });
+});
+
+describe("PATCH /v1/admin/payment-gateway", () => {
+  it("rejects switching to mollie when ff.payments.mollie is off (400)", async () => {
+    await db
+      .update(tenants)
+      .set({ paymentGateway: "stripe", mollieApiKey: null, featureFlags: {} })
+      .where(eq(tenants.id, ORG_A));
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/admin/payment-gateway",
+      headers: authHeader(token),
+      payload: { paymentGateway: "mollie", mollieApiKey: "test_xxx" },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ detail: string }>();
+    expect(body.detail).toContain("Mollie is not enabled");
+  });
+
+  it("rejects switching to mollie without an api key (400) even when the flag is on", async () => {
+    await db
+      .update(tenants)
+      .set({
+        paymentGateway: "stripe",
+        mollieApiKey: null,
+        featureFlags: { "ff.payments.mollie": true },
+      })
+      .where(eq(tenants.id, ORG_A));
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/admin/payment-gateway",
+      headers: authHeader(token),
+      payload: { paymentGateway: "mollie" },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ detail: string }>();
+    expect(body.detail).toContain("Mollie API key is required");
+  });
+
+  it("activates Mollie when the flag is on AND an api key is provided", async () => {
+    // Explicitly reset BOTH tenants to a known clean state — the test file
+    // is shared across re-runs against the same `givernance_test` DB, and
+    // a prior run's "isolates" test could have left ORG_B at `manual`.
+    await db
+      .update(tenants)
+      .set({
+        paymentGateway: "stripe",
+        mollieApiKey: null,
+        featureFlags: { "ff.payments.mollie": true },
+      })
+      .where(eq(tenants.id, ORG_A));
+    await db
+      .update(tenants)
+      .set({ paymentGateway: "stripe", mollieApiKey: null, featureFlags: {} })
+      .where(eq(tenants.id, ORG_B));
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/admin/payment-gateway",
+      headers: authHeader(token),
+      payload: { paymentGateway: "mollie", mollieApiKey: "test_xxx_yyy" },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { paymentGateway: string; mollieConfigured: boolean };
+    }>();
+    expect(body.data.paymentGateway).toBe("mollie");
+    expect(body.data.mollieConfigured).toBe(true);
+
+    // Cross-tenant isolation: ORG_B must NOT have been touched.
+    const [orgB] = await db
+      .select({ paymentGateway: tenants.paymentGateway, mollieApiKey: tenants.mollieApiKey })
+      .from(tenants)
+      .where(eq(tenants.id, ORG_B));
+    expect(orgB?.paymentGateway).toBe("stripe");
+    expect(orgB?.mollieApiKey).toBeNull();
+  });
+
+  it("isolates the PATCH to the calling org (cross-tenant)", async () => {
+    // Tenant B switches its own gateway — must not affect Tenant A.
+    await db
+      .update(tenants)
+      .set({
+        paymentGateway: "stripe",
+        mollieApiKey: null,
+        featureFlags: { "ff.payments.mollie": true },
+      })
+      .where(eq(tenants.id, ORG_B));
+    await db
+      .update(tenants)
+      .set({ paymentGateway: "stripe", mollieApiKey: "preserved" })
+      .where(eq(tenants.id, ORG_A));
+
+    const tokenB = signTokenB(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/admin/payment-gateway",
+      headers: authHeader(tokenB),
+      payload: { paymentGateway: "manual" },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const [orgA] = await db
+      .select({ paymentGateway: tenants.paymentGateway, mollieApiKey: tenants.mollieApiKey })
+      .from(tenants)
+      .where(eq(tenants.id, ORG_A));
+    expect(orgA?.paymentGateway).toBe("stripe");
+    expect(orgA?.mollieApiKey).toBe("preserved");
+  });
+});

--- a/packages/api/src/tests/integration/payments.test.ts
+++ b/packages/api/src/tests/integration/payments.test.ts
@@ -48,7 +48,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await db.execute(sql`DELETE FROM webhook_events WHERE stripe_event_id LIKE 'evt_test_%'`);
+  await db.execute(sql`DELETE FROM webhook_events WHERE provider_event_id LIKE 'evt_test_%'`);
+  await db.execute(sql`DELETE FROM webhook_events WHERE provider_event_id LIKE 'tr_test_%'`);
   await app.close();
 });
 
@@ -415,8 +416,9 @@ describe("POST /v1/donations/stripe-webhook", () => {
     const [persisted] = await db
       .select()
       .from(webhookEvents)
-      .where(eq(webhookEvents.stripeEventId, eventId));
+      .where(eq(webhookEvents.providerEventId, eventId));
     expect(persisted).toBeTruthy();
+    expect(persisted?.provider).toBe("stripe");
     expect(persisted?.eventType).toBe("payment_intent.succeeded");
     expect(persisted?.status).toBe("pending");
     // Payload should be event.data.object, NOT the full envelope

--- a/packages/api/src/tests/integration/public-donations.test.ts
+++ b/packages/api/src/tests/integration/public-donations.test.ts
@@ -551,7 +551,12 @@ describe("POST /v1/public/campaigns/:id/donate", () => {
       expect(body.type).toBe("https://httpproblems.com/http-status/502");
       expect(body.title).toBe("Bad Gateway");
       expect(body.status).toBe(502);
-      expect(body.detail).toBe("Payment processing failed");
+      // Issue #62: gateway-unavailable conditions ("not onboarded", "Mollie
+      // not configured", "manual gateway") collapse to a single donor-facing
+      // detail so a donor cannot distinguish between operator-side errors —
+      // they're all unrecoverable on the donor side and should land at the
+      // same generic message. Internal logs carry the structured `reason`.
+      expect(body.detail).toBe("Payment provider is not configured");
       // Donor must NOT see the underlying Stripe-onboarding message.
       expect(body.detail).not.toContain("onboarding");
     } finally {

--- a/packages/api/src/tests/setup.ts
+++ b/packages/api/src/tests/setup.ts
@@ -21,6 +21,12 @@ process.env.ADMIN_SECRET ??= "test-secret";
 // is mocked in test files that exercise the real service path); just needs
 // to pass the env-validation gate.
 process.env.STRIPE_SECRET_KEY ??= "sk_test_dummy_for_tests";
+// Mollie webhook secret (issue #62) — Mollie webhook tests sign synthetic
+// bodies with this same value, so any change here MUST be mirrored in
+// `tests/integration/mollie-payments.test.ts`. Set unconditionally (not
+// `??=`) so a developer with `MOLLIE_WEBHOOK_SECRET` exported in their
+// shell doesn't get a signature mismatch in tests.
+process.env.MOLLIE_WEBHOOK_SECRET = "test-mollie-secret";
 process.env.LOG_LEVEL ??= "silent";
 
 const TEST_JWKS = {

--- a/packages/shared/src/constants/pino-redact.ts
+++ b/packages/shared/src/constants/pino-redact.ts
@@ -56,6 +56,21 @@ export const PINO_REDACT_PATHS: readonly string[] = [
   "body.cvv",
   "body.pan",
 
+  // ─── Payment-provider credentials (issue #62) ─────────────────────────────
+  // The Mollie API key is per-tenant, stored in `tenants.mollie_api_key`,
+  // and reaches the API via `PATCH /v1/admin/payment-gateway` body. It is
+  // a `live_…` / `test_…` token that — if leaked into Loki / Tempo — lets
+  // an attacker drive payments and refunds against the NPO's Mollie account.
+  // Pino's `redact` is one-level-wildcard, so enumerate the carriers we know
+  // about (request body + nested tenant rows that someone might log).
+  "body.mollieApiKey",
+  "req.body.mollieApiKey",
+  "request.body.mollieApiKey",
+  "mollieApiKey",
+  "*.mollieApiKey",
+  "tenant.mollieApiKey",
+  "*.mollie_api_key",
+
   // ─── PII (docs/17 §6.1, docs/06) ──────────────────────────────────────────
   // Direct identifiers — covered on request bodies, responses, and anywhere
   // they end up attached under a `constituent` object logged by mistake.

--- a/packages/shared/src/jobs/index.ts
+++ b/packages/shared/src/jobs/index.ts
@@ -60,9 +60,34 @@ export interface ProcessStripeWebhookJob {
   name: "process-stripe-webhook";
   data: {
     webhookEventId: string;
+    /**
+     * Provider-native event id (kept on `stripeEventId` for backward
+     * compatibility with the BullMQ payload shape). Equivalent to
+     * `webhook_events.provider_event_id` post-migration 0033.
+     */
     stripeEventId: string;
     eventType: string;
     accountId: string | null;
+    payload: Record<string, unknown>;
+  };
+}
+
+/**
+ * Process a Mollie webhook event asynchronously. The Mollie webhook contract
+ * sends only the affected payment id and status — the worker fetches the
+ * full payment from Mollie API using the per-tenant `tenants.mollie_api_key`
+ * before creating a donation row. `provider_event_id` is the synthesised
+ * `${paymentId}-${status}` so retries on the same status are idempotent.
+ */
+export interface ProcessMollieWebhookJob {
+  name: "process-mollie-webhook";
+  data: {
+    webhookEventId: string;
+    /** Synthesised `${paymentId}-${status}` — matches `webhook_events.provider_event_id`. */
+    providerEventId: string;
+    /** Mollie payment id (`tr_…`) — what the worker passes to `mollie.payments.get`. */
+    molliePaymentId: string;
+    eventType: string;
     payload: Record<string, unknown>;
   };
 }
@@ -74,7 +99,8 @@ export type JobDefinition =
   | ExportDataJob
   | GdprErasureJob
   | GenerateCampaignDocumentsJob
-  | ProcessStripeWebhookJob;
+  | ProcessStripeWebhookJob
+  | ProcessMollieWebhookJob;
 
 /** Queue names */
 export const QUEUE_NAMES = {

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -3,6 +3,7 @@
  * All tables include org_id for row-level security and audit columns.
  */
 
+import { sql } from "drizzle-orm";
 import {
   type AnyPgColumn,
   bigint,
@@ -73,6 +74,32 @@ export const webhookEventStatusEnum = pgEnum("webhook_event_status", [
   "completed",
   "failed",
 ]);
+
+// ─── Payment Gateway Enums ─────────────────────────────────────────────────
+
+/**
+ * Per-tenant payment gateway selector. ADR-010: Stripe is the default, Mollie
+ * is co-primary for FR/BE/NL tenants gated by `ff.payments.mollie`, and
+ * `manual` is reserved for offline reconciliation flows.
+ *
+ * Stored as VARCHAR(20) with a CHECK constraint rather than a Postgres ENUM
+ * so adding new gateways (saferpay, mangopay) is a no-downtime constraint
+ * change rather than a `pg_enum` add followed by a rewrite.
+ */
+export const PAYMENT_GATEWAY_VALUES = ["stripe", "mollie", "manual"] as const;
+export type PaymentGatewayKey = (typeof PAYMENT_GATEWAY_VALUES)[number];
+
+// ─── Feature flag keys ─────────────────────────────────────────────────────
+
+/**
+ * Registry of feature-flag keys we look up in `tenants.feature_flags`. The
+ * full doc-18 system (registry table, Redis cache, admin UI) is forthcoming;
+ * this MVP store keeps the surface tiny — flags read from a JSONB column on
+ * the tenant row, default to `false`, and gate code paths via
+ * `hasFeatureFlag()` in the API.
+ */
+export const FEATURE_FLAG_KEYS = ["ff.payments.mollie"] as const;
+export type FeatureFlagKey = (typeof FEATURE_FLAG_KEYS)[number];
 
 // ─── Enums ────────────────────────────────────────────────────────────────────
 
@@ -154,6 +181,56 @@ export const tenants = pgTable(
       .default("fr")
       .$type<Locale>(),
     stripeAccountId: varchar("stripe_account_id", { length: 255 }),
+    /**
+     * Per-tenant payment gateway selection. ADR-010 / issue #62. Default
+     * `'stripe'` matches the platform default; `'mollie'` requires
+     * `ff.payments.mollie` to be enabled in `feature_flags`. The CHECK
+     * constraint (migration 0033) enforces the closed set; keep
+     * `PAYMENT_GATEWAY_VALUES` in lockstep with that constraint.
+     */
+    paymentGateway: varchar("payment_gateway", { length: 20 })
+      .notNull()
+      .default("stripe")
+      .$type<PaymentGatewayKey>(),
+    /**
+     * Per-tenant Mollie API key — each NPO brings its own (test_… or
+     * live_… prefix), pasted into the org-admin Settings → Payments form.
+     * NULL when the tenant uses Stripe (or hasn't pasted a key yet);
+     * the gateway factory raises a clear "Mollie not configured" error
+     * if the key is missing when `payment_gateway = 'mollie'`.
+     *
+     * Storage caveat (out of scope for #62): VARCHAR plaintext today —
+     * production should encrypt with KMS / pgcrypto + per-tenant DEK.
+     * Filed as a follow-up so we don't ship live-mode keys at rest in
+     * cleartext beyond the FR/BE/NL pilot. See doc-20 §6 PCI scope; no
+     * card data passes through this column.
+     */
+    mollieApiKey: varchar("mollie_api_key", { length: 255 }),
+    /**
+     * Minimal feature-flag store ahead of the full doc-18 system (see
+     * `FEATURE_FLAG_KEYS`). JSONB shape is `{ "ff.payments.mollie":
+     * boolean, ... }`; missing keys resolve to `false`. The full doc-18
+     * plan layers Redis caching + a `tenant_flag_overrides` table on top
+     * of this MVP — when that lands, this column is the migration
+     * target for existing per-tenant state.
+     */
+    featureFlags: jsonb("feature_flags")
+      .notNull()
+      .default(sql`'{}'::jsonb`)
+      .$type<Partial<Record<FeatureFlagKey, boolean>>>(),
+    /**
+     * Cached Stripe Connect state, populated by the `account.updated`
+     * webhook (issue #62). `stripeChargesEnabled = true` is what doc-20
+     * §5.2 calls "live mode" — the donor flow flips from test cards to
+     * real charges when this becomes `true`. Live `accounts.retrieve`
+     * stays the source of truth for the org-admin Settings panel; this
+     * cached snapshot drives the donor-side test/live-mode rendering
+     * without round-tripping to Stripe per page view.
+     */
+    stripeChargesEnabled: boolean("stripe_charges_enabled").notNull().default(false),
+    stripePayoutsEnabled: boolean("stripe_payouts_enabled").notNull().default(false),
+    stripeDetailsSubmitted: boolean("stripe_details_submitted").notNull().default(false),
+    stripeAccountStateAt: timestamp("stripe_account_state_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -161,6 +238,7 @@ export const tenants = pgTable(
     unique("tenants_stripe_account_id_uniq").on(table.stripeAccountId),
     index("tenants_status_idx").on(table.status),
     index("tenants_created_via_idx").on(table.createdVia),
+    index("tenants_payment_gateway_idx").on(table.paymentGateway),
   ],
 );
 
@@ -819,12 +897,34 @@ export const campaignPublicPages = pgTable(
 
 // ─── Webhook Events ────────────────────────────────────────────────────────
 
-/** Webhook Events — idempotent tracking of inbound payment gateway webhooks */
+/**
+ * Webhook Events — idempotent tracking of inbound payment-gateway webhooks.
+ *
+ * Multi-gateway since migration 0033 (issue #62): the unique key is
+ * `(provider, provider_event_id)` so Stripe `evt_…` ids and Mollie payment
+ * `tr_…` ids share the table without colliding. The Mollie webhook contract
+ * doesn't emit unique event ids — only the affected resource id — so the
+ * Mollie route synthesises `${paymentId}-${status}` to keep one row per
+ * status transition and dedupe genuine retries.
+ *
+ * `account_id` is Stripe-specific (the connected account that emitted the
+ * event); for Mollie events this column is null and the worker resolves the
+ * tenant via the payment metadata instead. The column name is kept rather
+ * than renamed to `provider_account_id` because (a) only Stripe populates
+ * it today, and (b) renaming columns is bigger than the gain.
+ */
 export const webhookEvents = pgTable(
   "webhook_events",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    stripeEventId: varchar("stripe_event_id", { length: 255 }).notNull().unique(),
+    /** `'stripe' | 'mollie'` — see `PAYMENT_GATEWAY_VALUES` (excludes `'manual'`). */
+    provider: varchar("provider", { length: 20 }).notNull().default("stripe"),
+    /**
+     * Provider-native event identifier. For Stripe this is `evt_…`; for
+     * Mollie it's the synthesised `${paymentId}-${status}` so each status
+     * transition is processed exactly once per (provider, id) pair.
+     */
+    providerEventId: varchar("provider_event_id", { length: 255 }).notNull(),
     eventType: varchar("event_type", { length: 255 }).notNull(),
     accountId: varchar("account_id", { length: 255 }),
     payload: jsonb("payload").notNull(),
@@ -834,5 +934,8 @@ export const webhookEvents = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     processedAt: timestamp("processed_at", { withTimezone: true }),
   },
-  (table) => [index("webhook_events_stripe_event_id_idx").on(table.stripeEventId)],
+  (table) => [
+    unique("webhook_events_provider_event_uniq").on(table.provider, table.providerEventId),
+    index("webhook_events_provider_event_id_idx").on(table.providerEventId),
+  ],
 );

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import { PaymentGatewayPanel } from "@/components/settings/payment-gateway-panel";
 import { SettingsNavigation } from "@/components/settings/settings-navigation";
 import { SettingsSnapshotPanel } from "@/components/settings/settings-snapshot-panel";
 import { StripeConnectPanel } from "@/components/settings/stripe-connect-panel";
@@ -24,6 +25,7 @@ export default async function SettingsPage() {
       />
       <SettingsNavigation />
       <TenantSettingsForm orgId={auth.orgId} canManageTenant={auth.roles.includes("org_admin")} />
+      <PaymentGatewayPanel canManageTenant={auth.roles.includes("org_admin")} />
       <StripeConnectPanel canManageTenant={auth.roles.includes("org_admin")} />
       <SettingsSnapshotPanel orgId={auth.orgId} canExport={auth.roles.includes("org_admin")} />
     </div>

--- a/packages/web/src/app/(public)/p/[id]/page.tsx
+++ b/packages/web/src/app/(public)/p/[id]/page.tsx
@@ -103,6 +103,7 @@ export default async function PublicCampaignPage({ params }: PublicCampaignPageP
               locale={locale}
               goalAmountCents={page.goalAmountCents}
               defaultCurrency={page.defaultCurrency}
+              paymentGateway={page.paymentGateway}
               publishableKey={process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? null}
               tenantStripeAccountId={page.stripeAccountId}
             />

--- a/packages/web/src/components/campaigns/public-donation-form.test.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.test.tsx
@@ -35,6 +35,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={50000}
         publishableKey={null}
+        paymentGateway="stripe"
         tenantStripeAccountId={null}
       />,
     );
@@ -51,6 +52,7 @@ describe("PublicDonationForm", () => {
     const user = userEvent.setup();
 
     vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      provider: "stripe",
       clientSecret: "pi_secret_123",
       stripeAccountId: "acct_test_123",
     });
@@ -62,6 +64,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={50000}
         publishableKey="pk_test_dummy"
+        paymentGateway="stripe"
         tenantStripeAccountId="acct_test_999"
       />,
     );
@@ -99,6 +102,7 @@ describe("PublicDonationForm", () => {
     const user = userEvent.setup();
 
     vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      provider: "stripe",
       clientSecret: "pi_secret_456",
       stripeAccountId: "acct_test_123",
     });
@@ -110,6 +114,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey="pk_test_dummy"
+        paymentGateway="stripe"
         tenantStripeAccountId="acct_test_999"
       />,
     );
@@ -138,6 +143,7 @@ describe("PublicDonationForm", () => {
     const user = userEvent.setup();
 
     vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      provider: "stripe",
       clientSecret: "pi_secret_999",
       stripeAccountId: "acct_test_999",
     });
@@ -149,6 +155,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey="pk_test_dummy"
+        paymentGateway="stripe"
         tenantStripeAccountId="acct_test_999"
       />,
     );
@@ -170,6 +177,7 @@ describe("PublicDonationForm", () => {
     const user = userEvent.setup();
 
     vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      provider: "stripe",
       clientSecret: "pi_secret_888",
       stripeAccountId: "acct_live_888",
     });
@@ -181,6 +189,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey="pk_live_real_key"
+        paymentGateway="stripe"
         tenantStripeAccountId="acct_live_888"
       />,
     );
@@ -200,6 +209,7 @@ describe("PublicDonationForm", () => {
     const user = userEvent.setup();
 
     vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      provider: "stripe",
       clientSecret: "pi_secret_123",
       stripeAccountId: "acct_test_123",
     });
@@ -211,6 +221,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey={null}
+        paymentGateway="stripe"
         tenantStripeAccountId={null}
       />,
     );
@@ -244,6 +255,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey={null}
+        paymentGateway="stripe"
         tenantStripeAccountId={null}
       />,
     );
@@ -284,6 +296,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey="pk_test_dummy"
+        paymentGateway="stripe"
         tenantStripeAccountId="acct_test_999"
       />,
     );
@@ -330,6 +343,7 @@ describe("PublicDonationForm", () => {
         locale="en"
         goalAmountCents={null}
         publishableKey="pk_test_dummy"
+        paymentGateway="stripe"
         tenantStripeAccountId="acct_test_999"
       />,
     );

--- a/packages/web/src/components/campaigns/public-donation-form.test.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.test.tsx
@@ -55,6 +55,7 @@ describe("PublicDonationForm", () => {
       provider: "stripe",
       clientSecret: "pi_secret_123",
       stripeAccountId: "acct_test_123",
+      paymentIntentId: "pi_test_mock",
     });
 
     render(
@@ -105,6 +106,7 @@ describe("PublicDonationForm", () => {
       provider: "stripe",
       clientSecret: "pi_secret_456",
       stripeAccountId: "acct_test_123",
+      paymentIntentId: "pi_test_mock",
     });
 
     render(
@@ -146,6 +148,7 @@ describe("PublicDonationForm", () => {
       provider: "stripe",
       clientSecret: "pi_secret_999",
       stripeAccountId: "acct_test_999",
+      paymentIntentId: "pi_test_mock",
     });
 
     render(
@@ -180,6 +183,7 @@ describe("PublicDonationForm", () => {
       provider: "stripe",
       clientSecret: "pi_secret_888",
       stripeAccountId: "acct_live_888",
+      paymentIntentId: "pi_test_mock",
     });
 
     render(
@@ -212,6 +216,7 @@ describe("PublicDonationForm", () => {
       provider: "stripe",
       clientSecret: "pi_secret_123",
       stripeAccountId: "acct_test_123",
+      paymentIntentId: "pi_test_mock",
     });
 
     render(
@@ -359,5 +364,79 @@ describe("PublicDonationForm", () => {
     // pattern because empty search → falsy → would redirect us to "/" and
     // change the route under test (caught in PR #193 review).
     window.history.replaceState({}, "", `${window.location.pathname}${originalSearch}`);
+  });
+
+  // ─── Issue #62: Mollie redirect branch ──────────────────────────────────
+
+  it("redirects to Mollie checkout when paymentGateway='mollie'", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(CampaignPublicPageService, "createPublicDonationIntent").mockResolvedValue({
+      provider: "mollie",
+      checkoutUrl: "https://www.mollie.com/checkout/test/tr_redirect_e2e",
+      molliePaymentId: "tr_redirect_e2e",
+    });
+
+    // jsdom guards `window.location` against `vi.spyOn` (its descriptor
+    // is non-configurable). Replace the whole `location` object for this
+    // test with a stub that captures `.assign` calls; restore on teardown
+    // so the rest of the suite gets the original.
+    const originalLocation = window.location;
+    const assignSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, assign: assignSpy },
+    });
+
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={null}
+        paymentGateway="mollie"
+        publishableKey={null}
+        tenantStripeAccountId={null}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^First name/), "Mollie");
+    await user.type(screen.getByLabelText(/^Last name/), "Donor");
+    await user.type(screen.getByLabelText(/^Email/), "mollie@example.org");
+    await user.type(screen.getByLabelText(/^Amount/), "50");
+    await user.click(screen.getByRole("button", { name: "Continue to payment" }));
+
+    await waitFor(() =>
+      expect(assignSpy).toHaveBeenCalledWith(
+        "https://www.mollie.com/checkout/test/tr_redirect_e2e",
+      ),
+    );
+
+    // We must NOT have mounted the Stripe Elements step on the Mollie path.
+    expect(screen.queryByTestId("stripe-payment-element")).not.toBeInTheDocument();
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("renders the offline-only notice when paymentGateway='manual'", async () => {
+    render(
+      <PublicDonationForm
+        campaignId="11111111-1111-4111-8111-111111111111"
+        colorPrimary="#096447"
+        locale="en"
+        goalAmountCents={null}
+        paymentGateway="manual"
+        publishableKey={null}
+        tenantStripeAccountId={null}
+      />,
+    );
+
+    expect(await screen.findByText(/accepts donations offline only/i)).toBeInTheDocument();
+    // The donor-details form should NOT appear — there's nothing to submit.
+    expect(screen.queryByLabelText(/^First name/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Continue to payment" })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/campaigns/public-donation-form.tsx
+++ b/packages/web/src/components/campaigns/public-donation-form.tsx
@@ -20,7 +20,7 @@ import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import { getReadableTextColor } from "@/lib/color";
 import { formatCurrency } from "@/lib/format";
-import type { PublicDonationCurrency } from "@/models/public-page";
+import type { PaymentGatewayKey, PublicDonationCurrency } from "@/models/public-page";
 import { CampaignPublicPageService } from "@/services/CampaignPublicPageService";
 
 interface PublicDonationFormProps {
@@ -29,6 +29,14 @@ interface PublicDonationFormProps {
   locale: string;
   goalAmountCents: number | null;
   defaultCurrency?: PublicDonationCurrency;
+  /**
+   * Tenant's selected payment gateway (issue #62). Drives the post-submit
+   * branch:
+   *   - `'stripe'` → mount the Payment Element step
+   *   - `'mollie'` → redirect the browser to Mollie's hosted checkout
+   *   - `'manual'` → render an "offline donations only" notice
+   */
+  paymentGateway: PaymentGatewayKey;
   /**
    * Stripe platform publishable key (`pk_test_...` / `pk_live_...`). Threaded
    * from the server component so we don't have to re-evaluate
@@ -63,12 +71,20 @@ interface FormErrors {
   amount?: string;
 }
 
-interface PaymentSession {
-  clientSecret: string;
-  stripeAccountId: string;
-  amountCents: number;
-  currency: PublicDonationCurrency;
-}
+type PaymentSession =
+  | {
+      provider: "stripe";
+      clientSecret: string;
+      stripeAccountId: string;
+      amountCents: number;
+      currency: PublicDonationCurrency;
+    }
+  | {
+      provider: "mollie";
+      checkoutUrl: string;
+      amountCents: number;
+      currency: PublicDonationCurrency;
+    };
 
 /**
  * Outcome resolved from `?payment_intent_client_secret=…` query params on
@@ -105,6 +121,7 @@ export function PublicDonationForm({
   locale,
   goalAmountCents,
   defaultCurrency = "EUR",
+  paymentGateway,
   publishableKey,
   tenantStripeAccountId,
 }: PublicDonationFormProps) {
@@ -178,13 +195,24 @@ export function PublicDonationForm({
         createIdempotencyKey(),
       );
 
-      setSession({
-        clientSecret: result.clientSecret,
-        stripeAccountId: result.stripeAccountId,
-        amountCents,
-        currency: values.currency,
-      });
-      toast.success(t("success.intentCreated"));
+      if (result.provider === "stripe") {
+        setSession({
+          provider: "stripe",
+          clientSecret: result.clientSecret,
+          stripeAccountId: result.stripeAccountId,
+          amountCents,
+          currency: values.currency,
+        });
+        toast.success(t("success.intentCreated"));
+      } else {
+        // Mollie's hosted checkout requires a full-page redirect; we hop
+        // off Givernance entirely and the donor lands back on this page
+        // (URL: `${APP_URL}/p/:id`) once Mollie finishes. The webhook
+        // creates the donation row independently of the redirect — if the
+        // donor closes the tab, we still get the webhook and credit the
+        // donation; if they come back, the page just re-renders normally.
+        window.location.assign(result.checkoutUrl);
+      }
     } catch (error) {
       const message =
         error instanceof ApiProblem
@@ -232,7 +260,7 @@ export function PublicDonationForm({
           tenantStripeAccountId={tenantStripeAccountId}
           onDismiss={() => setPostRedirect(null)}
         />
-      ) : session ? (
+      ) : session && session.provider === "stripe" ? (
         publishableKey ? (
           <div className="mt-6">
             <PublicDonationPaymentStep
@@ -255,6 +283,13 @@ export function PublicDonationForm({
             {tPayment("errors.missingPublishableKey")}
           </p>
         )
+      ) : paymentGateway === "manual" ? (
+        // No online checkout for manual reconciliation — the org takes
+        // donations via bank transfer / cheque. Render a non-blocking
+        // notice so the page is still informational.
+        <p className="mt-6 rounded-2xl border border-outline-variant bg-surface px-4 py-3 text-sm text-on-surface-variant">
+          {t("manualGateway")}
+        </p>
       ) : (
         <DonorDetailsForm
           values={values}

--- a/packages/web/src/components/settings/payment-gateway-panel.tsx
+++ b/packages/web/src/components/settings/payment-gateway-panel.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { CheckCircle2, CreditCard, Lock, Wallet } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { type FormEvent, useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { PaymentGatewayKey } from "@/models/public-page";
+import {
+  PaymentGatewayService,
+  type PaymentGatewaySettings,
+} from "@/services/PaymentGatewayService";
+
+interface PaymentGatewayPanelProps {
+  canManageTenant: boolean;
+}
+
+type Stage = "loading" | "idle" | "saving" | "error";
+
+function resolveErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiProblem) {
+    return error.detail ?? error.title ?? fallback;
+  }
+  return fallback;
+}
+
+/**
+ * Org-admin gateway selector (issue #62). Lets the operator switch between
+ * Stripe / Mollie / Manual reconciliation, and paste a Mollie API key when
+ * Mollie is selected. Mollie is gated by `ff.payments.mollie` — when the
+ * flag is off the option is disabled in the dropdown so the operator sees
+ * "why this isn't an option for me" rather than a silent omission.
+ *
+ * The Mollie API key field is intentionally an `<Input type="password">`
+ * — the existing-stored key is NEVER pre-filled (the API only echoes a
+ * `mollieConfigured` boolean), and we treat it as a write-only credential.
+ * Storage at rest is plaintext today (see schema comment); rotating the
+ * key from this UI is the operator's documented remediation path.
+ */
+export function PaymentGatewayPanel({ canManageTenant }: PaymentGatewayPanelProps) {
+  const t = useTranslations("settings.paymentGateway");
+  const [settings, setSettings] = useState<PaymentGatewaySettings | null>(null);
+  const [selected, setSelected] = useState<PaymentGatewayKey>("stripe");
+  const [mollieKey, setMollieKey] = useState("");
+  const [stage, setStage] = useState<Stage>("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!canManageTenant) {
+      setStage("idle");
+      return;
+    }
+    let active = true;
+    async function load() {
+      try {
+        const next = await PaymentGatewayService.getSettings(createClientApiClient());
+        if (!active) return;
+        setSettings(next);
+        setSelected(next.paymentGateway);
+        setStage("idle");
+      } catch (err) {
+        if (!active) return;
+        setErrorMessage(resolveErrorMessage(err, t("errors.load")));
+        setStage("error");
+      }
+    }
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [canManageTenant, t]);
+
+  if (!canManageTenant) {
+    return (
+      <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+        <PanelHeader t={t} />
+        <div className="mt-4 inline-flex items-center gap-2 rounded-xl bg-surface-container px-4 py-3 text-sm text-on-surface-variant">
+          <Lock size={16} aria-hidden="true" />
+          <span>{t("adminOnly")}</span>
+        </div>
+      </section>
+    );
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!settings) return;
+    setStage("saving");
+    setErrorMessage(null);
+
+    try {
+      const updated = await PaymentGatewayService.updateSettings(createClientApiClient(), {
+        paymentGateway: selected,
+        // Only send the key field when the user actually typed something OR
+        // when they switched off Mollie (so we leave the existing key alone
+        // and don't accidentally clear it). When switching TO Mollie, a
+        // typed key is required by the API; we surface the 400 if missing.
+        ...(mollieKey ? { mollieApiKey: mollieKey } : {}),
+      });
+      setSettings(updated);
+      setSelected(updated.paymentGateway);
+      setMollieKey("");
+      setStage("idle");
+      toast.success(t("success.saved"));
+    } catch (err) {
+      const message = resolveErrorMessage(err, t("errors.save"));
+      setErrorMessage(message);
+      toast.error(message);
+      setStage("idle");
+    }
+  }
+
+  const flagOn = settings?.flags["ff.payments.mollie"] ?? false;
+  const requiresMollieKey =
+    selected === "mollie" && (settings?.paymentGateway !== "mollie" || !settings.mollieConfigured);
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+      <PanelHeader t={t} />
+      {stage === "loading" ? (
+        <p className="mt-4 text-sm text-on-surface-variant">{t("loading")}</p>
+      ) : settings ? (
+        <form className="mt-4 space-y-5" onSubmit={handleSubmit}>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={settings.paymentGateway === "manual" ? "neutral" : "info"}>
+              {t(`current.${settings.paymentGateway}`)}
+            </Badge>
+            {settings.paymentGateway === "mollie" && settings.mollieConfigured ? (
+              <span className="inline-flex items-center gap-1 text-xs text-on-surface-variant">
+                <CheckCircle2 size={12} aria-hidden="true" />
+                {t("mollieKeyConfigured")}
+              </span>
+            ) : null}
+            {!flagOn ? (
+              <span className="text-xs text-on-surface-variant">{t("flagOffHint")}</span>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="payment-gateway-select" className="text-sm font-medium text-on-surface">
+              {t("fields.gateway")}
+            </label>
+            <Select
+              value={selected}
+              onValueChange={(next) => setSelected(next as PaymentGatewayKey)}
+            >
+              <SelectTrigger id="payment-gateway-select" className="max-w-md">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="stripe">{t("options.stripe")}</SelectItem>
+                <SelectItem value="mollie" disabled={!flagOn}>
+                  {t("options.mollie")}
+                </SelectItem>
+                <SelectItem value="manual">{t("options.manual")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs leading-5 text-on-surface-variant">
+              {t(`descriptions.${selected}`)}
+            </p>
+          </div>
+
+          {selected === "mollie" ? (
+            <div className="space-y-2">
+              <label
+                htmlFor="payment-gateway-mollie-key"
+                className="text-sm font-medium text-on-surface"
+              >
+                {t("fields.mollieApiKey")}
+                {requiresMollieKey ? <span className="ml-1 text-error">*</span> : null}
+              </label>
+              <Input
+                id="payment-gateway-mollie-key"
+                type="password"
+                autoComplete="off"
+                value={mollieKey}
+                onChange={(e) => setMollieKey(e.target.value)}
+                placeholder={t("fields.mollieApiKeyPlaceholder")}
+                className="max-w-md"
+              />
+              <p className="text-xs leading-5 text-on-surface-variant">
+                {t("fields.mollieApiKeyHint")}
+              </p>
+            </div>
+          ) : null}
+
+          {errorMessage ? <p className="text-sm text-error">{errorMessage}</p> : null}
+
+          <Button type="submit" disabled={stage === "saving"}>
+            <Wallet size={16} aria-hidden="true" />
+            {stage === "saving" ? t("actions.saving") : t("actions.save")}
+          </Button>
+        </form>
+      ) : errorMessage ? (
+        <p className="mt-4 text-sm text-error">{errorMessage}</p>
+      ) : null}
+    </section>
+  );
+}
+
+function PanelHeader({ t }: { t: ReturnType<typeof useTranslations> }) {
+  return (
+    <div>
+      <div className="inline-flex items-center gap-2 rounded-full bg-surface-container px-3 py-1 text-xs font-medium text-on-surface-variant">
+        <CreditCard size={12} aria-hidden="true" />
+        {t("badge")}
+      </div>
+      <h2 className="mt-4 font-heading text-2xl leading-tight text-on-surface">{t("title")}</h2>
+      <p className="mt-2 text-sm leading-6 text-on-surface-variant">{t("subtitle")}</p>
+    </div>
+  );
+}

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -889,6 +889,47 @@
       "errorProblem": "Export failed (HTTP {status}).",
       "lastDownloaded": "Last download: {value}"
     },
+    "paymentGateway": {
+      "badge": "Payments",
+      "title": "Payment gateway",
+      "subtitle": "Choose how donors pay your organisation. Only one provider can be active at a time.",
+      "loading": "Loading payment gateway settings…",
+      "adminOnly": "Only organisation administrators can change the payment gateway.",
+      "current": {
+        "stripe": "Active: Stripe",
+        "mollie": "Active: Mollie",
+        "manual": "Active: Manual (offline only)"
+      },
+      "options": {
+        "stripe": "Stripe Connect",
+        "mollie": "Mollie",
+        "manual": "Manual / offline"
+      },
+      "descriptions": {
+        "stripe": "Cards, Apple Pay, and SEPA via Stripe Connect. Recommended for most organisations.",
+        "mollie": "iDEAL, Bancontact, and cards via Mollie. Recommended for FR/BE/NL associations with simplified verification.",
+        "manual": "No online checkout. Donors are told to contact you directly."
+      },
+      "fields": {
+        "gateway": "Payment provider",
+        "mollieApiKey": "Mollie API key",
+        "mollieApiKeyPlaceholder": "test_… or live_…",
+        "mollieApiKeyHint": "Paste the API key from your Mollie dashboard. We never echo it back; rotate from this field whenever you need to."
+      },
+      "mollieKeyConfigured": "Mollie key configured",
+      "flagOffHint": "Mollie is not enabled for your organisation. Contact support to request access.",
+      "actions": {
+        "save": "Save changes",
+        "saving": "Saving…"
+      },
+      "success": {
+        "saved": "Payment gateway updated"
+      },
+      "errors": {
+        "load": "Could not load payment gateway settings.",
+        "save": "Could not save payment gateway settings."
+      }
+    },
     "stripeConnect": {
       "badge": "Payments",
       "title": "Stripe Connect",
@@ -1579,7 +1620,8 @@
         "nextStepTitle": "Next step",
         "nextStepBody": "Use the card form to complete your donation securely with Stripe."
       },
-      "footnote": "Submitting this form prepares a secure payment. Your card will be charged on the next step."
+      "footnote": "Submitting this form prepares a secure payment. Your card will be charged on the next step.",
+      "manualGateway": "This organization currently accepts donations offline only. Please contact them directly to support this campaign."
     },
     "payment": {
       "summary": {

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -889,6 +889,47 @@
       "errorProblem": "L'export a échoué (HTTP {status}).",
       "lastDownloaded": "Dernier téléchargement : {value}"
     },
+    "paymentGateway": {
+      "badge": "Paiements",
+      "title": "Plateforme de paiement",
+      "subtitle": "Choisissez comment les donateurs payent votre organisation. Un seul prestataire peut être actif à la fois.",
+      "loading": "Chargement des paramètres de paiement…",
+      "adminOnly": "Seuls les administrateurs de l'organisation peuvent changer la plateforme de paiement.",
+      "current": {
+        "stripe": "Actif : Stripe",
+        "mollie": "Actif : Mollie",
+        "manual": "Actif : Manuel (hors ligne uniquement)"
+      },
+      "options": {
+        "stripe": "Stripe Connect",
+        "mollie": "Mollie",
+        "manual": "Manuel / hors ligne"
+      },
+      "descriptions": {
+        "stripe": "Cartes, Apple Pay et SEPA via Stripe Connect. Recommandé pour la plupart des organisations.",
+        "mollie": "iDEAL, Bancontact et cartes via Mollie. Recommandé pour les associations FR/BE/NL avec une vérification simplifiée.",
+        "manual": "Pas de paiement en ligne. Les donateurs sont invités à vous contacter directement."
+      },
+      "fields": {
+        "gateway": "Prestataire de paiement",
+        "mollieApiKey": "Clé API Mollie",
+        "mollieApiKeyPlaceholder": "test_… ou live_…",
+        "mollieApiKeyHint": "Collez la clé API depuis votre tableau de bord Mollie. Nous ne la renvoyons jamais ; faites-la tourner depuis ce champ à chaque fois que nécessaire."
+      },
+      "mollieKeyConfigured": "Clé Mollie configurée",
+      "flagOffHint": "Mollie n'est pas activé pour votre organisation. Contactez le support pour demander l'accès.",
+      "actions": {
+        "save": "Enregistrer",
+        "saving": "Enregistrement…"
+      },
+      "success": {
+        "saved": "Plateforme de paiement mise à jour"
+      },
+      "errors": {
+        "load": "Impossible de charger les paramètres de paiement.",
+        "save": "Impossible d'enregistrer les paramètres de paiement."
+      }
+    },
     "stripeConnect": {
       "badge": "Paiements",
       "title": "Stripe Connect",
@@ -1579,7 +1620,8 @@
         "nextStepTitle": "Étape suivante",
         "nextStepBody": "Utilisez le formulaire de carte pour finaliser votre don de manière sécurisée avec Stripe."
       },
-      "footnote": "En soumettant ce formulaire, vous préparez un paiement sécurisé. Votre carte sera débitée à l'étape suivante."
+      "footnote": "En soumettant ce formulaire, vous préparez un paiement sécurisé. Votre carte sera débitée à l'étape suivante.",
+      "manualGateway": "Cette association n'accepte les dons qu'en dehors de la plateforme. Merci de la contacter directement pour soutenir cette campagne."
     },
     "payment": {
       "summary": {

--- a/packages/web/src/models/public-page.ts
+++ b/packages/web/src/models/public-page.ts
@@ -72,6 +72,7 @@ export type PublicDonationIntent =
       clientSecret: string;
       /** Connected account the PaymentIntent lives on; needed by `loadStripe(pk, { stripeAccount })`. */
       stripeAccountId: string;
+      paymentIntentId: string;
     }
   | {
       provider: "mollie";

--- a/packages/web/src/models/public-page.ts
+++ b/packages/web/src/models/public-page.ts
@@ -2,6 +2,8 @@ import type { CampaignPublicPageColor } from "@givernance/shared/validators";
 
 export type PublicPageStatus = "draft" | "published";
 export type PublicDonationCurrency = "EUR" | "GBP" | "CHF";
+/** Mirrors `tenants.payment_gateway` enum (issue #62). Drives donor-frontend branching. */
+export type PaymentGatewayKey = "stripe" | "mollie" | "manual";
 
 export interface CampaignPublicPage {
   id: string;
@@ -28,7 +30,9 @@ export interface PublishedCampaignPublicPage {
   colorPrimary: CampaignPublicPageColor | null;
   goalAmountCents: number | null;
   defaultCurrency: PublicDonationCurrency;
-  /** `acct_…` for the campaign's tenant; null when not yet onboarded. */
+  /** Tenant's selected gateway (issue #62) — drives donor-frontend branching. */
+  paymentGateway: PaymentGatewayKey;
+  /** `acct_…` for the campaign's tenant; null when not yet onboarded or non-Stripe gateway. */
   stripeAccountId: string | null;
   /** Cumulative cleared donations in the tenant's base currency (issue #200). */
   raisedCents: number;
@@ -56,14 +60,25 @@ export interface PublicDonationIntentInput {
   lastName: string;
 }
 
-export interface PublicDonationIntent {
-  clientSecret: string;
-  /**
-   * Connected account the PaymentIntent lives on. Stripe.js needs this when
-   * confirming a direct-charge intent — `loadStripe(pk, { stripeAccount })`.
-   */
-  stripeAccountId: string;
-}
+/**
+ * Discriminated union returned by `POST /v1/public/campaigns/:id/donate`
+ * (issue #62). The donor frontend renders Stripe Elements when
+ * `provider === 'stripe'` or redirects to Mollie's checkout URL when
+ * `provider === 'mollie'`.
+ */
+export type PublicDonationIntent =
+  | {
+      provider: "stripe";
+      clientSecret: string;
+      /** Connected account the PaymentIntent lives on; needed by `loadStripe(pk, { stripeAccount })`. */
+      stripeAccountId: string;
+    }
+  | {
+      provider: "mollie";
+      /** Mollie-hosted checkout URL — the browser navigates here. */
+      checkoutUrl: string;
+      molliePaymentId: string;
+    };
 
 export interface PublicDonationIntentResponse {
   data: PublicDonationIntent;

--- a/packages/web/src/services/PaymentGatewayService.ts
+++ b/packages/web/src/services/PaymentGatewayService.ts
@@ -1,0 +1,40 @@
+import type { ApiClient } from "@/lib/api";
+import type { PaymentGatewayKey } from "@/models/public-page";
+
+export interface PaymentGatewaySettings {
+  paymentGateway: PaymentGatewayKey;
+  /** True when the tenant has a stored Mollie API key (the value itself never leaves the API). */
+  mollieConfigured: boolean;
+  flags: {
+    "ff.payments.mollie": boolean;
+  };
+}
+
+export interface PaymentGatewayUpdate {
+  paymentGateway: PaymentGatewayKey;
+  /**
+   * Mollie API key. Send a non-empty string to set / rotate, `null` or `""`
+   * to clear, or omit to keep the existing value untouched. Required when
+   * switching `paymentGateway` to `'mollie'` for the first time.
+   */
+  mollieApiKey?: string | null;
+}
+
+export const PaymentGatewayService = {
+  async getSettings(client: ApiClient): Promise<PaymentGatewaySettings> {
+    const response = await client.get<{ data: PaymentGatewaySettings }>(
+      "/v1/admin/payment-gateway",
+    );
+    return response.data;
+  },
+  async updateSettings(
+    client: ApiClient,
+    input: PaymentGatewayUpdate,
+  ): Promise<PaymentGatewaySettings> {
+    const response = await client.patch<{ data: PaymentGatewaySettings }>(
+      "/v1/admin/payment-gateway",
+      input,
+    );
+    return response.data;
+  },
+};

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -14,6 +14,7 @@
     "@aws-sdk/client-s3": "^3.1030.0",
     "@aws-sdk/lib-storage": "^3.1030.0",
     "@givernance/shared": "workspace:*",
+    "@mollie/api-client": "^4.5.0",
     "@sinclair/typebox": "^0.34.12",
     "bullmq": "^5.31.0",
     "drizzle-orm": "^0.36.4",

--- a/packages/worker/src/processors/mollie-webhook.ts
+++ b/packages/worker/src/processors/mollie-webhook.ts
@@ -1,0 +1,338 @@
+/** Job processor — handle Mollie webhook events asynchronously (issue #62) */
+
+import { ExchangeRateService } from "@givernance/shared";
+import type { ProcessMollieWebhookJob } from "@givernance/shared/jobs";
+import {
+  campaigns,
+  constituents,
+  donations,
+  outboxEvents,
+  tenants,
+  webhookEvents,
+} from "@givernance/shared/schema";
+import createMollieClient, { type Payment, PaymentStatus } from "@mollie/api-client";
+import type { Job } from "bullmq";
+import { and, eq, sql } from "drizzle-orm";
+import { env } from "../env.js";
+import { db, withWorkerContext } from "../lib/db.js";
+import { jobLogger } from "../lib/logger.js";
+
+/**
+ * Process a Mollie webhook event.
+ *
+ * Mollie's webhook contract is "the resource changed, go fetch it" —
+ * we re-fetch the payment via the per-tenant API key on every webhook
+ * receipt to avoid trusting client-side state. The status drives the
+ * downstream action:
+ *
+ *   - `paid`              → upsert donation row, emit DonationCreated
+ *   - `failed` / `canceled` / `expired` → log; donation row stays absent
+ *   - `pending` / `open` / `authorized` → log; nothing else (the next
+ *      transition will fire another webhook).
+ *
+ * The unique index on `webhook_events(provider, provider_event_id)` is
+ * keyed on the Mollie payment id at route time. The worker re-keys on
+ * `${id}-${status}` for the second-stage idempotency: if a webhook
+ * fires twice for the same status (Mollie retry), we already inserted
+ * the donation and the donation-side `(org_id, payment_method,
+ * payment_ref)` unique index also catches it.
+ */
+export async function processMollieWebhook(
+  job: Job<ProcessMollieWebhookJob["data"]>,
+): Promise<void> {
+  const { webhookEventId, providerEventId, molliePaymentId } = job.data;
+  const log = jobLogger({ jobId: job.id, traceId: providerEventId });
+
+  log.info({ molliePaymentId }, "Processing Mollie webhook event");
+
+  await db
+    .update(webhookEvents)
+    .set({ status: "processing" })
+    .where(eq(webhookEvents.id, webhookEventId));
+
+  try {
+    const resolved = await resolveMolliePayment(molliePaymentId);
+    if (!resolved) {
+      log.warn({ molliePaymentId }, "No Mollie tenant claimed this payment — skipping");
+      await markWebhookCompleted(webhookEventId);
+      return;
+    }
+
+    await rekeyWebhookEvent(
+      webhookEventId,
+      providerEventId,
+      molliePaymentId,
+      resolved.payment,
+      log,
+    );
+
+    if (
+      resolved.payment.status === PaymentStatus.paid ||
+      resolved.payment.status === PaymentStatus.authorized
+    ) {
+      await handleMolliePaid(resolved.orgId, resolved.payment, log);
+    } else {
+      log.info(
+        { molliePaymentId, status: resolved.payment.status },
+        "Mollie payment not paid — no donation row inserted",
+      );
+    }
+
+    await markWebhookCompleted(webhookEventId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    log.error({ err: message, molliePaymentId }, "Failed to process Mollie webhook event");
+
+    await db
+      .update(webhookEvents)
+      .set({ status: "failed", error: message })
+      .where(eq(webhookEvents.id, webhookEventId));
+
+    throw err;
+  }
+}
+
+async function markWebhookCompleted(webhookEventId: string): Promise<void> {
+  await db
+    .update(webhookEvents)
+    .set({ status: "completed", processedAt: new Date() })
+    .where(eq(webhookEvents.id, webhookEventId));
+}
+
+/**
+ * Resolve the tenant that owns a Mollie payment id by fetching it with each
+ * Mollie-enabled tenant's API key in turn. 404 = wrong tenant, try the next;
+ * other errors propagate so BullMQ retries.
+ *
+ * With small numbers of Mollie-enabled tenants per Phase 1 deployment this
+ * is acceptable; a Mollie Connect / OAuth flow would let us tag a `profileId`
+ * on the webhook and skip the probing entirely (filed as ADR-010 future work).
+ */
+async function resolveMolliePayment(
+  molliePaymentId: string,
+): Promise<{ payment: Payment; orgId: string } | null> {
+  const mollieTenants = await db
+    .select({ id: tenants.id, mollieApiKey: tenants.mollieApiKey })
+    .from(tenants)
+    .where(eq(tenants.paymentGateway, "mollie"));
+
+  const candidates = mollieTenants.filter((t): t is { id: string; mollieApiKey: string } =>
+    Boolean(t.mollieApiKey),
+  );
+
+  for (const t of candidates) {
+    const fetched = await fetchPaymentWithKey(t.mollieApiKey, molliePaymentId);
+    if (fetched) {
+      return { payment: fetched, orgId: t.id };
+    }
+  }
+  return null;
+}
+
+async function fetchPaymentWithKey(apiKey: string, paymentId: string): Promise<Payment | null> {
+  try {
+    const client = createMollieClient({ apiKey });
+    return await client.payments.get(paymentId);
+  } catch (err) {
+    const status =
+      err && typeof err === "object" && "statusCode" in err
+        ? (err as { statusCode?: number }).statusCode
+        : undefined;
+    if (status === 404) return null;
+    throw err;
+  }
+}
+
+/**
+ * Re-key the webhook_events row with `${id}-${status}` so subsequent status
+ * transitions for the same payment don't collide on the unique index. A
+ * collision (Mollie retry on the same status) silently no-ops; the donation
+ * insert below is also idempotent on (org_id, payment_method, payment_ref).
+ */
+async function rekeyWebhookEvent(
+  webhookEventId: string,
+  currentEventId: string,
+  molliePaymentId: string,
+  payment: Payment,
+  log: ReturnType<typeof jobLogger>,
+): Promise<void> {
+  const statusEventId = `${molliePaymentId}-${payment.status}`;
+  if (statusEventId === currentEventId) return;
+
+  await db
+    .update(webhookEvents)
+    .set({ providerEventId: statusEventId })
+    .where(eq(webhookEvents.id, webhookEventId))
+    .catch((err) => {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to rekey Mollie webhook_event id (likely a duplicate transition); continuing",
+      );
+    });
+}
+
+interface MollieDonationMeta {
+  constituentEmail?: string;
+  constituentFirstName: string;
+  constituentLastName: string;
+  campaignId: string | null;
+  platformFeeCents: number;
+}
+
+function extractMollieDonationMeta(payment: Payment): MollieDonationMeta {
+  const meta = (payment.metadata as Record<string, unknown> | null) ?? {};
+  return {
+    constituentEmail:
+      typeof meta.constituent_email === "string" ? meta.constituent_email : undefined,
+    constituentFirstName:
+      typeof meta.constituent_first_name === "string" ? meta.constituent_first_name : "Anonymous",
+    constituentLastName:
+      typeof meta.constituent_last_name === "string" ? meta.constituent_last_name : "Donor",
+    campaignId: typeof meta.campaign_id === "string" ? meta.campaign_id : null,
+    platformFeeCents:
+      typeof meta.application_fee_cents === "number" ? meta.application_fee_cents : 0,
+  };
+}
+
+/**
+ * Find-or-create the constituent for a Mollie donation. Mirrors the Stripe
+ * flow's behaviour: prefer email-keyed lookup, fall back to a fresh anonymous
+ * row when no email is available.
+ */
+async function findOrCreateMollieConstituent(
+  tx: Parameters<Parameters<typeof withWorkerContext>[1]>[0],
+  orgId: string,
+  meta: MollieDonationMeta,
+  log: ReturnType<typeof jobLogger>,
+): Promise<string> {
+  if (meta.constituentEmail) {
+    const [existing] = await tx
+      .select({ id: constituents.id })
+      .from(constituents)
+      .where(
+        sql`${constituents.orgId} = ${orgId} AND ${constituents.email} = ${meta.constituentEmail}`,
+      );
+    if (existing) return existing.id;
+
+    const [created] = await tx
+      .insert(constituents)
+      .values({
+        orgId,
+        firstName: meta.constituentFirstName,
+        lastName: meta.constituentLastName,
+        email: meta.constituentEmail,
+        type: "donor",
+      })
+      .returning({ id: constituents.id });
+    // biome-ignore lint/style/noNonNullAssertion: insert returning always returns
+    log.info({ constituentId: created!.id }, "Created new constituent from Mollie");
+    // biome-ignore lint/style/noNonNullAssertion: insert returning always returns
+    return created!.id;
+  }
+
+  const [created] = await tx
+    .insert(constituents)
+    .values({
+      orgId,
+      firstName: meta.constituentFirstName,
+      lastName: meta.constituentLastName,
+      type: "donor",
+    })
+    .returning({ id: constituents.id });
+  // biome-ignore lint/style/noNonNullAssertion: insert returning always returns
+  return created!.id;
+}
+
+async function handleMolliePaid(
+  orgId: string,
+  payment: Payment,
+  log: ReturnType<typeof jobLogger>,
+): Promise<void> {
+  const meta = extractMollieDonationMeta(payment);
+  const amountCents = Math.round(Number(payment.amount.value) * 100);
+  const currency = payment.amount.currency.toUpperCase();
+  const paymentRef = payment.id;
+  const { campaignId, platformFeeCents } = meta;
+
+  await withWorkerContext(orgId, async (tx) => {
+    const exchangeRateService = new ExchangeRateService({
+      apiKey: env.EXCHANGE_RATE_API_KEY,
+      dbClient: tx,
+      logger: log,
+    });
+    const baseCurrency = await exchangeRateService.getOrgBaseCurrency(orgId);
+    const convertedAmount = await exchangeRateService.convertAmountCents(
+      amountCents,
+      currency,
+      baseCurrency,
+    );
+
+    const constituentId = await findOrCreateMollieConstituent(tx, orgId, meta, log);
+
+    const [donation] = await tx
+      .insert(donations)
+      .values({
+        orgId,
+        constituentId,
+        amountCents,
+        currency,
+        exchangeRate: convertedAmount.exchangeRate.toFixed(8),
+        amountBaseCents: convertedAmount.amountBaseCents,
+        campaignId: campaignId || undefined,
+        status: "cleared",
+        platformFeeCents,
+        paymentMethod: "mollie",
+        paymentRef,
+        donatedAt: new Date(),
+        fiscalYear: new Date().getFullYear(),
+      })
+      .onConflictDoNothing()
+      .returning();
+
+    if (!donation) {
+      log.info({ paymentRef }, "Donation already exists (retry), skipping");
+      return;
+    }
+
+    if (campaignId && platformFeeCents > 0) {
+      // Same defence-in-depth pattern as the Stripe path — explicit org_id
+      // filter alongside the RLS context so a tampered `metadata.campaign_id`
+      // can't cross tenant boundaries.
+      await tx
+        .update(campaigns)
+        .set({
+          platformFeesCents: sql`${campaigns.platformFeesCents} + ${platformFeeCents}`,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
+    }
+
+    await tx.insert(outboxEvents).values({
+      tenantId: orgId,
+      type: "donation.created",
+      payload: {
+        donationId: donation.id,
+        constituentId,
+        amountCents,
+        currency,
+        paymentMethod: "mollie",
+        paymentRef,
+        source: "mollie_webhook",
+      },
+    });
+
+    log.info(
+      {
+        amountBaseCents: convertedAmount.amountBaseCents,
+        baseCurrency,
+        constituentId,
+        currency,
+        donationId: donation.id,
+        exchangeRate: convertedAmount.exchangeRate,
+        amountCents,
+        paymentRef,
+      },
+      "Donation created from Mollie payment.paid",
+    );
+  });
+}

--- a/packages/worker/src/processors/mollie-webhook.ts
+++ b/packages/worker/src/processors/mollie-webhook.ts
@@ -3,7 +3,6 @@
 import { ExchangeRateService } from "@givernance/shared";
 import type { ProcessMollieWebhookJob } from "@givernance/shared/jobs";
 import {
-  campaigns,
   constituents,
   donations,
   outboxEvents,
@@ -12,7 +11,7 @@ import {
 } from "@givernance/shared/schema";
 import createMollieClient, { type Payment, PaymentStatus } from "@mollie/api-client";
 import type { Job } from "bullmq";
-import { and, eq, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { env } from "../env.js";
 import { db, withWorkerContext } from "../lib/db.js";
 import { jobLogger } from "../lib/logger.js";
@@ -66,12 +65,15 @@ export async function processMollieWebhook(
       log,
     );
 
-    if (
-      resolved.payment.status === PaymentStatus.paid ||
-      resolved.payment.status === PaymentStatus.authorized
-    ) {
+    if (resolved.payment.status === PaymentStatus.paid) {
       await handleMolliePaid(resolved.orgId, resolved.payment, log);
     } else {
+      // `authorized` is intentionally NOT treated as paid: for "pay later"
+      // methods (Klarna, etc.) `authorized` means the funds are held but
+      // NOT captured. Inserting a `cleared` donation now would mean a
+      // booked-but-unfunded receipt if the payment never gets captured
+      // (Mollie auto-expires authorized-only payments). The capture flow
+      // will fire its own `paid` webhook later — that's the trigger.
       log.info(
         { molliePaymentId, status: resolved.payment.status },
         "Mollie payment not paid — no donation row inserted",
@@ -176,7 +178,6 @@ interface MollieDonationMeta {
   constituentFirstName: string;
   constituentLastName: string;
   campaignId: string | null;
-  platformFeeCents: number;
 }
 
 function extractMollieDonationMeta(payment: Payment): MollieDonationMeta {
@@ -189,8 +190,6 @@ function extractMollieDonationMeta(payment: Payment): MollieDonationMeta {
     constituentLastName:
       typeof meta.constituent_last_name === "string" ? meta.constituent_last_name : "Donor",
     campaignId: typeof meta.campaign_id === "string" ? meta.campaign_id : null,
-    platformFeeCents:
-      typeof meta.application_fee_cents === "number" ? meta.application_fee_cents : 0,
   };
 }
 
@@ -252,7 +251,19 @@ async function handleMolliePaid(
   const amountCents = Math.round(Number(payment.amount.value) * 100);
   const currency = payment.amount.currency.toUpperCase();
   const paymentRef = payment.id;
-  const { campaignId, platformFeeCents } = meta;
+  const { campaignId } = meta;
+  // Granular payment method (`ideal`, `bancontact`, `creditcard`, `sepadirectdebit`,
+  // …). Falls back to the bare gateway name if Mollie didn't tag it on the payment
+  // (older API versions / certain legacy methods). Belgian/Dutch NPOs care strongly
+  // about Bancontact-vs-card share in reporting, and the SEPA reconciliation
+  // pipeline keys on `sepadirectdebit` rows.
+  const paymentMethod = typeof payment.method === "string" ? payment.method : "mollie";
+  // Phase 1: Mollie has no Connect-equivalent fee mechanism, so we record
+  // `platform_fee_cents = 0` for Mollie donations rather than crediting
+  // ourselves a fee Mollie didn't actually deduct (which would overstate
+  // platform revenue and understate funds available to the NPO).
+  // The Mollie monetisation model is a follow-up.
+  const platformFeeCents = 0;
 
   await withWorkerContext(orgId, async (tx) => {
     const exchangeRateService = new ExchangeRateService({
@@ -281,7 +292,7 @@ async function handleMolliePaid(
         campaignId: campaignId || undefined,
         status: "cleared",
         platformFeeCents,
-        paymentMethod: "mollie",
+        paymentMethod,
         paymentRef,
         donatedAt: new Date(),
         fiscalYear: new Date().getFullYear(),
@@ -294,18 +305,9 @@ async function handleMolliePaid(
       return;
     }
 
-    if (campaignId && platformFeeCents > 0) {
-      // Same defence-in-depth pattern as the Stripe path — explicit org_id
-      // filter alongside the RLS context so a tampered `metadata.campaign_id`
-      // can't cross tenant boundaries.
-      await tx
-        .update(campaigns)
-        .set({
-          platformFeesCents: sql`${campaigns.platformFeesCents} + ${platformFeeCents}`,
-          updatedAt: new Date(),
-        })
-        .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
-    }
+    // No platform-fee accumulation on the Mollie path — see comment above.
+    // The campaign's `platform_fees_cents` column is updated only by the Stripe
+    // worker today; introducing a Mollie fee here would mis-attribute revenue.
 
     await tx.insert(outboxEvents).values({
       tenantId: orgId,
@@ -315,7 +317,7 @@ async function handleMolliePaid(
         constituentId,
         amountCents,
         currency,
-        paymentMethod: "mollie",
+        paymentMethod,
         paymentRef,
         source: "mollie_webhook",
       },

--- a/packages/worker/src/processors/stripe-webhook.ts
+++ b/packages/worker/src/processors/stripe-webhook.ts
@@ -44,6 +44,13 @@ function asCharge(payload: Record<string, unknown>): Stripe.Charge {
   return payload as unknown as Stripe.Charge;
 }
 
+function asAccount(payload: Record<string, unknown>): Stripe.Account {
+  if (typeof payload.id !== "string") {
+    throw new Error(`Malformed account payload: id=${typeof payload.id}`);
+  }
+  return payload as unknown as Stripe.Account;
+}
+
 /** Look up the tenant associated with a Stripe connected account ID */
 async function findTenantByStripeAccount(stripeAccountId: string) {
   const [tenant] = await db
@@ -56,7 +63,7 @@ async function findTenantByStripeAccount(stripeAccountId: string) {
 
 /**
  * Process a Stripe webhook event.
- * Handles: payment_intent.succeeded, charge.refunded.
+ * Handles: payment_intent.succeeded, charge.refunded, account.updated.
  * Other event types are acknowledged + marked completed without action so the
  * `webhook_events` row carries an audit trail of "we saw it" without forcing
  * a retry storm; extend the routing block below to handle new types.
@@ -80,6 +87,8 @@ export async function processStripeWebhook(
       await handlePaymentIntentSucceeded(accountId, asPaymentIntent(payload), log);
     } else if (eventType === "charge.refunded") {
       await handleChargeRefunded(accountId, asCharge(payload), log);
+    } else if (eventType === "account.updated") {
+      await handleAccountUpdated(asAccount(payload), log);
     } else {
       log.info({ eventType }, "Unhandled Stripe event type, marking completed");
     }
@@ -380,4 +389,67 @@ async function handleChargeRefunded(
       "Donation refunded from Stripe charge.refunded",
     );
   });
+}
+
+/**
+ * Handle `account.updated` (issue #62). Caches the connected account's
+ * `charges_enabled` / `payouts_enabled` / `details_submitted` flags onto
+ * the matching tenant row so the donor flow can flip from test mode to
+ * live mode without a per-page-load `accounts.retrieve` round-trip.
+ *
+ * "Auto-switch to live mode" in doc-20 §5.2 = persisting
+ * `stripe_charges_enabled = true`. Downstream consumers (donor flow,
+ * platform-finance dashboard) read the cached column instead of calling
+ * Stripe live; the cached snapshot is refreshed on every `account.updated`
+ * webhook so it never lags behind by more than a few seconds in healthy
+ * deployments.
+ *
+ * Stripe sends `account.updated` events without a top-level `account` id —
+ * the connected account whose state changed is the event payload itself
+ * (`event.data.object.id`). The handler resolves the tenant by that id;
+ * a missing tenant row is logged but not thrown so a webhook for a
+ * connected account that we no longer own (e.g. mid-migration) doesn't
+ * DLQ the queue.
+ */
+async function handleAccountUpdated(
+  account: Stripe.Account,
+  log: ReturnType<typeof jobLogger>,
+): Promise<void> {
+  const stripeAccountId = account.id;
+
+  const [tenant] = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(eq(tenants.stripeAccountId, stripeAccountId));
+
+  if (!tenant) {
+    log.warn({ stripeAccountId }, "account.updated for unknown connected account, skipping");
+    return;
+  }
+
+  const chargesEnabled = Boolean(account.charges_enabled);
+  const payoutsEnabled = Boolean(account.payouts_enabled);
+  const detailsSubmitted = Boolean(account.details_submitted);
+
+  await db
+    .update(tenants)
+    .set({
+      stripeChargesEnabled: chargesEnabled,
+      stripePayoutsEnabled: payoutsEnabled,
+      stripeDetailsSubmitted: detailsSubmitted,
+      stripeAccountStateAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(tenants.id, tenant.id));
+
+  log.info(
+    {
+      orgId: tenant.id,
+      stripeAccountId,
+      chargesEnabled,
+      payoutsEnabled,
+      detailsSubmitted,
+    },
+    "Cached Stripe account.updated state on tenant",
+  );
 }

--- a/packages/worker/src/tests/integration/mollie-webhook.test.ts
+++ b/packages/worker/src/tests/integration/mollie-webhook.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Mollie webhook worker integration tests (issue #62).
+ *
+ * Mocks `@mollie/api-client` so we can drive `processMollieWebhook` against
+ * synthetic Mollie Payment shapes without a real Mollie API call. Covers:
+ *   - happy path: paid → donation row + outbox event + cleared status
+ *   - duplicate paid (BullMQ retry / Mollie retry): no second donation
+ *   - non-paid status (failed / authorized / pending): no donation inserted
+ *   - cross-tenant probing: 404 from one tenant's key, 200 from another
+ *   - webhook_events row re-keyed with `${id}-${status}` for second-stage idempotency
+ */
+
+import { clearExchangeRateApiCache } from "@givernance/shared";
+import { donations, outboxEvents, webhookEvents } from "@givernance/shared/schema";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "../../lib/db.js";
+
+// `@mollie/api-client` is mocked at the module boundary so the worker
+// receives the synthetic Payment shapes we build per test. Hoisted
+// `mockPaymentsGet` / `mockCreateMollieClient` so `vi.mock`'s factory
+// (which is hoisted above all imports by Vitest) can close over them.
+const { mockPaymentsGet, mockCreateMollieClient } = vi.hoisted(() => {
+  const mockGet = vi.fn();
+  const mockClient = vi.fn().mockImplementation(() => ({
+    payments: { get: mockGet },
+  }));
+  return { mockPaymentsGet: mockGet, mockCreateMollieClient: mockClient };
+});
+
+vi.mock("@mollie/api-client", () => ({
+  default: mockCreateMollieClient,
+  PaymentStatus: {
+    open: "open",
+    canceled: "canceled",
+    pending: "pending",
+    authorized: "authorized",
+    expired: "expired",
+    failed: "failed",
+    paid: "paid",
+  },
+}));
+
+// processMollieWebhook is imported AFTER vi.mock so it uses the mocked SDK.
+const { processMollieWebhook } = await import("../../processors/mollie-webhook.js");
+
+const ORG_ID = "00000000-0000-0000-0000-00000000010a";
+const ORG_ID_OTHER = "00000000-0000-0000-0000-00000000010b";
+const MOLLIE_KEY = "test_mollie_primary";
+const MOLLIE_KEY_OTHER = "test_mollie_other";
+
+function makeMockJob(data: Record<string, unknown>) {
+  return {
+    data,
+    id: "test-mollie-job-1",
+    log: vi.fn(),
+  } as never;
+}
+
+function makePaidPayment(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "tr_test_paid_1",
+    status: "paid",
+    method: "ideal",
+    amount: { value: "25.00", currency: "EUR" },
+    metadata: {
+      org_id: ORG_ID,
+      campaign_id: null,
+      constituent_first_name: "Mollie",
+      constituent_last_name: "Donor",
+      constituent_email: "mollie-donor@example.org",
+    },
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  // Seed two Mollie tenants so the cross-tenant probe has somewhere to fail.
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, payment_gateway, mollie_api_key, base_currency)
+        VALUES (${ORG_ID}, 'Mollie Worker Test', 'mollie-worker-test', 'mollie', ${MOLLIE_KEY}, 'EUR')
+        ON CONFLICT (id) DO UPDATE
+        SET payment_gateway = 'mollie',
+            mollie_api_key = ${MOLLIE_KEY},
+            base_currency = 'EUR'`,
+  );
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, payment_gateway, mollie_api_key, base_currency)
+        VALUES (${ORG_ID_OTHER}, 'Mollie Worker Other', 'mollie-worker-other', 'mollie', ${MOLLIE_KEY_OTHER}, 'EUR')
+        ON CONFLICT (id) DO UPDATE
+        SET payment_gateway = 'mollie',
+            mollie_api_key = ${MOLLIE_KEY_OTHER},
+            base_currency = 'EUR'`,
+  );
+});
+
+beforeEach(() => {
+  clearExchangeRateApiCache();
+  mockPaymentsGet.mockReset();
+  mockCreateMollieClient.mockClear();
+});
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM outbox_events WHERE tenant_id IN (${ORG_ID}, ${ORG_ID_OTHER})`);
+  await db.execute(sql`DELETE FROM donations WHERE org_id IN (${ORG_ID}, ${ORG_ID_OTHER})`);
+  await db.execute(sql`DELETE FROM constituents WHERE org_id IN (${ORG_ID}, ${ORG_ID_OTHER})`);
+  await db.execute(sql`DELETE FROM webhook_events WHERE provider_event_id LIKE 'tr_test_%'`);
+  // Reset to stripe so other test files don't see stray Mollie tenants.
+  await db.execute(
+    sql`UPDATE tenants SET payment_gateway = 'stripe', mollie_api_key = NULL
+        WHERE id IN (${ORG_ID}, ${ORG_ID_OTHER})`,
+  );
+});
+
+describe("processMollieWebhook", () => {
+  it("creates a donation + outbox event when status=paid", async () => {
+    const paymentId = "tr_test_paid_create";
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000f1",
+      provider: "mollie",
+      providerEventId: paymentId,
+      eventType: "payment.notification",
+      accountId: null,
+      payload: { id: paymentId },
+      status: "pending",
+      livemode: false,
+    });
+    mockPaymentsGet.mockResolvedValueOnce(makePaidPayment({ id: paymentId }));
+
+    const job = makeMockJob({
+      webhookEventId: "00000000-0000-0000-0000-0000000000f1",
+      providerEventId: paymentId,
+      molliePaymentId: paymentId,
+      eventType: "payment.notification",
+      payload: { id: paymentId },
+    });
+
+    await processMollieWebhook(job);
+
+    const [donation] = await db
+      .select()
+      .from(donations)
+      .where(and(eq(donations.orgId, ORG_ID), eq(donations.paymentRef, paymentId)));
+
+    expect(donation).toBeTruthy();
+    expect(donation?.amountCents).toBe(2500);
+    expect(donation?.currency).toBe("EUR");
+    // Granular payment method preserved (the user-cared-about iDEAL distinction).
+    expect(donation?.paymentMethod).toBe("ideal");
+    // Phase 1: NO platform fee on Mollie path.
+    expect(donation?.platformFeeCents).toBe(0);
+    expect(donation?.status).toBe("cleared");
+
+    const [event] = await db
+      .select()
+      .from(outboxEvents)
+      .where(and(eq(outboxEvents.tenantId, ORG_ID)));
+    expect(event?.type).toBe("donation.created");
+
+    const [whEvt] = await db
+      .select()
+      .from(webhookEvents)
+      .where(eq(webhookEvents.id, "00000000-0000-0000-0000-0000000000f1"));
+    expect(whEvt?.status).toBe("completed");
+    // Re-keyed: `${id}-${status}` so the next status transition has its
+    // own row without colliding on the unique index.
+    expect(whEvt?.providerEventId).toBe(`${paymentId}-paid`);
+  });
+
+  it("skips donation insert for non-paid statuses (authorized, failed, pending)", async () => {
+    for (const status of ["authorized", "failed", "pending"] as const) {
+      const paymentId = `tr_test_status_${status}`;
+      await db.insert(webhookEvents).values({
+        id: `00000000-0000-0000-0000-0000000000${status === "authorized" ? "f2" : status === "failed" ? "f3" : "f4"}`,
+        provider: "mollie",
+        providerEventId: paymentId,
+        eventType: "payment.notification",
+        accountId: null,
+        payload: { id: paymentId },
+        status: "pending",
+        livemode: false,
+      });
+      mockPaymentsGet.mockResolvedValueOnce(makePaidPayment({ id: paymentId, status }));
+
+      const job = makeMockJob({
+        webhookEventId: `00000000-0000-0000-0000-0000000000${status === "authorized" ? "f2" : status === "failed" ? "f3" : "f4"}`,
+        providerEventId: paymentId,
+        molliePaymentId: paymentId,
+        eventType: "payment.notification",
+        payload: { id: paymentId },
+      });
+
+      await processMollieWebhook(job);
+
+      // No donation row for this paymentRef
+      const [donation] = await db
+        .select()
+        .from(donations)
+        .where(eq(donations.paymentRef, paymentId));
+      expect(donation).toBeUndefined();
+    }
+  });
+
+  it("idempotent against a duplicate paid webhook (donation insert no-ops)", async () => {
+    const paymentId = "tr_test_paid_dup";
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000f5",
+      provider: "mollie",
+      providerEventId: paymentId,
+      eventType: "payment.notification",
+      accountId: null,
+      payload: { id: paymentId },
+      status: "pending",
+      livemode: false,
+    });
+    mockPaymentsGet.mockResolvedValue(makePaidPayment({ id: paymentId }));
+
+    await processMollieWebhook(
+      makeMockJob({
+        webhookEventId: "00000000-0000-0000-0000-0000000000f5",
+        providerEventId: paymentId,
+        molliePaymentId: paymentId,
+        eventType: "payment.notification",
+        payload: { id: paymentId },
+      }),
+    );
+
+    // Insert a SECOND webhook_events row for the duplicate (the route would
+    // have inserted only one, but the worker doesn't enforce that — the
+    // inner donation `onConflictDoNothing` is the second-stage guard).
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000f6",
+      provider: "mollie",
+      providerEventId: `${paymentId}-retry`,
+      eventType: "payment.notification",
+      accountId: null,
+      payload: { id: paymentId },
+      status: "pending",
+      livemode: false,
+    });
+
+    await processMollieWebhook(
+      makeMockJob({
+        webhookEventId: "00000000-0000-0000-0000-0000000000f6",
+        providerEventId: `${paymentId}-retry`,
+        molliePaymentId: paymentId,
+        eventType: "payment.notification",
+        payload: { id: paymentId },
+      }),
+    );
+
+    // EXACTLY one donation row for the (org, payment_method, payment_ref) tuple
+    const rows = await db
+      .select({ id: donations.id })
+      .from(donations)
+      .where(and(eq(donations.orgId, ORG_ID), eq(donations.paymentRef, paymentId)));
+    expect(rows.length).toBe(1);
+  });
+
+  it("cross-tenant probe: 404 from first tenant's key falls through to the next", async () => {
+    const paymentId = "tr_test_xprobe";
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000f7",
+      provider: "mollie",
+      providerEventId: paymentId,
+      eventType: "payment.notification",
+      accountId: null,
+      payload: { id: paymentId },
+      status: "pending",
+      livemode: false,
+    });
+    // First call (probably ORG_ID_OTHER) returns 404 → second call returns
+    // a paid payment owned by ORG_ID. Order isn't strictly guaranteed (depends
+    // on DB row ordering) so we set up both arms via mock implementation.
+    mockPaymentsGet.mockImplementationOnce(async () => {
+      const err = new Error("Not Found");
+      (err as { statusCode?: number }).statusCode = 404;
+      throw err;
+    });
+    mockPaymentsGet.mockResolvedValueOnce(
+      makePaidPayment({ id: paymentId, metadata: { org_id: ORG_ID } }),
+    );
+
+    await processMollieWebhook(
+      makeMockJob({
+        webhookEventId: "00000000-0000-0000-0000-0000000000f7",
+        providerEventId: paymentId,
+        molliePaymentId: paymentId,
+        eventType: "payment.notification",
+        payload: { id: paymentId },
+      }),
+    );
+
+    // The probe must have called payments.get exactly twice — once for the
+    // 404 candidate, once for the matching tenant.
+    expect(mockPaymentsGet).toHaveBeenCalledTimes(2);
+    expect(mockCreateMollieClient).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/worker/src/tests/integration/stripe-webhook.test.ts
+++ b/packages/worker/src/tests/integration/stripe-webhook.test.ts
@@ -43,7 +43,8 @@ beforeAll(async () => {
   // Insert a webhook_events row for the processor to update
   await db.insert(webhookEvents).values({
     id: "00000000-0000-0000-0000-0000000000e1",
-    stripeEventId: "evt_test_pi_succeeded",
+    provider: "stripe",
+    providerEventId: "evt_test_pi_succeeded",
     eventType: "payment_intent.succeeded",
     accountId: STRIPE_ACCOUNT_ID,
     payload: {},
@@ -61,7 +62,7 @@ afterAll(async () => {
   await db.execute(sql`DELETE FROM outbox_events WHERE tenant_id IN (${ORG_ID}, ${ORG_ID_OTHER})`);
   await db.execute(sql`DELETE FROM donations WHERE org_id IN (${ORG_ID}, ${ORG_ID_OTHER})`);
   await db.execute(sql`DELETE FROM constituents WHERE org_id IN (${ORG_ID}, ${ORG_ID_OTHER})`);
-  await db.execute(sql`DELETE FROM webhook_events WHERE stripe_event_id LIKE 'evt_test_%'`);
+  await db.execute(sql`DELETE FROM webhook_events WHERE provider_event_id LIKE 'evt_test_%'`);
   await db.execute(
     sql`DELETE FROM exchange_rates WHERE currency = 'EUR' AND base_currency = 'CHF' AND date = ${TODAY}`,
   );
@@ -121,7 +122,7 @@ describe("processStripeWebhook", () => {
     const [webhookEvt] = await db
       .select()
       .from(webhookEvents)
-      .where(eq(webhookEvents.stripeEventId, "evt_test_pi_succeeded"));
+      .where(eq(webhookEvents.providerEventId, "evt_test_pi_succeeded"));
 
     expect(webhookEvt?.status).toBe("completed");
     expect(webhookEvt?.processedAt).toBeTruthy();
@@ -131,7 +132,8 @@ describe("processStripeWebhook", () => {
     // Insert webhook event for the unknown account test
     await db.insert(webhookEvents).values({
       id: "00000000-0000-0000-0000-0000000000e2",
-      stripeEventId: "evt_test_unknown_account",
+      provider: "stripe",
+      providerEventId: "evt_test_unknown_account",
       eventType: "payment_intent.succeeded",
       accountId: "acct_nonexistent",
       payload: {},
@@ -159,7 +161,8 @@ describe("processStripeWebhook", () => {
     // Insert webhook event targeting Tenant A's Stripe account
     await db.insert(webhookEvents).values({
       id: "00000000-0000-0000-0000-0000000000e3",
-      stripeEventId: "evt_test_cross_tenant",
+      provider: "stripe",
+      providerEventId: "evt_test_cross_tenant",
       eventType: "payment_intent.succeeded",
       accountId: STRIPE_ACCOUNT_ID,
       payload: {},
@@ -203,7 +206,8 @@ describe("processStripeWebhook", () => {
     // Insert webhook event for retry test
     await db.insert(webhookEvents).values({
       id: "00000000-0000-0000-0000-0000000000e4",
-      stripeEventId: "evt_test_retry_dup",
+      provider: "stripe",
+      providerEventId: "evt_test_retry_dup",
       eventType: "payment_intent.succeeded",
       accountId: STRIPE_ACCOUNT_ID,
       payload: {},
@@ -256,7 +260,8 @@ describe("processStripeWebhook", () => {
       });
     await db.insert(webhookEvents).values({
       id: "00000000-0000-0000-0000-0000000000e5",
-      stripeEventId: "evt_test_foreign_currency",
+      provider: "stripe",
+      providerEventId: "evt_test_foreign_currency",
       eventType: "payment_intent.succeeded",
       accountId: STRIPE_ACCOUNT_ID_MULTI,
       payload: {},
@@ -302,7 +307,8 @@ describe("processStripeWebhook", () => {
     // its `failed` status update.
     await db.insert(webhookEvents).values({
       id: "00000000-0000-0000-0000-0000000000ee",
-      stripeEventId: "evt_test_malformed_pi",
+      provider: "stripe",
+      providerEventId: "evt_test_malformed_pi",
       eventType: "payment_intent.succeeded",
       accountId: STRIPE_ACCOUNT_ID,
       payload: {},
@@ -364,7 +370,8 @@ describe("processStripeWebhook", () => {
     );
     await db.insert(webhookEvents).values({
       id: "00000000-0000-0000-0000-0000000000ef",
-      stripeEventId: "evt_test_refund_1",
+      provider: "stripe",
+      providerEventId: "evt_test_refund_1",
       eventType: "charge.refunded",
       accountId: STRIPE_ACCOUNT_ID,
       payload: {},
@@ -453,7 +460,8 @@ describe("processStripeWebhook", () => {
     );
     await db.insert(webhookEvents).values({
       id: "00000000-0000-0000-0000-0000000000ea",
-      stripeEventId: "evt_test_refund_idempotent",
+      provider: "stripe",
+      providerEventId: "evt_test_refund_idempotent",
       eventType: "charge.refunded",
       accountId: STRIPE_ACCOUNT_ID,
       payload: {},
@@ -485,5 +493,83 @@ describe("processStripeWebhook", () => {
       (e) => (e.payload as { paymentRef?: string }).paymentRef === paymentRef,
     );
     expect(matchingPayloads.length).toBeLessThanOrEqual(1);
+  });
+
+  // ─── account.updated (issue #62) ─────────────────────────────────────────
+
+  it("caches Stripe charges_enabled / payouts_enabled / details_submitted on the tenant", async () => {
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000eb",
+      provider: "stripe",
+      providerEventId: "evt_test_account_updated",
+      eventType: "account.updated",
+      accountId: STRIPE_ACCOUNT_ID,
+      payload: {},
+      status: "pending",
+    });
+
+    // Reset cached state to false so we can observe the flip.
+    await db.execute(
+      sql`UPDATE tenants
+          SET stripe_charges_enabled = false,
+              stripe_payouts_enabled = false,
+              stripe_details_submitted = false,
+              stripe_account_state_at = NULL
+          WHERE id = ${ORG_ID}`,
+    );
+
+    const job = makeMockJob({
+      webhookEventId: "00000000-0000-0000-0000-0000000000eb",
+      stripeEventId: "evt_test_account_updated",
+      eventType: "account.updated",
+      accountId: null,
+      payload: {
+        id: STRIPE_ACCOUNT_ID,
+        charges_enabled: true,
+        payouts_enabled: true,
+        details_submitted: true,
+      },
+    });
+
+    await processStripeWebhook(job);
+
+    const result = await db.execute(
+      sql`SELECT stripe_charges_enabled, stripe_payouts_enabled, stripe_details_submitted, stripe_account_state_at
+          FROM tenants WHERE id = ${ORG_ID}`,
+    );
+    const tenant = (result as { rows?: Record<string, unknown>[] }).rows?.[0] ?? undefined;
+    expect(tenant?.stripe_charges_enabled).toBe(true);
+    expect(tenant?.stripe_payouts_enabled).toBe(true);
+    expect(tenant?.stripe_details_submitted).toBe(true);
+    expect(tenant?.stripe_account_state_at).toBeTruthy();
+  });
+
+  it("ignores account.updated for an unknown connected account (no DLQ throw)", async () => {
+    await db.insert(webhookEvents).values({
+      id: "00000000-0000-0000-0000-0000000000ec",
+      provider: "stripe",
+      providerEventId: "evt_test_account_updated_unknown",
+      eventType: "account.updated",
+      accountId: "acct_definitely_not_a_real_tenant",
+      payload: {},
+      status: "pending",
+    });
+
+    const job = makeMockJob({
+      webhookEventId: "00000000-0000-0000-0000-0000000000ec",
+      stripeEventId: "evt_test_account_updated_unknown",
+      eventType: "account.updated",
+      accountId: null,
+      payload: {
+        id: "acct_definitely_not_a_real_tenant",
+        charges_enabled: true,
+        payouts_enabled: true,
+        details_submitted: true,
+      },
+    });
+
+    // Must NOT throw — unknown account is logged + marked completed so the
+    // job doesn't enter the DLQ.
+    await expect(processStripeWebhook(job)).resolves.toBeUndefined();
   });
 });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -11,6 +11,7 @@ import { extractTraceId } from "./lib/trace-context.js";
 import { processGenerateCampaignDocuments } from "./processors/campaign-documents.js";
 import { processGdprErasure } from "./processors/gdpr-erasure.js";
 import { processGenerateReceipt } from "./processors/generate-receipt.js";
+import { processMollieWebhook } from "./processors/mollie-webhook.js";
 import { processSendBulkEmail } from "./processors/send-bulk-email.js";
 import {
   processSignupVerificationEmail,
@@ -202,11 +203,32 @@ function startWorkers() {
     ...defaultJobOpts,
   });
 
-  const webhooksWorker = new Worker(QUEUE_NAMES.WEBHOOKS, processStripeWebhook, {
-    connection: createRedisConnection(),
-    concurrency: 5,
-    ...defaultJobOpts,
-  });
+  /**
+   * Single webhook queue, multiple processors — dispatched by `job.name`
+   * so Stripe and Mollie webhooks share BullMQ infrastructure (one
+   * concurrency budget, one DLQ, one retry policy) but run different
+   * handlers. Adding a new gateway is a new processor + a new arm here.
+   */
+  const webhooksWorker = new Worker(
+    QUEUE_NAMES.WEBHOOKS,
+    async (job) => {
+      if (job.name === "process-stripe-webhook") {
+        return processStripeWebhook(job as Parameters<typeof processStripeWebhook>[0]);
+      }
+      if (job.name === "process-mollie-webhook") {
+        return processMollieWebhook(job as Parameters<typeof processMollieWebhook>[0]);
+      }
+      // Unknown job name — fail loudly so it lands in BullMQ's failed set
+      // and surfaces in the DLQ telemetry rather than silently being
+      // marked completed.
+      throw new Error(`Unknown webhook job name: ${job.name}`);
+    },
+    {
+      connection: createRedisConnection(),
+      concurrency: 5,
+      ...defaultJobOpts,
+    },
+  );
 
   const tenantLifecycleWorker = new Worker(QUEUE_NAMES.TENANT_LIFECYCLE, processTenantLifecycle, {
     connection: createRedisConnection(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@givernance/shared':
         specifier: workspace:*
         version: link:../shared
+      '@mollie/api-client':
+        specifier: ^4.5.0
+        version: 4.5.0
       '@sinclair/typebox':
         specifier: ^0.34.12
         version: 0.34.49
@@ -316,6 +319,9 @@ importers:
       '@givernance/shared':
         specifier: workspace:*
         version: link:../shared
+      '@mollie/api-client':
+        specifier: ^4.5.0
+        version: 4.5.0
       '@sinclair/typebox':
         specifier: ^0.34.12
         version: 0.34.49
@@ -1481,6 +1487,10 @@ packages:
 
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
+
+  '@mollie/api-client@4.5.0':
+    resolution: {integrity: sha512-Aj3Erv3EqY74fFK8gYegjzXZxPNq4T7cbsoPueRx5aF6o0kL8kR9eeaLZPaFkv2zHA4XQW6ky8yG7CMyu4oqnw==}
     engines: {node: '>=8'}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
@@ -2717,6 +2727,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -3720,6 +3733,15 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
@@ -4063,6 +4085,9 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
+  ruply@1.0.1:
+    resolution: {integrity: sha512-p39LnaaJyuucPGlgaB0KiyifpcuOkn24+Hq5y0ejAD/LlH+mRAbkHn2tckCLgHir+S+nis1WYG+TYEC4zHX0WQ==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -4283,6 +4308,9 @@ packages:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
@@ -4446,6 +4474,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -4462,6 +4493,9 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -5666,6 +5700,14 @@ snapshots:
 
   '@lukeed/ms@2.0.2': {}
 
+  '@mollie/api-client@4.5.0':
+    dependencies:
+      '@types/node-fetch': 2.6.13
+      node-fetch: 2.7.0
+      ruply: 1.0.1
+    transitivePeerDependencies:
+      - encoding
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -6830,6 +6872,11 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 25.6.0
+      form-data: 4.0.5
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -7851,6 +7898,10 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
       detect-libc: 2.1.2
@@ -8176,6 +8227,8 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
+  ruply@1.0.1: {}
+
   safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.0:
@@ -8375,6 +8428,8 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
+  tr46@0.0.3: {}
+
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -8541,6 +8596,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -8553,6 +8610,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-module@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Implements Sprint 5 / issue #62: Mollie as a co-primary payment gateway alongside Stripe Connect, plus Stripe `account.updated` webhook lifecycle.

- **Mollie integration is fully wired end-to-end.** Donors on a Mollie tenant get redirected to Mollie's hosted checkout; the worker fetches the payment back, creates a donation row, and emits the `donation.created` outbox event so the receipt pipeline runs as it does for Stripe.
- **`PaymentGateway` interface + factory** at `packages/api/src/lib/payments/`. The donor `/donate` endpoint now dispatches to `StripeGateway` or `MollieGateway` based on `tenants.payment_gateway` — no other module imports Stripe or Mollie SDK types directly.
- **Org-admin gateway selector** at Settings → Payment gateway, gated behind `ff.payments.mollie` for selecting Mollie. Mollie API key is per-tenant (each NPO brings their own).
- **Stripe `account.updated` worker handler** caches `charges_enabled` / `payouts_enabled` / `details_submitted` on the tenant row — the "auto-switch to live mode" flip from doc-20 §5.2.

## Closes

close #62

## What's new

### Schema (migration 0033)
- `tenants.payment_gateway` (`stripe` | `mollie` | `manual`, default `'stripe'`)
- `tenants.mollie_api_key` (per-tenant credential; plaintext today, KMS-encrypt as a follow-up)
- `tenants.feature_flags` JSONB (minimal MVP store ahead of full doc-18 system — used to gate `ff.payments.mollie`)
- `tenants.stripe_charges_enabled` / `stripe_payouts_enabled` / `stripe_details_submitted` / `stripe_account_state_at`
- `webhook_events.stripe_event_id` → `provider_event_id` (rename) + new `provider` column with composite uniq `(provider, provider_event_id)`

### API
- New `POST /v1/donations/mollie-webhook` — HMAC-SHA256 verify on `X-Mollie-Signature`, persist to `webhook_events`, enqueue `process-mollie-webhook` BullMQ job
- New `GET` / `PATCH /v1/admin/payment-gateway` for the org-admin to read / switch gateway and store the Mollie API key
- Public `/page` response now includes `paymentGateway`; donor `/donate` returns a discriminated union (`{provider:'stripe',clientSecret,...}` or `{provider:'mollie',checkoutUrl,...}`)

### Worker
- `account.updated` handler updates the cached Stripe account state on the tenant
- New `mollie-webhook` processor: probes each Mollie-enabled tenant's API key for the payment, verifies status, creates donation + outbox event in a single transaction
- Single webhooks queue, dispatched by `job.name`

### Frontend
- `PublicDonationForm` branches on `paymentGateway` — Stripe Elements for `'stripe'`, full-page redirect to Mollie checkout for `'mollie'`, "offline donations only" notice for `'manual'`
- New `PaymentGatewayPanel` settings card with provider selector + masked Mollie API key input
- i18n strings (EN + FR)

## Test plan

- [x] `pnpm typecheck` — green across all packages
- [x] `pnpm run lint` — 0 errors (14 pre-existing warnings unchanged)
- [x] `pnpm run format` — clean
- [x] `pnpm test` — 612 API + 28 worker + 67 web = **707 passing**
- [x] New: `mollie-payments.test.ts` covers signature verify (missing / invalid / valid / `sha256=` prefix), idempotency, and `GET`/`PATCH /admin/payment-gateway` (auth, role, flag-off rejection, flag-on activation, cross-tenant isolation)
- [x] New: `stripe-webhook.test.ts` covers `account.updated` (caches flags) + the unknown-account skip path
- [ ] Manual smoke against staging Mollie test mode (operator-side; not part of this PR)

### Acceptance checklist (from issue #62)

- [x] `ff.payments.mollie` feature flag gates Mollie activation per tenant
- [x] `POST /v1/donations/mollie-webhook` with signature verification + idempotency (reuses `webhook_events` table, now multi-gateway)
- [x] `PaymentGateway` factory routes to `MollieGateway` when `tenant.payment_gateway = 'mollie'`
- [x] Webhook handler for `account.updated`
- [x] Auto-switch tenant to live mode when `charges_enabled: true` (cached on `tenants.stripe_charges_enabled`)

## Deferred / follow-ups

- **KMS encryption of `tenants.mollie_api_key`** — plaintext is acceptable for the FR/BE/NL pilot per ADR-010 §6 PCI scope (no card data touches the column), but production should encrypt with pgcrypto + per-tenant DEK. File a follow-up issue.
- **Mollie Connect / OAuth** — current model has each NPO bring their own Mollie API key. A future Mollie Connect flow would let us tag a `profileId` on the webhook and skip the per-tenant key probing in the worker. ADR-010 §5.1 future work.
- **Donor-side idempotency on Mollie** — Mollie's API has no request-level idempotency header; we fold the donor's idempotency key into payment metadata for after-the-fact reconciliation. A repeat browser submit creates a fresh Mollie payment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)