### PR TITLE
ci(i18n): wire ADR-015 translation parity check + cover api messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      # ADR-015 (i18n): fail CI if any locale drifts from the source `fr` in
+      # either the web (next-intl) or API (RFC 9457 / email) message tree.
+      - name: Check translation key parity
+        run: pnpm check:translations
+
       - name: Build
         run: pnpm build
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "pnpm -r --workspace-concurrency=1 test",
     "test:watch": "vitest",
     "typecheck": "pnpm -r run typecheck",
+    "check:translations": "node scripts/check-translations.mjs",
     "db:generate": "pnpm --filter @givernance/api run db:generate",
     "db:migrate": "pnpm --filter @givernance/api run db:migrate",
     "docker:up": "docker compose up -d",

--- a/scripts/check-translations.mjs
+++ b/scripts/check-translations.mjs
@@ -2,17 +2,28 @@
 
 /**
  * CI check: verify all locales have the same translation keys.
- * ADR-015 — run as part of `pnpm test` or CI pipeline.
+ * ADR-015 — wired into CI as `pnpm check:translations`.
+ *
+ * Validates two message trees:
+ *   - packages/web/src/messages — UI strings (next-intl)
+ *   - packages/api/messages     — RFC 9457 `detail` + email templates (i18next)
+ *
+ * Source locale is `fr`. Exits 1 if any locale in any tree has missing or
+ * extra keys relative to the source.
  *
  * Usage: node scripts/check-translations.mjs
- * Exit code 0 = all keys match, 1 = missing keys found.
  */
 
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
-const MESSAGES_DIR = join(import.meta.dirname, "../packages/web/messages");
-const SOURCE_LOCALE = "fr"; // French is the source language
+const SOURCE_LOCALE = "fr";
+const REPO_ROOT = join(import.meta.dirname, "..");
+
+const MESSAGE_TREES = [
+  { name: "web", dir: join(REPO_ROOT, "packages/web/src/messages") },
+  { name: "api", dir: join(REPO_ROOT, "packages/api/messages") },
+];
 
 /** Recursively extract all dot-separated keys from a nested object. */
 function extractKeys(obj, prefix = "") {
@@ -28,55 +39,67 @@ function extractKeys(obj, prefix = "") {
   return keys;
 }
 
-const files = readdirSync(MESSAGES_DIR).filter((f) => f.endsWith(".json"));
-const localeKeys = {};
+function checkTree({ name, dir }) {
+  console.log(`\n=== ${name} (${dir}) ===`);
 
-for (const file of files) {
-  const locale = file.replace(".json", "");
-  const content = JSON.parse(readFileSync(join(MESSAGES_DIR, file), "utf-8"));
-  localeKeys[locale] = new Set(extractKeys(content));
-}
+  const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  if (files.length === 0) {
+    console.error(`  No locale files found in ${dir}`);
+    return false;
+  }
 
-const sourceKeys = localeKeys[SOURCE_LOCALE];
-if (!sourceKeys) {
-  console.error(`Source locale "${SOURCE_LOCALE}" not found in ${MESSAGES_DIR}`);
-  process.exit(1);
-}
+  const localeKeys = {};
+  for (const file of files) {
+    const locale = file.replace(".json", "");
+    const content = JSON.parse(readFileSync(join(dir, file), "utf-8"));
+    localeKeys[locale] = new Set(extractKeys(content));
+  }
 
-let hasErrors = false;
+  const sourceKeys = localeKeys[SOURCE_LOCALE];
+  if (!sourceKeys) {
+    console.error(`  Source locale "${SOURCE_LOCALE}" not found in ${dir}`);
+    return false;
+  }
 
-for (const [locale, keys] of Object.entries(localeKeys)) {
-  if (locale === SOURCE_LOCALE) continue;
+  let treeOk = true;
+  for (const [locale, keys] of Object.entries(localeKeys)) {
+    if (locale === SOURCE_LOCALE) continue;
 
-  // Keys in source but missing in this locale
-  const missing = [...sourceKeys].filter((k) => !keys.has(k));
-  // Keys in this locale but not in source (extra)
-  const extra = [...keys].filter((k) => !sourceKeys.has(k));
+    const missing = [...sourceKeys].filter((k) => !keys.has(k));
+    const extra = [...keys].filter((k) => !sourceKeys.has(k));
 
-  if (missing.length > 0) {
-    hasErrors = true;
-    console.error(`\n[${locale}] Missing ${missing.length} keys (present in ${SOURCE_LOCALE}):`);
-    for (const key of missing) {
-      console.error(`  - ${key}`);
+    if (missing.length > 0) {
+      treeOk = false;
+      console.error(`  [${locale}] Missing ${missing.length} keys (present in ${SOURCE_LOCALE}):`);
+      for (const key of missing) console.error(`    - ${key}`);
+    }
+    if (extra.length > 0) {
+      treeOk = false;
+      console.error(`  [${locale}] Extra ${extra.length} keys (not in ${SOURCE_LOCALE}):`);
+      for (const key of extra) console.error(`    - ${key}`);
+    }
+    if (missing.length === 0 && extra.length === 0) {
+      console.log(`  [${locale}] OK — ${keys.size} keys match source (${SOURCE_LOCALE}).`);
     }
   }
 
-  if (extra.length > 0) {
-    hasErrors = true;
-    console.error(`\n[${locale}] Extra ${extra.length} keys (not in ${SOURCE_LOCALE}):`);
-    for (const key of extra) {
-      console.error(`  - ${key}`);
-    }
+  if (treeOk) {
+    console.log(`  ${name}: PASS (${files.length} locales, ${sourceKeys.size} keys each)`);
+  } else {
+    console.error(`  ${name}: FAIL`);
   }
-
-  if (missing.length === 0 && extra.length === 0) {
-    console.log(`[${locale}] All ${keys.size} keys match source (${SOURCE_LOCALE}).`);
-  }
+  return treeOk;
 }
 
-if (hasErrors) {
+let allOk = true;
+for (const tree of MESSAGE_TREES) {
+  if (!checkTree(tree)) allOk = false;
+}
+
+if (allOk) {
+  console.log("\nAll message trees pass key parity.");
+  process.exit(0);
+} else {
   console.error("\nTranslation key check FAILED. Fix missing/extra keys above.");
   process.exit(1);
-} else {
-  console.log(`\nAll ${files.length} locales have matching keys (${sourceKeys.size} keys each).`);
 }


### PR DESCRIPTION
## Summary

- Rewrite `scripts/check-translations.mjs` to walk **both** message trees (`packages/web/src/messages` + `packages/api/messages`) with per-tree pass/fail and a non-zero exit if any locale drifts from `fr`.
- Add `pnpm check:translations` to root `package.json`.
- Add a CI step in `.github/workflows/ci.yml` between `Typecheck` and `Build` so missing/extra keys fail fast.

## Why this is more relevant than the issue suggests

[scripts/check-translations.mjs](scripts/check-translations.mjs) at `main` hard-coded `packages/web/messages` — a path that **has never existed** in this repo (web messages live at `packages/web/src/messages`). Combined with the script not being wired into `pnpm`/CI, the practical state today is: **zero locale parity enforcement on any tree**. Per ADR-015 that's exactly what should fail CI.

## Local verification

- `pnpm check:translations` happy path:
  - web: 1241 keys × 2 locales — PASS
  - api: 14 keys × 2 locales — PASS
- Failure path: deleted `errors.notFound` from `packages/api/messages/en.json` → script exits 1 with the missing key listed; restored → exits 0.
- Full pipeline green locally: `pnpm install && pnpm format && pnpm lint && pnpm typecheck && pnpm build && pnpm test` (35 + 20 + 6 test files, 642 + 67 + 26 tests).

## Acceptance criteria (from #74)

- [x] Script validates `packages/web/src/messages` **and** `packages/api/messages`; missing/extra keys in either tree fail with non-zero exit.
- [x] `pnpm check:translations` works locally from repo root.
- [x] CI runs the check on every PR; deliberately-missing key fails the workflow (verified locally — CI step is a thin `pnpm check:translations` wrapper, so script behavior == CI behavior).
- [x] `pnpm install && pnpm build && pnpm run format && pnpm run lint && pnpm typecheck && pnpm test` still green.

## Manual acceptance checklist

- [ ] CI shows a new `Check translation key parity` step between `Typecheck` and `Build`, and it passes on this PR.
- [ ] On a follow-up PR, deliberately omit a key from `packages/web/src/messages/en.json` or `packages/api/messages/en.json` and confirm CI fails on that step (do **not** merge such a PR).
- [ ] Output format reads cleanly in the CI log: per-tree header, per-locale summary, final aggregate.

## Notes

- Skipped the multi-agent specialist review — surface is 3 files / ~70 lines of build-time Node script with no runtime, UI, or security implications, so parallel specialist agents would be theatre, not value. Happy to run it if reviewers disagree.
- Branched from `main` (not from `chore/dependabot-and-13-alerts` which was the active branch when this work started) to avoid chained-branch rebase pain.

close #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)