### PR TITLE
feat(identity): split platform_admins from tenant users (ADR-022)

### DIFF
--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -245,4 +245,11 @@ accessories:
         - KEYCLOAK_ADMIN_PASSWORD
     files:
       - infra/keycloak/realm-givernance.json:/opt/keycloak/data/import/realm.json
+      # Staging-specific theme.properties — overrides the dev value
+      # baked into the custom Keycloak image (`infra/keycloak/Dockerfile`)
+      # so `info.ftl` resolves `${properties.gvAppLoginUrl}` to the
+      # staging SPA URL. Without this mount the post-action page would
+      # link new admins at `http://localhost:3000/login` (issue #254
+      # PR #253 smoke-test feedback).
+      - infra/keycloak/themes/givernance/login/theme.staging.properties:/opt/keycloak/themes/givernance/login/theme.properties
     cmd: start-dev --import-realm

--- a/docs/15-infra-adr.md
+++ b/docs/15-infra-adr.md
@@ -23,3 +23,4 @@ This document serves as an index for the Givernance Architecture Decision Record
 - [ADR-019: Cross-Tenant Foreign-Key Violations Return 404 (Not 422)](./adrs/adr-019-cross-tenant-foreign-key-violations-return-404-not-422.md)
 - [ADR-020: BullMQ Dead-Letter Strategy — `failed` Set + Structured Alerting for Phase 1](./adrs/adr-020-bullmq-dead-letter-strategy-failed-set-structured-alerting-for-phase-1.md)
 - [ADR-021: User Lifecycle — Soft-delete in App, Hard-delete in Keycloak, Anonymisation for GDPR](./adrs/adr-021-user-lifecycle-soft-delete-in-app-hard-delete-in-keycloak-anonymisation-for-gdpr.md)
+- [ADR-022: Platform Admins Disjoint from Tenant Users — `platform_admins` Table over `PLATFORM_TENANT_ID` Sentinel](./adrs/adr-022-platform-admins-disjoint-from-tenant-users.md)

--- a/docs/adrs/adr-022-platform-admins-disjoint-from-tenant-users.md
+++ b/docs/adrs/adr-022-platform-admins-disjoint-from-tenant-users.md
@@ -96,6 +96,23 @@ The application no longer creates a `tenants` row at `…a1`. The `org_id` claim
 
 The Keycloak realm-import keeps the seeded admin user's `org_id` attribute at `…a1` (matching the platform Organization). The app DB has no row at `…a1`; the auth plugin's super-admin exemption makes this fine.
 
+### Amendment (issue #254): sentinel platform tenant row for audit FK integrity
+
+The original ADR-022 statement "drop the synthetic platform `tenants` row" was tightened during PR #253 + #254 implementation. `audit_logs.org_id` is `NOT NULL REFERENCES tenants(id)`, so platform-level lifecycle events (the new platform-admin CRUD writes `platform_admin.created`, `platform_admin.renamed`, `platform_admin.password_reset_sent`, `platform_admin.removed` audit rows) need a tenant id to FK against.
+
+We keep ONE row in `tenants` at the platform id (`…a1`), distinguished from customer tenants by:
+
+- `slug = '__platform__'` — double-underscore is reserved (ADR-016 reserved-slugs guard) so it cannot collide with a user-facing slug.
+- `status = 'archived'` — every customer-facing list endpoint filters `status != 'archived'` already, so the row is structurally invisible.
+- `name = 'Givernance Platform (sentinel)'` — human-readable so an SOC reviewer grepping `audit_logs` recognises the row.
+
+This row is **not** a tenant in any operational sense:
+- No `users` row points at it (super-admins live in `platform_admins`; the invariant "every `users.org_id` resolves to a customer tenant" still holds because customer-facing code filters by status).
+- No constituents / campaigns / donations / impersonation sessions reference it.
+- The dev seed creates it idempotently; production deployments must apply the same insert as part of the deploy bootstrap.
+
+The amendment is the minimum-viable compromise: ADR-022's core wins (disjoint identity surface, no `PLATFORM_TENANT_ID` constant in app code, no UUID-equality magic in the impersonation guard) are preserved.
+
 ### Consequences
 
 **Wins:**

--- a/docs/adrs/adr-022-platform-admins-disjoint-from-tenant-users.md
+++ b/docs/adrs/adr-022-platform-admins-disjoint-from-tenant-users.md
@@ -1,0 +1,124 @@
+## ADR-022: Platform Admins Disjoint from Tenant Users — `platform_admins` Table over `PLATFORM_TENANT_ID` Sentinel
+
+**Status**: Accepted (issue #252)
+**Related**: ADR-016 (tenant onboarding & KC organizations), ADR-017 (one logical DB per tool), ADR-021 (user lifecycle — soft-delete), `docs/19-impersonation.md` (impersonation strategy)
+
+### Context
+
+Phase 1 modeled Givernance super-admins (platform staff with the Keycloak realm role `super_admin`) as `users` rows pointing at a synthetic "platform" tenant — a `tenants` row whose UUID was pinned at `00000000-0000-0000-0000-0000000000a1` and exposed as the constant `PLATFORM_TENANT_ID` in `@givernance/shared/constants`. The impersonation guard refused to start a session against any target whose `org_id` matched this sentinel, on the rationale that nested operator-on-operator impersonation breaks the audit chain.
+
+Two consequences surfaced:
+
+1. **Dev-seed UUID collision.** The seeded "Givernance Demo NPO" tenant reused the platform UUID so the seeded super-admin would land in a tenant with realistic data on first login. Any user created inside that demo NPO — a perfectly normal org-admin — tripped the impersonation guard with `Cannot impersonate a platform user; nested impersonation is forbidden`. Structurally, an org-admin in a customer tenant looked identical to a Givernance staffer.
+2. **Audit story buried under a magic UUID.** "List every super-admin we have ever had" required `users JOIN tenants ON tenants.id = users.org_id WHERE tenants.id = '…a1'`. Super-admins are a regulated identity surface — the people who can read across tenants and start impersonation sessions. The source of truth deserved a first-class table that an SOC reviewer or DPO can query without folklore.
+
+ADR-021 already noted in passing that "super-admins are platform principals; they don't have a `users` row in any tenant by design" — but the seed and the impersonation guard were both treating super-admins *as if* they did. ADR-022 reconciles the codebase with ADR-021's stated position.
+
+### Decision
+
+Platform admins are modeled as a separate identity surface from tenant users. A new table `platform_admins` holds the staff records; the `users` table holds tenant members only. **A single Keycloak person belongs to exactly one of the two** — never both. If staff need to see what a customer sees, they impersonate (that is the feature).
+
+| Property | `users` (tenant members) | `platform_admins` (staff) |
+|---|---|---|
+| Tenant binding | `org_id NOT NULL` → `tenants.id` | None — no `org_id`, no FK to `tenants` |
+| Source of truth for "is super-admin?" | (n/a) | Row in `platform_admins WHERE deleted_at IS NULL` |
+| Source of truth for runtime authorization | (n/a) | Keycloak realm role `super_admin` (unchanged) |
+| Lifecycle | Soft-delete (ADR-021) | Soft-delete (ADR-021 universal rule) |
+| RLS | Yes — `org_id` drives the policy | No — accessed only through `systemDb` (BYPASSRLS) |
+| Visible to the picker / list endpoints | Yes (filtered by tenant) | No — staff are not impersonation targets |
+
+#### Schema
+
+`platform_admins`:
+- `id uuid PRIMARY KEY DEFAULT gen_random_uuid()`
+- `keycloak_id varchar(255) NOT NULL` — the JWT `sub`; nullable only across rejoin (mirrors `users.keycloak_id` semantics)
+- `email varchar(255) NOT NULL`
+- `first_name varchar(255) NOT NULL`
+- `last_name varchar(255) NOT NULL`
+- `last_login_at timestamptz` — useful for the audit story ("who has been active in the last 30 days")
+- `deleted_at timestamptz` — soft-delete (ADR-021)
+- `created_at timestamptz NOT NULL DEFAULT now()`
+- `updated_at timestamptz NOT NULL DEFAULT now()`
+
+Indexes:
+- `UNIQUE INDEX platform_admins_keycloak_id_uniq ON (keycloak_id) WHERE deleted_at IS NULL` — same partial-unique pattern as `users`, so an offboarded super-admin's email/keycloak-id can be re-issued cleanly.
+- `UNIQUE INDEX platform_admins_email_uniq ON (lower(email)) WHERE deleted_at IS NULL` — case-insensitive, same partial pattern.
+
+The table sits outside RLS. It is read and written exclusively through `systemDb` (the BYPASSRLS owner role).
+
+#### Impersonation guard
+
+The guard becomes a single indexed lookup against `platform_admins.keycloak_id`. It no longer references any UUID constant:
+
+```ts
+const isPlatformAdmin = await systemDb.execute(sql`
+  SELECT 1 FROM platform_admins
+  WHERE keycloak_id = ${target.keycloakId}
+    AND deleted_at IS NULL
+  LIMIT 1
+`);
+if (isPlatformAdmin.rows.length > 0) {
+  throw new ImpersonationServiceError(
+    400,
+    "TARGET_NESTED_SUPER_ADMIN",
+    "Cannot impersonate a platform admin; nested impersonation is forbidden.",
+  );
+}
+```
+
+The error code `TARGET_NESTED_SUPER_ADMIN` is preserved (clients/test suites depend on it). The structural meaning is unchanged: nested operator-on-operator impersonation is rejected.
+
+#### `/v1/users/me` branches on identity surface
+
+The endpoint now branches on the JWT's realm roles:
+
+- **`super_admin` realm role present** → resolve via `platform_admins` keyed on `keycloak_id`. The response payload uses a `kind: "platform_admin"` discriminator and omits `orgId` / `orgSlug` / `orgName`. The frontend's sidebar and switcher render the platform-admin variant of the chrome.
+- **otherwise** → existing path: inner-join `users` ↔ `tenants` on `(sub, org_id)`, return the tenant-scoped profile.
+
+The two payload shapes are exposed as a discriminated union on the OpenAPI schema so clients can switch on `kind`.
+
+#### Keycloak realm seed
+
+The Keycloak side is largely unchanged:
+
+- The "Givernance Platform" Organization stays as a logical grouping for staff.
+- Its `org_id` attribute (`…a1`) is retained because the OIDC Organization Membership Mapper requires the attribute to emit the `org_id` claim. Super-admin tokens still carry `org_id: …a1`.
+- The seeded super-admin user's user-attribute `org_id` stays for now (the `keycloak-realm-seed.test.ts` cross-check remains green); a follow-up may remove it once the JWT verifier reads the org membership exclusively from the Organization mapper.
+
+The application no longer creates a `tenants` row at `…a1`. The `org_id` claim on a super-admin token is a Keycloak-side detail that no app-DB row mirrors. The auth plugin already exempts super-admins from the active-row check (per ADR-021), so the absence of a matching tenant row is correct, not broken.
+
+#### Dev seed
+
+- The synthetic platform tenant insert is removed.
+- "Givernance Demo NPO" moves to a fresh UUID `00000000-0000-0000-0000-0000000000c1`. The seeded constituents/campaigns/donations land here. This is the data-rich tenant.
+- "Demo Workspace (impersonation playground)" stays at `…b1` with its three pre-seeded users (Camille / Léo / Inès). Empty playground for clean-flow testing.
+- The seeded super-admin lands in `platform_admins` (not `users`).
+
+The Keycloak realm-import keeps the seeded admin user's `org_id` attribute at `…a1` (matching the platform Organization). The app DB has no row at `…a1`; the auth plugin's super-admin exemption makes this fine.
+
+### Consequences
+
+**Wins:**
+- The "Givernance Demo NPO" tenant becomes a real customer tenant for testing — org-admins inside it can be impersonated end-to-end without tripping the nested-impersonation guard.
+- The audit story is trivial: `SELECT * FROM platform_admins`. Including soft-deleted rows: `SELECT * FROM platform_admins WHERE deleted_at IS NOT NULL`.
+- The `PLATFORM_TENANT_ID` magic constant disappears from the application codebase. No code path depends on a UUID literal.
+- `users.org_id` stays `NOT NULL` and always points at a real customer tenant. The schema invariant "every `users` row belongs to a real customer" is now true at the type level.
+- An accidental future schema change can no longer introduce a tenant whose UUID happens to collide with the platform sentinel. There is no platform sentinel anymore.
+
+**Costs:**
+- Two identity surfaces means two lookup paths in `/v1/users/me` and any future endpoint that has to render "the current user's profile". The discriminated-union payload shape is the explicit cost.
+- Listings that need to attribute "who took this action" across both staff and tenant users (e.g. cross-tenant audit timeline) need to UNION over both tables when the join is by `keycloak_id`. The `audit_logs` table already references `keycloak_id` strings (not `users.id` UUIDs), so existing audit queries are not affected.
+- A schema migration is required. There are no existing rows to migrate (Phase 0/1; production not yet deployed), so the migration is purely additive plus a removal of the platform `tenants` insert from the dev seed.
+
+### Rejected alternatives
+
+- **Boolean `users.is_super_admin` column.** Rejected because it does not free `users.org_id` from the requirement to point at a synthetic tenant. The collision risk would persist.
+- **Look up Keycloak realm roles for the target via the Admin API.** Rejected because it adds a per-`startSession` round-trip and creates a hard dependency on Keycloak availability for the impersonation guard. The DB lookup is local, fast, and survives a Keycloak outage.
+- **Drop the impersonation guard entirely.** Rejected. Operator-on-operator impersonation breaks audit accountability and has no legitimate support use case.
+- **Keep `PLATFORM_TENANT_ID` and rename the colliding seed tenant.** Rejected because it leaves the sentinel UUID as a load-bearing constant in production code, which is the root cause of the audit-discoverability problem, not just the dev-seed collision.
+
+### Revisit criteria
+
+Revisit if any of the following becomes true:
+- A platform admin needs to be a tenant member at the same time (e.g. Givernance staff become customers of their own product). Today the answer is "use a separate Keycloak account"; if that becomes onerous, ADR-022 must be reopened and the disjoint-identity invariant relaxed.
+- Cross-tenant audit timelines need to render the actor's display name without a UNION across `users` and `platform_admins` becoming a hot-path bottleneck. A materialized `principals` view spanning both tables would address this without collapsing them.

--- a/infra/keycloak/themes/givernance/login/info.ftl
+++ b/infra/keycloak/themes/givernance/login/info.ftl
@@ -36,16 +36,17 @@
       flow KC has consumed that cookie — clicking the link landed the
       user on a "Restart login cookie not found" error page.
 
-      Resolution chain:
+      Resolution chain (must NEVER hardcode an absolute URL — multi-env
+      theme):
         1. `client.baseUrl` if a `client_id` was scoped on the action
            AND the client has an absolute `baseUrl`. Stable, doesn't
            depend on auth-session state.
-        2. `properties.gvAppLoginUrl` from `theme.properties`.
-        3. Hardcoded dev fallback `http://localhost:3000/login`. KC's
-           per-process theme cache makes (2) unreliable across container
-           restarts; the hardcode guarantees a working button in dev
-           regardless. Production deployments override this template
-           (or set the property reliably) per environment.
+        2. `properties.gvAppLoginUrl` from `theme.properties`. The dev
+           value lives in this repo's `theme.properties`; staging/prod
+           override that file at deploy time (see infra docs).
+        3. No button — render text-only instructions. Defensive: better
+           to show "open the app to sign in" than a broken link, and
+           better than a hardcoded URL that breaks staging/prod.
 
       Rendered as a primary button so the user can't miss it — pre-fix
       the page just said "Your account has been updated" with no
@@ -57,13 +58,18 @@
         <#assign gvBackUrl = client.baseUrl />
       <#elseif properties.gvAppLoginUrl?? && properties.gvAppLoginUrl?has_content>
         <#assign gvBackUrl = properties.gvAppLoginUrl />
-      <#else>
-        <#assign gvBackUrl = "http://localhost:3000/login" />
       </#if>
-      <a class="gv-btn gv-btn--primary" href="${gvBackUrl}"
-         style="display:block;text-align:center;margin-top:20px;">
-        ${msg("backToLogin")}
-      </a>
+
+      <#if gvBackUrl?has_content>
+        <a class="gv-btn gv-btn--primary" href="${gvBackUrl}"
+           style="display:block;text-align:center;margin-top:20px;">
+          ${msg("backToLogin")}
+        </a>
+      <#else>
+        <p style="margin-top:20px;text-align:center;font-size:0.875rem;color:var(--gv-text-secondary);line-height:1.5;">
+          ${msg("backToLoginInstructions")}
+        </p>
+      </#if>
     </#if>
   </#if>
 

--- a/infra/keycloak/themes/givernance/login/info.ftl
+++ b/infra/keycloak/themes/givernance/login/info.ftl
@@ -27,11 +27,37 @@
       </a>
     </#if>
 
+    <#--
+      Back-to-login link.
+
+      Pre-PR-#253-smoke-fix: this rendered `${url.loginUrl}`, which is a
+      `/realms/{realm}/login-actions/...` URL that requires the auth
+      session cookie. After an `execute-actions-email` UPDATE_PASSWORD
+      flow, KC has consumed that cookie — clicking the link landed the
+      user on a "Restart login cookie not found" error page.
+
+      Resolution chain:
+        1. `client.baseUrl` if the email passed `client_id` AND the
+           client has an absolute `baseUrl` configured. Stable, doesn't
+           depend on auth-session state. (Same posture error.ftl uses.)
+        2. `properties.gvAppLoginUrl` from theme.properties — a
+           hardcoded SPA login URL per environment. The dev value
+           lives in `theme.properties`.
+        3. No link at all. The user closes the window and navigates
+           manually. Defensive — info.ftl never errors.
+    -->
     <#if !(skipLink?? && skipLink)>
-      <a class="gv-link" href="${url.loginUrl}"
-         style="display:block;text-align:center;margin-top:12px;font-size:0.8125rem;">
-        ${msg("backToLogin")}
-      </a>
+      <#if client?? && client.baseUrl?has_content>
+        <a class="gv-link" href="${client.baseUrl}"
+           style="display:block;text-align:center;margin-top:12px;font-size:0.8125rem;">
+          ${msg("backToLogin")}
+        </a>
+      <#elseif properties.gvAppLoginUrl?? && properties.gvAppLoginUrl?has_content>
+        <a class="gv-link" href="${properties.gvAppLoginUrl}"
+           style="display:block;text-align:center;margin-top:12px;font-size:0.8125rem;">
+          ${msg("backToLogin")}
+        </a>
+      </#if>
     </#if>
   </#if>
 

--- a/infra/keycloak/themes/givernance/login/info.ftl
+++ b/infra/keycloak/themes/givernance/login/info.ftl
@@ -1,8 +1,8 @@
 <#--
   Givernance — Keycloak Login Theme — info.ftl
-  Shown after successful actions that don't redirect immediately (e.g., email
-  sent for verification / password reset). Wraps the KC info state in the
-  Givernance layout instead of the default shell.
+  Shown after successful actions that don't redirect immediately (e.g.,
+  email sent for verification / password reset). Wraps the KC info
+  state in the Givernance layout instead of the default shell.
 -->
 <#import "template.ftl" as layout>
 <@layout.registrationLayout displayMessage=true; section>
@@ -28,36 +28,42 @@
     </#if>
 
     <#--
-      Back-to-login link.
+      Back-to-login button.
 
-      Pre-PR-#253-smoke-fix: this rendered `${url.loginUrl}`, which is a
+      Pre-PR-#253-smoke-fix this rendered `${url.loginUrl}`, which is a
       `/realms/{realm}/login-actions/...` URL that requires the auth
       session cookie. After an `execute-actions-email` UPDATE_PASSWORD
-      flow, KC has consumed that cookie — clicking the link landed the
+      flow KC has consumed that cookie — clicking the link landed the
       user on a "Restart login cookie not found" error page.
 
       Resolution chain:
-        1. `client.baseUrl` if the email passed `client_id` AND the
-           client has an absolute `baseUrl` configured. Stable, doesn't
-           depend on auth-session state. (Same posture error.ftl uses.)
-        2. `properties.gvAppLoginUrl` from theme.properties — a
-           hardcoded SPA login URL per environment. The dev value
-           lives in `theme.properties`.
-        3. No link at all. The user closes the window and navigates
-           manually. Defensive — info.ftl never errors.
+        1. `client.baseUrl` if a `client_id` was scoped on the action
+           AND the client has an absolute `baseUrl`. Stable, doesn't
+           depend on auth-session state.
+        2. `properties.gvAppLoginUrl` from `theme.properties`.
+        3. Hardcoded dev fallback `http://localhost:3000/login`. KC's
+           per-process theme cache makes (2) unreliable across container
+           restarts; the hardcode guarantees a working button in dev
+           regardless. Production deployments override this template
+           (or set the property reliably) per environment.
+
+      Rendered as a primary button so the user can't miss it — pre-fix
+      the page just said "Your account has been updated" with no
+      affordance to continue (caught in dev: PR #253 smoke-test feedback).
     -->
     <#if !(skipLink?? && skipLink)>
+      <#assign gvBackUrl = "" />
       <#if client?? && client.baseUrl?has_content>
-        <a class="gv-link" href="${client.baseUrl}"
-           style="display:block;text-align:center;margin-top:12px;font-size:0.8125rem;">
-          ${msg("backToLogin")}
-        </a>
+        <#assign gvBackUrl = client.baseUrl />
       <#elseif properties.gvAppLoginUrl?? && properties.gvAppLoginUrl?has_content>
-        <a class="gv-link" href="${properties.gvAppLoginUrl}"
-           style="display:block;text-align:center;margin-top:12px;font-size:0.8125rem;">
-          ${msg("backToLogin")}
-        </a>
+        <#assign gvBackUrl = properties.gvAppLoginUrl />
+      <#else>
+        <#assign gvBackUrl = "http://localhost:3000/login" />
       </#if>
+      <a class="gv-btn gv-btn--primary" href="${gvBackUrl}"
+         style="display:block;text-align:center;margin-top:20px;">
+        ${msg("backToLogin")}
+      </a>
     </#if>
   </#if>
 

--- a/infra/keycloak/themes/givernance/login/messages/messages_en.properties
+++ b/infra/keycloak/themes/givernance/login/messages/messages_en.properties
@@ -59,6 +59,18 @@ emailVerifyInstruction3link=request a new link.
 errorTitle=Something went wrong
 backToLogin=Back to sign in
 
+# Info page (post-action success — UPDATE_PASSWORD, etc.). The custom
+# info.ftl renders this as the page heading; without it, FreeMarker
+# emits the literal "infoTitle" because the parent KC theme doesn't
+# define this key (PR #253 smoke-test feedback).
+infoTitle=All set
+proceedWithAction=Continue
+# Fallback rendered when neither `client.baseUrl` nor
+# `properties.gvAppLoginUrl` (theme.properties) provides an absolute
+# URL — e.g. an environment whose theme.properties wasn't overridden
+# at deploy time. Plain instructions beat a broken link.
+backToLoginInstructions=You can now sign in to the Givernance application.
+
 pageExpiredTitle=Session expired
 pageExpiredMsg1=To continue, please
 pageExpiredMsg2=or

--- a/infra/keycloak/themes/givernance/login/messages/messages_fr.properties
+++ b/infra/keycloak/themes/givernance/login/messages/messages_fr.properties
@@ -59,6 +59,13 @@ emailVerifyInstruction3link=demandez un nouveau lien.
 errorTitle=Une erreur est survenue
 backToLogin=Retour \u00e0 la connexion
 
+# Page d'info post-action (UPDATE_PASSWORD, etc.). Le info.ftl
+# personnalis\u00e9 affiche ce titre en en-t\u00eate ; sans cette cl\u00e9, FreeMarker
+# rend la cha\u00eene litt\u00e9rale "infoTitle" car le theme parent KC ne d\u00e9finit
+# pas cette cl\u00e9 (retour de smoke-test PR #253).
+infoTitle=Tout est pr\u00eat
+proceedWithAction=Continuer
+
 # Override Keycloak base messages that contain raw MessageFormat escapes (s''est → s'est).
 # Keycloak sometimes stores message.summary without running MessageFormat, so the ''
 # escape leaks through to the UI. These overrides use a plain apostrophe.

--- a/infra/keycloak/themes/givernance/login/messages/messages_fr.properties
+++ b/infra/keycloak/themes/givernance/login/messages/messages_fr.properties
@@ -65,6 +65,11 @@ backToLogin=Retour \u00e0 la connexion
 # pas cette cl\u00e9 (retour de smoke-test PR #253).
 infoTitle=Tout est pr\u00eat
 proceedWithAction=Continuer
+# Fallback rendered when neither `client.baseUrl` nor
+# `properties.gvAppLoginUrl` (theme.properties) provides an absolute
+# URL \u2014 e.g. un environnement dont theme.properties n'a pas \u00e9t\u00e9
+# surcharg\u00e9 au d\u00e9ploiement. Pr\u00e9f\u00e9rable \u00e0 un lien cass\u00e9.
+backToLoginInstructions=Vous pouvez maintenant vous connecter sur l'application Givernance.
 
 # Override Keycloak base messages that contain raw MessageFormat escapes (s''est → s'est).
 # Keycloak sometimes stores message.summary without running MessageFormat, so the ''

--- a/infra/keycloak/themes/givernance/login/theme.properties
+++ b/infra/keycloak/themes/givernance/login/theme.properties
@@ -15,10 +15,24 @@ styles=css/givernance.css
 # variable and are unaffected by this override.
 scripts=
 
-# Stable SPA login URL surfaced to FTL templates as `${properties.gvAppLoginUrl}`.
+# Stable SPA login URL surfaced to FTL templates as
+# `${properties.gvAppLoginUrl}`.
+#
 # Used by info.ftl to render a "Back to login" link after flows that
 # consume the KC auth-session cookie (e.g. UPDATE_PASSWORD via
 # `execute-actions-email`) — `${url.loginUrl}` is a /login-actions URL
 # that requires the consumed cookie, so we point at the SPA instead.
-# Dev value below; staging/prod override via per-env theme.
+#
+# !! PER-ENVIRONMENT VALUE !!
+#
+# This file ships the dev value. Staging and production MUST override
+# the URL — Kamal mounts a per-env `theme.properties` overlay during
+# deploy. The value should be the absolute SPA login URL, e.g.:
+#   - dev:     http://localhost:3000/login
+#   - staging: https://staging.givernance.org/login
+#   - prod:    https://app.givernance.org/login
+#
+# If the override is missing, info.ftl falls back to plain-text
+# instructions (no link rendered) — better than shipping a broken /
+# wrong-environment link to a fresh super-admin.
 gvAppLoginUrl=http://localhost:3000/login

--- a/infra/keycloak/themes/givernance/login/theme.properties
+++ b/infra/keycloak/themes/givernance/login/theme.properties
@@ -14,3 +14,11 @@ styles=css/givernance.css
 # are added dynamically by KC's flow processor via the FreeMarker `scripts`
 # variable and are unaffected by this override.
 scripts=
+
+# Stable SPA login URL surfaced to FTL templates as `${properties.gvAppLoginUrl}`.
+# Used by info.ftl to render a "Back to login" link after flows that
+# consume the KC auth-session cookie (e.g. UPDATE_PASSWORD via
+# `execute-actions-email`) — `${url.loginUrl}` is a /login-actions URL
+# that requires the consumed cookie, so we point at the SPA instead.
+# Dev value below; staging/prod override via per-env theme.
+gvAppLoginUrl=http://localhost:3000/login

--- a/infra/keycloak/themes/givernance/login/theme.staging.properties
+++ b/infra/keycloak/themes/givernance/login/theme.staging.properties
@@ -23,19 +23,8 @@ scripts=
 # `execute-actions-email`) — `${url.loginUrl}` is a /login-actions URL
 # that requires the consumed cookie, so we point at the SPA instead.
 #
-# !! PER-ENVIRONMENT VALUE !!
-#
-# This file is the DEV variant — baked into the Keycloak Docker image at
-# build time (see `infra/keycloak/Dockerfile`). Other environments
-# override it via Kamal's `files:` bind-mount in their respective
-# `config/deploy-*.yml`:
-#
-#   - staging: `theme.staging.properties` next to this file, mounted
-#     via `config/deploy-staging.yml`
-#   - prod:    `theme.production.properties` (when prod ships) mounted
-#     via `config/deploy-production.yml`
-#
-# If the override is missing in a non-dev environment, info.ftl falls
-# back to plain-text instructions (no link rendered) — better than
-# shipping a broken / wrong-environment link to a fresh super-admin.
-gvAppLoginUrl=http://localhost:3000/login
+# This file is the STAGING variant. Kamal's `files:` directive in
+# `config/deploy-staging.yml` bind-mounts it over the Dockerfile-baked
+# `theme.properties` at runtime. The dev variant
+# (`theme.properties` next to this file) ships the localhost URL.
+gvAppLoginUrl=https://staging.givernance.org/login

--- a/packages/api/migrations/0034_platform_admins.sql
+++ b/packages/api/migrations/0034_platform_admins.sql
@@ -59,3 +59,34 @@ DO $$ BEGIN
     EXECUTE 'REVOKE ALL ON platform_admins FROM givernance_app';
   END IF;
 END $$;
+
+-- Sentinel platform tenant (ADR-022 amendment).
+--
+-- `audit_logs.org_id` is `NOT NULL REFERENCES tenants(id)`. Platform-level
+-- lifecycle events (super-admin onboarded/removed/etc., issue #254) need
+-- a tenant id to FK against — they do not belong to any customer tenant
+-- by definition. We keep ONE row in `tenants` at the platform id (`…a1`)
+-- as the FK target.
+--
+-- This insert is idempotent (`ON CONFLICT DO NOTHING`) and runs on every
+-- environment (dev / staging / prod) so the first call to
+-- `createPlatformAdmin` never fails on FK. The dev seed reconciles the
+-- row's name/slug/status if any drifted; production deploys use this
+-- migration as the single source of truth.
+--
+-- Distinguishing properties:
+--   - `slug = '__platform__'` — double-underscore is reserved (ADR-016
+--     reserved-slugs guard) so it cannot collide with a customer slug.
+--   - `status = 'archived'` — every customer-facing list endpoint already
+--     filters `status != 'archived'`, so the row is structurally invisible.
+--   - `name = 'Givernance Platform (sentinel)'` — human-readable for SOC
+--     reviewers grepping the audit table.
+INSERT INTO tenants (id, name, slug, plan, status)
+VALUES (
+  '00000000-0000-0000-0000-0000000000a1',
+  'Givernance Platform (sentinel)',
+  '__platform__',
+  'starter',
+  'archived'
+)
+ON CONFLICT (id) DO NOTHING;

--- a/packages/api/migrations/0034_platform_admins.sql
+++ b/packages/api/migrations/0034_platform_admins.sql
@@ -1,0 +1,61 @@
+-- Migration: 0034_platform_admins
+-- ADR-022: Platform Admins disjoint from tenant users.
+--
+-- Creates the `platform_admins` table that holds Givernance staff records.
+-- A platform admin is a Keycloak principal with the `super_admin` realm role;
+-- they are NOT tenant members and never appear in the `users` table. This
+-- replaces the `PLATFORM_TENANT_ID` sentinel previously used by the
+-- impersonation guard with a first-class table the audit story can query
+-- directly.
+--
+-- Soft-delete only (universal Givernance rule, ADR-021): a removed
+-- super-admin's row is preserved with `deleted_at IS NOT NULL` so the audit
+-- trail of who has had platform access stays intact even after offboarding.
+--
+-- No RLS: the table is platform-level by definition. All reads/writes go
+-- through the BYPASSRLS owner pool (`systemDb`). The defensive REVOKE on
+-- the app role mirrors the impersonation_sessions pattern from
+-- 0033_impersonation_sessions.sql — a future code path that accidentally
+-- queries through `db` (NOBYPASSRLS) gets a hard error instead of an
+-- empty result set.
+--
+-- Idempotent (matches 0032/0033 conventions).
+
+CREATE TABLE IF NOT EXISTS platform_admins (
+  id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  keycloak_id     VARCHAR(255),
+  email           VARCHAR(255) NOT NULL,
+  first_name      VARCHAR(255) NOT NULL,
+  last_name       VARCHAR(255) NOT NULL,
+  last_login_at   TIMESTAMPTZ,
+  deleted_at      TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- Partial unique on keycloak_id (active rows only) — mirrors the users
+-- pattern from 0032_user_soft_delete.sql so a soft-deleted super-admin's
+-- Keycloak id can be re-bound after offboarding without conflict.
+CREATE UNIQUE INDEX IF NOT EXISTS platform_admins_keycloak_id_active_uniq
+  ON platform_admins (keycloak_id)
+  WHERE deleted_at IS NULL AND keycloak_id IS NOT NULL;
+
+-- Partial unique on lower(email) — same active-only pattern; case-folded so
+-- "Admin@…" and "admin@…" don't both slip through.
+CREATE UNIQUE INDEX IF NOT EXISTS platform_admins_email_active_uniq
+  ON platform_admins (lower(email))
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS platform_admins_deleted_at_idx
+  ON platform_admins (deleted_at);
+
+-- Defensive REVOKE: the app pool is NOBYPASSRLS but `platform_admins` has no
+-- RLS policy. Without REVOKE, an accidental `db.select().from(platformAdmins)`
+-- through the app pool would return all rows. Forcing every read through
+-- `systemDb` is the architectural invariant; a 42501 error here is the
+-- desired failure mode if that invariant is violated in code.
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'givernance_app') THEN
+    EXECUTE 'REVOKE ALL ON platform_admins FROM givernance_app';
+  END IF;
+END $$;

--- a/packages/api/migrations/0035_invitation_purpose_platform_admin.sql
+++ b/packages/api/migrations/0035_invitation_purpose_platform_admin.sql
@@ -1,0 +1,15 @@
+-- Migration: 0035_invitation_purpose_platform_admin
+-- Issue #254 fix-commit 4 — admit `platform_admin_invite` as a valid
+-- `invitations.purpose` so the platform-admin invitation flow can write
+-- to the shared `invitations` table.
+--
+-- Idempotent: drops the prior check constraint (0022) and re-adds it
+-- with the widened set of allowed values. Keeps the constraint name
+-- stable so the next widening (e.g. another invitation purpose) follows
+-- the same DROP/ADD pattern.
+
+ALTER TABLE invitations DROP CONSTRAINT IF EXISTS invitations_purpose_chk;
+
+ALTER TABLE invitations
+  ADD CONSTRAINT invitations_purpose_chk
+  CHECK (purpose IN ('team_invite', 'signup_verification', 'platform_admin_invite'));

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1777500000000,
       "tag": "0034_platform_admins",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1777750000000,
+      "tag": "0035_invitation_purpose_platform_admin",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1777400000000,
       "tag": "0033_impersonation_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1777500000000,
+      "tag": "0034_platform_admins",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/scripts/seed.ts
+++ b/packages/api/scripts/seed.ts
@@ -272,31 +272,61 @@ async function findOrCreateTenant(): Promise<string> {
 }
 
 /**
- * Best-effort cleanup of the legacy `…a1` synthetic platform tenant that
- * pre-ADR-022 seeds created. If a developer pulls this branch with their
- * existing `pnpm db:seed` state, the old row will still be present —
- * archive it (ADR cascading) so it's invisible to listing endpoints
- * without touching its history. New seeds skip this entirely.
+ * Sentinel platform tenant row (ADR-022 amendment).
+ *
+ * `audit_logs.org_id` is `NOT NULL REFERENCES tenants(id)` — every audit
+ * row needs a tenant to FK against. Platform-level lifecycle events
+ * (super-admin onboarded/removed/etc., issue #254) don't belong to any
+ * customer tenant by definition, so we keep ONE row in `tenants` at the
+ * platform id (`…a1`) purely as the FK target for those audit rows.
+ *
+ * Distinguishing properties:
+ *   - `status = 'archived'` so customer-facing listing endpoints
+ *     (which already filter `status != 'archived'`) never surface it.
+ *   - `slug = '__platform__'` (double-underscore is reserved by ADR-016
+ *     reserved-slugs guard) so it cannot collide with any user-facing slug.
+ *   - `name` is human-readable for SOC reviewers grepping the audit table.
+ *
+ * Other invariants preserved by ADR-022 (still true):
+ *   - No super-admin `users` row in this tenant. Platform admins live in
+ *     `platform_admins`.
+ *   - No constituents / campaigns / donations are seeded under this id.
+ *   - Customer-facing tenant lookups exclude `status = 'archived'`.
  */
-async function archiveLegacyPlatformTenant(): Promise<void> {
-  const LEGACY_PLATFORM_TENANT_ID = "00000000-0000-0000-0000-0000000000a1";
-  const [legacy] = await db
-    .select({ id: tenants.id, status: tenants.status })
+const PLATFORM_TENANT_ID = "00000000-0000-0000-0000-0000000000a1";
+const PLATFORM_TENANT_SLUG = "__platform__";
+const PLATFORM_TENANT_NAME = "Givernance Platform (sentinel)";
+
+async function ensurePlatformSentinelTenant(): Promise<void> {
+  const [existing] = await db
+    .select({ id: tenants.id, status: tenants.status, slug: tenants.slug })
     .from(tenants)
-    .where(eq(tenants.id, LEGACY_PLATFORM_TENANT_ID));
-  if (!legacy) return;
-  if (legacy.status === "archived") {
-    console.log(
-      `[seed] Legacy platform tenant ${LEGACY_PLATFORM_TENANT_ID} already archived — skipping`,
-    );
+    .where(eq(tenants.id, PLATFORM_TENANT_ID));
+  if (existing) {
+    // Reconcile to the canonical sentinel state in case a previous seed
+    // left it in a different shape. Idempotent on a no-op.
+    if (existing.status !== "archived" || existing.slug !== PLATFORM_TENANT_SLUG) {
+      await db
+        .update(tenants)
+        .set({ status: "archived", slug: PLATFORM_TENANT_SLUG, name: PLATFORM_TENANT_NAME })
+        .where(eq(tenants.id, PLATFORM_TENANT_ID));
+      console.log(
+        `[seed] Reconciled platform sentinel tenant to canonical shape (${PLATFORM_TENANT_ID})`,
+      );
+    } else {
+      console.log(`[seed] Platform sentinel tenant present (${PLATFORM_TENANT_ID})`);
+    }
     return;
   }
-  await db
-    .update(tenants)
-    .set({ status: "archived" })
-    .where(eq(tenants.id, LEGACY_PLATFORM_TENANT_ID));
-  console.warn(
-    `[seed] Archived legacy platform tenant ${LEGACY_PLATFORM_TENANT_ID} (ADR-022). It remains in the DB for history but is invisible to listing endpoints.`,
+  await db.insert(tenants).values({
+    id: PLATFORM_TENANT_ID,
+    name: PLATFORM_TENANT_NAME,
+    slug: PLATFORM_TENANT_SLUG,
+    plan: "starter",
+    status: "archived",
+  });
+  console.log(
+    `[seed] Created platform sentinel tenant ${PLATFORM_TENANT_ID} (audit FK target only).`,
   );
 }
 
@@ -482,7 +512,7 @@ async function seedDemoTenant(): Promise<void> {
 
 async function main() {
   console.log("[seed] Starting Givernance dev seed…");
-  await archiveLegacyPlatformTenant();
+  await ensurePlatformSentinelTenant();
   const orgId = await findOrCreateTenant();
   await seedPlatformAdmin();
   await seedOrgData(orgId);

--- a/packages/api/scripts/seed.ts
+++ b/packages/api/scripts/seed.ts
@@ -1,37 +1,58 @@
 /**
- * Development database seed — populates the `givernance` tenant with
- * realistic but fake constituents, campaigns, and donations so the
- * frontend (issue #41, PR-B2) has data to render.
+ * Development database seed — populates the "Givernance Demo NPO" tenant
+ * with realistic but fake constituents, campaigns, and donations so the
+ * frontend (issue #41, PR-B2) has data to render, plus a second empty
+ * tenant ("Demo Workspace") that exists purely as an impersonation
+ * playground.
  *
  * Run with:
  *   pnpm --filter @givernance/api run db:seed
  *
- * Tenant invariant: the row with id = TENANT_ID is the authoritative
- * "givernance" tenant. This matches the seeded Keycloak user's `org_id`
- * attribute (see `infra/keycloak/realm-givernance.json`). If a pre-existing
- * tenant holds the slug under a different id (e.g. created via the signup
- * flow), its slug is renamed to free the fixture slot rather than reused —
- * this prevents Keycloak/DB id drift that otherwise yields 404s on
- * tenant-scoped admin routes. Constituents/campaigns/donations are
- * inserted fresh on every run. Intended for local dev only — never run
- * against production.
+ * Tenancy layout (ADR-022):
+ *   - **Demo NPO** (`…c1`) — realistic data; the operator practises support
+ *     scenarios here. This is a regular customer tenant, not a platform
+ *     tenant, so org-admins inside it are valid impersonation targets.
+ *   - **Demo Workspace** (`…b1`) — empty tenant with three pre-seeded users
+ *     (org_admin / user / viewer) for clean-flow impersonation testing.
+ *   - **Super-admin** lands in `platform_admins` (no `org_id`, no tenant
+ *     row). The Keycloak side keeps the "Givernance Platform" Organization
+ *     with `org_id` attribute `…a1` for the OIDC mapper, but no app-DB
+ *     `tenants` row exists at that id by design.
+ *
+ * If a pre-existing tenant holds the Demo NPO slug under a different id
+ * (e.g. created via the signup flow), its slug is renamed to free the
+ * fixture slot rather than reused — this prevents id drift that otherwise
+ * yields 404s on tenant-scoped admin routes. Constituents/campaigns/donations
+ * are inserted fresh on every run. Intended for local dev only — never
+ * run against production.
  */
 
-import { campaigns, constituents, donations, tenants, users } from "@givernance/shared/schema";
-import { eq } from "drizzle-orm";
-import { db, withTenantContext } from "../src/lib/db.js";
+import {
+  campaigns,
+  constituents,
+  donations,
+  platformAdmins,
+  tenants,
+  users,
+} from "@givernance/shared/schema";
+import { and, eq, isNull } from "drizzle-orm";
+import { db, systemDb, withTenantContext } from "../src/lib/db.js";
 
 const TENANT_SLUG = "givernance";
 const TENANT_NAME = "Givernance Demo NPO";
-/** Fixed UUID referenced by the seeded Keycloak user's `org_id` attribute. */
-const TENANT_ID = "00000000-0000-0000-0000-0000000000a1";
+/**
+ * Fresh UUID for "Givernance Demo NPO" — a regular customer tenant that
+ * holds the seeded realistic data. Deliberately NOT `…a1` (which is the
+ * Keycloak platform Organization's `org_id` attribute, no longer mirrored
+ * in `tenants`; ADR-022).
+ */
+const TENANT_ID = "00000000-0000-0000-0000-0000000000c1";
 
 /**
- * Second dev tenant used to test impersonation flows. The `PLATFORM_TENANT_ID`
- * security guard in `impersonation-service.ts` rejects targets in the
- * platform tenant, so we need at least one non-platform tenant with real
- * users for the operator to practise against. UUID is deliberately distant
- * from `TENANT_ID` so it's obvious in test fixtures and audit logs.
+ * Second dev tenant — empty impersonation playground. Three pre-seeded
+ * users in distinct roles so the operator can practise pure-impersonation
+ * vs delegation flows without the noise of realistic data. Distinct UUID
+ * (`…b1`) so it's obvious in fixtures and audit logs.
  */
 const DEMO_TENANT_ID = "00000000-0000-0000-0000-0000000000b1";
 const DEMO_TENANT_SLUG = "givernance-demo";
@@ -61,12 +82,13 @@ const DEMO_USERS = [
   },
 ] as const;
 /**
- * Fixed Keycloak `sub` for the seeded super-admin user. Pinned to the
- * `id` field on `admin@givernance.org` in `infra/keycloak/realm-givernance.json`.
- * The `users` row inserted below carries this in `keycloak_id` so that
- * `GET /v1/users/me` (which inner-joins `users` ↔ `tenants` on the JWT
- * `sub` + `org_id`) resolves a real row for the super admin and the sidebar
- * renders the tenant name instead of the placeholder.
+ * Fixed Keycloak `sub` for the seeded super-admin (ADR-022). Pinned to
+ * the `id` field on `admin@givernance.org` in
+ * `infra/keycloak/realm-givernance.json`. The `platform_admins` row inserted
+ * below carries this in `keycloak_id` so that `GET /v1/users/me` resolves
+ * the platform-admin profile when the super-admin logs in. Platform admins
+ * have no `users` row and no tenant binding — their identity surface is
+ * disjoint from tenant members by invariant.
  */
 const ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-000000000ad1";
 const ADMIN_EMAIL = "admin@givernance.org";
@@ -211,10 +233,8 @@ function emailFromName(first: string, last: string, suffix: number): string {
 }
 
 async function findOrCreateTenant(): Promise<string> {
-  // The seeded Keycloak user's `org_id` attribute points at TENANT_ID
-  // (see infra/keycloak/realm-givernance.json). Lookup must be by id, not
-  // by slug, so signup-created tenants sharing the slug don't win the lookup
-  // and leave the Keycloak user orphaned.
+  // Lookup must be by id, not by slug, so signup-created tenants sharing
+  // the slug don't win the lookup and leave the seed misaligned.
   const [byId] = await db.select().from(tenants).where(eq(tenants.id, TENANT_ID));
   if (byId) {
     console.log(`[seed] Reusing tenant ${TENANT_SLUG} (${byId.id})`);
@@ -249,6 +269,35 @@ async function findOrCreateTenant(): Promise<string> {
 
   console.log(`[seed] Created tenant ${TENANT_SLUG} (${created.id})`);
   return created.id;
+}
+
+/**
+ * Best-effort cleanup of the legacy `…a1` synthetic platform tenant that
+ * pre-ADR-022 seeds created. If a developer pulls this branch with their
+ * existing `pnpm db:seed` state, the old row will still be present —
+ * archive it (ADR cascading) so it's invisible to listing endpoints
+ * without touching its history. New seeds skip this entirely.
+ */
+async function archiveLegacyPlatformTenant(): Promise<void> {
+  const LEGACY_PLATFORM_TENANT_ID = "00000000-0000-0000-0000-0000000000a1";
+  const [legacy] = await db
+    .select({ id: tenants.id, status: tenants.status })
+    .from(tenants)
+    .where(eq(tenants.id, LEGACY_PLATFORM_TENANT_ID));
+  if (!legacy) return;
+  if (legacy.status === "archived") {
+    console.log(
+      `[seed] Legacy platform tenant ${LEGACY_PLATFORM_TENANT_ID} already archived — skipping`,
+    );
+    return;
+  }
+  await db
+    .update(tenants)
+    .set({ status: "archived" })
+    .where(eq(tenants.id, LEGACY_PLATFORM_TENANT_ID));
+  console.warn(
+    `[seed] Archived legacy platform tenant ${LEGACY_PLATFORM_TENANT_ID} (ADR-022). It remains in the DB for history but is invisible to listing endpoints.`,
+  );
 }
 
 function buildConstituent(index: number) {
@@ -342,33 +391,53 @@ async function seedOrgData(orgId: string) {
 }
 
 /**
- * Idempotently seed a `users` row for the super-admin so `GET /v1/users/me`
- * can resolve a row when admin@givernance.org logs in. The Keycloak realm
- * import creates the user on the IdP side; the application DB needs a
- * matching row keyed on `keycloak_id` for the sidebar / org switcher to work.
+ * Idempotently seed a `platform_admins` row for the super-admin so
+ * `GET /v1/users/me` can resolve a profile when admin@givernance.org logs
+ * in (ADR-022). The Keycloak realm import creates the user on the IdP
+ * side; the application DB needs a matching `platform_admins` row keyed
+ * on `keycloak_id` for the sidebar / chrome to render.
+ *
+ * Also detects-and-soft-deletes any legacy `users` row that pre-ADR-022
+ * seeds may have inserted for the super-admin in the synthetic platform
+ * tenant — soft-delete preserves the audit history while making the row
+ * invisible to listing endpoints. New seeds skip this entirely.
  */
-async function seedAdminUser(orgId: string): Promise<void> {
-  const [existing] = await db
+async function seedPlatformAdmin(): Promise<void> {
+  // Soft-delete any legacy `users` row from a pre-ADR-022 seed.
+  const legacyUsers = await systemDb
     .select({ id: users.id })
     .from(users)
-    .where(eq(users.keycloakId, ADMIN_KEYCLOAK_ID))
+    .where(and(eq(users.keycloakId, ADMIN_KEYCLOAK_ID), isNull(users.deletedAt)))
+    .limit(1);
+  if (legacyUsers.length > 0) {
+    await systemDb
+      .update(users)
+      .set({ deletedAt: new Date(), keycloakId: null })
+      .where(eq(users.keycloakId, ADMIN_KEYCLOAK_ID));
+    console.warn(
+      `[seed] Soft-deleted legacy admin user row (keycloakId=${ADMIN_KEYCLOAK_ID}) — ADR-022 moves super-admins to platform_admins.`,
+    );
+  }
+
+  const [existing] = await systemDb
+    .select({ id: platformAdmins.id })
+    .from(platformAdmins)
+    .where(
+      and(eq(platformAdmins.keycloakId, ADMIN_KEYCLOAK_ID), isNull(platformAdmins.deletedAt)),
+    )
     .limit(1);
   if (existing) {
-    console.log(`[seed] Admin user already present (keycloakId=${ADMIN_KEYCLOAK_ID})`);
+    console.log(`[seed] Platform admin already present (keycloakId=${ADMIN_KEYCLOAK_ID})`);
     return;
   }
 
-  await withTenantContext(orgId, async (tx) => {
-    await tx.insert(users).values({
-      orgId,
-      email: ADMIN_EMAIL,
-      firstName: ADMIN_FIRST_NAME,
-      lastName: ADMIN_LAST_NAME,
-      role: "org_admin",
-      keycloakId: ADMIN_KEYCLOAK_ID,
-    });
+  await systemDb.insert(platformAdmins).values({
+    email: ADMIN_EMAIL,
+    firstName: ADMIN_FIRST_NAME,
+    lastName: ADMIN_LAST_NAME,
+    keycloakId: ADMIN_KEYCLOAK_ID,
   });
-  console.log(`[seed] Inserted admin user ${ADMIN_EMAIL}`);
+  console.log(`[seed] Inserted platform admin ${ADMIN_EMAIL}`);
 }
 
 /**
@@ -413,8 +482,9 @@ async function seedDemoTenant(): Promise<void> {
 
 async function main() {
   console.log("[seed] Starting Givernance dev seed…");
+  await archiveLegacyPlatformTenant();
   const orgId = await findOrCreateTenant();
-  await seedAdminUser(orgId);
+  await seedPlatformAdmin();
   await seedOrgData(orgId);
   await seedDemoTenant();
   console.log("[seed] Done.");

--- a/packages/api/src/lib/keycloak-admin.ts
+++ b/packages/api/src/lib/keycloak-admin.ts
@@ -248,9 +248,47 @@ export interface KeycloakAdminClient {
   createIdentityProvider(idp: KeycloakIdentityProvider): Promise<void>;
   deleteIdentityProvider(alias: string): Promise<void>;
 
+  // Realm-role assignment (issue #254 — platform admin CRUD)
+  /**
+   * Look up a realm role by name and return its id + name. Returns null if
+   * the role doesn't exist. The id is required by `assignRealmRoleToUser`
+   * because Keycloak's `POST /users/{id}/role-mappings/realm` body needs
+   * BOTH `id` and `name` fields populated — sending name-only is silently
+   * rejected on KC 26.
+   */
+  getRealmRole(name: string): Promise<{ id: string; name: string } | null>;
+  /**
+   * Assign a realm role to a user. Idempotent on the KC side — assigning
+   * an already-held role is a 204 no-op.
+   */
+  assignRealmRoleToUser(userId: string, role: { id: string; name: string }): Promise<void>;
+  /**
+   * Trigger a Keycloak required-actions email (e.g. UPDATE_PASSWORD). The
+   * user clicks the link in their inbox and KC walks them through the
+   * required actions — for UPDATE_PASSWORD that means setting a new
+   * password. Lifespan defaults to KC's realm setting; pass `lifespanSec`
+   * to override per call.
+   */
+  sendExecuteActionsEmail(
+    userId: string,
+    actions: ExecuteAction[],
+    opts?: { lifespanSec?: number; clientId?: string; redirectUri?: string },
+  ): Promise<void>;
+
   // Test hooks
   _circuitState(): "closed" | "open" | "half-open";
 }
+
+/**
+ * Required-actions Keycloak supports out-of-the-box. We only use
+ * UPDATE_PASSWORD today (issue #254) but the type is open so the same
+ * helper covers a future "verify email" or "configure TOTP" flow.
+ */
+export type ExecuteAction =
+  | "UPDATE_PASSWORD"
+  | "VERIFY_EMAIL"
+  | "CONFIGURE_TOTP"
+  | "UPDATE_PROFILE";
 
 /**
  * Create a Keycloak Admin API client. Factory style (not a singleton) so tests
@@ -693,6 +731,42 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
         value: password,
         temporary: false,
       });
+    },
+
+    getRealmRole: async (name) => {
+      try {
+        const role = await adminRequest<{ id: string; name: string } | null>(
+          "GET",
+          `/roles/${e(name)}`,
+        );
+        return role && role.id && role.name ? { id: role.id, name: role.name } : null;
+      } catch (err) {
+        // 404 = role doesn't exist; surface as null instead of throwing so
+        // callers can decide how to handle (typically: build error message).
+        if (err instanceof KeycloakAdminError && err.status === 404) return null;
+        throw err;
+      }
+    },
+
+    assignRealmRoleToUser: async (userId, role) => {
+      // KC 26 expects an ARRAY of {id,name} on this POST. Idempotent on KC's
+      // side — re-assigning an already-held role is a 204 no-op.
+      await adminRequest<void>("POST", `/users/${e(userId)}/role-mappings/realm`, [
+        { id: role.id, name: role.name },
+      ]);
+    },
+
+    sendExecuteActionsEmail: async (userId, actions, opts) => {
+      // Path: PUT /admin/realms/{realm}/users/{id}/execute-actions-email
+      // Body: ["UPDATE_PASSWORD", ...]
+      // Optional query params: client_id, redirect_uri, lifespan (seconds).
+      const params = new URLSearchParams();
+      if (opts?.clientId) params.set("client_id", opts.clientId);
+      if (opts?.redirectUri) params.set("redirect_uri", opts.redirectUri);
+      if (opts?.lifespanSec) params.set("lifespan", String(opts.lifespanSec));
+      const qs = params.toString();
+      const path = `/users/${e(userId)}/execute-actions-email${qs ? `?${qs}` : ""}`;
+      await adminRequest<void>("PUT", path, actions);
     },
 
     setUserAttributes: async (userId, attributes) => {

--- a/packages/api/src/lib/keycloak-admin.ts
+++ b/packages/api/src/lib/keycloak-admin.ts
@@ -87,6 +87,15 @@ export interface CreateUserInput {
   password: string;
   emailVerified?: boolean;
   /**
+   * When `true`, KC marks the credential as temporary so the user must
+   * UPDATE_PASSWORD on first login regardless of any email-delivery
+   * outcome. Defense-in-depth for flows that rely on the
+   * `sendExecuteActionsEmail` follow-up step (issue #254 platform-admin
+   * create). Default `false` for backward compatibility with the existing
+   * signup / invitation paths that set the user's chosen password.
+   */
+  temporary?: boolean;
+  /**
    * Realm-user profile attributes set at creation time. Keycloak emits
    * configured ones (e.g. `org_id`, `role`) into the access/ID/userinfo token
    * via `oidc-usermodel-attribute-mapper` on the `organization` client scope —
@@ -643,7 +652,15 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
       await adminRequest<void>("POST", `/organizations/${e(orgId)}/identity-providers`, { alias });
     },
 
-    createUser: async ({ email, firstName, lastName, password, emailVerified, attributes }) => {
+    createUser: async ({
+      email,
+      firstName,
+      lastName,
+      password,
+      emailVerified,
+      temporary,
+      attributes,
+    }) => {
       const normalisedEmail = email.trim().toLowerCase();
       try {
         const out = await adminRequest<KeycloakUser & { __locationHeader?: string }>(
@@ -656,7 +673,7 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
             lastName,
             enabled: true,
             emailVerified: emailVerified ?? false,
-            credentials: [{ type: "password", value: password, temporary: false }],
+            credentials: [{ type: "password", value: password, temporary: temporary ?? false }],
             ...(attributes ? { attributes } : {}),
           },
         );

--- a/packages/api/src/modules/admin/impersonation-service.ts
+++ b/packages/api/src/modules/admin/impersonation-service.ts
@@ -13,8 +13,13 @@
  */
 
 import { createHash } from "node:crypto";
-import { PLATFORM_TENANT_ID } from "@givernance/shared/constants";
-import { auditLogs, impersonationSessions, tenants, users } from "@givernance/shared/schema";
+import {
+  auditLogs,
+  impersonationSessions,
+  platformAdmins,
+  tenants,
+  users,
+} from "@givernance/shared/schema";
 import type { ImpersonationModeName } from "@givernance/shared/types";
 import { and, desc, eq, gt, isNull, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
@@ -66,16 +71,17 @@ export class ImpersonationServiceError extends Error {
 export async function startSession(input: StartSessionInput): Promise<StartSessionResult> {
   const target = await resolveTarget(input.targetUserId);
 
-  // Reject impersonating any user who belongs to the platform tenant
-  // (super-admins live there). The `users.role` enum has no `super_admin`
-  // value — that role is realm-level only — so the structural signal is
-  // the target's `org_id`. Nested operator-on-operator impersonation
-  // breaks the audit chain and has no legitimate support use case.
-  if (target.orgId === PLATFORM_TENANT_ID) {
+  // Reject impersonating any platform admin (ADR-022). Nested
+  // operator-on-operator impersonation breaks the audit chain and has no
+  // legitimate support use case. Platform admins are a first-class
+  // identity surface (`platform_admins` table) — disjoint from `users`
+  // by invariant — so a normal customer-tenant member can no longer
+  // structurally collide with a Givernance staffer.
+  if (await isPlatformAdmin(target.keycloakId)) {
     throw new ImpersonationServiceError(
       400,
       "TARGET_NESTED_SUPER_ADMIN",
-      "Cannot impersonate a platform user; nested impersonation is forbidden.",
+      "Cannot impersonate a platform admin; nested impersonation is forbidden.",
     );
   }
 
@@ -206,6 +212,22 @@ interface ResolvedTarget {
   orgId: string;
   role: string;
   email: string;
+}
+
+/**
+ * Returns true if the given Keycloak `sub` corresponds to an active
+ * `platform_admins` row (ADR-022). Used by the impersonation guard to
+ * refuse operator-on-operator nesting. Single indexed lookup against the
+ * BYPASSRLS pool — `platform_admins` has no RLS policy and the migration
+ * REVOKEs the app role's access (0034_platform_admins.sql).
+ */
+async function isPlatformAdmin(keycloakId: string): Promise<boolean> {
+  const rows = await systemDb
+    .select({ id: platformAdmins.id })
+    .from(platformAdmins)
+    .where(and(eq(platformAdmins.keycloakId, keycloakId), isNull(platformAdmins.deletedAt)))
+    .limit(1);
+  return rows.length > 0;
 }
 
 async function resolveTarget(targetUserId: string): Promise<ResolvedTarget> {
@@ -359,8 +381,9 @@ export async function listSessions(opts: ListSessionsOptions = {}) {
 /**
  * Picker-scoped user search for the start-impersonation form (super-admin
  * only). Cross-tenant by definition; runs through `systemDb` (BYPASSRLS)
- * since super-admin operates outside any tenant context. Excludes
- * platform-tenant users (they can't be impersonated — see startSession).
+ * since super-admin operates outside any tenant context. Platform admins
+ * (ADR-022) live in `platform_admins`, not `users`, so they are
+ * structurally absent from the picker — no filter needed.
  */
 export interface ImpersonationTargetCandidate {
   id: string;
@@ -380,11 +403,11 @@ export async function searchTargets(filters: {
   limit?: number;
 }): Promise<ImpersonationTargetCandidate[]> {
   const limit = Math.min(Math.max(filters.limit ?? 20, 1), 50);
-  // The picker shows every active user; the platform-tenant block lives at
-  // start-session time (`startSession` rejects with 400 + the
-  // TARGET_NESTED_SUPER_ADMIN code). Filtering it out here would zero out
-  // the picker in dev environments where the demo tenant shares the
-  // platform UUID (see packages/api/scripts/seed.ts).
+  // The picker shows every active tenant user. Platform admins live in
+  // `platform_admins` (ADR-022) and are structurally absent from `users`,
+  // so no filter is needed here. The defense-in-depth check at start-time
+  // (`isPlatformAdmin`) still rejects with TARGET_NESTED_SUPER_ADMIN if a
+  // future code path ever crosses the surfaces.
   const conditions = [isNull(users.deletedAt)];
 
   if (filters.tenantId) {
@@ -445,10 +468,8 @@ export async function searchTargets(filters: {
 
 /**
  * Lightweight tenant list for the picker — every non-archived tenant.
- * We deliberately do NOT exclude the platform tenant here: the
- * start-session guard already blocks targets in it, and excluding it
- * would zero out the picker in dev where the demo tenant happens to
- * share the platform UUID.
+ * Post-ADR-022 there is no synthetic platform tenant: every tenant in
+ * `tenants` is a real customer tenant, and no filter is required.
  */
 export async function listTenantsForPicker(
   q?: string,

--- a/packages/api/src/modules/admin/platform-admins-routes.ts
+++ b/packages/api/src/modules/admin/platform-admins-routes.ts
@@ -1,0 +1,343 @@
+/**
+ * Platform-admin CRUD API (issue #254).
+ *
+ * Endpoints (RBAC: super_admin only — non-super-admins get 404 per
+ * `requireSuperAdmin`'s anti-disclosure posture):
+ *
+ *   GET    /v1/admin/platform-admins                  — list (sort/filter/paginate).
+ *   GET    /v1/admin/platform-admins/:id              — detail.
+ *   POST   /v1/admin/platform-admins                  — create + KC provisioning + UPDATE_PASSWORD email.
+ *   PATCH  /v1/admin/platform-admins/:id              — rename (firstName / lastName).
+ *   POST   /v1/admin/platform-admins/:id/reset-password — re-trigger UPDATE_PASSWORD email.
+ *   DELETE /v1/admin/platform-admins/:id              — soft-delete + KC user delete + blocklist.
+ *
+ * Errors are RFC 9457 Problem Details. The service throws typed
+ * `PlatformAdminServiceError` instances; this module maps them to HTTP
+ * status + a fixed `detail` so test fixtures can lock the body shape
+ * (per the project memory "lock RFC 9457 body shape on at least one test
+ * per error path").
+ *
+ * IP + user-agent are hashed/captured for `audit_logs.ip_hash` and
+ * `audit_logs.user_agent` so a SOC reviewer can correlate an account
+ * change with a specific operator session.
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { requireSuperAdmin } from "../../lib/guards.js";
+import { DataResponse, ErrorResponses, problemDetail, UuidSchema } from "../../lib/schemas.js";
+import { hashIp } from "./impersonation-service.js";
+import {
+  createPlatformAdmin,
+  getPlatformAdminById,
+  listPlatformAdmins,
+  PLATFORM_ADMIN_SORT_FIELDS,
+  PlatformAdminServiceError,
+  type PlatformAdminSortField,
+  type PlatformAdminSortOrder,
+  resetPlatformAdminPassword,
+  softDeletePlatformAdmin,
+  updatePlatformAdminName,
+} from "./platform-admins-service.js";
+
+// ─── Schemas ────────────────────────────────────────────────────────────────
+
+const PlatformAdminIdParams = Type.Object({ id: UuidSchema });
+
+const SortFieldSchema = Type.Union(PLATFORM_ADMIN_SORT_FIELDS.map((v) => Type.Literal(v)));
+const SortOrderSchema = Type.Union([Type.Literal("asc"), Type.Literal("desc")]);
+
+const ListQuery = Type.Object({
+  q: Type.Optional(Type.String({ maxLength: 255 })),
+  includeDeleted: Type.Optional(Type.Boolean({ default: false })),
+  sort: Type.Optional(SortFieldSchema),
+  order: Type.Optional(SortOrderSchema),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200, default: 50 })),
+  offset: Type.Optional(Type.Integer({ minimum: 0, default: 0 })),
+});
+
+const PlatformAdminSchema = Type.Object({
+  id: UuidSchema,
+  keycloakId: Type.Union([Type.String(), Type.Null()]),
+  email: Type.String(),
+  firstName: Type.String(),
+  lastName: Type.String(),
+  lastLoginAt: Type.Union([Type.String(), Type.Null()]),
+  deletedAt: Type.Union([Type.String(), Type.Null()]),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+});
+
+const ListResponse = Type.Object({
+  data: Type.Array(PlatformAdminSchema),
+  meta: Type.Object({
+    total: Type.Integer(),
+    limit: Type.Integer(),
+    offset: Type.Integer(),
+  }),
+});
+
+const CreateBody = Type.Object({
+  email: Type.String({ format: "email", minLength: 3, maxLength: 255 }),
+  firstName: Type.String({ minLength: 1, maxLength: 255 }),
+  lastName: Type.String({ minLength: 1, maxLength: 255 }),
+});
+
+const UpdateBody = Type.Object(
+  {
+    firstName: Type.String({ minLength: 1, maxLength: 255 }),
+    lastName: Type.String({ minLength: 1, maxLength: 255 }),
+  },
+  { minProperties: 1, additionalProperties: false },
+);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function serialize(row: {
+  id: string;
+  keycloakId: string | null;
+  email: string;
+  firstName: string;
+  lastName: string;
+  lastLoginAt: Date | null;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}) {
+  return {
+    id: row.id,
+    keycloakId: row.keycloakId,
+    email: row.email,
+    firstName: row.firstName,
+    lastName: row.lastName,
+    lastLoginAt: row.lastLoginAt?.toISOString() ?? null,
+    deletedAt: row.deletedAt?.toISOString() ?? null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function mapErrorToProblem(err: PlatformAdminServiceError) {
+  return problemDetail(err.status, mapTitle(err.status), err.message);
+}
+
+function mapTitle(status: number): string {
+  if (status === 400) return "Bad Request";
+  if (status === 404) return "Not Found";
+  if (status === 409) return "Conflict";
+  if (status === 502) return "Bad Gateway";
+  return "Error";
+}
+
+function actorContext(request: FastifyRequest) {
+  return {
+    actorKeycloakId: request.auth?.userId ?? "",
+    ipHash: hashIp(request.ip),
+    userAgent: request.headers["user-agent"] ?? null,
+  };
+}
+
+// ─── Routes ─────────────────────────────────────────────────────────────────
+
+export async function platformAdminsRoutes(app: FastifyInstance) {
+  /** GET /v1/admin/platform-admins — list with sort/filter/paginate */
+  app.get(
+    "/admin/platform-admins",
+    {
+      preHandler: requireSuperAdmin,
+      schema: {
+        tags: ["Admin", "Platform Admins"],
+        querystring: ListQuery,
+        response: {
+          200: ListResponse,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request) => {
+      const q = request.query as {
+        q?: string;
+        includeDeleted?: boolean;
+        sort?: PlatformAdminSortField;
+        order?: PlatformAdminSortOrder;
+        limit?: number;
+        offset?: number;
+      };
+      const limit = q.limit ?? 50;
+      const offset = q.offset ?? 0;
+      const result = await listPlatformAdmins({
+        q: q.q,
+        includeDeleted: q.includeDeleted ?? false,
+        sort: q.sort ?? "createdAt",
+        order: q.order ?? "desc",
+        limit,
+        offset,
+      });
+      return {
+        data: result.rows.map(serialize),
+        meta: { total: result.total, limit, offset },
+      };
+    },
+  );
+
+  /** GET /v1/admin/platform-admins/:id — detail */
+  app.get(
+    "/admin/platform-admins/:id",
+    {
+      preHandler: requireSuperAdmin,
+      schema: {
+        tags: ["Admin", "Platform Admins"],
+        params: PlatformAdminIdParams,
+        response: {
+          200: DataResponse(PlatformAdminSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const row = await getPlatformAdminById(id);
+      if (!row) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Platform admin not found."));
+      }
+      return { data: serialize(row) };
+    },
+  );
+
+  /** POST /v1/admin/platform-admins — create + KC provisioning */
+  app.post(
+    "/admin/platform-admins",
+    {
+      preHandler: requireSuperAdmin,
+      schema: {
+        tags: ["Admin", "Platform Admins"],
+        body: CreateBody,
+        response: {
+          201: DataResponse(PlatformAdminSchema),
+          ...ErrorResponses,
+          409: ErrorResponses[404],
+          502: ErrorResponses[404],
+        },
+      },
+    },
+    async (request, reply) => {
+      const body = request.body as { email: string; firstName: string; lastName: string };
+      try {
+        const row = await createPlatformAdmin({
+          email: body.email,
+          firstName: body.firstName,
+          lastName: body.lastName,
+          ...actorContext(request),
+        });
+        return reply.status(201).send({ data: serialize(row) });
+      } catch (err) {
+        if (err instanceof PlatformAdminServiceError) {
+          return reply.status(err.status).send(mapErrorToProblem(err));
+        }
+        request.log.error({ err }, "platform-admins: create failed");
+        throw err;
+      }
+    },
+  );
+
+  /** PATCH /v1/admin/platform-admins/:id — rename */
+  app.patch(
+    "/admin/platform-admins/:id",
+    {
+      preHandler: requireSuperAdmin,
+      schema: {
+        tags: ["Admin", "Platform Admins"],
+        params: PlatformAdminIdParams,
+        body: UpdateBody,
+        response: {
+          200: DataResponse(PlatformAdminSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const body = request.body as { firstName: string; lastName: string };
+      try {
+        const row = await updatePlatformAdminName({
+          id,
+          firstName: body.firstName,
+          lastName: body.lastName,
+          ...actorContext(request),
+        });
+        return { data: serialize(row) };
+      } catch (err) {
+        if (err instanceof PlatformAdminServiceError) {
+          return reply.status(err.status).send(mapErrorToProblem(err));
+        }
+        request.log.error({ err }, "platform-admins: rename failed");
+        throw err;
+      }
+    },
+  );
+
+  /** POST /v1/admin/platform-admins/:id/reset-password — re-send password reset email */
+  app.post(
+    "/admin/platform-admins/:id/reset-password",
+    {
+      preHandler: requireSuperAdmin,
+      schema: {
+        tags: ["Admin", "Platform Admins"],
+        params: PlatformAdminIdParams,
+        response: {
+          204: Type.Null(),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      try {
+        await resetPlatformAdminPassword({
+          id,
+          ...actorContext(request),
+        });
+        return reply.status(204).send();
+      } catch (err) {
+        if (err instanceof PlatformAdminServiceError) {
+          return reply.status(err.status).send(mapErrorToProblem(err));
+        }
+        request.log.error({ err }, "platform-admins: reset-password failed");
+        throw err;
+      }
+    },
+  );
+
+  /** DELETE /v1/admin/platform-admins/:id — soft-delete + KC delete + blocklist */
+  app.delete(
+    "/admin/platform-admins/:id",
+    {
+      preHandler: requireSuperAdmin,
+      schema: {
+        tags: ["Admin", "Platform Admins"],
+        params: PlatformAdminIdParams,
+        response: {
+          204: Type.Null(),
+          ...ErrorResponses,
+          400: ErrorResponses[404],
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      try {
+        await softDeletePlatformAdmin({
+          id,
+          ...actorContext(request),
+        });
+        return reply.status(204).send();
+      } catch (err) {
+        if (err instanceof PlatformAdminServiceError) {
+          return reply.status(err.status).send(mapErrorToProblem(err));
+        }
+        request.log.error({ err }, "platform-admins: soft-delete failed");
+        throw err;
+      }
+    },
+  );
+}

--- a/packages/api/src/modules/admin/platform-admins-routes.ts
+++ b/packages/api/src/modules/admin/platform-admins-routes.ts
@@ -28,8 +28,10 @@ import { requireSuperAdmin } from "../../lib/guards.js";
 import { DataResponse, ErrorResponses, problemDetail, UuidSchema } from "../../lib/schemas.js";
 import { hashIp } from "./impersonation-service.js";
 import {
-  createPlatformAdmin,
+  acceptPlatformAdminInvitation,
   getPlatformAdminById,
+  getPlatformAdminInvitationByToken,
+  invitePlatformAdmin,
   listPlatformAdmins,
   PLATFORM_ADMIN_SORT_FIELDS,
   PlatformAdminServiceError,
@@ -90,6 +92,31 @@ const UpdateBody = Type.Object(
   },
   { minProperties: 1, additionalProperties: false },
 );
+
+const InvitationSummarySchema = Type.Object({
+  invitationId: UuidSchema,
+  email: Type.String(),
+  firstName: Type.String(),
+  lastName: Type.String(),
+  expiresAt: Type.String(),
+});
+
+/**
+ * Public invitation read shape — surfaces only what the accept page needs
+ * to render. NEVER returns the token itself or any internal-id fields.
+ */
+const PublicInvitationSchema = Type.Object({
+  email: Type.String(),
+  firstName: Type.String(),
+  lastName: Type.String(),
+  expiresAt: Type.String(),
+});
+
+const AcceptBody = Type.Object({
+  password: Type.String({ minLength: 12, maxLength: 255 }),
+  firstName: Type.String({ minLength: 1, maxLength: 255 }),
+  lastName: Type.String({ minLength: 1, maxLength: 255 }),
+});
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -204,7 +231,18 @@ export async function platformAdminsRoutes(app: FastifyInstance) {
     },
   );
 
-  /** POST /v1/admin/platform-admins — create + KC provisioning */
+  /**
+   * POST /v1/admin/platform-admins — issue an invitation.
+   *
+   * Post fix-commit-4 refactor (PR #253): no longer creates the KC user
+   * synchronously. Inserts an invitations row + outbox event; the worker
+   * sends the email; the invitee accepts on the public page which then
+   * does the KC create + role + Org + platform_admins insert.
+   *
+   * Response shape: returns the invitation id + email + expiresAt so the
+   * UI can render "invitation sent" without leaking identity-surface
+   * state before the invitee accepts.
+   */
   app.post(
     "/admin/platform-admins",
     {
@@ -213,7 +251,7 @@ export async function platformAdminsRoutes(app: FastifyInstance) {
         tags: ["Admin", "Platform Admins"],
         body: CreateBody,
         response: {
-          201: DataResponse(PlatformAdminSchema),
+          201: DataResponse(InvitationSummarySchema),
           ...ErrorResponses,
           409: ErrorResponses[404],
           502: ErrorResponses[404],
@@ -223,18 +261,110 @@ export async function platformAdminsRoutes(app: FastifyInstance) {
     async (request, reply) => {
       const body = request.body as { email: string; firstName: string; lastName: string };
       try {
-        const row = await createPlatformAdmin({
+        const result = await invitePlatformAdmin({
           email: body.email,
           firstName: body.firstName,
           lastName: body.lastName,
           ...actorContext(request),
+        });
+        return reply.status(201).send({
+          data: {
+            invitationId: result.invitationId,
+            email: result.email,
+            firstName: result.firstName,
+            lastName: result.lastName,
+            expiresAt: result.expiresAt.toISOString(),
+          },
+        });
+      } catch (err) {
+        if (err instanceof PlatformAdminServiceError) {
+          return reply.status(err.status).send(mapErrorToProblem(err));
+        }
+        request.log.error({ err }, "platform-admins: invite failed");
+        throw err;
+      }
+    },
+  );
+
+  // ─── Public accept flow ──────────────────────────────────────────────────
+  //
+  // Two public routes — no JWT required — that handle the invitee's
+  // session-conflict-friendly acceptance. The web app's
+  // `/admin/platform-admins/accept?token=...` page reads from these.
+  //
+  // Anti-enumeration: every state that isn't "pending + unaccepted +
+  // unexpired" returns 404 with the same body. The token itself is the
+  // capability — a valid token reveals invitee email + name; an invalid
+  // one reveals nothing.
+
+  /** GET /v1/public/platform-admins/invitations/:token — read invitation */
+  app.get(
+    "/public/platform-admins/invitations/:token",
+    {
+      schema: {
+        tags: ["Public", "Platform Admins"],
+        params: Type.Object({ token: Type.String({ format: "uuid" }) }),
+        response: {
+          200: DataResponse(PublicInvitationSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { token } = request.params as { token: string };
+      const invite = await getPlatformAdminInvitationByToken(token);
+      if (!invite) {
+        return reply
+          .status(404)
+          .send(
+            problemDetail(404, "Not Found", "Invitation not found, expired, or already accepted."),
+          );
+      }
+      return {
+        data: {
+          email: invite.email,
+          firstName: invite.firstName,
+          lastName: invite.lastName,
+          expiresAt: invite.expiresAt.toISOString(),
+        },
+      };
+    },
+  );
+
+  /** POST /v1/public/platform-admins/invitations/:token/accept — accept + provision KC */
+  app.post(
+    "/public/platform-admins/invitations/:token/accept",
+    {
+      schema: {
+        tags: ["Public", "Platform Admins"],
+        params: Type.Object({ token: Type.String({ format: "uuid" }) }),
+        body: AcceptBody,
+        response: {
+          201: DataResponse(PlatformAdminSchema),
+          ...ErrorResponses,
+          409: ErrorResponses[404],
+          502: ErrorResponses[404],
+        },
+      },
+    },
+    async (request, reply) => {
+      const { token } = request.params as { token: string };
+      const body = request.body as { password: string; firstName: string; lastName: string };
+      try {
+        const row = await acceptPlatformAdminInvitation({
+          token,
+          password: body.password,
+          firstName: body.firstName,
+          lastName: body.lastName,
+          ipHash: hashIp(request.ip),
+          userAgent: request.headers["user-agent"] ?? null,
         });
         return reply.status(201).send({ data: serialize(row) });
       } catch (err) {
         if (err instanceof PlatformAdminServiceError) {
           return reply.status(err.status).send(mapErrorToProblem(err));
         }
-        request.log.error({ err }, "platform-admins: create failed");
+        request.log.error({ err }, "platform-admins: accept failed");
         throw err;
       }
     },

--- a/packages/api/src/modules/admin/platform-admins-service.ts
+++ b/packages/api/src/modules/admin/platform-admins-service.ts
@@ -70,22 +70,24 @@ const PASSWORD_RESET_LIFESPAN_SEC = 4 * 60 * 60;
 const SUPER_ADMIN_ROLE_NAME = "super_admin";
 const PLATFORM_ORG_ALIAS = "platform";
 
-/**
- * Keycloak client id the password-reset email link is associated with.
- * KC uses this to render the "Back to application" button on the
- * success page after UPDATE_PASSWORD completes.
- *
- * We deliberately do NOT pass `redirect_uri` to `sendExecuteActionsEmail`:
- * KC's inline redirect-after-action depends on the transient `KC_RESTART`
- * cookie, which has its own short TTL independent of the email
- * `lifespan` and gets dropped by some browser cookie policies. Without
- * `redirect_uri`, KC shows a standard success page with the "Back to
- * application" button (sourced from this client's `baseUrl` /
- * redirectUris), and the user starts a fresh OIDC code flow from there.
- * Robust against the KC_RESTART cookie issue. (Caught in dev: PR #253
- * smoke-test feedback.)
- */
-const KC_WEB_CLIENT_ID = "givernance-web";
+// Note on `sendExecuteActionsEmail` parameters:
+//
+// We deliberately pass NEITHER `client_id` NOR `redirect_uri` to KC's
+// `execute-actions-email` endpoint. Both attempt to re-enter an auth
+// flow after the action completes — `redirect_uri` does an inline
+// redirect, and `client_id` triggers a server-side hop to the client's
+// authorize URL. Both require the auth-session cookie KC consumed
+// during UPDATE_PASSWORD to still be present, which is fragile (short
+// TTL, browser cookie policies, multi-tab).
+//
+// Without either param, KC ends the flow on the standard "info" page
+// (`info.ftl`). The custom Givernance theme renders that page with a
+// stable link to the SPA login that does NOT depend on auth-session
+// state. The user clicks it, lands on the SPA, kicks off a fresh OIDC
+// code flow with their freshly-set password — works every time.
+//
+// Caught in dev: PR #253 smoke-test feedback (KC_RESTART cookie missing
+// after UPDATE_PASSWORD).
 
 // ─── Errors ──────────────────────────────────────────────────────────────────
 
@@ -400,11 +402,8 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
   try {
     await keycloakAdmin().sendExecuteActionsEmail(kcUserId, ["UPDATE_PASSWORD"], {
       lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
-      // `client_id` only — KC's success page after UPDATE_PASSWORD
-      // shows a "Back to application" button pointing at this client's
-      // base URL. See the comment on KC_WEB_CLIENT_ID for why we don't
-      // pass `redirectUri` here.
-      clientId: KC_WEB_CLIENT_ID,
+      // No `clientId` / `redirectUri` — see the comment block above for
+      // why. KC's info.ftl handles the "you're done, go log in" UX.
     });
   } catch (err) {
     emailDeliveryFailed = err as Error;
@@ -514,9 +513,7 @@ export async function resetPlatformAdminPassword(input: ResetPasswordInput): Pro
 
   await keycloakAdmin().sendExecuteActionsEmail(existing.keycloakId!, ["UPDATE_PASSWORD"], {
     lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
-    // Same posture as the create flow — `client_id` only, no
-    // `redirectUri`. See KC_WEB_CLIENT_ID comment.
-    clientId: KC_WEB_CLIENT_ID,
+    // No `clientId` / `redirectUri` — see the create flow's comment.
   });
 
   await systemDb.transaction(async (tx) => {

--- a/packages/api/src/modules/admin/platform-admins-service.ts
+++ b/packages/api/src/modules/admin/platform-admins-service.ts
@@ -43,7 +43,6 @@ import {
 } from "@givernance/shared/schema";
 import { and, asc, desc, eq, ilike, isNotNull, isNull, or, type SQL, sql } from "drizzle-orm";
 import pino from "pino";
-import { env } from "../../env.js";
 import { systemDb } from "../../lib/db.js";
 import { KeycloakUserExistsError, keycloakAdmin } from "../../lib/keycloak-admin.js";
 import { blocklistUser } from "../session/service.js";
@@ -71,17 +70,22 @@ const PASSWORD_RESET_LIFESPAN_SEC = 4 * 60 * 60;
 const SUPER_ADMIN_ROLE_NAME = "super_admin";
 const PLATFORM_ORG_ALIAS = "platform";
 
-/** Keycloak client id the password-reset email link should land on. */
-const KC_WEB_CLIENT_ID = "givernance-web";
-
 /**
- * Where the UPDATE_PASSWORD email link redirects after password set.
- * Resolves from `APP_URL` so dev / staging / prod each land the new admin
- * on the right back-office origin. KC will reject a redirect that isn't
- * registered on `givernance-web` — the realm seed already lists
- * `<APP_URL>/*` for every environment.
+ * Keycloak client id the password-reset email link is associated with.
+ * KC uses this to render the "Back to application" button on the
+ * success page after UPDATE_PASSWORD completes.
+ *
+ * We deliberately do NOT pass `redirect_uri` to `sendExecuteActionsEmail`:
+ * KC's inline redirect-after-action depends on the transient `KC_RESTART`
+ * cookie, which has its own short TTL independent of the email
+ * `lifespan` and gets dropped by some browser cookie policies. Without
+ * `redirect_uri`, KC shows a standard success page with the "Back to
+ * application" button (sourced from this client's `baseUrl` /
+ * redirectUris), and the user starts a fresh OIDC code flow from there.
+ * Robust against the KC_RESTART cookie issue. (Caught in dev: PR #253
+ * smoke-test feedback.)
  */
-const KC_PLATFORM_ADMIN_REDIRECT_URL = `${env.APP_URL.replace(/\/$/, "")}/admin/platform-admins`;
+const KC_WEB_CLIENT_ID = "givernance-web";
 
 // ─── Errors ──────────────────────────────────────────────────────────────────
 
@@ -396,11 +400,11 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
   try {
     await keycloakAdmin().sendExecuteActionsEmail(kcUserId, ["UPDATE_PASSWORD"], {
       lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
-      // Land the new admin on the back-office login page after they
-      // finish the UPDATE_PASSWORD flow (platform review M3). Without
-      // this, KC dumps them on the bare account console.
+      // `client_id` only — KC's success page after UPDATE_PASSWORD
+      // shows a "Back to application" button pointing at this client's
+      // base URL. See the comment on KC_WEB_CLIENT_ID for why we don't
+      // pass `redirectUri` here.
       clientId: KC_WEB_CLIENT_ID,
-      ...(KC_PLATFORM_ADMIN_REDIRECT_URL ? { redirectUri: KC_PLATFORM_ADMIN_REDIRECT_URL } : {}),
     });
   } catch (err) {
     emailDeliveryFailed = err as Error;
@@ -510,6 +514,9 @@ export async function resetPlatformAdminPassword(input: ResetPasswordInput): Pro
 
   await keycloakAdmin().sendExecuteActionsEmail(existing.keycloakId!, ["UPDATE_PASSWORD"], {
     lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
+    // Same posture as the create flow — `client_id` only, no
+    // `redirectUri`. See KC_WEB_CLIENT_ID comment.
+    clientId: KC_WEB_CLIENT_ID,
   });
 
   await systemDb.transaction(async (tx) => {

--- a/packages/api/src/modules/admin/platform-admins-service.ts
+++ b/packages/api/src/modules/admin/platform-admins-service.ts
@@ -328,6 +328,16 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
   // even if the UPDATE_PASSWORD email-trigger path fails afterward, the
   // user CANNOT log in with it — KC will force them through the password
   // reset on first login regardless. Defense-in-depth (security review m4).
+  //
+  // The `org_id` user attribute is what makes the JWT carry a top-level
+  // `org_id` claim — `verifyKeycloakJwt` (api + web) requires it on every
+  // token. The seeded `admin@givernance.org` has the same attribute set
+  // in `realm-givernance.json`. Without this, a freshly-invited admin
+  // logs in successfully on the KC side but every Givernance route 401s
+  // with `missing_org_id` (caught in dev: PR #253 review feedback).
+  // The matching `role` attribute is set for parity with the seed; the
+  // realm role `super_admin` is what actually drives RBAC, so the value
+  // here is informational.
   let kcUserId: string;
   try {
     const out = await keycloakAdmin().createUser({
@@ -339,6 +349,10 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
       password: cryptoRandomPassword(),
       emailVerified: true,
       temporary: true,
+      attributes: {
+        org_id: [PLATFORM_AUDIT_ORG_ID],
+        role: ["org_admin"],
+      },
     });
     kcUserId = out.id;
   } catch (err) {

--- a/packages/api/src/modules/admin/platform-admins-service.ts
+++ b/packages/api/src/modules/admin/platform-admins-service.ts
@@ -42,9 +42,13 @@ import {
   users,
 } from "@givernance/shared/schema";
 import { and, asc, desc, eq, ilike, isNotNull, isNull, or, type SQL, sql } from "drizzle-orm";
+import pino from "pino";
+import { env } from "../../env.js";
 import { systemDb } from "../../lib/db.js";
 import { KeycloakUserExistsError, keycloakAdmin } from "../../lib/keycloak-admin.js";
 import { blocklistUser } from "../session/service.js";
+
+const logger = pino({ name: "platform-admins-service" });
 
 /**
  * The Keycloak "Givernance Platform" Organization's `org_id` attribute —
@@ -66,6 +70,18 @@ const PASSWORD_RESET_LIFESPAN_SEC = 4 * 60 * 60;
 
 const SUPER_ADMIN_ROLE_NAME = "super_admin";
 const PLATFORM_ORG_ALIAS = "platform";
+
+/** Keycloak client id the password-reset email link should land on. */
+const KC_WEB_CLIENT_ID = "givernance-web";
+
+/**
+ * Where the UPDATE_PASSWORD email link redirects after password set.
+ * Resolves from `APP_URL` so dev / staging / prod each land the new admin
+ * on the right back-office origin. KC will reject a redirect that isn't
+ * registered on `givernance-web` — the realm seed already lists
+ * `<APP_URL>/*` for every environment.
+ */
+const KC_PLATFORM_ADMIN_REDIRECT_URL = `${env.APP_URL.replace(/\/$/, "")}/admin/platform-admins`;
 
 // ─── Errors ──────────────────────────────────────────────────────────────────
 
@@ -204,11 +220,22 @@ export async function listPlatformAdmins(filters: ListFilters): Promise<ListResu
   return { rows, total: totalRow[0]?.count ?? 0 };
 }
 
-export async function getPlatformAdminById(id: string): Promise<PlatformAdminRow | null> {
+export async function getPlatformAdminById(
+  id: string,
+  opts: { includeDeleted?: boolean } = {},
+): Promise<PlatformAdminRow | null> {
+  const conditions: SQL[] = [eq(platformAdmins.id, id)];
+  if (!opts.includeDeleted) {
+    // Default: hide offboarded admins from the detail surface — same
+    // posture as `listPlatformAdmins`. Routes that explicitly want the
+    // historical record opt in via `includeDeleted: true`. Closes the
+    // data-architect minor #6.
+    conditions.push(isNull(platformAdmins.deletedAt));
+  }
   const [row] = await systemDb
     .select()
     .from(platformAdmins)
-    .where(eq(platformAdmins.id, id))
+    .where(and(...conditions))
     .limit(1);
   return row ?? null;
 }
@@ -297,19 +324,21 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     );
   }
 
-  // Provision the KC user. The temporary password is a high-entropy
-  // throwaway — the user never sees it because we immediately trigger
-  // UPDATE_PASSWORD which forces them to set their own.
+  // Provision the KC user. The throwaway password is `temporary: true` so
+  // even if the UPDATE_PASSWORD email-trigger path fails afterward, the
+  // user CANNOT log in with it — KC will force them through the password
+  // reset on first login regardless. Defense-in-depth (security review m4).
   let kcUserId: string;
   try {
     const out = await keycloakAdmin().createUser({
       email,
       firstName: input.firstName,
       lastName: input.lastName,
-      // 32 bytes of entropy in hex — never logged or transmitted; immediately
-      // overwritten by the UPDATE_PASSWORD flow before first login.
+      // 32 bytes of entropy in hex — never logged or transmitted; KC will
+      // force UPDATE_PASSWORD on first login because `temporary: true`.
       password: cryptoRandomPassword(),
       emailVerified: true,
+      temporary: true,
     });
     kcUserId = out.id;
   } catch (err) {
@@ -323,22 +352,44 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     throw err;
   }
 
-  // From here on, any failure must compensate by deleting the KC user
-  // we just created — otherwise the realm accumulates orphans.
+  // Phase 1 — assign the realm role + Org membership. Both are required
+  // for the user to function as a super-admin. A mid-flight failure here
+  // means the user has no super-admin authority and must be rolled back
+  // (otherwise the realm accumulates orphans with partial state).
   try {
     await keycloakAdmin().assignRealmRoleToUser(kcUserId, role);
     await keycloakAdmin().attachUserToOrg(org.id, kcUserId);
-    await keycloakAdmin().sendExecuteActionsEmail(kcUserId, ["UPDATE_PASSWORD"], {
-      lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
-    });
   } catch (err) {
-    await compensatingKcDelete(kcUserId);
+    await compensatingKcDelete(kcUserId, "role/org-assignment-failed");
     if (err instanceof PlatformAdminServiceError) throw err;
     throw new PlatformAdminServiceError(
       502,
       "KEYCLOAK_FAILURE",
       `Keycloak provisioning failed mid-flight; rolled back the realm user. Original error: ${(err as Error).message}`,
     );
+  }
+
+  // Phase 2 — trigger the UPDATE_PASSWORD email. The user is fully
+  // provisioned at this point (role + Org membership). If the email
+  // delivery fails (transient SMTP, KC 5xx) we DO NOT roll back the KC
+  // user — instead we proceed to insert the `platform_admins` row and
+  // surface a 502 to the operator. The operator can re-trigger the
+  // email via `POST /v1/admin/platform-admins/:id/reset-password`
+  // (platform review M2). Tearing down the KC user on a transient SMTP
+  // outage would force the operator to recreate the row with a new
+  // `platform_admins.id` and lose audit-trail continuity.
+  let emailDeliveryFailed: Error | null = null;
+  try {
+    await keycloakAdmin().sendExecuteActionsEmail(kcUserId, ["UPDATE_PASSWORD"], {
+      lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
+      // Land the new admin on the back-office login page after they
+      // finish the UPDATE_PASSWORD flow (platform review M3). Without
+      // this, KC dumps them on the bare account console.
+      clientId: KC_WEB_CLIENT_ID,
+      ...(KC_PLATFORM_ADMIN_REDIRECT_URL ? { redirectUri: KC_PLATFORM_ADMIN_REDIRECT_URL } : {}),
+    });
+  } catch (err) {
+    emailDeliveryFailed = err as Error;
   }
 
   // DB row + audit in one transaction — if either fails the KC user is
@@ -372,6 +423,19 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     });
     return row;
   });
+
+  // Surface the email-delivery failure as a 502 AFTER the row is in place,
+  // so the operator gets a structured signal but the row exists for them
+  // to retry against via `/reset-password`. The compensating-delete path
+  // is NOT taken here — the user has a temporary password they cannot
+  // use, the role + Org are correct, the row is queryable.
+  if (emailDeliveryFailed) {
+    throw new PlatformAdminServiceError(
+      502,
+      "KEYCLOAK_FAILURE",
+      `Platform admin provisioned (id=${created.id}), but the UPDATE_PASSWORD email failed to send. Use POST /v1/admin/platform-admins/${created.id}/reset-password to retry. Original error: ${emailDeliveryFailed.message}`,
+    );
+  }
 
   return created;
 }
@@ -454,9 +518,12 @@ export async function resetPlatformAdminPassword(input: ResetPasswordInput): Pro
 // ─── Soft-delete ─────────────────────────────────────────────────────────────
 
 export async function softDeletePlatformAdmin(input: SoftDeleteInput): Promise<void> {
-  const existing = await getActiveAdminOrThrow(input.id);
-
-  if (existing.keycloakId === input.actorKeycloakId) {
+  // Self-removal guard — fast pre-flight before opening a transaction.
+  // The active-row + last-admin checks happen inside the SERIALIZABLE
+  // transaction below so two concurrent operators racing on the
+  // second-to-last admin can't both pass the count gate.
+  const preflight = await getActiveAdminOrThrow(input.id);
+  if (preflight.keycloakId === input.actorKeycloakId) {
     throw new PlatformAdminServiceError(
       400,
       "SELF_REMOVAL_FORBIDDEN",
@@ -464,55 +531,104 @@ export async function softDeletePlatformAdmin(input: SoftDeleteInput): Promise<v
     );
   }
 
-  // Last-admin guard. Refuse the soft-delete that would leave zero
-  // active platform admins. Counting on `systemDb` is fine — the table
-  // is platform-level and has no RLS.
-  const counts = await systemDb
-    .select({ count: sql<number>`COUNT(*)::int` })
-    .from(platformAdmins)
-    .where(isNull(platformAdmins.deletedAt));
-  const activeCount = counts[0]?.count ?? 0;
-  if (activeCount <= 1) {
-    throw new PlatformAdminServiceError(
-      400,
-      "LAST_ADMIN_FORBIDDEN",
-      "Cannot remove the last active platform admin. At least one super-admin must remain.",
+  // Atomic delete + last-admin guard + audit insert in one SERIALIZABLE
+  // transaction (security review M1, QA M4, data architect #13). The
+  // count + UPDATE happen against the same snapshot; concurrent removers
+  // serialize on the platform_admins lock and the loser sees activeCount
+  // = 1 and gets a 400.
+  //
+  // We also row-lock the target admin's row (`FOR UPDATE`) so two
+  // operators racing on the SAME id can't both enter — Postgres queues
+  // them and the second sees `keycloak_id = null` after the first commits.
+  const targetKeycloakId = await systemDb.transaction(
+    async (tx) => {
+      // Re-read the row INSIDE the tx, locked. If two requests target the
+      // same admin id, the second blocks until the first commits, then sees
+      // the post-soft-delete state and exits with NOT_FOUND.
+      const lockedRows = await tx.execute<{
+        keycloak_id: string;
+      }>(sql`
+        SELECT keycloak_id
+        FROM platform_admins
+        WHERE id = ${input.id}
+          AND deleted_at IS NULL
+          AND keycloak_id IS NOT NULL
+        FOR UPDATE
+      `);
+      const locked = lockedRows.rows[0];
+      if (!locked) {
+        throw new PlatformAdminServiceError(
+          404,
+          "NOT_FOUND",
+          "Platform admin not found or already removed.",
+        );
+      }
+      const lockedKeycloakId = locked.keycloak_id;
+
+      // Atomic last-admin guard — count active rows under the same
+      // tx-snapshot. If we're the second-to-last and a sibling tx also
+      // targets the last admin, one of us serializes and aborts.
+      const counts = await tx
+        .select({ count: sql<number>`COUNT(*)::int` })
+        .from(platformAdmins)
+        .where(isNull(platformAdmins.deletedAt));
+      const activeCount = counts[0]?.count ?? 0;
+      if (activeCount <= 1) {
+        throw new PlatformAdminServiceError(
+          400,
+          "LAST_ADMIN_FORBIDDEN",
+          "Cannot remove the last active platform admin. At least one super-admin must remain.",
+        );
+      }
+
+      // Soft-delete the row + null keycloak_id (ADR-021 mirror). Audit
+      // row inside the same tx so audit chain and lifecycle land
+      // atomically.
+      await tx
+        .update(platformAdmins)
+        .set({ deletedAt: new Date(), keycloakId: null, updatedAt: new Date() })
+        .where(eq(platformAdmins.id, input.id));
+
+      await tx.execute(
+        sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
+      );
+      await tx.insert(auditLogs).values({
+        orgId: PLATFORM_AUDIT_ORG_ID,
+        userId: lockedKeycloakId,
+        actorId: input.actorKeycloakId,
+        action: "platform_admin.removed",
+        resourceType: "platform_admin",
+        resourceId: input.id,
+        ipHash: input.ipHash,
+        userAgent: input.userAgent ?? undefined,
+      });
+      return lockedKeycloakId;
+    },
+    { isolationLevel: "serializable" },
+  );
+
+  // Token revocation lives outside the DB tx — a Redis or KC failure
+  // here is independent of the soft-delete commit. The blocklist is set
+  // before KC.deleteUser so the ADR-021 zero-second propagation window
+  // closes immediately, even if the KC delete fails. If KC.deleteUser
+  // fails (5xx), the row is already soft-deleted in the DB and the sub
+  // is on the blocklist — operator can manually clean up the realm.
+  try {
+    await blocklistUser(targetKeycloakId);
+  } catch (err) {
+    logger.error(
+      { err, kcSub: targetKeycloakId, adminId: input.id },
+      "platform_admin: soft-delete committed but blocklist write failed; access revocation falls back to KC user delete",
     );
   }
-
-  // Mirror the user-lifecycle pattern (ADR-021): blocklist the KC `sub`
-  // first (zero-second propagation), then KC delete, then DB soft-delete +
-  // audit.
-  await blocklistUser(existing.keycloakId!);
-  await keycloakAdmin().deleteUser(existing.keycloakId!);
-
-  await systemDb.transaction(async (tx) => {
-    await tx
-      .update(platformAdmins)
-      .set({
-        deletedAt: new Date(),
-        // ADR-021 mirror — null the keycloak_id so a stale FK can never
-        // resolve to a live KC user. The audit row still references the
-        // historical sub via `auditLogs.userId`.
-        keycloakId: null,
-        updatedAt: new Date(),
-      })
-      .where(eq(platformAdmins.id, input.id));
-
-    await tx.execute(
-      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
+  try {
+    await keycloakAdmin().deleteUser(targetKeycloakId);
+  } catch (err) {
+    logger.error(
+      { err, kcSub: targetKeycloakId, adminId: input.id },
+      "platform_admin: soft-delete committed but KC user delete failed; orphan KC user remains, manual cleanup required",
     );
-    await tx.insert(auditLogs).values({
-      orgId: PLATFORM_AUDIT_ORG_ID,
-      userId: existing.keycloakId,
-      actorId: input.actorKeycloakId,
-      action: "platform_admin.removed",
-      resourceType: "platform_admin",
-      resourceId: input.id,
-      ipHash: input.ipHash,
-      userAgent: input.userAgent ?? undefined,
-    });
-  });
+  }
 }
 
 // ─── Internals ───────────────────────────────────────────────────────────────
@@ -539,14 +655,25 @@ async function getActiveAdminOrThrow(id: string): Promise<PlatformAdminRow> {
   return row;
 }
 
-async function compensatingKcDelete(kcUserId: string): Promise<void> {
+async function compensatingKcDelete(kcUserId: string, reason: string): Promise<void> {
   try {
     await keycloakAdmin().deleteUser(kcUserId);
-  } catch {
+    logger.warn(
+      { kcUserId, reason },
+      "platform_admin: compensating KC user delete after partial create",
+    );
+  } catch (err) {
     // Don't bubble — the original failure is what the caller should see.
-    // The route layer logs the original error with full context; the
-    // compensating delete is best-effort. If it fails, the realm keeps
-    // an orphan user that an operator can clean up manually.
+    // BUT we MUST log the orphan loud so SOC has a structured signal:
+    // a KC user with `super_admin` realm role + platform Org membership
+    // exists with no `platform_admins` row and the operator was told the
+    // create failed. This is the worst-case scenario this module can
+    // produce; an unattended orphan retains realm-level super-admin
+    // authority. (Platform review C1, security review m2.)
+    logger.error(
+      { err, kcUserId, reason },
+      "platform_admin: ORPHAN — compensating KC delete failed; realm has a super_admin user with no DB row, manual cleanup required",
+    );
   }
 }
 

--- a/packages/api/src/modules/admin/platform-admins-service.ts
+++ b/packages/api/src/modules/admin/platform-admins-service.ts
@@ -1,0 +1,558 @@
+/**
+ * Service layer for the platform-admin CRUD API (issue #254).
+ *
+ * Platform admins are Givernance staff with the Keycloak realm role
+ * `super_admin` — modeled as a first-class identity surface disjoint from
+ * tenant `users` (ADR-022). This module owns:
+ *
+ *   - List/detail with sort + filter + pagination.
+ *   - Create — direct Keycloak provisioning: createUser → assign
+ *     `super_admin` realm role → attach to the "Givernance Platform"
+ *     Organization → trigger UPDATE_PASSWORD email so the new admin sets
+ *     their own password on first login.
+ *   - Rename — first/last name only (email rotation is out of scope).
+ *   - Reset-password — re-trigger the UPDATE_PASSWORD email.
+ *   - Soft-delete — write `deleted_at`, blocklist the Keycloak `sub`
+ *     (zero-second propagation per ADR-021), and hard-delete the realm
+ *     user so the email is freed and refresh tokens are dropped.
+ *
+ * Guards (non-negotiable):
+ *   - Self-removal disallowed (operator cannot soft-delete their own row).
+ *   - Last-admin guard: refuse a soft-delete that would leave zero active
+ *     platform admins.
+ *   - Identity invariant: refuse a create whose email matches an existing
+ *     `users` row (active or soft-deleted) — a Keycloak person is either
+ *     a platform admin or a tenant member, never both.
+ *
+ * Audit: every mutation writes an `audit_logs` row with the operator's
+ * `actor_id`. The lifecycle actions are `platform_admin.created`,
+ * `platform_admin.renamed`, `platform_admin.password_reset_sent`,
+ * `platform_admin.removed`. Audit rows are written under the *legacy*
+ * platform-org id (`PLATFORM_AUDIT_ORG_ID`) so an SOC reviewer can grep
+ * one tenant id for the full platform-admin lifecycle without having to
+ * UNION across customer tenants. The id is a Keycloak-side constant; no
+ * `tenants` row exists at it (ADR-022).
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+  auditLogs,
+  platformAdmins,
+  type platformAdmins as platformAdminsTable,
+  users,
+} from "@givernance/shared/schema";
+import { and, asc, desc, eq, ilike, isNotNull, isNull, or, type SQL, sql } from "drizzle-orm";
+import { systemDb } from "../../lib/db.js";
+import { KeycloakUserExistsError, keycloakAdmin } from "../../lib/keycloak-admin.js";
+import { blocklistUser } from "../session/service.js";
+
+/**
+ * The Keycloak "Givernance Platform" Organization's `org_id` attribute —
+ * mirrors the realm-import seed (`infra/keycloak/realm-givernance.json`).
+ * It is **not** an app-DB tenant id (ADR-022 removed the synthetic
+ * `tenants` row). Used only as the `audit_logs.org_id` value for the
+ * platform-admin lifecycle so a reviewer can scope a query to the
+ * platform tenant id and see every super-admin lifecycle event.
+ */
+const PLATFORM_AUDIT_ORG_ID = "00000000-0000-0000-0000-0000000000a1";
+
+/**
+ * Lifespan for the UPDATE_PASSWORD email link (4 hours). Long enough that
+ * a new admin can set up at their own pace; short enough that a leaked
+ * email cannot be redeemed days later. The realm-level default is
+ * typically 12h; we pin a tighter value here.
+ */
+const PASSWORD_RESET_LIFESPAN_SEC = 4 * 60 * 60;
+
+const SUPER_ADMIN_ROLE_NAME = "super_admin";
+const PLATFORM_ORG_ALIAS = "platform";
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+export class PlatformAdminServiceError extends Error {
+  readonly status: number;
+  readonly code:
+    | "NOT_FOUND"
+    | "EMAIL_TAKEN_BY_TENANT_USER"
+    | "EMAIL_TAKEN_BY_KEYCLOAK"
+    | "EMAIL_TAKEN_BY_PLATFORM_ADMIN"
+    | "SELF_REMOVAL_FORBIDDEN"
+    | "LAST_ADMIN_FORBIDDEN"
+    | "KEYCLOAK_ROLE_MISSING"
+    | "KEYCLOAK_ORG_MISSING"
+    | "KEYCLOAK_FAILURE";
+  constructor(status: number, code: PlatformAdminServiceError["code"], message: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export type PlatformAdminRow = typeof platformAdminsTable.$inferSelect;
+
+export const PLATFORM_ADMIN_SORT_FIELDS = [
+  "lastName",
+  "email",
+  "createdAt",
+  "lastLoginAt",
+] as const;
+export type PlatformAdminSortField = (typeof PLATFORM_ADMIN_SORT_FIELDS)[number];
+export type PlatformAdminSortOrder = "asc" | "desc";
+
+export interface ListFilters {
+  q?: string;
+  /** When `true`, include soft-deleted rows. Default false. */
+  includeDeleted?: boolean;
+  sort: PlatformAdminSortField;
+  order: PlatformAdminSortOrder;
+  limit: number;
+  offset: number;
+}
+
+export interface ListResult {
+  rows: PlatformAdminRow[];
+  total: number;
+}
+
+export interface CreateInput {
+  email: string;
+  firstName: string;
+  lastName: string;
+  /** Keycloak `sub` of the operator performing the create. */
+  actorKeycloakId: string;
+  /** Hash of operator IP + user-agent for audit_logs. */
+  ipHash: string | null;
+  userAgent: string | null;
+}
+
+export interface UpdateNameInput {
+  id: string;
+  firstName: string;
+  lastName: string;
+  actorKeycloakId: string;
+  ipHash: string | null;
+  userAgent: string | null;
+}
+
+export interface ResetPasswordInput {
+  id: string;
+  actorKeycloakId: string;
+  ipHash: string | null;
+  userAgent: string | null;
+}
+
+export interface SoftDeleteInput {
+  id: string;
+  /** Keycloak `sub` of the operator. The self-removal guard compares against this. */
+  actorKeycloakId: string;
+  ipHash: string | null;
+  userAgent: string | null;
+}
+
+// ─── List + detail ───────────────────────────────────────────────────────────
+
+export async function listPlatformAdmins(filters: ListFilters): Promise<ListResult> {
+  const conditions: SQL[] = [];
+  if (!filters.includeDeleted) {
+    conditions.push(isNull(platformAdmins.deletedAt));
+  }
+  if (filters.q) {
+    const raw = filters.q.trim();
+    if (raw.length > 0) {
+      const like = `%${raw}%`;
+      const lowered = `%${raw.toLowerCase()}%`;
+      conditions.push(
+        or(
+          ilike(platformAdmins.firstName, like),
+          ilike(platformAdmins.lastName, like),
+          sql`lower(${platformAdmins.email}) LIKE ${lowered}`,
+        )!,
+      );
+    }
+  }
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const orderColumn = (() => {
+    switch (filters.sort) {
+      case "lastName":
+        return platformAdmins.lastName;
+      case "email":
+        return platformAdmins.email;
+      case "lastLoginAt":
+        return platformAdmins.lastLoginAt;
+      case "createdAt":
+        return platformAdmins.createdAt;
+    }
+  })();
+
+  const orderClause = filters.order === "asc" ? asc(orderColumn) : desc(orderColumn);
+
+  const [rows, totalRow] = await Promise.all([
+    systemDb
+      .select()
+      .from(platformAdmins)
+      .where(whereClause)
+      .orderBy(orderClause)
+      .limit(filters.limit)
+      .offset(filters.offset),
+    systemDb.select({ count: sql<number>`COUNT(*)::int` }).from(platformAdmins).where(whereClause),
+  ]);
+
+  return { rows, total: totalRow[0]?.count ?? 0 };
+}
+
+export async function getPlatformAdminById(id: string): Promise<PlatformAdminRow | null> {
+  const [row] = await systemDb
+    .select()
+    .from(platformAdmins)
+    .where(eq(platformAdmins.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
+// ─── Create ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a new platform admin end-to-end:
+ *
+ *   1. Identity-invariant check — refuse if the email belongs to an
+ *      existing `users` row (active OR soft-deleted; ADR-022).
+ *   2. Pre-flight Keycloak realm-role lookup — fail fast if `super_admin`
+ *      is missing rather than half-create the user.
+ *   3. Pre-flight Keycloak Organization lookup — fail fast if the platform
+ *      Org is missing.
+ *   4. `kcAdmin.createUser` — random temporary password (the user never
+ *      sees it; UPDATE_PASSWORD email forces them to set their own).
+ *   5. `kcAdmin.assignRealmRoleToUser(super_admin)`.
+ *   6. `kcAdmin.attachUserToOrg(platformOrgId, kcUserId)`.
+ *   7. `kcAdmin.sendExecuteActionsEmail(["UPDATE_PASSWORD"])`.
+ *   8. INSERT `platform_admins` row + `audit_logs.platform_admin.created`
+ *      in a single transaction.
+ *
+ * On any KC-side failure after step 4, attempts a best-effort
+ * compensating `deleteUser` so the realm doesn't keep an orphan account.
+ * If the compensating delete itself fails, the orphan is logged so an
+ * operator can clean it up — we don't rollback further than KC will let
+ * us. The DB insert is the last step, so a DB failure leaves a fully
+ * provisioned KC user but no app row; the operator retries with the same
+ * email and the create call fails on the KC `getUserByEmail` lookup. We
+ * return a typed `EMAIL_TAKEN_BY_KEYCLOAK` so the route can surface a
+ * recoverable 409.
+ */
+export async function createPlatformAdmin(input: CreateInput): Promise<PlatformAdminRow> {
+  const email = input.email.trim().toLowerCase();
+
+  // Identity invariant — ADR-022. A Keycloak person is either a platform
+  // admin or a tenant member, never both. Reject regardless of soft-delete
+  // status because the email is reserved by an existing identity.
+  const [collisionUser] = await systemDb
+    .select({ id: users.id, deletedAt: users.deletedAt })
+    .from(users)
+    .where(sql`lower(${users.email}) = ${email}`)
+    .limit(1);
+  if (collisionUser) {
+    throw new PlatformAdminServiceError(
+      409,
+      "EMAIL_TAKEN_BY_TENANT_USER",
+      "This email belongs to a tenant member; the same Keycloak person cannot be both a platform admin and a tenant user (ADR-022).",
+    );
+  }
+
+  // Same-table collision: another active platform admin holds this email.
+  const [collisionAdmin] = await systemDb
+    .select({ id: platformAdmins.id })
+    .from(platformAdmins)
+    .where(and(sql`lower(${platformAdmins.email}) = ${email}`, isNull(platformAdmins.deletedAt)))
+    .limit(1);
+  if (collisionAdmin) {
+    throw new PlatformAdminServiceError(
+      409,
+      "EMAIL_TAKEN_BY_PLATFORM_ADMIN",
+      "A platform admin already exists with this email.",
+    );
+  }
+
+  // Pre-flight KC role + organization. Fail fast before we mutate KC state
+  // — a missing role / org points at a misconfigured realm and is an
+  // operator-visible 502 rather than a half-finished provision.
+  const [role, org] = await Promise.all([
+    keycloakAdmin().getRealmRole(SUPER_ADMIN_ROLE_NAME),
+    keycloakAdmin().getOrganizationByAlias(PLATFORM_ORG_ALIAS),
+  ]);
+  if (!role) {
+    throw new PlatformAdminServiceError(
+      502,
+      "KEYCLOAK_ROLE_MISSING",
+      `Keycloak realm role '${SUPER_ADMIN_ROLE_NAME}' is missing — realm needs re-importing.`,
+    );
+  }
+  if (!org) {
+    throw new PlatformAdminServiceError(
+      502,
+      "KEYCLOAK_ORG_MISSING",
+      `Keycloak Organization with alias '${PLATFORM_ORG_ALIAS}' is missing — realm needs re-importing.`,
+    );
+  }
+
+  // Provision the KC user. The temporary password is a high-entropy
+  // throwaway — the user never sees it because we immediately trigger
+  // UPDATE_PASSWORD which forces them to set their own.
+  let kcUserId: string;
+  try {
+    const out = await keycloakAdmin().createUser({
+      email,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      // 32 bytes of entropy in hex — never logged or transmitted; immediately
+      // overwritten by the UPDATE_PASSWORD flow before first login.
+      password: cryptoRandomPassword(),
+      emailVerified: true,
+    });
+    kcUserId = out.id;
+  } catch (err) {
+    if (err instanceof KeycloakUserExistsError) {
+      throw new PlatformAdminServiceError(
+        409,
+        "EMAIL_TAKEN_BY_KEYCLOAK",
+        "A Keycloak user with this email already exists. If this is an orphan from a previous failed create, an operator must clean it up in Keycloak before retrying.",
+      );
+    }
+    throw err;
+  }
+
+  // From here on, any failure must compensate by deleting the KC user
+  // we just created — otherwise the realm accumulates orphans.
+  try {
+    await keycloakAdmin().assignRealmRoleToUser(kcUserId, role);
+    await keycloakAdmin().attachUserToOrg(org.id, kcUserId);
+    await keycloakAdmin().sendExecuteActionsEmail(kcUserId, ["UPDATE_PASSWORD"], {
+      lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
+    });
+  } catch (err) {
+    await compensatingKcDelete(kcUserId);
+    if (err instanceof PlatformAdminServiceError) throw err;
+    throw new PlatformAdminServiceError(
+      502,
+      "KEYCLOAK_FAILURE",
+      `Keycloak provisioning failed mid-flight; rolled back the realm user. Original error: ${(err as Error).message}`,
+    );
+  }
+
+  // DB row + audit in one transaction — if either fails the KC user is
+  // already provisioned. The `EMAIL_TAKEN_BY_KEYCLOAK` recovery path on
+  // retry handles this case (the operator gets a structured 409 they can
+  // act on instead of a 500 cascade).
+  const created = await systemDb.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(platformAdmins)
+      .values({
+        keycloakId: kcUserId,
+        email,
+        firstName: input.firstName,
+        lastName: input.lastName,
+      })
+      .returning();
+    if (!row) throw new Error("createPlatformAdmin: insert returned no row");
+
+    await tx.execute(
+      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
+    );
+    await tx.insert(auditLogs).values({
+      orgId: PLATFORM_AUDIT_ORG_ID,
+      userId: kcUserId,
+      actorId: input.actorKeycloakId,
+      action: "platform_admin.created",
+      resourceType: "platform_admin",
+      resourceId: row.id,
+      ipHash: input.ipHash,
+      userAgent: input.userAgent ?? undefined,
+    });
+    return row;
+  });
+
+  return created;
+}
+
+// ─── Rename ──────────────────────────────────────────────────────────────────
+
+export async function updatePlatformAdminName(input: UpdateNameInput): Promise<PlatformAdminRow> {
+  const existing = await getActiveAdminOrThrow(input.id);
+
+  await keycloakAdmin().updateUser(existing.keycloakId!, {
+    firstName: input.firstName,
+    lastName: input.lastName,
+  });
+
+  const updated = await systemDb.transaction(async (tx) => {
+    const [row] = await tx
+      .update(platformAdmins)
+      .set({
+        firstName: input.firstName,
+        lastName: input.lastName,
+        updatedAt: new Date(),
+      })
+      .where(eq(platformAdmins.id, input.id))
+      .returning();
+    if (!row) throw new Error("updatePlatformAdminName: update returned no row");
+
+    await tx.execute(
+      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
+    );
+    await tx.insert(auditLogs).values({
+      orgId: PLATFORM_AUDIT_ORG_ID,
+      userId: existing.keycloakId,
+      actorId: input.actorKeycloakId,
+      action: "platform_admin.renamed",
+      resourceType: "platform_admin",
+      resourceId: input.id,
+      oldValues: {
+        firstName: existing.firstName,
+        lastName: existing.lastName,
+      },
+      newValues: {
+        firstName: input.firstName,
+        lastName: input.lastName,
+      },
+      ipHash: input.ipHash,
+      userAgent: input.userAgent ?? undefined,
+    });
+    return row;
+  });
+
+  return updated;
+}
+
+// ─── Reset password ──────────────────────────────────────────────────────────
+
+export async function resetPlatformAdminPassword(input: ResetPasswordInput): Promise<void> {
+  const existing = await getActiveAdminOrThrow(input.id);
+
+  await keycloakAdmin().sendExecuteActionsEmail(existing.keycloakId!, ["UPDATE_PASSWORD"], {
+    lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
+  });
+
+  await systemDb.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
+    );
+    await tx.insert(auditLogs).values({
+      orgId: PLATFORM_AUDIT_ORG_ID,
+      userId: existing.keycloakId,
+      actorId: input.actorKeycloakId,
+      action: "platform_admin.password_reset_sent",
+      resourceType: "platform_admin",
+      resourceId: input.id,
+      ipHash: input.ipHash,
+      userAgent: input.userAgent ?? undefined,
+    });
+  });
+}
+
+// ─── Soft-delete ─────────────────────────────────────────────────────────────
+
+export async function softDeletePlatformAdmin(input: SoftDeleteInput): Promise<void> {
+  const existing = await getActiveAdminOrThrow(input.id);
+
+  if (existing.keycloakId === input.actorKeycloakId) {
+    throw new PlatformAdminServiceError(
+      400,
+      "SELF_REMOVAL_FORBIDDEN",
+      "Operators cannot soft-delete their own platform-admin row. Ask another super-admin.",
+    );
+  }
+
+  // Last-admin guard. Refuse the soft-delete that would leave zero
+  // active platform admins. Counting on `systemDb` is fine — the table
+  // is platform-level and has no RLS.
+  const counts = await systemDb
+    .select({ count: sql<number>`COUNT(*)::int` })
+    .from(platformAdmins)
+    .where(isNull(platformAdmins.deletedAt));
+  const activeCount = counts[0]?.count ?? 0;
+  if (activeCount <= 1) {
+    throw new PlatformAdminServiceError(
+      400,
+      "LAST_ADMIN_FORBIDDEN",
+      "Cannot remove the last active platform admin. At least one super-admin must remain.",
+    );
+  }
+
+  // Mirror the user-lifecycle pattern (ADR-021): blocklist the KC `sub`
+  // first (zero-second propagation), then KC delete, then DB soft-delete +
+  // audit.
+  await blocklistUser(existing.keycloakId!);
+  await keycloakAdmin().deleteUser(existing.keycloakId!);
+
+  await systemDb.transaction(async (tx) => {
+    await tx
+      .update(platformAdmins)
+      .set({
+        deletedAt: new Date(),
+        // ADR-021 mirror — null the keycloak_id so a stale FK can never
+        // resolve to a live KC user. The audit row still references the
+        // historical sub via `auditLogs.userId`.
+        keycloakId: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(platformAdmins.id, input.id));
+
+    await tx.execute(
+      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
+    );
+    await tx.insert(auditLogs).values({
+      orgId: PLATFORM_AUDIT_ORG_ID,
+      userId: existing.keycloakId,
+      actorId: input.actorKeycloakId,
+      action: "platform_admin.removed",
+      resourceType: "platform_admin",
+      resourceId: input.id,
+      ipHash: input.ipHash,
+      userAgent: input.userAgent ?? undefined,
+    });
+  });
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────────
+
+async function getActiveAdminOrThrow(id: string): Promise<PlatformAdminRow> {
+  const [row] = await systemDb
+    .select()
+    .from(platformAdmins)
+    .where(
+      and(
+        eq(platformAdmins.id, id),
+        isNull(platformAdmins.deletedAt),
+        isNotNull(platformAdmins.keycloakId),
+      ),
+    )
+    .limit(1);
+  if (!row) {
+    throw new PlatformAdminServiceError(
+      404,
+      "NOT_FOUND",
+      "Platform admin not found or already removed.",
+    );
+  }
+  return row;
+}
+
+async function compensatingKcDelete(kcUserId: string): Promise<void> {
+  try {
+    await keycloakAdmin().deleteUser(kcUserId);
+  } catch {
+    // Don't bubble — the original failure is what the caller should see.
+    // The route layer logs the original error with full context; the
+    // compensating delete is best-effort. If it fails, the realm keeps
+    // an orphan user that an operator can clean up manually.
+  }
+}
+
+function cryptoRandomPassword(): string {
+  // 32 bytes of entropy → 64 hex chars. Far above any reasonable realm
+  // password policy (the seed realm enforces length(12) and notUsername).
+  // Never logged or surfaced; immediately invalidated by UPDATE_PASSWORD.
+  return randomBytes(32).toString("hex");
+}

--- a/packages/api/src/modules/admin/platform-admins-service.ts
+++ b/packages/api/src/modules/admin/platform-admins-service.ts
@@ -34,14 +34,16 @@
  * `tenants` row exists at it (ADR-022).
  */
 
-import { randomBytes } from "node:crypto";
+import { APP_DEFAULT_LOCALE } from "@givernance/shared/i18n";
 import {
   auditLogs,
+  invitations,
+  outboxEvents,
   platformAdmins,
   type platformAdmins as platformAdminsTable,
   users,
 } from "@givernance/shared/schema";
-import { and, asc, desc, eq, ilike, isNotNull, isNull, or, type SQL, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, ilike, isNotNull, isNull, or, type SQL, sql } from "drizzle-orm";
 import pino from "pino";
 import { systemDb } from "../../lib/db.js";
 import { KeycloakUserExistsError, keycloakAdmin } from "../../lib/keycloak-admin.js";
@@ -246,36 +248,46 @@ export async function getPlatformAdminById(
   return row ?? null;
 }
 
-// ─── Create ──────────────────────────────────────────────────────────────────
+// ─── Invite (create flow, post-PR-#253-smoke-feedback refactor) ──────────────
 
 /**
- * Create a new platform admin end-to-end:
- *
- *   1. Identity-invariant check — refuse if the email belongs to an
- *      existing `users` row (active OR soft-deleted; ADR-022).
- *   2. Pre-flight Keycloak realm-role lookup — fail fast if `super_admin`
- *      is missing rather than half-create the user.
- *   3. Pre-flight Keycloak Organization lookup — fail fast if the platform
- *      Org is missing.
- *   4. `kcAdmin.createUser` — random temporary password (the user never
- *      sees it; UPDATE_PASSWORD email forces them to set their own).
- *   5. `kcAdmin.assignRealmRoleToUser(super_admin)`.
- *   6. `kcAdmin.attachUserToOrg(platformOrgId, kcUserId)`.
- *   7. `kcAdmin.sendExecuteActionsEmail(["UPDATE_PASSWORD"])`.
- *   8. INSERT `platform_admins` row + `audit_logs.platform_admin.created`
- *      in a single transaction.
- *
- * On any KC-side failure after step 4, attempts a best-effort
- * compensating `deleteUser` so the realm doesn't keep an orphan account.
- * If the compensating delete itself fails, the orphan is logged so an
- * operator can clean it up — we don't rollback further than KC will let
- * us. The DB insert is the last step, so a DB failure leaves a fully
- * provisioned KC user but no app row; the operator retries with the same
- * email and the create call fails on the KC `getUserByEmail` lookup. We
- * return a typed `EMAIL_TAKEN_BY_KEYCLOAK` so the route can surface a
- * recoverable 409.
+ * Result of `invitePlatformAdmin`. Returns the invitation id (NOT a
+ * `platform_admins.id` — the row doesn't exist yet) so the caller can
+ * surface "invitation sent" without exposing identity-surface state
+ * before the invitee accepts.
  */
-export async function createPlatformAdmin(input: CreateInput): Promise<PlatformAdminRow> {
+export interface InviteResult {
+  invitationId: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  expiresAt: Date;
+}
+
+/**
+ * Issue an invitation for a new platform admin (issue #254, refactor
+ * fix-commit 4 after KC `execute-actions-email` smoke-test issues).
+ *
+ * Behaviour:
+ *   1. Identity-invariant check — refuse if email belongs to a tenant
+ *      `users` row (ADR-022) or another active platform admin.
+ *   2. Insert an `invitations` row (purpose = `platform_admin_invite`)
+ *      under the platform sentinel tenant with a fresh token.
+ *   3. Emit `platform_admin.invited` to the outbox so the worker sends
+ *      the email out-of-band.
+ *   4. Audit `platform_admin.invited` under the platform sentinel
+ *      tenant.
+ *
+ * The KC user, role assignment, Org membership, and `platform_admins`
+ * row all land at *accept* time (`acceptPlatformAdminInvitation`),
+ * triggered when the invitee submits the password form on the public
+ * accept page. This avoids KC's `execute-actions-email` flow entirely
+ * — which had three compounding issues in dev (KC_RESTART cookie
+ * timeout, broken back-link in `info.ftl`, "already authenticated as
+ * different user" rejection). The Givernance-side accept page handles
+ * the session-conflict UX gracefully, same posture as `team_invite`.
+ */
+export async function invitePlatformAdmin(input: CreateInput): Promise<InviteResult> {
   const email = input.email.trim().toLowerCase();
 
   // Identity invariant — ADR-022. A Keycloak person is either a platform
@@ -294,7 +306,6 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     );
   }
 
-  // Same-table collision: another active platform admin holds this email.
   const [collisionAdmin] = await systemDb
     .select({ id: platformAdmins.id })
     .from(platformAdmins)
@@ -308,9 +319,193 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     );
   }
 
-  // Pre-flight KC role + organization. Fail fast before we mutate KC state
-  // — a missing role / org points at a misconfigured realm and is an
-  // operator-visible 502 rather than a half-finished provision.
+  // Same-table collision on a pending (not-yet-accepted, not-yet-expired)
+  // invitation: don't issue duplicates. The operator can re-trigger the
+  // existing invitation via the (separate) reset-invitation endpoint —
+  // out of scope for this fix.
+  const [pendingInvite] = await systemDb
+    .select({ id: invitations.id })
+    .from(invitations)
+    .where(
+      and(
+        eq(invitations.purpose, "platform_admin_invite"),
+        sql`lower(${invitations.email}) = ${email}`,
+        isNull(invitations.acceptedAt),
+        gt(invitations.expiresAt, new Date()),
+      ),
+    )
+    .limit(1);
+  if (pendingInvite) {
+    throw new PlatformAdminServiceError(
+      409,
+      "EMAIL_TAKEN_BY_PLATFORM_ADMIN",
+      "A pending platform-admin invitation already exists for this email.",
+    );
+  }
+
+  const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
+
+  return systemDb.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(invitations)
+      .values({
+        orgId: PLATFORM_AUDIT_ORG_ID,
+        email,
+        firstName: input.firstName,
+        lastName: input.lastName,
+        // `users.role` enum doesn't have `super_admin`; the realm role
+        // is the source of truth for super-admin RBAC. Stamping
+        // `org_admin` here for parity with team_invite and so the
+        // schema constraint is satisfied. The accept flow ignores it.
+        role: "org_admin",
+        purpose: "platform_admin_invite",
+        expiresAt,
+      })
+      .returning({
+        id: invitations.id,
+        email: invitations.email,
+        firstName: invitations.firstName,
+        lastName: invitations.lastName,
+        expiresAt: invitations.expiresAt,
+      });
+    if (!row) throw new Error("invitePlatformAdmin: insert returned no row");
+
+    // Outbox event → relay → BullMQ → worker `processPlatformAdminInviteEmail`.
+    // Same SEC-7 posture as team_invite: do NOT put the raw token in the
+    // outbox payload — the worker reads it back from the row inside its
+    // own trust boundary.
+    await tx.insert(outboxEvents).values({
+      tenantId: PLATFORM_AUDIT_ORG_ID,
+      type: "platform_admin.invited",
+      payload: {
+        tenantId: PLATFORM_AUDIT_ORG_ID,
+        invitationId: row.id,
+        email: row.email,
+        inviterKeycloakId: input.actorKeycloakId,
+        expiresAt: row.expiresAt.toISOString(),
+        // Locale: platform admins don't have a stored preference at
+        // invite time; default to APP_DEFAULT_LOCALE. The worker can
+        // override at send time if it has a better signal.
+        locale: APP_DEFAULT_LOCALE,
+      },
+    });
+
+    await tx.execute(
+      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
+    );
+    await tx.insert(auditLogs).values({
+      orgId: PLATFORM_AUDIT_ORG_ID,
+      // The invitee's KC sub doesn't exist yet — leave userId null until
+      // the accept flow lands the platform_admins row.
+      userId: null,
+      actorId: input.actorKeycloakId,
+      action: "platform_admin.invited",
+      resourceType: "invitation",
+      resourceId: row.id,
+      newValues: { purpose: "platform_admin_invite" },
+      ipHash: input.ipHash,
+      userAgent: input.userAgent ?? undefined,
+    });
+
+    return {
+      invitationId: row.id,
+      email: row.email,
+      firstName: row.firstName ?? input.firstName,
+      lastName: row.lastName ?? input.lastName,
+      expiresAt: row.expiresAt,
+    };
+  });
+}
+
+const INVITATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ─── Accept (public flow, no auth required) ───────────────────────────────────
+
+export interface InvitationDetail {
+  email: string;
+  firstName: string;
+  lastName: string;
+  expiresAt: Date;
+}
+
+/**
+ * Public read of an invitation by token. Returns enough to render the
+ * accept page; never returns the token itself or any sensitive
+ * metadata. Returns null on missing / expired / accepted so the route
+ * surfaces a single 404 (anti-enumeration of valid token shape).
+ */
+export async function getPlatformAdminInvitationByToken(
+  token: string,
+): Promise<InvitationDetail | null> {
+  const [row] = await systemDb
+    .select({
+      email: invitations.email,
+      firstName: invitations.firstName,
+      lastName: invitations.lastName,
+      acceptedAt: invitations.acceptedAt,
+      expiresAt: invitations.expiresAt,
+    })
+    .from(invitations)
+    .where(and(eq(invitations.token, token), eq(invitations.purpose, "platform_admin_invite")))
+    .limit(1);
+  if (!row) return null;
+  if (row.acceptedAt) return null;
+  if (row.expiresAt.getTime() <= Date.now()) return null;
+  return {
+    email: row.email,
+    firstName: row.firstName ?? "",
+    lastName: row.lastName ?? "",
+    expiresAt: row.expiresAt,
+  };
+}
+
+export interface AcceptInput {
+  token: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  ipHash: string | null;
+  userAgent: string | null;
+}
+
+/**
+ * Accept a platform-admin invitation:
+ *   1. Validate token + state (must be unaccepted + unexpired).
+ *   2. Pre-flight Keycloak realm-role + Organization lookup.
+ *   3. `kcAdmin.createUser` with the invitee's chosen password
+ *      (NOT temporary — they just typed it; KC respects it as their
+ *      working credential).
+ *   4. Assign `super_admin` realm role + attach to platform Org.
+ *   5. INSERT `platform_admins` row + mark invitation accepted +
+ *      audit `platform_admin.created`. All in one transaction.
+ *
+ * Compensating delete on KC failure mirrors the previous create path.
+ */
+export async function acceptPlatformAdminInvitation(input: AcceptInput): Promise<PlatformAdminRow> {
+  // Validate the invitation first — atomic with the eventual
+  // accepted_at write further below to prevent double-accept.
+  const [invite] = await systemDb
+    .select({
+      id: invitations.id,
+      email: invitations.email,
+      acceptedAt: invitations.acceptedAt,
+      expiresAt: invitations.expiresAt,
+    })
+    .from(invitations)
+    .where(
+      and(eq(invitations.token, input.token), eq(invitations.purpose, "platform_admin_invite")),
+    )
+    .limit(1);
+  if (!invite) {
+    throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation not found.");
+  }
+  if (invite.acceptedAt) {
+    throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation has already been accepted.");
+  }
+  if (invite.expiresAt.getTime() <= Date.now()) {
+    throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation has expired.");
+  }
+
   const [role, org] = await Promise.all([
     keycloakAdmin().getRealmRole(SUPER_ADMIN_ROLE_NAME),
     keycloakAdmin().getOrganizationByAlias(PLATFORM_ORG_ALIAS),
@@ -330,32 +525,21 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     );
   }
 
-  // Provision the KC user. The throwaway password is `temporary: true` so
-  // even if the UPDATE_PASSWORD email-trigger path fails afterward, the
-  // user CANNOT log in with it — KC will force them through the password
-  // reset on first login regardless. Defense-in-depth (security review m4).
-  //
-  // The `org_id` user attribute is what makes the JWT carry a top-level
-  // `org_id` claim — `verifyKeycloakJwt` (api + web) requires it on every
-  // token. The seeded `admin@givernance.org` has the same attribute set
-  // in `realm-givernance.json`. Without this, a freshly-invited admin
-  // logs in successfully on the KC side but every Givernance route 401s
-  // with `missing_org_id` (caught in dev: PR #253 review feedback).
-  // The matching `role` attribute is set for parity with the seed; the
-  // realm role `super_admin` is what actually drives RBAC, so the value
-  // here is informational.
+  // KC create with the user's chosen password. NOT temporary — they
+  // just typed it; KC respects it as their working credential.
   let kcUserId: string;
   try {
     const out = await keycloakAdmin().createUser({
-      email,
+      email: invite.email,
       firstName: input.firstName,
       lastName: input.lastName,
-      // 32 bytes of entropy in hex — never logged or transmitted; KC will
-      // force UPDATE_PASSWORD on first login because `temporary: true`.
-      password: cryptoRandomPassword(),
+      password: input.password,
       emailVerified: true,
-      temporary: true,
+      temporary: false,
       attributes: {
+        // Same `org_id` user attribute as the seeded admin so the JWT
+        // carries the flat `org_id` claim that `verifyKeycloakJwt`
+        // requires. (See PR #253 review feedback.)
         org_id: [PLATFORM_AUDIT_ORG_ID],
         role: ["org_admin"],
       },
@@ -372,15 +556,11 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     throw err;
   }
 
-  // Phase 1 — assign the realm role + Org membership. Both are required
-  // for the user to function as a super-admin. A mid-flight failure here
-  // means the user has no super-admin authority and must be rolled back
-  // (otherwise the realm accumulates orphans with partial state).
   try {
     await keycloakAdmin().assignRealmRoleToUser(kcUserId, role);
     await keycloakAdmin().attachUserToOrg(org.id, kcUserId);
   } catch (err) {
-    await compensatingKcDelete(kcUserId, "role/org-assignment-failed");
+    await compensatingKcDelete(kcUserId, "accept-side-effects-failed");
     if (err instanceof PlatformAdminServiceError) throw err;
     throw new PlatformAdminServiceError(
       502,
@@ -389,41 +569,33 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     );
   }
 
-  // Phase 2 — trigger the UPDATE_PASSWORD email. The user is fully
-  // provisioned at this point (role + Org membership). If the email
-  // delivery fails (transient SMTP, KC 5xx) we DO NOT roll back the KC
-  // user — instead we proceed to insert the `platform_admins` row and
-  // surface a 502 to the operator. The operator can re-trigger the
-  // email via `POST /v1/admin/platform-admins/:id/reset-password`
-  // (platform review M2). Tearing down the KC user on a transient SMTP
-  // outage would force the operator to recreate the row with a new
-  // `platform_admins.id` and lose audit-trail continuity.
-  let emailDeliveryFailed: Error | null = null;
-  try {
-    await keycloakAdmin().sendExecuteActionsEmail(kcUserId, ["UPDATE_PASSWORD"], {
-      lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
-      // No `clientId` / `redirectUri` — see the comment block above for
-      // why. KC's info.ftl handles the "you're done, go log in" UX.
-    });
-  } catch (err) {
-    emailDeliveryFailed = err as Error;
-  }
+  // DB writes + invitation marking + audit in one transaction. The
+  // `acceptedAt` clause in the UPDATE prevents double-accept races.
+  return systemDb.transaction(async (tx) => {
+    const updateRes = await tx
+      .update(invitations)
+      .set({ acceptedAt: new Date() })
+      .where(and(eq(invitations.id, invite.id), isNull(invitations.acceptedAt)))
+      .returning({ id: invitations.id });
+    if (updateRes.length === 0) {
+      // Another request accepted between our SELECT and UPDATE.
+      throw new PlatformAdminServiceError(
+        409,
+        "NOT_FOUND",
+        "Invitation has already been accepted.",
+      );
+    }
 
-  // DB row + audit in one transaction — if either fails the KC user is
-  // already provisioned. The `EMAIL_TAKEN_BY_KEYCLOAK` recovery path on
-  // retry handles this case (the operator gets a structured 409 they can
-  // act on instead of a 500 cascade).
-  const created = await systemDb.transaction(async (tx) => {
     const [row] = await tx
       .insert(platformAdmins)
       .values({
         keycloakId: kcUserId,
-        email,
+        email: invite.email,
         firstName: input.firstName,
         lastName: input.lastName,
       })
       .returning();
-    if (!row) throw new Error("createPlatformAdmin: insert returned no row");
+    if (!row) throw new Error("acceptPlatformAdminInvitation: insert returned no row");
 
     await tx.execute(
       sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
@@ -431,7 +603,11 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     await tx.insert(auditLogs).values({
       orgId: PLATFORM_AUDIT_ORG_ID,
       userId: kcUserId,
-      actorId: input.actorKeycloakId,
+      // No `actorId` — the invitee accepted the invitation themselves.
+      // The original inviter is recorded on the `platform_admin.invited`
+      // audit row, joinable by `resource_id` (invitation.id) ↔
+      // (the prior audit row's resourceId).
+      actorId: null,
       action: "platform_admin.created",
       resourceType: "platform_admin",
       resourceId: row.id,
@@ -440,21 +616,6 @@ export async function createPlatformAdmin(input: CreateInput): Promise<PlatformA
     });
     return row;
   });
-
-  // Surface the email-delivery failure as a 502 AFTER the row is in place,
-  // so the operator gets a structured signal but the row exists for them
-  // to retry against via `/reset-password`. The compensating-delete path
-  // is NOT taken here — the user has a temporary password they cannot
-  // use, the role + Org are correct, the row is queryable.
-  if (emailDeliveryFailed) {
-    throw new PlatformAdminServiceError(
-      502,
-      "KEYCLOAK_FAILURE",
-      `Platform admin provisioned (id=${created.id}), but the UPDATE_PASSWORD email failed to send. Use POST /v1/admin/platform-admins/${created.id}/reset-password to retry. Original error: ${emailDeliveryFailed.message}`,
-    );
-  }
-
-  return created;
 }
 
 // ─── Rename ──────────────────────────────────────────────────────────────────
@@ -693,11 +854,4 @@ async function compensatingKcDelete(kcUserId: string, reason: string): Promise<v
       "platform_admin: ORPHAN — compensating KC delete failed; realm has a super_admin user with no DB row, manual cleanup required",
     );
   }
-}
-
-function cryptoRandomPassword(): string {
-  // 32 bytes of entropy → 64 hex chars. Far above any reasonable realm
-  // password policy (the seed realm enforces length(12) and notUsername).
-  // Never logged or surfaced; immediately invalidated by UPDATE_PASSWORD.
-  return randomBytes(32).toString("hex");
 }

--- a/packages/api/src/modules/users/routes.ts
+++ b/packages/api/src/modules/users/routes.ts
@@ -2,11 +2,11 @@
 
 import { createHash } from "node:crypto";
 import { SUPPORTED_LOCALES } from "@givernance/shared/i18n";
-import { auditLogs, outboxEvents, tenants, users } from "@givernance/shared/schema";
+import { auditLogs, outboxEvents, platformAdmins, tenants, users } from "@givernance/shared/schema";
 import { Type } from "@sinclair/typebox";
 import { and, eq, isNull, ne, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { withTenantContext } from "../../lib/db.js";
+import { systemDb, withTenantContext } from "../../lib/db.js";
 import { requireAuth, requireOrgAdmin } from "../../lib/guards.js";
 import { resolveTranslations } from "../../lib/i18n.js";
 import { keycloakAdmin } from "../../lib/keycloak-admin.js";
@@ -120,6 +120,59 @@ export async function userRoutes(app: FastifyInstance) {
     async (request, reply) => {
       const userId = request.auth?.userId as string;
       const orgId = request.auth?.orgId as string;
+      const isSuperAdmin = request.auth?.roles?.includes("super_admin") ?? false;
+
+      // ADR-022 — platform admins are a disjoint identity surface. They
+      // have no `users` row and no app-DB tenant. Resolve via
+      // `platform_admins` and synthesise the tenant-shaped fields from
+      // the JWT's `org_id` claim (which mirrors the Keycloak "platform"
+      // Organization id) so the existing MeProfile contract on the
+      // client stays a single shape.
+      if (isSuperAdmin) {
+        const [admin] = await systemDb
+          .select({
+            id: platformAdmins.id,
+            keycloakId: platformAdmins.keycloakId,
+            email: platformAdmins.email,
+            firstName: platformAdmins.firstName,
+            lastName: platformAdmins.lastName,
+            createdAt: platformAdmins.createdAt,
+            updatedAt: platformAdmins.updatedAt,
+          })
+          .from(platformAdmins)
+          .where(and(eq(platformAdmins.keycloakId, userId), isNull(platformAdmins.deletedAt)))
+          .limit(1);
+
+        if (!admin) {
+          const t = resolveTranslations(request);
+          return reply.status(404).send({
+            type: "https://httpproblems.com/http-status/404",
+            title: "Not Found",
+            status: 404,
+            detail: t("errors.notFound", { resource: t("resources.user") }),
+          });
+        }
+
+        return reply.send({
+          data: {
+            id: admin.id,
+            orgId,
+            keycloakId: admin.keycloakId,
+            email: admin.email,
+            firstName: admin.firstName,
+            lastName: admin.lastName,
+            role: "super_admin",
+            firstAdmin: false,
+            provisionalUntil: null,
+            locale: null,
+            tenantDefaultLocale: "en" as const,
+            orgSlug: "platform",
+            orgName: "Givernance Platform",
+            createdAt: admin.createdAt.toISOString(),
+            updatedAt: admin.updatedAt.toISOString(),
+          },
+        });
+      }
 
       const row = await withTenantContext(orgId, async (tx) => {
         const [r] = await tx

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -117,9 +117,11 @@ function normaliseAcr(raw: unknown): string | undefined {
  *
  * Note on the absent `no_org_claim` discriminator: `verifyKeycloakJwt`
  * already requires `org_id` to be present (every Keycloak token in this
- * realm carries it; super_admin tokens too — they reuse a placeholder
- * tenant id since the realm mapper can't omit the claim). A JWT without
- * `org_id` is rejected upstream and surfaces here as `"none"`.
+ * realm carries it). For super_admin tokens the claim is sourced from the
+ * Keycloak "Givernance Platform" Organization's `org_id` attribute and
+ * does NOT correspond to any app-DB `tenants` row by design (ADR-022) —
+ * the active-row check below is exempted on the `super_admin` realm role.
+ * A JWT without `org_id` is rejected upstream and surfaces here as `"none"`.
  */
 type TokenResult =
   | "ok"
@@ -171,12 +173,14 @@ async function applyAuthFromToken(request: FastifyRequest): Promise<TokenResult>
   const realmRoles = decoded.realm_access?.roles ?? [];
   const isSuperAdmin = realmRoles.includes("super_admin");
 
-  // ADR-021 — active-row check for tenant-scoped principals. Super_admin
-  // is platform-level (no app-side users row required), so it's
-  // exempted; everyone else must resolve an active `users` row for
-  // `(sub, org_id)`. Closes the soft-delete + tenant-removal window
-  // where the JWT is still cryptographically valid but the subject is
-  // gone.
+  // ADR-021 + ADR-022 — active-row check for tenant-scoped principals.
+  // Super_admin is platform-level: post-ADR-022 super-admins live in
+  // `platform_admins` (no `users` row, no `tenants` row), so the
+  // tenant-membership check is exempted. The `/v1/users/me` endpoint
+  // resolves super-admins through `platform_admins` directly. Tenant
+  // members must still resolve an active `users` row for `(sub, org_id)`
+  // — this closes the soft-delete + tenant-removal window where the JWT
+  // is still cryptographically valid but the subject is gone.
   if (!isSuperAdmin) {
     const isActive = await resolveActiveMembership(decoded.sub, decoded.org_id);
     if (!isActive) return "no_active_membership";

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -12,6 +12,7 @@ import { env } from "./env.js";
 import { redis } from "./lib/redis.js";
 import { PROBLEM_JSON, problemDetail } from "./lib/schemas.js";
 import { impersonationRoutes } from "./modules/admin/impersonation-routes.js";
+import { platformAdminsRoutes } from "./modules/admin/platform-admins-routes.js";
 import { auditRoutes } from "./modules/audit/routes.js";
 import { campaignRoutes } from "./modules/campaigns/routes.js";
 import { constituentRoutes } from "./modules/constituents/routes.js";
@@ -172,6 +173,7 @@ export async function createServer(opts: CreateServerOpts = {}): Promise<Fastify
   await app.register(signupRoutes, { prefix: "/v1" });
   await app.register(reportsRoutes, { prefix: "/v1" });
   await app.register(impersonationRoutes, { prefix: "/v1" });
+  await app.register(platformAdminsRoutes, { prefix: "/v1" });
   await app.register(tenantAdminRoutes, { prefix: "/v1" });
   await app.register(sessionRoutes, { prefix: "/v1" });
   await app.register(disputeRoutes, { prefix: "/v1" });

--- a/packages/api/src/tests/helpers/auth.ts
+++ b/packages/api/src/tests/helpers/auth.ts
@@ -119,6 +119,14 @@ export async function ensureTestTenants() {
   await db.execute(
     sql`INSERT INTO tenants (id, name, slug) VALUES (${ORG_B}, 'Org B', 'test-org-b') ON CONFLICT (id) DO NOTHING`,
   );
+  // Sentinel platform tenant (ADR-022 amendment) — required as the
+  // FK target for any audit_logs row written under PLATFORM_AUDIT_ORG_ID
+  // (e.g. platform-admin lifecycle events from issue #254). Migration
+  // 0034 inserts it idempotently for prod/dev; we mirror the insert
+  // here so a fresh test DB doesn't trip FK on the first audit write.
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, status) VALUES ('00000000-0000-0000-0000-0000000000a1', 'Givernance Platform (sentinel)', '__platform__', 'archived') ON CONFLICT (id) DO NOTHING`,
+  );
   // Seed users matching the synthetic JWT subjects used by `signToken` /
   // `signTokenB`. The auth plugin's active-row check requires
   // `(keycloak_id, org_id, deleted_at IS NULL)` to resolve — without

--- a/packages/api/src/tests/integration/impersonation.test.ts
+++ b/packages/api/src/tests/integration/impersonation.test.ts
@@ -7,7 +7,6 @@
  * Redis lookup are exercised end-to-end.
  */
 
-import { PLATFORM_TENANT_ID } from "@givernance/shared/constants";
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -37,9 +36,13 @@ const TARGET_USER_APP_ID = "00000000-0000-0000-0000-0000000aaaaa";
 const TARGET_USER_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000aa101";
 const TARGET_SUPER_ADMIN_APP_ID = "00000000-0000-0000-0000-0000000aaaab";
 const TARGET_SUPER_ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000aa102";
-// Platform-tenant target — used by the nested-impersonation test (QA F1)
-// to exercise the service-side guard that rejects targets in the seeded
-// platform tenant. Tenant row is upserted in beforeAll.
+// Platform-admin target — used by the nested-impersonation test (QA F1)
+// to exercise the service-side guard that rejects targets which are
+// platform admins (ADR-022). The fixture inserts BOTH a `platform_admins`
+// row keyed on PLATFORM_TARGET_KEYCLOAK_ID AND a regular `users` row in
+// ORG_A sharing that keycloak_id, so the impersonation service resolves
+// a tenant user (it looks up `users` by app id) but the
+// `isPlatformAdmin(target.keycloakId)` post-check fires.
 const PLATFORM_TARGET_APP_ID = "00000000-0000-0000-0000-0000000aaa01";
 const PLATFORM_TARGET_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000aa103";
 // Viewer-role target — used to verify pure-impersonation honours the
@@ -57,15 +60,10 @@ beforeAll(async () => {
 
   await ensureTestTenants();
 
-  // Seed the platform tenant + a member user, so the nested-impersonation
-  // guard test can exercise the structural barrier on `target.orgId`.
-  await db.execute(sql`
-    INSERT INTO tenants (id, name, slug)
-    VALUES (${PLATFORM_TENANT_ID}, 'Givernance Platform', 'platform')
-    ON CONFLICT (id) DO NOTHING
-  `);
-
-  // Seed a target user under ORG_A that the operator will impersonate.
+  // Seed target users for ORG_A. The PLATFORM_TARGET fixture lives in
+  // ORG_A like a normal customer-tenant member; the
+  // `isPlatformAdmin(keycloakId)` guard (ADR-022) is what rejects it,
+  // not its tenant binding.
   await db.execute(sql`
     DELETE FROM users WHERE id IN (${TARGET_USER_APP_ID}, ${TARGET_SUPER_ADMIN_APP_ID}, ${PLATFORM_TARGET_APP_ID}, ${VIEWER_TARGET_APP_ID})
   `);
@@ -74,8 +72,17 @@ beforeAll(async () => {
     VALUES
       (${TARGET_USER_APP_ID}, ${ORG_A}, ${TARGET_USER_KEYCLOAK_ID}, 'target@example.org', 'Target', 'User', 'org_admin'),
       (${TARGET_SUPER_ADMIN_APP_ID}, ${ORG_A}, ${TARGET_SUPER_ADMIN_KEYCLOAK_ID}, 'super@example.org', 'Target', 'SuperAdmin', 'org_admin'),
-      (${PLATFORM_TARGET_APP_ID}, ${PLATFORM_TENANT_ID}, ${PLATFORM_TARGET_KEYCLOAK_ID}, 'platform-target@example.org', 'Platform', 'Target', 'org_admin'),
+      (${PLATFORM_TARGET_APP_ID}, ${ORG_A}, ${PLATFORM_TARGET_KEYCLOAK_ID}, 'platform-target@example.org', 'Platform', 'Target', 'org_admin'),
       (${VIEWER_TARGET_APP_ID}, ${ORG_A}, ${VIEWER_TARGET_KEYCLOAK_ID}, 'viewer-target@example.org', 'Viewer', 'Target', 'viewer')
+  `);
+
+  // ADR-022: insert a `platform_admins` row sharing the
+  // PLATFORM_TARGET_KEYCLOAK_ID so the nested-impersonation guard fires.
+  // Idempotent — `ON CONFLICT DO NOTHING` so the test suite is re-runnable.
+  await db.execute(sql`
+    INSERT INTO platform_admins (keycloak_id, email, first_name, last_name)
+    VALUES (${PLATFORM_TARGET_KEYCLOAK_ID}, 'platform-admin-fixture@example.org', 'Platform', 'AdminFixture')
+    ON CONFLICT DO NOTHING
   `);
 });
 
@@ -190,7 +197,7 @@ describe("POST /v1/admin/impersonation — RBAC + step-up", () => {
     expect(body).toMatchObject({ status: 400, title: expect.any(String) });
   });
 
-  it("blocks impersonating a platform-tenant member (nested impersonation) with 400", async () => {
+  it("blocks impersonating a platform admin (nested impersonation) with 400", async () => {
     const token = superAdminToken();
     const res = await app.inject({
       method: "POST",
@@ -204,7 +211,7 @@ describe("POST /v1/admin/impersonation — RBAC + step-up", () => {
       title: "Bad Request",
       status: 400,
     });
-    expect((res.json() as { detail?: string }).detail ?? "").toMatch(/platform/i);
+    expect((res.json() as { detail?: string }).detail ?? "").toMatch(/platform admin/i);
   });
 
   it("rejects target user without a Keycloak identity", async () => {

--- a/packages/api/src/tests/integration/onboarding-runtime.test.ts
+++ b/packages/api/src/tests/integration/onboarding-runtime.test.ts
@@ -83,6 +83,11 @@ function makeKcStub(overrides: Partial<KeycloakAdminClient> = {}): KeycloakAdmin
     getOrganizationByAlias: async () => null,
     createIdentityProvider: async () => {},
     deleteIdentityProvider: async () => {},
+    // Issue #254 — platform-admin CRUD helpers. Stubbed for parity; this
+    // suite never exercises the platform-admins flow.
+    getRealmRole: async () => null,
+    assignRealmRoleToUser: async () => {},
+    sendExecuteActionsEmail: async () => {},
     _circuitState: () => "closed" as const,
   };
   return { ...base, ...overrides };

--- a/packages/api/src/tests/integration/platform-admins.test.ts
+++ b/packages/api/src/tests/integration/platform-admins.test.ts
@@ -287,40 +287,37 @@ describe("POST /v1/admin/platform-admins", () => {
     expect(kcDeleteUser).toHaveBeenCalledTimes(1);
   });
 
-  it(
-    "does NOT roll back the KC user on email-delivery failure — row is created and 502 references it",
-    async () => {
-      // Platform review M2 — sendExecuteActionsEmail failure used to nuke
-      // the whole KC user. Post-fix-commit-1, the row is preserved and the
-      // operator can retry via /reset-password.
-      kcSendExecuteActions.mockRejectedValueOnce(new Error("simulated SMTP failure"));
-      const res = await app.inject({
-        method: "POST",
-        url: "/v1/admin/platform-admins",
-        headers: authHeader(superAdminToken()),
-        payload: {
-          email: `email-fail-${randomUUID().slice(0, 8)}@example.org`,
-          firstName: "X",
-          lastName: "Y",
-        },
-      });
-      expect(res.statusCode).toBe(502);
-      // Compensating delete must NOT have fired — KC user retained.
-      expect(kcDeleteUser).not.toHaveBeenCalled();
-      // The detail message references `/reset-password` so the operator
-      // knows the retry path.
-      expect((res.json() as { detail?: string }).detail ?? "").toMatch(/reset-password/);
-      // The row exists in the DB and is queryable. Extract the id from
-      // the detail string (`id=<uuid>`).
-      const detail = (res.json() as { detail?: string }).detail ?? "";
-      const idMatch = /id=([0-9a-f-]{36})/.exec(detail);
-      expect(idMatch?.[1]).toBeTruthy();
-      const rows = await systemDb.execute(
-        sql`SELECT id FROM platform_admins WHERE id = ${idMatch?.[1]} AND deleted_at IS NULL`,
-      );
-      expect(rows.rows.length).toBe(1);
-    },
-  );
+  it("does NOT roll back the KC user on email-delivery failure — row is created and 502 references it", async () => {
+    // Platform review M2 — sendExecuteActionsEmail failure used to nuke
+    // the whole KC user. Post-fix-commit-1, the row is preserved and the
+    // operator can retry via /reset-password.
+    kcSendExecuteActions.mockRejectedValueOnce(new Error("simulated SMTP failure"));
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: {
+        email: `email-fail-${randomUUID().slice(0, 8)}@example.org`,
+        firstName: "X",
+        lastName: "Y",
+      },
+    });
+    expect(res.statusCode).toBe(502);
+    // Compensating delete must NOT have fired — KC user retained.
+    expect(kcDeleteUser).not.toHaveBeenCalled();
+    // The detail message references `/reset-password` so the operator
+    // knows the retry path.
+    expect((res.json() as { detail?: string }).detail ?? "").toMatch(/reset-password/);
+    // The row exists in the DB and is queryable. Extract the id from
+    // the detail string (`id=<uuid>`).
+    const detail = (res.json() as { detail?: string }).detail ?? "";
+    const idMatch = /id=([0-9a-f-]{36})/.exec(detail);
+    expect(idMatch?.[1]).toBeTruthy();
+    const rows = await systemDb.execute(
+      sql`SELECT id FROM platform_admins WHERE id = ${idMatch?.[1]} AND deleted_at IS NULL`,
+    );
+    expect(rows.rows.length).toBe(1);
+  });
 });
 
 // ─── Rename ─────────────────────────────────────────────────────────────────

--- a/packages/api/src/tests/integration/platform-admins.test.ts
+++ b/packages/api/src/tests/integration/platform-admins.test.ts
@@ -160,11 +160,62 @@ describe("RBAC anti-disclosure", () => {
   });
 });
 
-// ─── Create ─────────────────────────────────────────────────────────────────
+// ─── Helpers (post-fix-commit-4 invitation flow) ───────────────────────────
 
-describe("POST /v1/admin/platform-admins", () => {
-  it("creates a platform admin: KC user + role + Org membership + UPDATE_PASSWORD email + audit row", async () => {
-    const email = `new-admin-${randomUUID().slice(0, 8)}@example.org`;
+/**
+ * Drive an invitation through to a fully-provisioned platform_admins row
+ * via the public accept endpoint. Encapsulates: POST invite → DB-read the
+ * token → POST accept → return id + keycloakId. Used by the rename /
+ * reset / delete tests that need an admin to operate on.
+ */
+async function inviteAndAccept(opts: {
+  email: string;
+  firstName: string;
+  lastName: string;
+  password?: string;
+}): Promise<{ id: string; keycloakId: string; invitationId: string }> {
+  const invite = await app.inject({
+    method: "POST",
+    url: "/v1/admin/platform-admins",
+    headers: authHeader(superAdminToken()),
+    payload: { email: opts.email, firstName: opts.firstName, lastName: opts.lastName },
+  });
+  if (invite.statusCode !== 201) {
+    throw new Error(`inviteAndAccept: invite failed ${invite.statusCode} ${invite.payload}`);
+  }
+  const inviteBody = invite.json() as { data: { invitationId: string } };
+  const invitationId = inviteBody.data.invitationId;
+
+  // Read the token directly from the DB — it's never returned in any
+  // API response (SEC-7), and the email is sent out-of-band via the
+  // worker which we don't run here.
+  const tokenRows = await systemDb.execute<{ token: string }>(
+    sql`SELECT token FROM invitations WHERE id = ${invitationId}`,
+  );
+  const token = tokenRows.rows[0]?.token;
+  if (!token) throw new Error("inviteAndAccept: token missing");
+
+  const accept = await app.inject({
+    method: "POST",
+    url: `/v1/public/platform-admins/invitations/${token}/accept`,
+    payload: {
+      firstName: opts.firstName,
+      lastName: opts.lastName,
+      password: opts.password ?? "Test-Password-1234",
+    },
+  });
+  if (accept.statusCode !== 201) {
+    throw new Error(`inviteAndAccept: accept failed ${accept.statusCode} ${accept.payload}`);
+  }
+  const acceptBody = accept.json() as { data: { id: string; keycloakId: string } };
+  return { id: acceptBody.data.id, keycloakId: acceptBody.data.keycloakId, invitationId };
+}
+
+// ─── Create (invitation flow) ───────────────────────────────────────────────
+
+describe("POST /v1/admin/platform-admins (issue invitation)", () => {
+  it("inserts an invitation row + outbox event + audit row; does NOT touch Keycloak", async () => {
+    const email = `invitee-${randomUUID().slice(0, 8)}@example.org`;
     const res = await app.inject({
       method: "POST",
       url: "/v1/admin/platform-admins",
@@ -172,31 +223,31 @@ describe("POST /v1/admin/platform-admins", () => {
       payload: { email, firstName: "New", lastName: "Admin" },
     });
     expect(res.statusCode).toBe(201);
-    const body = res.json() as { data: { id: string; keycloakId: string; email: string } };
+    const body = res.json() as {
+      data: { invitationId: string; email: string; expiresAt: string };
+    };
     expect(body.data.email).toBe(email);
-    expect(typeof body.data.keycloakId).toBe("string");
+    expect(body.data.invitationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
 
-    // KC side-effects all fired.
-    expect(kcCreateUser).toHaveBeenCalledTimes(1);
-    // The `org_id` user attribute MUST be set on the new admin or the
-    // JWT will lack the top-level `org_id` claim that
-    // `verifyKeycloakJwt` requires (caught in dev: PR #253 review).
-    expect(kcCreateUser.mock.calls[0]?.[0]?.attributes).toMatchObject({
-      org_id: [PLATFORM_TENANT_ID],
-    });
-    expect(kcAssignRealmRole).toHaveBeenCalledTimes(1);
-    expect(kcAssignRealmRole.mock.calls[0]?.[1]).toMatchObject({ name: "super_admin" });
-    expect(kcAttachUserToOrg).toHaveBeenCalledTimes(1);
-    expect(kcSendExecuteActions).toHaveBeenCalledTimes(1);
-    expect(kcSendExecuteActions.mock.calls[0]?.[1]).toEqual(["UPDATE_PASSWORD"]);
+    // Post fix-commit-4: KC is NOT contacted at invite time. The row
+    // materialises at accept time when the invitee submits the password.
+    expect(kcCreateUser).not.toHaveBeenCalled();
+    expect(kcAssignRealmRole).not.toHaveBeenCalled();
+    expect(kcAttachUserToOrg).not.toHaveBeenCalled();
+    expect(kcSendExecuteActions).not.toHaveBeenCalled();
 
-    // Audit row was written under the platform sentinel tenant.
-    const auditRows = await systemDb.execute<{
-      action: string;
-      org_id: string;
-      actor_id: string;
-    }>(
-      sql`SELECT action, org_id, actor_id FROM audit_logs WHERE resource_id = ${body.data.id} AND action = 'platform_admin.created'`,
+    // Outbox event was inserted for the worker to pick up.
+    const outboxRows = await systemDb.execute<{ type: string; payload: { invitationId: string } }>(
+      sql`SELECT type, payload FROM outbox_events WHERE payload->>'invitationId' = ${body.data.invitationId}`,
+    );
+    expect(outboxRows.rows.length).toBe(1);
+    expect(outboxRows.rows[0]?.type).toBe("platform_admin.invited");
+
+    // Audit row written under the platform sentinel tenant.
+    const auditRows = await systemDb.execute<{ org_id: string; actor_id: string }>(
+      sql`SELECT org_id, actor_id FROM audit_logs WHERE resource_id = ${body.data.invitationId} AND action = 'platform_admin.invited'`,
     );
     expect(auditRows.rows.length).toBe(1);
     expect(auditRows.rows[0]?.org_id).toBe(PLATFORM_TENANT_ID);
@@ -204,7 +255,6 @@ describe("POST /v1/admin/platform-admins", () => {
   });
 
   it("refuses (409 + RFC 9457) when the email belongs to a tenant user (ADR-022 invariant)", async () => {
-    // user-a@example.org is seeded by `ensureTestTenants` in setup.ts.
     const res = await app.inject({
       method: "POST",
       url: "/v1/admin/platform-admins",
@@ -218,105 +268,137 @@ describe("POST /v1/admin/platform-admins", () => {
       status: 409,
     });
     expect((res.json() as { detail?: string }).detail ?? "").toMatch(/tenant member/i);
-    // KC must not be touched on the invariant rejection — fail fast.
-    expect(kcCreateUser).not.toHaveBeenCalled();
   });
 
-  it("returns 502 when the super_admin realm role is missing in Keycloak (operator-visible misconfig)", async () => {
-    kcGetRealmRole.mockResolvedValueOnce(null);
-    const res = await app.inject({
+  it("refuses a duplicate pending invitation for the same email", async () => {
+    const email = `dup-${randomUUID().slice(0, 8)}@example.org`;
+    const first = await app.inject({
       method: "POST",
       url: "/v1/admin/platform-admins",
       headers: authHeader(superAdminToken()),
-      payload: {
-        email: `kc-fail-${randomUUID().slice(0, 8)}@example.org`,
-        firstName: "X",
-        lastName: "Y",
-      },
+      payload: { email, firstName: "X", lastName: "Y" },
     });
-    // Lock the RFC 9457 body shape on this error path (QA M1).
-    expect(res.statusCode).toBe(502);
-    expect(res.json()).toMatchObject({
-      type: "https://httpproblems.com/http-status/502",
-      title: "Bad Gateway",
-      status: 502,
-    });
-    expect((res.json() as { detail?: string }).detail ?? "").toMatch(/role.*super_admin/);
-    expect(kcCreateUser).not.toHaveBeenCalled();
-  });
-
-  it("rolls back the KC user when assignRealmRole fails mid-flight (locks 502 body shape)", async () => {
-    kcAssignRealmRole.mockRejectedValueOnce(new Error("simulated KC failure"));
-    const res = await app.inject({
+    expect(first.statusCode).toBe(201);
+    const second = await app.inject({
       method: "POST",
       url: "/v1/admin/platform-admins",
       headers: authHeader(superAdminToken()),
-      payload: {
-        email: `compensating-role-${randomUUID().slice(0, 8)}@example.org`,
-        firstName: "X",
-        lastName: "Y",
-      },
+      payload: { email, firstName: "X", lastName: "Y" },
     });
-    // Lock the RFC 9457 body shape on the compensating-delete path (QA M1 + M2).
-    expect(res.statusCode).toBe(502);
-    expect(res.json()).toMatchObject({
-      type: "https://httpproblems.com/http-status/502",
-      title: "Bad Gateway",
-      status: 502,
-    });
-    expect(kcDeleteUser).toHaveBeenCalledTimes(1);
+    expect(second.statusCode).toBe(409);
+    expect((second.json() as { detail?: string }).detail ?? "").toMatch(/pending/i);
   });
+});
 
-  // QA review M2 — extend compensating-delete coverage from 1 of 3 KC
-  // failure points to 2 of 3. The third (sendExecuteActionsEmail) now has
-  // distinct semantics post-fix-commit-1 (no rollback), so it gets its
-  // own dedicated test below.
-  it("rolls back the KC user when attachUserToOrg fails mid-flight", async () => {
-    kcAttachUserToOrg.mockRejectedValueOnce(new Error("simulated KC org failure"));
-    const res = await app.inject({
+// ─── Public accept ──────────────────────────────────────────────────────────
+
+describe("Public accept flow", () => {
+  it("GET token returns invitation details for a valid token", async () => {
+    const email = `probe-${randomUUID().slice(0, 8)}@example.org`;
+    const invite = await app.inject({
       method: "POST",
       url: "/v1/admin/platform-admins",
       headers: authHeader(superAdminToken()),
-      payload: {
-        email: `compensating-org-${randomUUID().slice(0, 8)}@example.org`,
-        firstName: "X",
-        lastName: "Y",
-      },
+      payload: { email, firstName: "Probe", lastName: "Admin" },
     });
-    expect(res.statusCode).toBe(502);
-    expect(kcDeleteUser).toHaveBeenCalledTimes(1);
-  });
-
-  it("does NOT roll back the KC user on email-delivery failure — row is created and 502 references it", async () => {
-    // Platform review M2 — sendExecuteActionsEmail failure used to nuke
-    // the whole KC user. Post-fix-commit-1, the row is preserved and the
-    // operator can retry via /reset-password.
-    kcSendExecuteActions.mockRejectedValueOnce(new Error("simulated SMTP failure"));
-    const res = await app.inject({
-      method: "POST",
-      url: "/v1/admin/platform-admins",
-      headers: authHeader(superAdminToken()),
-      payload: {
-        email: `email-fail-${randomUUID().slice(0, 8)}@example.org`,
-        firstName: "X",
-        lastName: "Y",
-      },
-    });
-    expect(res.statusCode).toBe(502);
-    // Compensating delete must NOT have fired — KC user retained.
-    expect(kcDeleteUser).not.toHaveBeenCalled();
-    // The detail message references `/reset-password` so the operator
-    // knows the retry path.
-    expect((res.json() as { detail?: string }).detail ?? "").toMatch(/reset-password/);
-    // The row exists in the DB and is queryable. Extract the id from
-    // the detail string (`id=<uuid>`).
-    const detail = (res.json() as { detail?: string }).detail ?? "";
-    const idMatch = /id=([0-9a-f-]{36})/.exec(detail);
-    expect(idMatch?.[1]).toBeTruthy();
-    const rows = await systemDb.execute(
-      sql`SELECT id FROM platform_admins WHERE id = ${idMatch?.[1]} AND deleted_at IS NULL`,
+    const invitationId = (invite.json() as { data: { invitationId: string } }).data.invitationId;
+    const tokenRows = await systemDb.execute<{ token: string }>(
+      sql`SELECT token FROM invitations WHERE id = ${invitationId}`,
     );
-    expect(rows.rows.length).toBe(1);
+    const token = tokenRows.rows[0]?.token;
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/public/platform-admins/invitations/${token}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { data: { email: string; firstName: string; lastName: string } };
+    expect(body.data.email).toBe(email);
+    expect(body.data.firstName).toBe("Probe");
+    expect(body.data.lastName).toBe("Admin");
+  });
+
+  it("GET token returns 404 with RFC 9457 body for a missing/expired token", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/public/platform-admins/invitations/00000000-0000-0000-0000-000000000000",
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({
+      type: "https://httpproblems.com/http-status/404",
+      title: "Not Found",
+      status: 404,
+    });
+  });
+
+  it("POST accept provisions the KC user + role + Org + platform_admins row + audit", async () => {
+    const email = `acceptee-${randomUUID().slice(0, 8)}@example.org`;
+    const result = await inviteAndAccept({ email, firstName: "Acc", lastName: "Eptee" });
+
+    // KC side-effects fired at accept time.
+    expect(kcCreateUser).toHaveBeenCalledTimes(1);
+    // The `org_id` user attribute MUST be set on the new admin.
+    expect(kcCreateUser.mock.calls[0]?.[0]?.attributes).toMatchObject({
+      org_id: [PLATFORM_TENANT_ID],
+    });
+    // Password is NOT temporary — the invitee just typed it.
+    expect(kcCreateUser.mock.calls[0]?.[0]?.temporary).toBe(false);
+    expect(kcAssignRealmRole).toHaveBeenCalledTimes(1);
+    expect(kcAttachUserToOrg).toHaveBeenCalledTimes(1);
+
+    // platform_admins row exists.
+    const rows = await systemDb.execute<{ email: string }>(
+      sql`SELECT email FROM platform_admins WHERE id = ${result.id}`,
+    );
+    expect(rows.rows[0]?.email).toBe(email);
+
+    // Invitation marked accepted.
+    const inviteRows = await systemDb.execute<{ accepted_at: string | null }>(
+      sql`SELECT accepted_at FROM invitations WHERE id = ${result.invitationId}`,
+    );
+    expect(inviteRows.rows[0]?.accepted_at).not.toBeNull();
+
+    // Audit `platform_admin.created` written; actor_id null (the invitee
+    // accepted themselves; the inviter is on the prior `invited` row).
+    const auditRows = await systemDb.execute<{ actor_id: string | null }>(
+      sql`SELECT actor_id FROM audit_logs WHERE resource_id = ${result.id} AND action = 'platform_admin.created'`,
+    );
+    expect(auditRows.rows.length).toBe(1);
+    expect(auditRows.rows[0]?.actor_id).toBeNull();
+  });
+
+  it("POST accept on an already-accepted token returns 404 + RFC 9457 body", async () => {
+    const email = `dbl-${randomUUID().slice(0, 8)}@example.org`;
+    const invite = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: { email, firstName: "Once", lastName: "Twice" },
+    });
+    const invitationId = (invite.json() as { data: { invitationId: string } }).data.invitationId;
+    const tokenRows = await systemDb.execute<{ token: string }>(
+      sql`SELECT token FROM invitations WHERE id = ${invitationId}`,
+    );
+    const token = tokenRows.rows[0]?.token;
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/v1/public/platform-admins/invitations/${token}/accept`,
+      payload: { firstName: "Once", lastName: "Twice", password: "Test-Password-1234" },
+    });
+    expect(first.statusCode).toBe(201);
+
+    const second = await app.inject({
+      method: "POST",
+      url: `/v1/public/platform-admins/invitations/${token}/accept`,
+      payload: { firstName: "Once", lastName: "Twice", password: "Test-Password-1234" },
+    });
+    expect(second.statusCode).toBe(404);
+    expect(second.json()).toMatchObject({
+      type: "https://httpproblems.com/http-status/404",
+      title: "Not Found",
+      status: 404,
+    });
   });
 });
 
@@ -325,14 +407,12 @@ describe("POST /v1/admin/platform-admins", () => {
 describe("PATCH /v1/admin/platform-admins/:id", () => {
   it("renames a platform admin and writes an audit row with old/new values", async () => {
     const email = `rename-${randomUUID().slice(0, 8)}@example.org`;
-    const create = await app.inject({
-      method: "POST",
-      url: "/v1/admin/platform-admins",
-      headers: authHeader(superAdminToken()),
-      payload: { email, firstName: "Before", lastName: "Name" },
+    const { id } = await inviteAndAccept({
+      email,
+      firstName: "Before",
+      lastName: "Name",
     });
-    expect(create.statusCode).toBe(201);
-    const id = (create.json() as { data: { id: string } }).data.id;
+    kcUpdateUser.mockClear();
 
     const res = await app.inject({
       method: "PATCH",
@@ -361,14 +441,7 @@ describe("PATCH /v1/admin/platform-admins/:id", () => {
 describe("POST /v1/admin/platform-admins/:id/reset-password", () => {
   it("triggers a fresh UPDATE_PASSWORD email and writes an audit row", async () => {
     const email = `reset-${randomUUID().slice(0, 8)}@example.org`;
-    const create = await app.inject({
-      method: "POST",
-      url: "/v1/admin/platform-admins",
-      headers: authHeader(superAdminToken()),
-      payload: { email, firstName: "X", lastName: "Y" },
-    });
-    expect(create.statusCode).toBe(201);
-    const id = (create.json() as { data: { id: string } }).data.id;
+    const { id } = await inviteAndAccept({ email, firstName: "X", lastName: "Y" });
     kcSendExecuteActions.mockClear();
 
     const res = await app.inject({
@@ -411,19 +484,11 @@ describe("DELETE /v1/admin/platform-admins/:id", () => {
     // Create a second admin first, then remove the seeded one — that
     // succeeds — but immediately re-attempt to remove the only remaining
     // admin and expect 400.
-    const second = await app.inject({
-      method: "POST",
-      url: "/v1/admin/platform-admins",
-      headers: authHeader(superAdminToken()),
-      payload: {
-        email: `second-${randomUUID().slice(0, 8)}@example.org`,
-        firstName: "Second",
-        lastName: "Admin",
-      },
+    const { id: secondId, keycloakId: secondKc } = await inviteAndAccept({
+      email: `second-${randomUUID().slice(0, 8)}@example.org`,
+      firstName: "Second",
+      lastName: "Admin",
     });
-    expect(second.statusCode).toBe(201);
-    const secondId = (second.json() as { data: { id: string } }).data.id;
-    const secondKc = (second.json() as { data: { keycloakId: string } }).data.keycloakId;
 
     // Use a fresh token signed as the *second* admin to soft-delete the
     // original (the original cannot self-remove). The second admin has the
@@ -465,20 +530,11 @@ describe("DELETE /v1/admin/platform-admins/:id", () => {
   });
 
   it("soft-deletes a platform admin: KC user deleted, sub blocklisted, audit row, deleted_at set, keycloak_id cleared", async () => {
-    const created = await app.inject({
-      method: "POST",
-      url: "/v1/admin/platform-admins",
-      headers: authHeader(superAdminToken()),
-      payload: {
-        email: `target-${randomUUID().slice(0, 8)}@example.org`,
-        firstName: "Target",
-        lastName: "User",
-      },
+    const { id, keycloakId: targetKc } = await inviteAndAccept({
+      email: `target-${randomUUID().slice(0, 8)}@example.org`,
+      firstName: "Target",
+      lastName: "User",
     });
-    expect(created.statusCode).toBe(201);
-    const id = (created.json() as { data: { id: string } }).data.id;
-    const targetKc = (created.json() as { data: { keycloakId: string } }).data.keycloakId;
-
     kcDeleteUser.mockClear();
 
     const res = await app.inject({

--- a/packages/api/src/tests/integration/platform-admins.test.ts
+++ b/packages/api/src/tests/integration/platform-admins.test.ts
@@ -178,6 +178,12 @@ describe("POST /v1/admin/platform-admins", () => {
 
     // KC side-effects all fired.
     expect(kcCreateUser).toHaveBeenCalledTimes(1);
+    // The `org_id` user attribute MUST be set on the new admin or the
+    // JWT will lack the top-level `org_id` claim that
+    // `verifyKeycloakJwt` requires (caught in dev: PR #253 review).
+    expect(kcCreateUser.mock.calls[0]?.[0]?.attributes).toMatchObject({
+      org_id: [PLATFORM_TENANT_ID],
+    });
     expect(kcAssignRealmRole).toHaveBeenCalledTimes(1);
     expect(kcAssignRealmRole.mock.calls[0]?.[1]).toMatchObject({ name: "super_admin" });
     expect(kcAttachUserToOrg).toHaveBeenCalledTimes(1);

--- a/packages/api/src/tests/integration/platform-admins.test.ts
+++ b/packages/api/src/tests/integration/platform-admins.test.ts
@@ -82,14 +82,10 @@ beforeAll(async () => {
   app = await createServer();
   await app.ready();
   _setKeycloakAdminSingleton(fakeKeycloakAdmin);
-
-  // Seed the platform sentinel tenant — required as the FK target for
-  // every audit row written by this module (ADR-022 amendment). Idempotent.
-  await db.execute(sql`
-    INSERT INTO tenants (id, name, slug, status)
-    VALUES (${PLATFORM_TENANT_ID}, 'Givernance Platform (sentinel)', '__platform__', 'archived')
-    ON CONFLICT (id) DO NOTHING
-  `);
+  // Sentinel platform tenant is seeded centrally by `ensureTestTenants`
+  // in `tests/setup.ts` (data-architect minor #7). Migration 0034 also
+  // inserts it idempotently for dev/prod.
+  void PLATFORM_TENANT_ID;
 });
 
 afterAll(async () => {

--- a/packages/api/src/tests/integration/platform-admins.test.ts
+++ b/packages/api/src/tests/integration/platform-admins.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Issue #254 — platform-admin CRUD API.
+ *
+ * Hits a real Postgres + Redis (per `tests/setup.ts`) and a stubbed
+ * Keycloak admin client. Coverage:
+ *   - RBAC anti-disclosure (non-super-admins get 404 on every endpoint)
+ *   - Identity invariant (email belonging to a tenant `users` row → 409)
+ *   - Self-removal forbidden (operator's own row → 400)
+ *   - Last-admin guard (count == 1 → 400)
+ *   - Audit rows written on every mutation
+ *   - Keycloak side-effects: createUser → assign super_admin role →
+ *     attach to platform Org → sendExecuteActionsEmail
+ *   - Soft-delete propagates: KC deleteUser called + user blocklisted
+ *   - RFC 9457 body shape locked on at least one error path
+ */
+
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { db, systemDb } from "../../lib/db.js";
+import { _setKeycloakAdminSingleton, type KeycloakAdminClient } from "../../lib/keycloak-admin.js";
+import { redis } from "../../lib/redis.js";
+import { createServer } from "../../server.js";
+import { authHeader, signToken } from "../helpers/auth.js";
+
+const PLATFORM_TENANT_ID = "00000000-0000-0000-0000-0000000000a1";
+const SUPER_ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000000ad";
+const SUPER_ADMIN_PLATFORM_ROW_ID = "00000000-0000-0000-0000-000000abcd01";
+
+let app: FastifyInstance;
+
+// ─── KC stub ────────────────────────────────────────────────────────────────
+
+// IDs returned by the KC stub MUST be UUID-format strings — the
+// `audit_logs` response schema constrains `user_id` to UUID. Some tests
+// sign tokens with `sub: <returned-id>` to exercise distinct super-admin
+// operators; a non-UUID would surface only when a *later* unrelated test
+// asks `/v1/audit` to serialize and trips fast-json-stringify.
+const kcCreateUser = vi.fn<KeycloakAdminClient["createUser"]>(async () => ({
+  id: randomUUID(),
+}));
+const kcGetRealmRole = vi.fn<KeycloakAdminClient["getRealmRole"]>(async () => ({
+  id: "kc-role-id",
+  name: "super_admin",
+}));
+const kcGetOrganizationByAlias = vi.fn<KeycloakAdminClient["getOrganizationByAlias"]>(async () => ({
+  id: "kc-platform-org-id",
+  name: "Givernance Platform",
+  alias: "platform",
+}));
+const kcAssignRealmRole = vi.fn<KeycloakAdminClient["assignRealmRoleToUser"]>(async () => {});
+const kcAttachUserToOrg = vi.fn<KeycloakAdminClient["attachUserToOrg"]>(async () => {});
+const kcSendExecuteActions = vi.fn<KeycloakAdminClient["sendExecuteActionsEmail"]>(async () => {});
+const kcUpdateUser = vi.fn<KeycloakAdminClient["updateUser"]>(async () => {});
+const kcDeleteUser = vi.fn<KeycloakAdminClient["deleteUser"]>(async () => {});
+
+const fakeKeycloakAdmin: KeycloakAdminClient = {
+  createOrganization: vi.fn(),
+  getOrganization: vi.fn(async () => null),
+  getOrganizationByAlias: kcGetOrganizationByAlias,
+  deleteOrganization: vi.fn(async () => {}),
+  addOrgDomain: vi.fn(async () => {}),
+  attachUserToOrg: kcAttachUserToOrg,
+  sendInvitation: vi.fn(async () => {}),
+  bindIdpToOrganization: vi.fn(async () => {}),
+  createUser: kcCreateUser,
+  getUserByEmail: vi.fn(async () => null),
+  resetUserPassword: vi.fn(async () => {}),
+  setUserAttributes: vi.fn(async () => {}),
+  updateUser: kcUpdateUser,
+  deleteUser: kcDeleteUser,
+  createIdentityProvider: vi.fn(async () => {}),
+  deleteIdentityProvider: vi.fn(async () => {}),
+  getRealmRole: kcGetRealmRole,
+  assignRealmRoleToUser: kcAssignRealmRole,
+  sendExecuteActionsEmail: kcSendExecuteActions,
+  _circuitState: () => "closed",
+};
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  _setKeycloakAdminSingleton(fakeKeycloakAdmin);
+
+  // Seed the platform sentinel tenant — required as the FK target for
+  // every audit row written by this module (ADR-022 amendment). Idempotent.
+  await db.execute(sql`
+    INSERT INTO tenants (id, name, slug, status)
+    VALUES (${PLATFORM_TENANT_ID}, 'Givernance Platform (sentinel)', '__platform__', 'archived')
+    ON CONFLICT (id) DO NOTHING
+  `);
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+afterEach(async () => {
+  // Reset KC stub call counts so each test asserts in isolation.
+  vi.clearAllMocks();
+
+  // Drop platform_admins rows other than the seeded operator so each test
+  // starts with COUNT(*) = 1. We can't truncate audit_logs (the table is
+  // append-only by trigger); audit rows accumulate across tests but every
+  // assertion filters by `resource_id`, which is unique per test.
+  await db.execute(sql`
+    DELETE FROM platform_admins WHERE id <> ${SUPER_ADMIN_PLATFORM_ROW_ID}
+  `);
+  // Restore the seeded operator to its canonical active shape — the
+  // soft-delete tests null its `keycloak_id` and set `deleted_at`.
+  await db.execute(sql`
+    INSERT INTO platform_admins (id, keycloak_id, email, first_name, last_name)
+    VALUES (${SUPER_ADMIN_PLATFORM_ROW_ID}, ${SUPER_ADMIN_KEYCLOAK_ID}, 'super@example.org', 'Super', 'Admin')
+    ON CONFLICT (id) DO UPDATE SET deleted_at = NULL, keycloak_id = ${SUPER_ADMIN_KEYCLOAK_ID}, first_name = 'Super', last_name = 'Admin'
+  `);
+
+  // Wipe any user-blocklist Redis keys the soft-delete tests wrote so
+  // subsequent tests aren't surprised when their actor's sub bounces.
+  const keys = await redis.keys("auth:user-blocklist:*");
+  if (keys.length) await redis.del(...keys);
+});
+
+function superAdminToken() {
+  return signToken(app, {
+    sub: SUPER_ADMIN_KEYCLOAK_ID,
+    realm_access: { roles: ["super_admin"] },
+    role: undefined,
+  });
+}
+
+// ─── RBAC ───────────────────────────────────────────────────────────────────
+
+describe("RBAC anti-disclosure", () => {
+  it("non-super_admin gets 404 on list (no role probing)", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(signToken(app)),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("non-super_admin gets 404 on create", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(signToken(app)),
+      payload: { email: "x@example.org", firstName: "X", lastName: "Y" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("super_admin sees the list with at least the seeded operator", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { data: Array<{ email: string }>; meta: { total: number } };
+    expect(body.meta.total).toBeGreaterThanOrEqual(1);
+    expect(body.data.some((r) => r.email === "super@example.org")).toBe(true);
+  });
+});
+
+// ─── Create ─────────────────────────────────────────────────────────────────
+
+describe("POST /v1/admin/platform-admins", () => {
+  it("creates a platform admin: KC user + role + Org membership + UPDATE_PASSWORD email + audit row", async () => {
+    const email = `new-admin-${randomUUID().slice(0, 8)}@example.org`;
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: { email, firstName: "New", lastName: "Admin" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json() as { data: { id: string; keycloakId: string; email: string } };
+    expect(body.data.email).toBe(email);
+    expect(typeof body.data.keycloakId).toBe("string");
+
+    // KC side-effects all fired.
+    expect(kcCreateUser).toHaveBeenCalledTimes(1);
+    expect(kcAssignRealmRole).toHaveBeenCalledTimes(1);
+    expect(kcAssignRealmRole.mock.calls[0]?.[1]).toMatchObject({ name: "super_admin" });
+    expect(kcAttachUserToOrg).toHaveBeenCalledTimes(1);
+    expect(kcSendExecuteActions).toHaveBeenCalledTimes(1);
+    expect(kcSendExecuteActions.mock.calls[0]?.[1]).toEqual(["UPDATE_PASSWORD"]);
+
+    // Audit row was written under the platform sentinel tenant.
+    const auditRows = await systemDb.execute<{
+      action: string;
+      org_id: string;
+      actor_id: string;
+    }>(
+      sql`SELECT action, org_id, actor_id FROM audit_logs WHERE resource_id = ${body.data.id} AND action = 'platform_admin.created'`,
+    );
+    expect(auditRows.rows.length).toBe(1);
+    expect(auditRows.rows[0]?.org_id).toBe(PLATFORM_TENANT_ID);
+    expect(auditRows.rows[0]?.actor_id).toBe(SUPER_ADMIN_KEYCLOAK_ID);
+  });
+
+  it("refuses (409 + RFC 9457) when the email belongs to a tenant user (ADR-022 invariant)", async () => {
+    // user-a@example.org is seeded by `ensureTestTenants` in setup.ts.
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: { email: "user-a@example.org", firstName: "X", lastName: "Y" },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({
+      type: "https://httpproblems.com/http-status/409",
+      title: "Conflict",
+      status: 409,
+    });
+    expect((res.json() as { detail?: string }).detail ?? "").toMatch(/tenant member/i);
+    // KC must not be touched on the invariant rejection — fail fast.
+    expect(kcCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when the super_admin realm role is missing in Keycloak (operator-visible misconfig)", async () => {
+    kcGetRealmRole.mockResolvedValueOnce(null);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: {
+        email: `kc-fail-${randomUUID().slice(0, 8)}@example.org`,
+        firstName: "X",
+        lastName: "Y",
+      },
+    });
+    expect(res.statusCode).toBe(502);
+    expect((res.json() as { detail?: string }).detail ?? "").toMatch(/role.*super_admin/);
+    expect(kcCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the KC user when a side-effect (assignRealmRole) fails mid-flight", async () => {
+    kcAssignRealmRole.mockRejectedValueOnce(new Error("simulated KC failure"));
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: {
+        email: `compensating-${randomUUID().slice(0, 8)}@example.org`,
+        firstName: "X",
+        lastName: "Y",
+      },
+    });
+    expect(res.statusCode).toBe(502);
+    // Compensating delete fired.
+    expect(kcDeleteUser).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Rename ─────────────────────────────────────────────────────────────────
+
+describe("PATCH /v1/admin/platform-admins/:id", () => {
+  it("renames a platform admin and writes an audit row with old/new values", async () => {
+    const email = `rename-${randomUUID().slice(0, 8)}@example.org`;
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: { email, firstName: "Before", lastName: "Name" },
+    });
+    expect(create.statusCode).toBe(201);
+    const id = (create.json() as { data: { id: string } }).data.id;
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/admin/platform-admins/${id}`,
+      headers: authHeader(superAdminToken()),
+      payload: { firstName: "After", lastName: "Renamed" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as { data: { firstName: string } }).data.firstName).toBe("After");
+    expect(kcUpdateUser).toHaveBeenCalledTimes(1);
+
+    const auditRows = await systemDb.execute<{
+      old_values: Record<string, unknown>;
+      new_values: Record<string, unknown>;
+    }>(
+      sql`SELECT old_values, new_values FROM audit_logs WHERE resource_id = ${id} AND action = 'platform_admin.renamed'`,
+    );
+    expect(auditRows.rows.length).toBe(1);
+    expect(auditRows.rows[0]?.old_values).toMatchObject({ firstName: "Before" });
+    expect(auditRows.rows[0]?.new_values).toMatchObject({ firstName: "After" });
+  });
+});
+
+// ─── Reset password ─────────────────────────────────────────────────────────
+
+describe("POST /v1/admin/platform-admins/:id/reset-password", () => {
+  it("triggers a fresh UPDATE_PASSWORD email and writes an audit row", async () => {
+    const email = `reset-${randomUUID().slice(0, 8)}@example.org`;
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: { email, firstName: "X", lastName: "Y" },
+    });
+    expect(create.statusCode).toBe(201);
+    const id = (create.json() as { data: { id: string } }).data.id;
+    kcSendExecuteActions.mockClear();
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/admin/platform-admins/${id}/reset-password`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(res.statusCode).toBe(204);
+    expect(kcSendExecuteActions).toHaveBeenCalledTimes(1);
+    expect(kcSendExecuteActions.mock.calls[0]?.[1]).toEqual(["UPDATE_PASSWORD"]);
+
+    const auditRows = await systemDb.execute(
+      sql`SELECT action FROM audit_logs WHERE resource_id = ${id} AND action = 'platform_admin.password_reset_sent'`,
+    );
+    expect(auditRows.rows.length).toBe(1);
+  });
+});
+
+// ─── Soft-delete ────────────────────────────────────────────────────────────
+
+describe("DELETE /v1/admin/platform-admins/:id", () => {
+  it("refuses self-removal with 400 (operator cannot soft-delete their own row)", async () => {
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/admin/platform-admins/${SUPER_ADMIN_PLATFORM_ROW_ID}`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(res.statusCode).toBe(400);
+    expect((res.json() as { detail?: string }).detail ?? "").toMatch(/own platform-admin row/i);
+    expect(kcDeleteUser).not.toHaveBeenCalled();
+  });
+
+  it("refuses the last-admin removal with 400", async () => {
+    // Create a second admin first, then remove the seeded one — that
+    // succeeds — but immediately re-attempt to remove the only remaining
+    // admin and expect 400.
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: {
+        email: `second-${randomUUID().slice(0, 8)}@example.org`,
+        firstName: "Second",
+        lastName: "Admin",
+      },
+    });
+    expect(second.statusCode).toBe(201);
+    const secondId = (second.json() as { data: { id: string } }).data.id;
+    const secondKc = (second.json() as { data: { keycloakId: string } }).data.keycloakId;
+
+    // Use a fresh token signed as the *second* admin to soft-delete the
+    // original (the original cannot self-remove). The second admin has the
+    // super_admin realm role injected in the JWT.
+    const secondToken = signToken(app, {
+      sub: secondKc,
+      realm_access: { roles: ["super_admin"] },
+      role: undefined,
+    });
+
+    const removeOriginal = await app.inject({
+      method: "DELETE",
+      url: `/v1/admin/platform-admins/${SUPER_ADMIN_PLATFORM_ROW_ID}`,
+      headers: authHeader(secondToken),
+    });
+    expect(removeOriginal.statusCode).toBe(204);
+
+    // Now `second` is the only active admin. Try to delete it from a
+    // distinct operator JWT (third synthetic super-admin sub) so the
+    // self-removal guard doesn't fire and we hit the last-admin guard.
+    const thirdToken = signToken(app, {
+      sub: "00000000-0000-0000-0000-0000000000fe",
+      realm_access: { roles: ["super_admin"] },
+      role: undefined,
+    });
+    const removeSecond = await app.inject({
+      method: "DELETE",
+      url: `/v1/admin/platform-admins/${secondId}`,
+      headers: authHeader(thirdToken),
+    });
+    expect(removeSecond.statusCode).toBe(400);
+    expect((removeSecond.json() as { detail?: string }).detail ?? "").toMatch(/last active/i);
+  });
+
+  it("soft-deletes a platform admin: KC user deleted, sub blocklisted, audit row, deleted_at set, keycloak_id cleared", async () => {
+    const created = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: {
+        email: `target-${randomUUID().slice(0, 8)}@example.org`,
+        firstName: "Target",
+        lastName: "User",
+      },
+    });
+    expect(created.statusCode).toBe(201);
+    const id = (created.json() as { data: { id: string } }).data.id;
+    const targetKc = (created.json() as { data: { keycloakId: string } }).data.keycloakId;
+
+    kcDeleteUser.mockClear();
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/admin/platform-admins/${id}`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(res.statusCode).toBe(204);
+
+    expect(kcDeleteUser).toHaveBeenCalledWith(targetKc);
+
+    // Sub blocklisted in Redis (zero-second propagation per ADR-021).
+    const blocklisted = await redis.get(`auth:user-blocklist:${targetKc}`);
+    expect(blocklisted).not.toBeNull();
+
+    // DB state — soft-deleted, keycloak_id nulled.
+    const rows = await systemDb.execute<{
+      deleted_at: string | null;
+      keycloak_id: string | null;
+    }>(sql`SELECT deleted_at, keycloak_id FROM platform_admins WHERE id = ${id}`);
+    expect(rows.rows[0]?.deleted_at).not.toBeNull();
+    expect(rows.rows[0]?.keycloak_id).toBeNull();
+
+    const auditRows = await systemDb.execute(
+      sql`SELECT action FROM audit_logs WHERE resource_id = ${id} AND action = 'platform_admin.removed'`,
+    );
+    expect(auditRows.rows.length).toBe(1);
+  });
+});

--- a/packages/api/src/tests/integration/platform-admins.test.ts
+++ b/packages/api/src/tests/integration/platform-admins.test.ts
@@ -228,27 +228,93 @@ describe("POST /v1/admin/platform-admins", () => {
         lastName: "Y",
       },
     });
+    // Lock the RFC 9457 body shape on this error path (QA M1).
     expect(res.statusCode).toBe(502);
+    expect(res.json()).toMatchObject({
+      type: "https://httpproblems.com/http-status/502",
+      title: "Bad Gateway",
+      status: 502,
+    });
     expect((res.json() as { detail?: string }).detail ?? "").toMatch(/role.*super_admin/);
     expect(kcCreateUser).not.toHaveBeenCalled();
   });
 
-  it("rolls back the KC user when a side-effect (assignRealmRole) fails mid-flight", async () => {
+  it("rolls back the KC user when assignRealmRole fails mid-flight (locks 502 body shape)", async () => {
     kcAssignRealmRole.mockRejectedValueOnce(new Error("simulated KC failure"));
     const res = await app.inject({
       method: "POST",
       url: "/v1/admin/platform-admins",
       headers: authHeader(superAdminToken()),
       payload: {
-        email: `compensating-${randomUUID().slice(0, 8)}@example.org`,
+        email: `compensating-role-${randomUUID().slice(0, 8)}@example.org`,
+        firstName: "X",
+        lastName: "Y",
+      },
+    });
+    // Lock the RFC 9457 body shape on the compensating-delete path (QA M1 + M2).
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toMatchObject({
+      type: "https://httpproblems.com/http-status/502",
+      title: "Bad Gateway",
+      status: 502,
+    });
+    expect(kcDeleteUser).toHaveBeenCalledTimes(1);
+  });
+
+  // QA review M2 — extend compensating-delete coverage from 1 of 3 KC
+  // failure points to 2 of 3. The third (sendExecuteActionsEmail) now has
+  // distinct semantics post-fix-commit-1 (no rollback), so it gets its
+  // own dedicated test below.
+  it("rolls back the KC user when attachUserToOrg fails mid-flight", async () => {
+    kcAttachUserToOrg.mockRejectedValueOnce(new Error("simulated KC org failure"));
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/admin/platform-admins",
+      headers: authHeader(superAdminToken()),
+      payload: {
+        email: `compensating-org-${randomUUID().slice(0, 8)}@example.org`,
         firstName: "X",
         lastName: "Y",
       },
     });
     expect(res.statusCode).toBe(502);
-    // Compensating delete fired.
     expect(kcDeleteUser).toHaveBeenCalledTimes(1);
   });
+
+  it(
+    "does NOT roll back the KC user on email-delivery failure — row is created and 502 references it",
+    async () => {
+      // Platform review M2 — sendExecuteActionsEmail failure used to nuke
+      // the whole KC user. Post-fix-commit-1, the row is preserved and the
+      // operator can retry via /reset-password.
+      kcSendExecuteActions.mockRejectedValueOnce(new Error("simulated SMTP failure"));
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/admin/platform-admins",
+        headers: authHeader(superAdminToken()),
+        payload: {
+          email: `email-fail-${randomUUID().slice(0, 8)}@example.org`,
+          firstName: "X",
+          lastName: "Y",
+        },
+      });
+      expect(res.statusCode).toBe(502);
+      // Compensating delete must NOT have fired — KC user retained.
+      expect(kcDeleteUser).not.toHaveBeenCalled();
+      // The detail message references `/reset-password` so the operator
+      // knows the retry path.
+      expect((res.json() as { detail?: string }).detail ?? "").toMatch(/reset-password/);
+      // The row exists in the DB and is queryable. Extract the id from
+      // the detail string (`id=<uuid>`).
+      const detail = (res.json() as { detail?: string }).detail ?? "";
+      const idMatch = /id=([0-9a-f-]{36})/.exec(detail);
+      expect(idMatch?.[1]).toBeTruthy();
+      const rows = await systemDb.execute(
+        sql`SELECT id FROM platform_admins WHERE id = ${idMatch?.[1]} AND deleted_at IS NULL`,
+      );
+      expect(rows.rows.length).toBe(1);
+    },
+  );
 });
 
 // ─── Rename ─────────────────────────────────────────────────────────────────
@@ -327,7 +393,13 @@ describe("DELETE /v1/admin/platform-admins/:id", () => {
       url: `/v1/admin/platform-admins/${SUPER_ADMIN_PLATFORM_ROW_ID}`,
       headers: authHeader(superAdminToken()),
     });
+    // Lock RFC 9457 body shape (QA M1).
     expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      type: "https://httpproblems.com/http-status/400",
+      title: "Bad Request",
+      status: 400,
+    });
     expect((res.json() as { detail?: string }).detail ?? "").toMatch(/own platform-admin row/i);
     expect(kcDeleteUser).not.toHaveBeenCalled();
   });
@@ -379,7 +451,13 @@ describe("DELETE /v1/admin/platform-admins/:id", () => {
       url: `/v1/admin/platform-admins/${secondId}`,
       headers: authHeader(thirdToken),
     });
+    // Lock RFC 9457 body shape on the last-admin path (QA M1).
     expect(removeSecond.statusCode).toBe(400);
+    expect(removeSecond.json()).toMatchObject({
+      type: "https://httpproblems.com/http-status/400",
+      title: "Bad Request",
+      status: 400,
+    });
     expect((removeSecond.json() as { detail?: string }).detail ?? "").toMatch(/last active/i);
   });
 

--- a/packages/api/src/tests/integration/signup.test.ts
+++ b/packages/api/src/tests/integration/signup.test.ts
@@ -80,6 +80,10 @@ const fakeKeycloakAdmin: KeycloakAdminClient = {
   deleteUser: vi.fn(async () => {}),
   createIdentityProvider: vi.fn(async () => {}),
   deleteIdentityProvider: vi.fn(async () => {}),
+  // Issue #254 — platform-admin CRUD helpers. Signup flow never calls them.
+  getRealmRole: vi.fn(async () => null),
+  assignRealmRoleToUser: vi.fn(async () => {}),
+  sendExecuteActionsEmail: vi.fn(async () => {}),
   _circuitState: () => "closed",
 };
 

--- a/packages/api/src/tests/integration/team-invitations.test.ts
+++ b/packages/api/src/tests/integration/team-invitations.test.ts
@@ -70,6 +70,11 @@ const fakeKeycloakAdmin: KeycloakAdminClient = {
   deleteUser: kcDeleteUser,
   createIdentityProvider: vi.fn(async () => {}),
   deleteIdentityProvider: vi.fn(async () => {}),
+  // Issue #254 — platform-admin CRUD helpers. The team-invitation flow
+  // never calls them; stubs preserve interface parity.
+  getRealmRole: vi.fn(async () => null),
+  assignRealmRoleToUser: vi.fn(async () => {}),
+  sendExecuteActionsEmail: vi.fn(async () => {}),
   _circuitState: () => "closed",
 };
 

--- a/packages/api/src/tests/integration/user-edit.test.ts
+++ b/packages/api/src/tests/integration/user-edit.test.ts
@@ -53,6 +53,10 @@ const fakeKeycloakAdmin: KeycloakAdminClient = {
   deleteUser: vi.fn(async () => {}),
   createIdentityProvider: vi.fn(async () => {}),
   deleteIdentityProvider: vi.fn(async () => {}),
+  // Issue #254 — platform-admin CRUD helpers. User-edit flow never calls them.
+  getRealmRole: vi.fn(async () => null),
+  assignRealmRoleToUser: vi.fn(async () => {}),
+  sendExecuteActionsEmail: vi.fn(async () => {}),
   _circuitState: () => "closed",
 };
 

--- a/packages/shared/src/constants/impersonation.ts
+++ b/packages/shared/src/constants/impersonation.ts
@@ -16,12 +16,3 @@ export const IMPERSONATION_END_REASON_VALUES = [
   "switched",
 ] as const;
 export type ImpersonationEndReason = (typeof IMPERSONATION_END_REASON_VALUES)[number];
-
-/**
- * Sentinel tenant id for the seeded platform organization that hosts
- * super-admin users (`infra/keycloak/realm-givernance.json` — see the
- * `platform` Organization). Used by the impersonation service to refuse
- * starting a session against a target who belongs to the platform tenant
- * — that's the structural barrier against operator → operator nesting.
- */
-export const PLATFORM_TENANT_ID = "00000000-0000-0000-0000-0000000000a1";

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -9,7 +9,6 @@ export {
   IMPERSONATION_MODE_VALUES,
   type ImpersonationEndReason,
   type ImpersonationMode,
-  PLATFORM_TENANT_ID,
 } from "./impersonation";
 export { isPersonalEmailDomain, PERSONAL_EMAIL_DOMAINS } from "./personal-email-domains";
 export { PINO_REDACT_PATHS } from "./pino-redact";

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -217,6 +217,51 @@ export const users = pgTable(
   ],
 );
 
+// ─── Platform admins (ADR-022) ────────────────────────────────────────────────
+
+/**
+ * Platform admins — Givernance staff with the Keycloak realm role
+ * `super_admin`. Disjoint from `users`: a Keycloak person is either a
+ * platform admin or a tenant member, never both (ADR-022). The table sits
+ * outside RLS — all reads/writes go through `systemDb` (BYPASSRLS) — and
+ * the migration explicitly REVOKEs ALL from the app role so an accidental
+ * query through the NOBYPASSRLS pool fails loud rather than returning rows.
+ *
+ * No `org_id`: platform admins do not belong to any tenant. The Keycloak
+ * "Givernance Platform" Organization remains as a logical staff grouping
+ * upstream, but it has no app-DB mirror in `tenants` (ADR-022).
+ *
+ * Soft-delete only (universal Givernance rule, ADR-021): the audit story
+ * "list every super-admin we have ever had" must include offboarded staff.
+ * The partial unique index on `keycloak_id WHERE deleted_at IS NULL` lets
+ * a Keycloak id be re-bound after offboarding without conflict.
+ */
+export const platformAdmins = pgTable(
+  "platform_admins",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    keycloakId: varchar("keycloak_id", { length: 255 }),
+    email: varchar("email", { length: 255 }).notNull(),
+    firstName: varchar("first_name", { length: 255 }).notNull(),
+    lastName: varchar("last_name", { length: 255 }).notNull(),
+    /** Optional last-login marker so the audit story can answer "who's been active". */
+    lastLoginAt: timestamp("last_login_at", { withTimezone: true }),
+    /** Soft-delete marker (ADR-021 universal). Listing endpoints filter `deleted_at IS NULL`. */
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("platform_admins_deleted_at_idx").on(table.deletedAt),
+    // Drizzle Kit doesn't model partial indexes — the migration declares the
+    // partial-unique on `keycloak_id WHERE deleted_at IS NULL` and on
+    // `lower(email) WHERE deleted_at IS NULL` directly. The unconditional
+    // unique here gives type-side parity for the Drizzle query builder.
+    unique("platform_admins_keycloak_id_uniq").on(table.keycloakId),
+    unique("platform_admins_email_uniq").on(table.email),
+  ],
+);
+
 // ─── Invitations ──────────────────────────────────────────────────────────────
 
 /** Purpose discriminator for invitation rows — team invite vs self-serve signup verification (migration 0022). */

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -265,7 +265,22 @@ export const platformAdmins = pgTable(
 // ─── Invitations ──────────────────────────────────────────────────────────────
 
 /** Purpose discriminator for invitation rows — team invite vs self-serve signup verification (migration 0022). */
-export const INVITATION_PURPOSE_VALUES = ["team_invite", "signup_verification"] as const;
+export const INVITATION_PURPOSE_VALUES = [
+  "team_invite",
+  "signup_verification",
+  /**
+   * Platform-admin invitation (issue #254). Sent when a super-admin
+   * invites a new Givernance staffer via the back-office; the invitee
+   * accepts on a public Givernance page that handles the
+   * "already-authenticated-as-different-user" UX gracefully.
+   *
+   * Distinct from `team_invite` because the accept flow does NOT
+   * insert into `users` — it inserts into `platform_admins` (ADR-022).
+   * The `org_id` on the invitations row is the platform sentinel
+   * tenant `…a1` (the FK target only; no actual tenant scoping).
+   */
+  "platform_admin_invite",
+] as const;
 export type InvitationPurpose = (typeof INVITATION_PURPOSE_VALUES)[number];
 
 /**

--- a/packages/web/src/app/(admin)/admin/platform-admins/[id]/page.tsx
+++ b/packages/web/src/app/(admin)/admin/platform-admins/[id]/page.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { PlatformAdminDetailActions } from "@/components/admin/platform-admin-detail-actions";
+import { formatAdminDate } from "@/components/admin/tenant-admin-shared";
+import { ApiProblem } from "@/lib/api";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import type { PlatformAdmin, PlatformAdminDetailResponse } from "@/models/platform-admin";
+
+export const dynamic = "force-dynamic";
+
+export default async function PlatformAdminDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const t = await getTranslations("admin.platformAdmins.detail");
+  const api = await createServerApiClient();
+
+  let admin: PlatformAdmin;
+  try {
+    const res = await api.get<PlatformAdminDetailResponse>(
+      `/v1/admin/platform-admins/${encodeURIComponent(id)}`,
+    );
+    admin = res.data;
+  } catch (err) {
+    if (err instanceof ApiProblem && err.status === 404) notFound();
+    throw err;
+  }
+
+  // Operator's Keycloak `sub` — feeds the self-removal hide rule on the
+  // remove button. The `(admin)` layout already gates super_admin, so
+  // requireAuth() here just resolves the JWT we already verified.
+  const operatorAuth = await requireAuth();
+  const operatorKeycloakId = operatorAuth.userId;
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <Link
+          href="/admin/platform-admins"
+          className="text-xs font-medium text-primary hover:underline"
+        >
+          {t("back")}
+        </Link>
+        <h1 className="mt-2 font-heading text-2xl text-on-surface">
+          {t("title", { firstName: admin.firstName, lastName: admin.lastName })}
+        </h1>
+        <p className="mt-1 text-sm text-on-surface-variant">
+          {admin.deletedAt
+            ? t("subtitleRemoved", { date: formatAdminDate(admin.deletedAt) })
+            : t("subtitleActive")}
+        </p>
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 rounded-2xl border border-outline-variant bg-surface p-6 md:grid-cols-2">
+        <Field label={t("fields.email")} value={admin.email} />
+        <Field label={t("fields.createdAt")} value={formatAdminDate(admin.createdAt)} />
+        <Field
+          label={t("fields.lastLoginAt")}
+          value={
+            admin.lastLoginAt ? formatAdminDate(admin.lastLoginAt) : t("fields.lastLoginNever")
+          }
+        />
+        {admin.deletedAt ? (
+          <Field label={t("fields.removedAt")} value={formatAdminDate(admin.deletedAt)} />
+        ) : (
+          <Field label={t("fields.keycloakId")} value={admin.keycloakId ?? "—"} mono />
+        )}
+      </section>
+
+      <PlatformAdminDetailActions admin={admin} operatorKeycloakId={operatorKeycloakId} />
+    </div>
+  );
+}
+
+function Field({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+        {label}
+      </p>
+      <p className={`mt-1 text-sm text-on-surface ${mono ? "font-mono" : ""}`}>{value}</p>
+    </div>
+  );
+}

--- a/packages/web/src/app/(admin)/admin/platform-admins/new/page.tsx
+++ b/packages/web/src/app/(admin)/admin/platform-admins/new/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+
+import { NewPlatformAdminForm } from "@/components/admin/new-platform-admin-form";
+
+/**
+ * Super-admin-only page for inviting a new platform admin (issue #254).
+ * The `(admin)` layout guards on `super_admin`; non-super-admins land on
+ * the platform 404 instead.
+ */
+export default async function NewPlatformAdminPage() {
+  const t = await getTranslations("admin.platformAdmins.new");
+  return (
+    <div className="space-y-8">
+      <header>
+        <Link
+          href="/admin/platform-admins"
+          className="text-xs font-medium text-primary hover:underline"
+        >
+          {t("back")}
+        </Link>
+        <h1 className="mt-2 font-heading text-2xl text-on-surface">{t("title")}</h1>
+        <p className="mt-1 text-sm text-on-surface-variant">{t("subtitle")}</p>
+      </header>
+
+      <div className="rounded-2xl border border-outline-variant bg-surface p-6">
+        <NewPlatformAdminForm />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/(admin)/admin/platform-admins/page.tsx
+++ b/packages/web/src/app/(admin)/admin/platform-admins/page.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+
+import { PlatformAdminsTable } from "@/components/admin/platform-admins-table";
+import { Button } from "@/components/ui/button";
+import { createServerApiClient } from "@/lib/api/client-server";
+import type {
+  PlatformAdminListResponse,
+  PlatformAdminSortField,
+  PlatformAdminSortOrder,
+} from "@/models/platform-admin";
+
+export const dynamic = "force-dynamic";
+
+const SORT_FIELDS = new Set<PlatformAdminSortField>([
+  "lastName",
+  "email",
+  "createdAt",
+  "lastLoginAt",
+]);
+
+function normalizeSort(value: string | undefined): PlatformAdminSortField {
+  if (value && SORT_FIELDS.has(value as PlatformAdminSortField)) {
+    return value as PlatformAdminSortField;
+  }
+  return "createdAt";
+}
+
+function normalizeOrder(value: string | undefined): PlatformAdminSortOrder {
+  return value === "asc" ? "asc" : "desc";
+}
+
+export default async function PlatformAdminsListPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ sort?: string; order?: string; q?: string; includeDeleted?: string }>;
+}) {
+  const search = await searchParams;
+  const t = await getTranslations("admin.platformAdmins.list");
+  const api = await createServerApiClient();
+  const sort = normalizeSort(search.sort);
+  const order = normalizeOrder(search.order);
+  const includeDeleted = search.includeDeleted === "true";
+
+  let data: PlatformAdminListResponse["data"] = [];
+  let total = 0;
+  try {
+    const params = new URLSearchParams({
+      sort,
+      order,
+      ...(search.q ? { q: search.q } : {}),
+      ...(includeDeleted ? { includeDeleted: "true" } : {}),
+      limit: "200",
+    });
+    const res = await api.get<PlatformAdminListResponse>(
+      `/v1/admin/platform-admins?${params.toString()}`,
+    );
+    data = res.data;
+    total = res.meta.total;
+  } catch {
+    data = [];
+    total = 0;
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="font-heading text-2xl text-text">{t("title")}</h1>
+          <p className="mt-1 text-sm text-text-secondary">{t("subtitle")}</p>
+        </div>
+        <Button asChild>
+          <Link href="/admin/platform-admins/new">{t("createCta")}</Link>
+        </Button>
+      </header>
+
+      <PlatformAdminsTable admins={data} total={total} sort={sort} order={order} />
+    </div>
+  );
+}

--- a/packages/web/src/app/(admin)/admin/platform-admins/page.tsx
+++ b/packages/web/src/app/(admin)/admin/platform-admins/page.tsx
@@ -1,3 +1,4 @@
+import { AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
@@ -30,51 +31,63 @@ function normalizeOrder(value: string | undefined): PlatformAdminSortOrder {
   return value === "asc" ? "asc" : "desc";
 }
 
+/**
+ * Super-admin-only list page for platform admins (issue #254). Search +
+ * include-deleted toggle UI are deferred to a follow-up — the API
+ * supports both, but until the UI ships there's no point reading the
+ * params from the URL (frontend review M2 — drop dead plumbing).
+ */
 export default async function PlatformAdminsListPage({
   searchParams,
 }: {
-  searchParams: Promise<{ sort?: string; order?: string; q?: string; includeDeleted?: string }>;
+  searchParams: Promise<{ sort?: string; order?: string }>;
 }) {
   const search = await searchParams;
   const t = await getTranslations("admin.platformAdmins.list");
   const api = await createServerApiClient();
   const sort = normalizeSort(search.sort);
   const order = normalizeOrder(search.order);
-  const includeDeleted = search.includeDeleted === "true";
 
-  let data: PlatformAdminListResponse["data"] = [];
+  let data: PlatformAdminListResponse["data"] | null = null;
   let total = 0;
+  let fetchFailed = false;
   try {
-    const params = new URLSearchParams({
-      sort,
-      order,
-      ...(search.q ? { q: search.q } : {}),
-      ...(includeDeleted ? { includeDeleted: "true" } : {}),
-      limit: "200",
-    });
+    const params = new URLSearchParams({ sort, order, limit: "200" });
     const res = await api.get<PlatformAdminListResponse>(
       `/v1/admin/platform-admins?${params.toString()}`,
     );
     data = res.data;
     total = res.meta.total;
   } catch {
-    data = [];
-    total = 0;
+    // Frontend review M1: a fetch failure rendered as an empty list
+    // ("No platform admins yet") was misleading and dangerous on a
+    // staff-management page. Distinct error banner instead.
+    fetchFailed = true;
   }
 
   return (
     <div className="space-y-8">
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h1 className="font-heading text-2xl text-text">{t("title")}</h1>
-          <p className="mt-1 text-sm text-text-secondary">{t("subtitle")}</p>
+          <h1 className="font-heading text-2xl text-on-surface">{t("title")}</h1>
+          <p className="mt-1 text-sm text-on-surface-variant">{t("subtitle")}</p>
         </div>
         <Button asChild>
           <Link href="/admin/platform-admins/new">{t("createCta")}</Link>
         </Button>
       </header>
 
-      <PlatformAdminsTable admins={data} total={total} sort={sort} order={order} />
+      {fetchFailed ? (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-2xl border border-error bg-error-container p-4 text-on-error-container"
+        >
+          <AlertTriangle aria-hidden="true" className="mt-0.5 shrink-0" size={20} />
+          <p className="text-sm">{t("fetchFailed")}</p>
+        </div>
+      ) : (
+        <PlatformAdminsTable admins={data ?? []} total={total} sort={sort} order={order} />
+      )}
     </div>
   );
 }

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -41,10 +41,32 @@ const fetchMeWithMembership = cache(async () => {
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const auth = await requireAuth();
+  const isSuperAdmin = auth.roles.includes("super_admin");
 
   const userName = auth.firstName ? `${auth.firstName} ${auth.lastName ?? ""}`.trim() : auth.email;
 
   const { me, membershipCount } = await fetchMeWithMembership();
+
+  // Broken state: a non-super-admin reached the authenticated layout but
+  // we couldn't resolve their tenant memberships. Two failure modes:
+  //   - `membershipCount === undefined`: `/v1/users/me/organizations`
+  //     rejected (transient 5xx, network blip).
+  //   - `membershipCount === 0`: the user has no active memberships —
+  //     usually a JWT that outlived a tenant-removal, which the auth
+  //     plugin's active-row check (ADR-021) is supposed to catch
+  //     upstream; landing here means the check was bypassed somehow.
+  //
+  // Either way the user has nothing to do in the app — silently
+  // rendering a half-broken sidebar / data-less dashboard would mask
+  // a real bug. Throwing surfaces it in logs + Next.js's error boundary
+  // so we can investigate. Super-admins are exempt: they legitimately
+  // have zero tenant memberships by design (ADR-022).
+  if (!isSuperAdmin && (membershipCount === undefined || membershipCount === 0)) {
+    throw new Error(
+      `Authenticated tenant user has no resolvable memberships (membershipCount=${membershipCount}). ` +
+        `Check /v1/users/me/organizations and the auth plugin's active-row guard.`,
+    );
+  }
 
   let provisionalAdmin: { provisionalUntil: string; orgSlug: string } | undefined;
   if (

--- a/packages/web/src/app/(auth)/admin/platform-admins/accept/page.test.tsx
+++ b/packages/web/src/app/(auth)/admin/platform-admins/accept/page.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import PlatformAdminAcceptPage from "./page";
+
+const TOKEN = "00000000-0000-0000-0000-000000000abc";
+
+vi.mock("next/navigation", async () => {
+  const { mockRouter } = await import("@/tests/mocks");
+  return {
+    useRouter: () => mockRouter,
+    usePathname: () => "/admin/platform-admins/accept",
+    useSearchParams: () => new URLSearchParams(`token=${TOKEN}`),
+  };
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+type RouteFn = () => Response | Promise<Response>;
+
+const DEFAULT_SESSION: RouteFn = () => new Response(null, { status: 401 });
+const DEFAULT_PROBE: RouteFn = () =>
+  new Response(
+    JSON.stringify({
+      data: { email: "new@example.org", firstName: "New", lastName: "Admin" },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+
+function pickRoute(url: string, routes: { session?: RouteFn; probe?: RouteFn }): RouteFn {
+  if (url.includes("/v1/users/me")) return routes.session ?? DEFAULT_SESSION;
+  if (url.includes("/v1/public/platform-admins/invitations/")) {
+    return routes.probe ?? DEFAULT_PROBE;
+  }
+  throw new Error(`Unhandled fetch in test: ${url}`);
+}
+
+function stubRoutedFetch(routes: { session?: RouteFn; probe?: RouteFn }) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return pickRoute(url, routes)();
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("PlatformAdminAcceptPage — session-conflict prompt round-trip", () => {
+  it("renders the sign-out prompt when /v1/users/me returns a signed-in user", async () => {
+    stubRoutedFetch({
+      session: () =>
+        new Response(
+          JSON.stringify({
+            data: { email: "alice@example.org", firstName: "Alice", lastName: "Martin" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    render(<PlatformAdminAcceptPage />);
+
+    const heading = await screen.findByRole("heading", {
+      name: "Sign out to accept this invitation",
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  /**
+   * Locks the return_to round-trip used by `/api/auth/logout`. Without
+   * this, regressing the path could silently route the post-logout
+   * redirect to `/login` (the route's allowlist fallback) — the exact
+   * UX bug surfaced in dev: the invitee signed out, lost the token in
+   * the URL, and got bounced to login with no password set yet.
+   *
+   * The route's allowlist test (in `route.test.ts`) covers the
+   * server-side guard; this test covers the client-side input.
+   */
+  it("submits return_to=/admin/platform-admins/accept?token=... to /api/auth/logout", async () => {
+    stubRoutedFetch({
+      session: () =>
+        new Response(
+          JSON.stringify({
+            data: { email: "alice@example.org", firstName: "Alice", lastName: "Martin" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    render(<PlatformAdminAcceptPage />);
+
+    const submit = await screen.findByRole("button", { name: "Sign out and continue" });
+    const form = submit.closest("form");
+    expect(form?.getAttribute("action")).toBe("/api/auth/logout");
+    expect(form?.getAttribute("method")?.toLowerCase()).toBe("post");
+    const hidden = form?.querySelector('input[name="return_to"]') as HTMLInputElement | null;
+    expect(hidden?.value).toBe(`/admin/platform-admins/accept?token=${TOKEN}`);
+  });
+
+  it("renders the password-set form when /v1/users/me returns 401", async () => {
+    stubRoutedFetch({});
+    render(<PlatformAdminAcceptPage />);
+
+    expect(
+      await screen.findByRole("button", { name: /Create my admin account/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Sign out and continue" })).not.toBeInTheDocument();
+  });
+
+  it("renders the expired/invalid screen when the token probe returns 404", async () => {
+    stubRoutedFetch({ probe: () => new Response(null, { status: 404 }) });
+    render(<PlatformAdminAcceptPage />);
+
+    expect(await screen.findByRole("heading", { name: /Invitation problem/ })).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/(auth)/admin/platform-admins/accept/page.tsx
+++ b/packages/web/src/app/(auth)/admin/platform-admins/accept/page.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import { CheckCircle2, LogOut, TriangleAlert } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { type FormEvent, Suspense, useCallback, useEffect, useId, useState } from "react";
+import { AuthCard } from "@/components/auth/auth-card";
+import { AuthLogo } from "@/components/auth/auth-logo";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  acceptPlatformAdminInvitation,
+  probePlatformAdminInvitation,
+} from "@/services/PlatformAdminInvitationService";
+
+const PASSWORD_MIN_LENGTH = 12;
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "/api";
+
+interface SignedInUser {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+type SessionProbe =
+  | { status: "checking" }
+  | { status: "anonymous" }
+  | { status: "signed_in"; user: SignedInUser };
+
+/**
+ * One-shot probe of `/v1/users/me` — same posture as the team-invite
+ * accept page. The (auth) layout deliberately doesn't mount AuthProvider,
+ * so we probe inline here to detect the "already signed in as someone
+ * else" case (the exact UX gap that issue #254's KC `execute-actions-email`
+ * approach couldn't solve).
+ */
+async function probeSession(): Promise<SessionProbe> {
+  try {
+    const res = await fetch(`${API_URL}/v1/users/me`, { credentials: "include" });
+    if (!res.ok) return { status: "anonymous" };
+    const body = (await res.json()) as { data?: SignedInUser };
+    if (!body.data?.email) return { status: "anonymous" };
+    return { status: "signed_in", user: body.data };
+  } catch {
+    return { status: "anonymous" };
+  }
+}
+
+type ValidationKey = "invalid" | "namesRequired" | "passwordTooShort" | "passwordMismatch";
+
+interface AcceptFormFields {
+  token: string;
+  firstName: string;
+  lastName: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+function validateAcceptForm(f: AcceptFormFields): ValidationKey | null {
+  if (!f.token) return "invalid";
+  if (f.firstName.trim().length < 1 || f.lastName.trim().length < 1) return "namesRequired";
+  if (f.password.length < PASSWORD_MIN_LENGTH) return "passwordTooShort";
+  if (f.password !== f.passwordConfirm) return "passwordMismatch";
+  return null;
+}
+
+/**
+ * Platform-admin invitation accept page (issue #254 fix-commit 4 refactor).
+ *
+ * Public — not behind the (admin) super_admin gate. Replaces the prior
+ * KC `execute-actions-email` flow that couldn't gracefully handle:
+ *   1. The KC_RESTART cookie expiring during password set.
+ *   2. KC's "Restart login cookie not found" page after UPDATE_PASSWORD.
+ *   3. KC's "already authenticated as different user" rejection when an
+ *      operator clicks the email while still logged in.
+ *
+ * The Givernance-side accept page handles all three: pre-flight token
+ * probe + session-conflict detection + post-accept redirect to /login.
+ */
+function AcceptContent() {
+  const t = useTranslations("auth.platformAdminAccept");
+  const params = useSearchParams();
+  const token = params.get("token") ?? "";
+
+  const ids = {
+    firstName: useId(),
+    lastName: useId(),
+    password: useId(),
+    passwordConfirm: useId(),
+  };
+
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [firstNameDirty, setFirstNameDirty] = useState(false);
+  const [lastNameDirty, setLastNameDirty] = useState(false);
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "done">("idle");
+  const [error, setError] = useState<string | undefined>();
+  const [errorKind, setErrorKind] = useState<
+    "validation" | "expired" | "conflict" | "generic" | undefined
+  >();
+  const [session, setSession] = useState<SessionProbe>({ status: "checking" });
+  type TokenProbeState = "checking" | "valid" | "invalid";
+  const [tokenProbe, setTokenProbe] = useState<TokenProbeState>("checking");
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    void probeSession().then((next) => {
+      if (!cancelled) setSession(next);
+    });
+    void probePlatformAdminInvitation(token).then((result) => {
+      if (cancelled) return;
+      if (result.kind === "valid") {
+        setTokenProbe("valid");
+        if (!firstNameDirty && result.data.firstName) setFirstName(result.data.firstName);
+        if (!lastNameDirty && result.data.lastName) setLastName(result.data.lastName);
+      } else {
+        setTokenProbe("invalid");
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [firstNameDirty, lastNameDirty, token]);
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const validation = validateAcceptForm({
+        token,
+        firstName,
+        lastName,
+        password,
+        passwordConfirm,
+      });
+      if (validation) {
+        setErrorKind("validation");
+        setError(t(`errors.${validation}`, { min: PASSWORD_MIN_LENGTH }));
+        return;
+      }
+      setStatus("submitting");
+      setError(undefined);
+      setErrorKind(undefined);
+      const res = await acceptPlatformAdminInvitation(
+        token,
+        firstName.trim(),
+        lastName.trim(),
+        password,
+      );
+      if (res.ok) {
+        setStatus("done");
+        // Fresh OIDC code flow with the just-set credential.
+        window.location.href = "/api/auth/login";
+        return;
+      }
+      setStatus("idle");
+      const errorKey = res.status === 404 ? "expired" : res.status === 409 ? "conflict" : "generic";
+      setErrorKind(errorKey);
+      setError(t(`errors.${errorKey}`));
+    },
+    [token, firstName, lastName, password, passwordConfirm, t],
+  );
+
+  if (!token) {
+    return (
+      <AuthCard>
+        <AuthLogo />
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-error-container text-on-error-container">
+          <TriangleAlert className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <h1 className="mb-2 text-center font-heading text-xl text-on-surface">{t("errorTitle")}</h1>
+        <p className="mb-6 text-center text-sm text-on-surface-variant">
+          {t("errors.missingToken")}
+        </p>
+        <Link
+          href="/login"
+          className="inline-flex h-[var(--btn-height-md)] w-full items-center justify-center rounded-button bg-primary px-6 text-sm font-medium text-on-primary"
+        >
+          {t("backToLogin")}
+        </Link>
+      </AuthCard>
+    );
+  }
+
+  if (status === "done") {
+    return (
+      <AuthCard>
+        <AuthLogo />
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary-50 text-primary">
+          <CheckCircle2 className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <h1 className="mb-2 text-center font-heading text-xl text-on-surface">
+          {t("successTitle")}
+        </h1>
+        <p className="mb-6 text-center text-sm text-on-surface-variant">{t("successBody")}</p>
+        <div className="flex items-center justify-center text-xs text-on-surface-variant">
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      </AuthCard>
+    );
+  }
+
+  if (session.status === "checking" || tokenProbe === "checking") {
+    return (
+      <AuthCard>
+        <AuthLogo />
+        <div className="flex items-center justify-center py-6">
+          <span
+            role="status"
+            aria-label={t("sessionCheck.checking")}
+            className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent"
+          />
+        </div>
+      </AuthCard>
+    );
+  }
+
+  // Session-conflict branch — same fix #154 used for team invites. The
+  // sign-out prompt MUST take precedence so a different-user session
+  // doesn't survive into the post-accept login redirect.
+  if (session.status === "signed_in") {
+    const returnTo = `/admin/platform-admins/accept?token=${encodeURIComponent(token)}`;
+    const displayName =
+      session.user.firstName || session.user.lastName
+        ? [session.user.firstName, session.user.lastName].filter(Boolean).join(" ")
+        : session.user.email;
+    return (
+      <AuthCard>
+        <AuthLogo />
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary-50 text-primary">
+          <LogOut className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <h1 className="mb-2 text-center font-heading text-xl text-on-surface">
+          {t("sessionCheck.title")}
+        </h1>
+        <p className="mb-2 text-center text-sm text-on-surface-variant">
+          {t("sessionCheck.signedInAs", { name: displayName, email: session.user.email })}
+        </p>
+        <p className="mb-6 text-center text-sm text-on-surface-variant">{t("sessionCheck.body")}</p>
+        <form method="POST" action="/api/auth/logout" className="space-y-3">
+          <input type="hidden" name="return_to" value={returnTo} />
+          <button
+            type="submit"
+            className="inline-flex h-[var(--btn-height-lg)] w-full items-center justify-center gap-2 rounded-button bg-primary px-8 font-body text-base font-medium text-on-primary transition-opacity duration-normal ease-out hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            <LogOut className="h-4 w-4" aria-hidden="true" />
+            {t("sessionCheck.signOut")}
+          </button>
+        </form>
+      </AuthCard>
+    );
+  }
+
+  if (tokenProbe === "invalid" || errorKind === "expired") {
+    return (
+      <AuthCard>
+        <AuthLogo />
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-error-container text-on-error-container">
+          <TriangleAlert className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <h1 className="mb-2 text-center font-heading text-xl text-on-surface">{t("errorTitle")}</h1>
+        <p className="mb-6 text-center text-sm text-on-surface-variant">{t("errors.expired")}</p>
+        <Link
+          href="/login"
+          className="inline-flex h-[var(--btn-height-md)] w-full items-center justify-center rounded-button bg-primary px-6 text-sm font-medium text-on-primary"
+        >
+          {t("backToLogin")}
+        </Link>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard>
+      <AuthLogo />
+      <h1 className="mb-2 text-center font-heading text-xl text-on-surface">{t("title")}</h1>
+      <p className="mb-6 text-center text-sm text-on-surface-variant">{t("subtitle")}</p>
+      <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+        <div>
+          <Label htmlFor={ids.firstName}>{t("fields.firstName")}</Label>
+          <Input
+            id={ids.firstName}
+            value={firstName}
+            onChange={(e) => {
+              setFirstName(e.target.value);
+              setFirstNameDirty(true);
+            }}
+            required
+            autoComplete="given-name"
+          />
+        </div>
+        <div>
+          <Label htmlFor={ids.lastName}>{t("fields.lastName")}</Label>
+          <Input
+            id={ids.lastName}
+            value={lastName}
+            onChange={(e) => {
+              setLastName(e.target.value);
+              setLastNameDirty(true);
+            }}
+            required
+            autoComplete="family-name"
+          />
+        </div>
+        <div>
+          <Label htmlFor={ids.password}>{t("fields.password")}</Label>
+          <Input
+            id={ids.password}
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={PASSWORD_MIN_LENGTH}
+            autoComplete="new-password"
+          />
+          <p className="mt-1 text-xs text-on-surface-variant">
+            {t("fields.passwordHint", { min: PASSWORD_MIN_LENGTH })}
+          </p>
+        </div>
+        <div>
+          <Label htmlFor={ids.passwordConfirm}>{t("fields.passwordConfirm")}</Label>
+          <Input
+            id={ids.passwordConfirm}
+            type="password"
+            value={passwordConfirm}
+            onChange={(e) => setPasswordConfirm(e.target.value)}
+            required
+            minLength={PASSWORD_MIN_LENGTH}
+            autoComplete="new-password"
+          />
+        </div>
+        {error ? (
+          <p
+            role="alert"
+            className="rounded-md bg-error-container p-3 text-sm text-on-error-container"
+          >
+            {error}
+          </p>
+        ) : null}
+        <button
+          type="submit"
+          disabled={status === "submitting"}
+          className="inline-flex h-[var(--btn-height-lg)] w-full items-center justify-center rounded-button bg-primary px-8 font-body text-base font-medium text-on-primary transition-opacity duration-normal ease-out hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {status === "submitting" ? t("submitting") : t("submit")}
+        </button>
+      </form>
+    </AuthCard>
+  );
+}
+
+export default function PlatformAdminAcceptPage() {
+  return (
+    <Suspense
+      fallback={
+        <AuthCard>
+          <AuthLogo />
+          <div className="flex items-center justify-center py-6">
+            <span
+              role="status"
+              className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent"
+            />
+          </div>
+        </AuthCard>
+      }
+    >
+      <AcceptContent />
+    </Suspense>
+  );
+}

--- a/packages/web/src/app/api/auth/logout/return-to-allowlist.ts
+++ b/packages/web/src/app/api/auth/logout/return-to-allowlist.ts
@@ -1,0 +1,21 @@
+/**
+ * Allowlist of safe `return_to` paths for `POST /api/auth/logout`.
+ *
+ * Prevents open-redirect by restricting the post-logout destination to
+ * known in-app routes that benefit from a round-trip — e.g. accept-style
+ * flows where the invitee may have arrived while another user was
+ * signed in. The route handler exact-matches `parsed.pathname` against
+ * this set; anything else falls back to `/login`.
+ *
+ * Lives in its own module (rather than `route.ts`) so unit tests can
+ * import it without pulling Next.js's server-only imports
+ * (`next/headers`, `next/server`).
+ */
+export const RETURN_TO_PATH_ALLOWLIST = new Set<string>([
+  // PR #154: team invitation accept flow.
+  "/invite/accept",
+  // Issue #254: platform-admin invitation accept flow. The session-
+  // conflict prompt round-trips through this allowlist after sign-out
+  // so the invitee lands back on the password-set form (not /login).
+  "/admin/platform-admins/accept",
+]);

--- a/packages/web/src/app/api/auth/logout/route.test.ts
+++ b/packages/web/src/app/api/auth/logout/route.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { RETURN_TO_PATH_ALLOWLIST } from "./return-to-allowlist";
+
+/**
+ * The post-logout `return_to` allowlist gates which in-app paths can be
+ * used as the destination after Keycloak's end-session redirect. Each
+ * accept-style flow that relies on the round-trip MUST appear here —
+ * see issue #254 for the bug class (the platform-admin accept page
+ * silently fell back to /login because the path was missing, losing
+ * the invitation token and stranding the new admin without a password).
+ *
+ * `parsed.pathname` is exact-matched in `resolvePostLogoutRedirectUri`,
+ * so additions here are the only knob for new round-trip targets.
+ */
+describe("logout route — return_to allowlist", () => {
+  it("includes /invite/accept (team invitation flow, PR #154)", () => {
+    expect(RETURN_TO_PATH_ALLOWLIST.has("/invite/accept")).toBe(true);
+  });
+
+  it("includes /admin/platform-admins/accept (platform-admin invitation flow, issue #254)", () => {
+    expect(RETURN_TO_PATH_ALLOWLIST.has("/admin/platform-admins/accept")).toBe(true);
+  });
+
+  it("does NOT include /login or arbitrary paths (anti-open-redirect)", () => {
+    expect(RETURN_TO_PATH_ALLOWLIST.has("/login")).toBe(false);
+    expect(RETURN_TO_PATH_ALLOWLIST.has("/admin")).toBe(false);
+    expect(RETURN_TO_PATH_ALLOWLIST.has("/")).toBe(false);
+    expect(RETURN_TO_PATH_ALLOWLIST.has("/admin/tenants")).toBe(false);
+  });
+});

--- a/packages/web/src/app/api/auth/logout/route.ts
+++ b/packages/web/src/app/api/auth/logout/route.ts
@@ -14,9 +14,17 @@ import {
  * Allowlist of safe `return_to` paths. Prevents open-redirect by restricting
  * the post-logout destination to known in-app routes that benefit from a
  * round-trip (e.g. the `/invite/accept` flow per PR #154 follow-up — the
- * invitee may have arrived while another user was signed in).
+ * invitee may have arrived while another user was signed in). Each new
+ * accept-style path that wants the same session-conflict UX (an operator
+ * clicking a fresh invitation link while still signed in as someone else)
+ * needs to be added here explicitly — `parsed.pathname` is exact-matched.
  */
-const RETURN_TO_PATH_ALLOWLIST = new Set<string>(["/invite/accept"]);
+const RETURN_TO_PATH_ALLOWLIST = new Set<string>([
+  "/invite/accept",
+  // Issue #254: the platform-admin invitation accept page. The session-
+  // conflict prompt round-trips through this allowlist after sign-out.
+  "/admin/platform-admins/accept",
+]);
 
 /**
  * POST /api/auth/logout

--- a/packages/web/src/app/api/auth/logout/route.ts
+++ b/packages/web/src/app/api/auth/logout/route.ts
@@ -9,22 +9,7 @@ import {
   LOGOUT_ENDPOINT,
   REFRESH_TOKEN_COOKIE_NAME,
 } from "@/lib/auth/keycloak";
-
-/**
- * Allowlist of safe `return_to` paths. Prevents open-redirect by restricting
- * the post-logout destination to known in-app routes that benefit from a
- * round-trip (e.g. the `/invite/accept` flow per PR #154 follow-up — the
- * invitee may have arrived while another user was signed in). Each new
- * accept-style path that wants the same session-conflict UX (an operator
- * clicking a fresh invitation link while still signed in as someone else)
- * needs to be added here explicitly — `parsed.pathname` is exact-matched.
- */
-const RETURN_TO_PATH_ALLOWLIST = new Set<string>([
-  "/invite/accept",
-  // Issue #254: the platform-admin invitation accept page. The session-
-  // conflict prompt round-trips through this allowlist after sign-out.
-  "/admin/platform-admins/accept",
-]);
+import { RETURN_TO_PATH_ALLOWLIST } from "./return-to-allowlist";
 
 /**
  * POST /api/auth/logout

--- a/packages/web/src/components/admin/new-platform-admin-form.test.tsx
+++ b/packages/web/src/components/admin/new-platform-admin-form.test.tsx
@@ -17,16 +17,14 @@ vi.mock("@/lib/api/client-browser", () => ({
 describe("NewPlatformAdminForm", () => {
   it("submits the create payload and toasts success", async () => {
     const user = userEvent.setup();
+    // Post fix-commit-4 refactor: create returns an invitation summary,
+    // not a `PlatformAdmin` row (the row materialises at accept time).
     vi.mocked(PlatformAdminService.create).mockResolvedValue({
-      id: "00000000-0000-0000-0000-0000000aaaaa",
-      keycloakId: "kc-123",
+      invitationId: "00000000-0000-0000-0000-0000000aaaaa",
       email: "ada@example.org",
       firstName: "Ada",
       lastName: "Lovelace",
-      lastLoginAt: null,
-      deletedAt: null,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
     });
 
     render(<NewPlatformAdminForm />);

--- a/packages/web/src/components/admin/new-platform-admin-form.test.tsx
+++ b/packages/web/src/components/admin/new-platform-admin-form.test.tsx
@@ -1,0 +1,96 @@
+import { ApiProblem } from "@/lib/api";
+import { PlatformAdminService } from "@/services/PlatformAdminService";
+import { mockRouter, mockToast, render, screen, userEvent, waitFor } from "@/tests/test-utils";
+
+import { NewPlatformAdminForm } from "./new-platform-admin-form";
+
+vi.mock("@/services/PlatformAdminService", () => ({
+  PlatformAdminService: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api/client-browser", () => ({
+  createClientApiClient: () => ({}),
+}));
+
+describe("NewPlatformAdminForm", () => {
+  it("submits the create payload and toasts success", async () => {
+    const user = userEvent.setup();
+    vi.mocked(PlatformAdminService.create).mockResolvedValue({
+      id: "00000000-0000-0000-0000-0000000aaaaa",
+      keycloakId: "kc-123",
+      email: "ada@example.org",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      lastLoginAt: null,
+      deletedAt: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    render(<NewPlatformAdminForm />);
+
+    await user.type(screen.getByLabelText(/First name/i), "Ada");
+    await user.type(screen.getByLabelText(/Last name/i), "Lovelace");
+    await user.type(screen.getByLabelText(/Email/i), "ada@example.org");
+    await user.click(screen.getByRole("button", { name: /Send invitation/i }));
+
+    await waitFor(() => {
+      expect(PlatformAdminService.create).toHaveBeenCalledWith(expect.anything(), {
+        firstName: "Ada",
+        lastName: "Lovelace",
+        email: "ada@example.org",
+      });
+    });
+    expect(mockToast.success).toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledWith("/admin/platform-admins");
+  });
+
+  it("maps a 409 with 'tenant member' detail to the email-collision field error (no toast)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(PlatformAdminService.create).mockRejectedValue(
+      new ApiProblem({
+        type: "about:blank",
+        title: "Conflict",
+        status: 409,
+        detail: "This email belongs to a tenant member; …",
+      }),
+    );
+
+    render(<NewPlatformAdminForm />);
+
+    await user.type(screen.getByLabelText(/First name/i), "Ada");
+    await user.type(screen.getByLabelText(/Last name/i), "Lovelace");
+    await user.type(screen.getByLabelText(/Email/i), "ada@example.org");
+    await user.click(screen.getByRole("button", { name: /Send invitation/i }));
+
+    expect(await screen.findByText(/email belongs to a tenant member/i)).toBeInTheDocument();
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it("maps a 502 to the keycloak-misconfig toast", async () => {
+    const user = userEvent.setup();
+    vi.mocked(PlatformAdminService.create).mockRejectedValue(
+      new ApiProblem({
+        type: "about:blank",
+        title: "Bad Gateway",
+        status: 502,
+        detail: "Keycloak realm role 'super_admin' is missing",
+      }),
+    );
+
+    render(<NewPlatformAdminForm />);
+
+    await user.type(screen.getByLabelText(/First name/i), "Ada");
+    await user.type(screen.getByLabelText(/Last name/i), "Lovelace");
+    await user.type(screen.getByLabelText(/Email/i), "ada@example.org");
+    await user.click(screen.getByRole("button", { name: /Send invitation/i }));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalled();
+    });
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/admin/new-platform-admin-form.tsx
+++ b/packages/web/src/components/admin/new-platform-admin-form.tsx
@@ -121,10 +121,14 @@ export function NewPlatformAdminForm() {
           control={form.control}
           name="email"
           rules={{
-            required: true,
+            required: t("errors.emailRequired"),
             pattern: {
               value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-              message: "",
+              // Frontend review C1: an empty message produced
+              // aria-invalid="true" with no FormMessage text — a screen
+              // reader landed on the field with no reason. Now we surface
+              // a translated message via FormMessage.
+              message: t("errors.emailFormat"),
             },
             maxLength: 255,
           }}

--- a/packages/web/src/components/admin/new-platform-admin-form.tsx
+++ b/packages/web/src/components/admin/new-platform-admin-form.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/shared/form-field";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { PlatformAdminService } from "@/services/PlatformAdminService";
+
+interface FormValues {
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+/**
+ * Invite-a-platform-admin form (issue #254). Behind the `(admin)/layout.tsx`
+ * super_admin gate. The submit:
+ *   1) provisions a Keycloak user with the `super_admin` realm role,
+ *   2) attaches them to the "Givernance Platform" Keycloak Organization,
+ *   3) triggers a UPDATE_PASSWORD email so the new admin sets their own
+ *      password on first login,
+ *   4) writes a `platform_admin.created` audit row under the platform tenant.
+ *
+ * Identity invariant (ADR-022): the API refuses with 409 if the email
+ * already belongs to a tenant `users` row — the form maps that to a
+ * targeted field error instead of a generic toast.
+ */
+export function NewPlatformAdminForm() {
+  const t = useTranslations("admin.platformAdmins.new");
+  const router = useRouter();
+  const form = useForm<FormValues>({
+    mode: "onBlur",
+    defaultValues: { firstName: "", lastName: "", email: "" },
+  });
+
+  async function onSubmit(values: FormValues) {
+    const client = createClientApiClient();
+    try {
+      await PlatformAdminService.create(client, {
+        firstName: values.firstName.trim(),
+        lastName: values.lastName.trim(),
+        email: values.email.trim(),
+      });
+      toast.success(t("success"));
+      router.push("/admin/platform-admins");
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiProblem) {
+        const detail = err.detail ?? "";
+        if (err.status === 409) {
+          if (/tenant member/i.test(detail)) {
+            form.setError("email", { type: "server", message: t("errors.emailTakenByTenant") });
+            return;
+          }
+          if (/Keycloak user with this email/i.test(detail)) {
+            form.setError("email", {
+              type: "server",
+              message: t("errors.emailTakenByKeycloak"),
+            });
+            return;
+          }
+          form.setError("email", { type: "server", message: t("errors.emailTakenByAdmin") });
+          return;
+        }
+        if (err.status === 502) {
+          toast.error(t("errors.keycloakMisconfig"));
+          return;
+        }
+      }
+      toast.error(t("errors.generic"));
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="firstName"
+            rules={{ required: true, minLength: 1, maxLength: 255 }}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("fields.firstName")}</FormLabel>
+                <FormControl>
+                  <Input {...field} autoComplete="given-name" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="lastName"
+            rules={{ required: true, minLength: 1, maxLength: 255 }}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("fields.lastName")}</FormLabel>
+                <FormControl>
+                  <Input {...field} autoComplete="family-name" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <FormField
+          control={form.control}
+          name="email"
+          rules={{
+            required: true,
+            pattern: {
+              value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+              message: "",
+            },
+            maxLength: 255,
+          }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("fields.email")}</FormLabel>
+              <FormControl>
+                <Input {...field} type="email" autoComplete="email" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex flex-wrap gap-3">
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting ? t("submitting") : t("submit")}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => router.back()}
+            disabled={form.formState.isSubmitting}
+          >
+            {t("cancel")}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/packages/web/src/components/admin/platform-admin-detail-actions.tsx
+++ b/packages/web/src/components/admin/platform-admin-detail-actions.tsx
@@ -6,6 +6,14 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 
 import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/shared/form-field";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -77,8 +85,11 @@ export function PlatformAdminDetailActions({ admin, operatorKeycloakId }: Props)
       toast.success(t("toast.renamed"));
       setEditOpen(false);
       router.refresh();
-    } catch (err) {
-      toast.error(err instanceof ApiProblem ? t("errors.generic") : t("errors.generic"));
+    } catch {
+      // The rename endpoint has no specific error path beyond the
+      // 404-not-found and the generic 502/500. Surface a generic toast;
+      // the user can retry or hard-refresh the page.
+      toast.error(t("errors.generic"));
     }
   }
 
@@ -152,12 +163,14 @@ export function PlatformAdminDetailActions({ admin, operatorKeycloakId }: Props)
             <DialogTitle>{t("editDialog.title")}</DialogTitle>
             <DialogDescription>{t("editDialog.description")}</DialogDescription>
           </DialogHeader>
-          <form
-            id="platform-admin-rename"
-            onSubmit={editForm.handleSubmit(onEditSubmit)}
-            className="space-y-4"
-          >
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <Form {...editForm}>
+            <form
+              id="platform-admin-rename"
+              onSubmit={editForm.handleSubmit(onEditSubmit)}
+              className="space-y-4"
+            >
+              {/* Email is shown read-only as context — outside the
+                  FormField provider since it's not a controlled field. */}
               <div className="block text-sm">
                 <label
                   htmlFor="platform-admin-edit-email"
@@ -167,34 +180,40 @@ export function PlatformAdminDetailActions({ admin, operatorKeycloakId }: Props)
                 </label>
                 <Input id="platform-admin-edit-email" value={admin.email} disabled />
               </div>
-              <div />
-              <div className="block text-sm">
-                <label
-                  htmlFor="platform-admin-edit-first-name"
-                  className="mb-1 block text-on-surface-variant"
-                >
-                  {tFields("firstName")}
-                </label>
-                <Input
-                  id="platform-admin-edit-first-name"
-                  {...editForm.register("firstName", { required: true, maxLength: 255 })}
-                  autoFocus
+
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                <FormField
+                  control={editForm.control}
+                  name="firstName"
+                  rules={{ required: true, minLength: 1, maxLength: 255 }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{tFields("firstName")}</FormLabel>
+                      <FormControl>
+                        {/* biome-ignore lint/a11y/noAutofocus: dialog focus convention */}
+                        <Input {...field} autoFocus autoComplete="given-name" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={editForm.control}
+                  name="lastName"
+                  rules={{ required: true, minLength: 1, maxLength: 255 }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{tFields("lastName")}</FormLabel>
+                      <FormControl>
+                        <Input {...field} autoComplete="family-name" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
               </div>
-              <div className="block text-sm">
-                <label
-                  htmlFor="platform-admin-edit-last-name"
-                  className="mb-1 block text-on-surface-variant"
-                >
-                  {tFields("lastName")}
-                </label>
-                <Input
-                  id="platform-admin-edit-last-name"
-                  {...editForm.register("lastName", { required: true, maxLength: 255 })}
-                />
-              </div>
-            </div>
-          </form>
+            </form>
+          </Form>
           <DialogFooter>
             <Button variant="ghost" onClick={() => setEditOpen(false)}>
               {t("editDialog.cancel")}

--- a/packages/web/src/components/admin/platform-admin-detail-actions.tsx
+++ b/packages/web/src/components/admin/platform-admin-detail-actions.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { PlatformAdmin } from "@/models/platform-admin";
+import { PlatformAdminService } from "@/services/PlatformAdminService";
+
+interface Props {
+  admin: PlatformAdmin;
+  /** Operator's own keycloak_id from the JWT — drives the self-removal hide rule. */
+  operatorKeycloakId: string | null;
+}
+
+/**
+ * Detail-page actions for a platform admin (issue #254): edit name,
+ * re-trigger the password-reset email, soft-delete the admin.
+ *
+ * The remove button is hidden when the admin is the operator (self-removal
+ * forbidden, matches the API guard). The dialogs map RFC 9457 status codes
+ * onto i18n strings — `400 + LAST_ADMIN_FORBIDDEN` and
+ * `400 + SELF_REMOVAL_FORBIDDEN` get distinct messages.
+ */
+export function PlatformAdminDetailActions({ admin, operatorKeycloakId }: Props) {
+  const t = useTranslations("admin.platformAdmins.detail");
+  const tFields = useTranslations("admin.platformAdmins.new.fields");
+  const router = useRouter();
+
+  const isSelf =
+    admin.keycloakId !== null &&
+    operatorKeycloakId !== null &&
+    admin.keycloakId === operatorKeycloakId;
+  const isRemoved = admin.deletedAt !== null;
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
+  const [removeOpen, setRemoveOpen] = useState(false);
+  const [pendingReset, setPendingReset] = useState(false);
+  const [pendingRemove, setPendingRemove] = useState(false);
+
+  const editForm = useForm<{ firstName: string; lastName: string }>({
+    defaultValues: { firstName: admin.firstName, lastName: admin.lastName },
+  });
+
+  async function onEditSubmit(values: { firstName: string; lastName: string }) {
+    const client = createClientApiClient();
+    try {
+      await PlatformAdminService.updateName(client, admin.id, {
+        firstName: values.firstName.trim(),
+        lastName: values.lastName.trim(),
+      });
+      toast.success(t("toast.renamed"));
+      setEditOpen(false);
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof ApiProblem ? t("errors.generic") : t("errors.generic"));
+    }
+  }
+
+  async function onResetConfirm() {
+    setPendingReset(true);
+    const client = createClientApiClient();
+    try {
+      await PlatformAdminService.resetPassword(client, admin.id);
+      toast.success(t("toast.passwordResetSent"));
+      setResetOpen(false);
+    } catch {
+      toast.error(t("errors.generic"));
+    } finally {
+      setPendingReset(false);
+    }
+  }
+
+  async function onRemoveConfirm() {
+    setPendingRemove(true);
+    const client = createClientApiClient();
+    try {
+      await PlatformAdminService.remove(client, admin.id);
+      toast.success(t("toast.removed"));
+      setRemoveOpen(false);
+      router.push("/admin/platform-admins");
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiProblem && err.status === 400) {
+        const detail = err.detail ?? "";
+        if (/own platform-admin row/i.test(detail)) {
+          toast.error(t("errors.selfRemoval"));
+        } else if (/last active/i.test(detail)) {
+          toast.error(t("errors.lastAdmin"));
+        } else {
+          toast.error(t("errors.generic"));
+        }
+      } else if (err instanceof ApiProblem && err.status === 404) {
+        toast.error(t("errors.notFound"));
+      } else {
+        toast.error(t("errors.generic"));
+      }
+    } finally {
+      setPendingRemove(false);
+    }
+  }
+
+  if (isRemoved) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-3">
+        <Button variant="secondary" onClick={() => setEditOpen(true)}>
+          {t("actions.editName")}
+        </Button>
+        <Button variant="secondary" onClick={() => setResetOpen(true)}>
+          {t("actions.resetPassword")}
+        </Button>
+        {!isSelf ? (
+          <Button variant="destructive" onClick={() => setRemoveOpen(true)}>
+            {t("actions.remove")}
+          </Button>
+        ) : null}
+      </div>
+
+      {/* Edit-name dialog */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("editDialog.title")}</DialogTitle>
+            <DialogDescription>{t("editDialog.description")}</DialogDescription>
+          </DialogHeader>
+          <form
+            id="platform-admin-rename"
+            onSubmit={editForm.handleSubmit(onEditSubmit)}
+            className="space-y-4"
+          >
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div className="block text-sm">
+                <label
+                  htmlFor="platform-admin-edit-email"
+                  className="mb-1 block text-on-surface-variant"
+                >
+                  {t("fields.email")}
+                </label>
+                <Input id="platform-admin-edit-email" value={admin.email} disabled />
+              </div>
+              <div />
+              <div className="block text-sm">
+                <label
+                  htmlFor="platform-admin-edit-first-name"
+                  className="mb-1 block text-on-surface-variant"
+                >
+                  {tFields("firstName")}
+                </label>
+                <Input
+                  id="platform-admin-edit-first-name"
+                  {...editForm.register("firstName", { required: true, maxLength: 255 })}
+                  autoFocus
+                />
+              </div>
+              <div className="block text-sm">
+                <label
+                  htmlFor="platform-admin-edit-last-name"
+                  className="mb-1 block text-on-surface-variant"
+                >
+                  {tFields("lastName")}
+                </label>
+                <Input
+                  id="platform-admin-edit-last-name"
+                  {...editForm.register("lastName", { required: true, maxLength: 255 })}
+                />
+              </div>
+            </div>
+          </form>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setEditOpen(false)}>
+              {t("editDialog.cancel")}
+            </Button>
+            <Button
+              type="submit"
+              form="platform-admin-rename"
+              disabled={editForm.formState.isSubmitting}
+            >
+              {editForm.formState.isSubmitting ? t("actions.saving") : t("editDialog.save")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Reset-password dialog */}
+      <AlertDialog open={resetOpen} onOpenChange={setResetOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("resetDialog.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("resetDialog.description", { email: admin.email })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pendingReset}>{t("resetDialog.cancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={onResetConfirm} disabled={pendingReset}>
+              {pendingReset ? t("actions.sending") : t("resetDialog.confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Remove-admin dialog */}
+      <AlertDialog open={removeOpen} onOpenChange={setRemoveOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("removeDialog.title")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("removeDialog.description")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pendingRemove}>
+              {t("removeDialog.cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={onRemoveConfirm}
+              disabled={pendingRemove}
+              className="bg-error text-on-error hover:bg-error/90"
+            >
+              {pendingRemove ? t("actions.removing") : t("removeDialog.confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/packages/web/src/components/admin/platform-admins-table.tsx
+++ b/packages/web/src/components/admin/platform-admins-table.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import { Eye, MoreHorizontal, ShieldCheck } from "lucide-react";
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useCallback, useMemo, useTransition } from "react";
+
+import { EmptyState } from "@/components/shared/empty-state";
+import { Button } from "@/components/ui/button";
+import { DataTable } from "@/components/ui/data-table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type {
+  PlatformAdmin,
+  PlatformAdminSortField,
+  PlatformAdminSortOrder,
+} from "@/models/platform-admin";
+
+import { formatAdminDate } from "./tenant-admin-shared";
+
+interface Props {
+  admins: PlatformAdmin[];
+  total: number;
+  sort: PlatformAdminSortField;
+  order: PlatformAdminSortOrder;
+}
+
+export function PlatformAdminsTable({ admins, total, sort, order }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const t = useTranslations("admin.platformAdmins.list");
+  const [isPending, startTransition] = useTransition();
+
+  const sorting = useMemo<SortingState>(
+    () => [{ id: sort, desc: order === "desc" }],
+    [sort, order],
+  );
+
+  const onSortingChange = useCallback(
+    (nextSorting: SortingState) => {
+      const [next] = nextSorting;
+      const params = new URLSearchParams(searchParams.toString());
+      if (!next) {
+        params.delete("sort");
+        params.delete("order");
+      } else {
+        params.set("sort", next.id);
+        params.set("order", next.desc ? "desc" : "asc");
+      }
+      const query = params.toString();
+      startTransition(() => {
+        router.replace(query ? `${pathname}?${query}` : pathname);
+      });
+    },
+    [pathname, router, searchParams],
+  );
+
+  const columns = useMemo<ColumnDef<PlatformAdmin>[]>(
+    () => [
+      {
+        id: "lastName",
+        accessorKey: "lastName",
+        header: () => t("columns.name"),
+        enableSorting: true,
+        cell: ({ row }) => (
+          <div>
+            <p className="font-medium text-on-surface">
+              {row.original.firstName} {row.original.lastName}
+            </p>
+          </div>
+        ),
+      },
+      {
+        id: "email",
+        accessorKey: "email",
+        header: () => t("columns.email"),
+        enableSorting: true,
+      },
+      {
+        id: "createdAt",
+        accessorKey: "createdAt",
+        header: () => t("columns.createdAt"),
+        enableSorting: true,
+        cell: ({ row }) => formatAdminDate(row.original.createdAt),
+      },
+      {
+        id: "lastLoginAt",
+        accessorKey: "lastLoginAt",
+        header: () => t("columns.lastLoginAt"),
+        enableSorting: true,
+        cell: ({ row }) =>
+          row.original.lastLoginAt
+            ? formatAdminDate(row.original.lastLoginAt)
+            : t("lastLoginNever"),
+      },
+      {
+        id: "status",
+        header: () => t("columns.status"),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const removed = row.original.deletedAt !== null;
+          return (
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                removed
+                  ? "bg-error-container text-on-error-container"
+                  : "bg-tertiary-container text-on-tertiary-container"
+              }`}
+            >
+              {removed ? t("status.removed") : t("status.active")}
+            </span>
+          );
+        },
+      },
+      {
+        id: "actions",
+        header: () => <span className="sr-only">{t("columns.actions")}</span>,
+        enableSorting: false,
+        cell: ({ row }) => (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="justify-center">
+                <MoreHorizontal size={16} aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link href={`/admin/platform-admins/${row.original.id}`}>
+                  <Eye size={16} aria-hidden="true" className="mr-2" />
+                  {t("columns.actions")}
+                </Link>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ),
+      },
+    ],
+    [t],
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      data={admins}
+      pagination={{
+        page: 1,
+        perPage: total || admins.length || 1,
+        total,
+        totalPages: 1,
+      }}
+      onPageChange={() => {}}
+      sorting={sorting}
+      onSortingChange={onSortingChange}
+      isPending={isPending}
+      onRowClick={(row) => router.push(`/admin/platform-admins/${row.original.id}`)}
+      emptyState={<EmptyState icon={ShieldCheck} title={t("empty")} />}
+    />
+  );
+}

--- a/packages/web/src/components/admin/platform-admins-table.tsx
+++ b/packages/web/src/components/admin/platform-admins-table.tsx
@@ -1,21 +1,13 @@
 "use client";
 
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
-import { Eye, MoreHorizontal, ShieldCheck } from "lucide-react";
-import Link from "next/link";
+import { ShieldCheck } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useMemo, useTransition } from "react";
 
 import { EmptyState } from "@/components/shared/empty-state";
-import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import type {
   PlatformAdmin,
   PlatformAdminSortField,
@@ -119,28 +111,10 @@ export function PlatformAdminsTable({ admins, total, sort, order }: Props) {
           );
         },
       },
-      {
-        id: "actions",
-        header: () => <span className="sr-only">{t("columns.actions")}</span>,
-        enableSorting: false,
-        cell: ({ row }) => (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="justify-center">
-                <MoreHorizontal size={16} aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem asChild>
-                <Link href={`/admin/platform-admins/${row.original.id}`}>
-                  <Eye size={16} aria-hidden="true" className="mr-2" />
-                  {t("columns.actions")}
-                </Link>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ),
-      },
+      // No actions column — the entire row is clickable via `onRowClick`
+      // and navigates to the detail page (same pattern as `tenants-table`
+      // when an admin opens a detail-only resource). Frontend review
+      // M3/M4 dropped the redundant dropdown that duplicated the row click.
     ],
     [t],
   );

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Megaphone,
   RefreshCw,
   ShieldAlert,
+  ShieldCheck,
   UserCog,
   Users,
 } from "lucide-react";
@@ -41,7 +42,7 @@ interface NavItem {
 
 interface AdminNavItem {
   href: string;
-  labelKey: "tenants" | "disputes" | "impersonation";
+  labelKey: "tenants" | "disputes" | "impersonation" | "platformAdmins";
   icon: ComponentType<SVGProps<SVGSVGElement> & { size?: number | string }>;
 }
 
@@ -66,6 +67,7 @@ const ADMIN_NAV_ITEMS: AdminNavItem[] = [
   { href: "/admin/tenants", labelKey: "tenants", icon: Building2 },
   { href: "/admin/disputes", labelKey: "disputes", icon: ShieldAlert },
   { href: "/admin/impersonation", labelKey: "impersonation", icon: UserCog },
+  { href: "/admin/platform-admins", labelKey: "platformAdmins", icon: ShieldCheck },
 ];
 
 interface SidebarProps {

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -105,7 +105,13 @@ export function Sidebar({
   // guard). Hide the dropdown link for everyone else so they don't dead-end
   // on a 404.
   const canManageOrgSettings = hasAppRole("org_admin");
-  const canSwitchOrganization = typeof membershipCount !== "number" || membershipCount > 1;
+  // Super-admins live in `platform_admins` with no tenant memberships
+  // (ADR-022), so "Change organisation" is meaningless noise for them.
+  // Tenant users still see it whenever they're in more than one workspace
+  // (or when membershipCount hasn't loaded yet — show by default to avoid
+  // a flicker that hides the link from multi-tenant users on initial paint).
+  const canSwitchOrganization =
+    !isSuperAdmin && (typeof membershipCount !== "number" || membershipCount > 1);
 
   const initials = user
     ? `${user.firstName?.[0] ?? ""}${user.lastName?.[0] ?? ""}`.toUpperCase() || "?"

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -107,11 +107,13 @@ export function Sidebar({
   const canManageOrgSettings = hasAppRole("org_admin");
   // Super-admins live in `platform_admins` with no tenant memberships
   // (ADR-022), so "Change organisation" is meaningless noise for them.
-  // Tenant users still see it whenever they're in more than one workspace
-  // (or when membershipCount hasn't loaded yet — show by default to avoid
-  // a flicker that hides the link from multi-tenant users on initial paint).
+  // Tenant users see it only when they're in more than one workspace.
+  // Strict numeric check — an undefined / 0 membership count for a
+  // non-super-admin is a broken state caught upstream in `(app)/layout.tsx`
+  // (it throws so we can investigate); silently falling back to "show
+  // the link" used to paper over that bug class.
   const canSwitchOrganization =
-    !isSuperAdmin && (typeof membershipCount !== "number" || membershipCount > 1);
+    !isSuperAdmin && typeof membershipCount === "number" && membershipCount > 1;
 
   const initials = user
     ? `${user.firstName?.[0] ?? ""}${user.lastName?.[0] ?? ""}`.toUpperCase() || "?"

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -699,25 +699,20 @@
         "title": "Platform admins",
         "subtitle": "Givernance staff with super-admin access. New admins receive a password-reset email and choose their password on first login.",
         "createCta": "Invite a platform admin",
-        "search": {
-          "label": "Search",
-          "placeholder": "Search by name or email"
-        },
-        "includeDeleted": "Show offboarded admins",
         "columns": {
           "name": "Name",
           "email": "Email",
           "createdAt": "Created",
           "lastLoginAt": "Last login",
-          "status": "Status",
-          "actions": "Actions"
+          "status": "Status"
         },
         "status": {
           "active": "Active",
           "removed": "Removed"
         },
         "lastLoginNever": "Never",
-        "empty": "No platform admins yet."
+        "empty": "No platform admins yet.",
+        "fetchFailed": "Couldn't load platform admins. Refresh the page to try again."
       },
       "new": {
         "back": "← Platform admins",
@@ -732,6 +727,8 @@
         "submitting": "Sending…",
         "cancel": "Cancel",
         "errors": {
+          "emailRequired": "Email is required.",
+          "emailFormat": "Enter a valid email address.",
           "emailTakenByTenant": "This email belongs to a tenant member; the same Keycloak person cannot be both a platform admin and a tenant user.",
           "emailTakenByAdmin": "A platform admin already exists with this email.",
           "emailTakenByKeycloak": "A Keycloak user with this email already exists. An operator must clean it up before retrying.",

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -276,7 +276,8 @@
         "section": "Back office",
         "tenants": "Tenants",
         "disputes": "Disputes",
-        "impersonation": "Support sessions"
+        "impersonation": "Support sessions",
+        "platformAdmins": "Platform admins"
       }
     },
     "topbar": {
@@ -690,6 +691,104 @@
             "copyFailed": "Couldn't copy the link to your clipboard.",
             "formInviteFailed": "Tenant created, but the first-admin invitation failed. Send it again below."
           }
+        }
+      }
+    },
+    "platformAdmins": {
+      "list": {
+        "title": "Platform admins",
+        "subtitle": "Givernance staff with super-admin access. New admins receive a password-reset email and choose their password on first login.",
+        "createCta": "Invite a platform admin",
+        "search": {
+          "label": "Search",
+          "placeholder": "Search by name or email"
+        },
+        "includeDeleted": "Show offboarded admins",
+        "columns": {
+          "name": "Name",
+          "email": "Email",
+          "createdAt": "Created",
+          "lastLoginAt": "Last login",
+          "status": "Status",
+          "actions": "Actions"
+        },
+        "status": {
+          "active": "Active",
+          "removed": "Removed"
+        },
+        "lastLoginNever": "Never",
+        "empty": "No platform admins yet."
+      },
+      "new": {
+        "back": "← Platform admins",
+        "title": "Invite a platform admin",
+        "subtitle": "Provisions a Keycloak account with the super-admin role and sends a password-reset email so the new admin sets their own password.",
+        "fields": {
+          "firstName": "First name",
+          "lastName": "Last name",
+          "email": "Email"
+        },
+        "submit": "Send invitation",
+        "submitting": "Sending…",
+        "cancel": "Cancel",
+        "errors": {
+          "emailTakenByTenant": "This email belongs to a tenant member; the same Keycloak person cannot be both a platform admin and a tenant user.",
+          "emailTakenByAdmin": "A platform admin already exists with this email.",
+          "emailTakenByKeycloak": "A Keycloak user with this email already exists. An operator must clean it up before retrying.",
+          "keycloakMisconfig": "Keycloak realm is misconfigured (the super_admin role or platform Organization is missing). Re-import the realm.",
+          "generic": "Something went wrong. Please retry."
+        },
+        "success": "Invitation sent — the new admin will receive a password-reset email."
+      },
+      "detail": {
+        "back": "← Platform admins",
+        "title": "{firstName} {lastName}",
+        "subtitleActive": "Active platform admin.",
+        "subtitleRemoved": "This admin was removed on {date} and no longer has access.",
+        "fields": {
+          "email": "Email",
+          "createdAt": "Created",
+          "lastLoginAt": "Last login",
+          "lastLoginNever": "Never",
+          "removedAt": "Removed",
+          "keycloakId": "Keycloak subject"
+        },
+        "actions": {
+          "editName": "Edit name",
+          "resetPassword": "Re-send password reset",
+          "remove": "Remove admin",
+          "saving": "Saving…",
+          "sending": "Sending…",
+          "removing": "Removing…"
+        },
+        "editDialog": {
+          "title": "Edit admin name",
+          "description": "Update the display name. The change is mirrored in Keycloak immediately.",
+          "save": "Save",
+          "cancel": "Cancel"
+        },
+        "resetDialog": {
+          "title": "Re-send password reset",
+          "description": "Sends a new UPDATE_PASSWORD email to {email}. The previous link is invalidated.",
+          "confirm": "Send email",
+          "cancel": "Cancel"
+        },
+        "removeDialog": {
+          "title": "Remove platform admin",
+          "description": "Soft-deletes the admin in the application database, deletes their Keycloak account, and revokes their existing tokens within seconds. This cannot be undone.",
+          "confirm": "Remove admin",
+          "cancel": "Cancel"
+        },
+        "toast": {
+          "renamed": "Admin name updated.",
+          "passwordResetSent": "Password-reset email sent.",
+          "removed": "Admin removed."
+        },
+        "errors": {
+          "selfRemoval": "You cannot remove your own admin account. Ask another super-admin.",
+          "lastAdmin": "You cannot remove the last active platform admin. Invite another super-admin first.",
+          "notFound": "This admin no longer exists.",
+          "generic": "Something went wrong. Please retry."
         }
       }
     }

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -220,6 +220,40 @@
         "keepCurrent": "Stay signed in"
       }
     },
+    "platformAdminAccept": {
+      "title": "Accept your platform-admin invitation",
+      "subtitle": "Confirm your name and choose a password to join Givernance as a platform admin.",
+      "submit": "Create my admin account",
+      "submitting": "Creating account…",
+      "successTitle": "You're in",
+      "successBody": "Redirecting you to sign in…",
+      "errorTitle": "Invitation problem",
+      "backToLogin": "Back to sign in",
+      "fields": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "password": "Choose a password",
+        "passwordHint": "At least {min} characters. You'll use this to sign in on the next screen.",
+        "passwordConfirm": "Confirm password"
+      },
+      "errors": {
+        "invalid": "This invitation link is invalid.",
+        "expired": "This invitation link is invalid, has expired, or has already been accepted. Ask the inviter to send a new one.",
+        "missingToken": "No invitation token supplied.",
+        "namesRequired": "Please provide your first and last name.",
+        "passwordTooShort": "Use a password of at least {min} characters.",
+        "passwordMismatch": "The two passwords don't match.",
+        "conflict": "An account already exists for this email.",
+        "generic": "We couldn't accept this invitation. Please retry or ask the inviter to resend."
+      },
+      "sessionCheck": {
+        "checking": "Checking your session…",
+        "title": "Sign out to accept this invitation",
+        "signedInAs": "You're currently signed in as {name} ({email}).",
+        "body": "Accepting a platform-admin invitation creates a new sign-in. Sign out first so the next sign-in lands on the right account.",
+        "signOut": "Sign out and continue"
+      }
+    },
     "selectOrganization": {
       "title": "Which workspace would you like to enter?",
       "subtitle": "Your account belongs to multiple organisations.",
@@ -735,7 +769,7 @@
           "keycloakMisconfig": "Keycloak realm is misconfigured (the super_admin role or platform Organization is missing). Re-import the realm.",
           "generic": "Something went wrong. Please retry."
         },
-        "success": "Invitation sent — the new admin will receive a password-reset email."
+        "success": "Invitation sent — the new admin will receive an email to set their password and accept."
       },
       "detail": {
         "back": "← Platform admins",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -276,7 +276,8 @@
         "section": "Back-office",
         "tenants": "Tenants",
         "disputes": "Litiges",
-        "impersonation": "Sessions de support"
+        "impersonation": "Sessions de support",
+        "platformAdmins": "Admins plateforme"
       }
     },
     "topbar": {
@@ -690,6 +691,104 @@
             "copyFailed": "Impossible de copier le lien dans le presse-papiers.",
             "formInviteFailed": "Tenant créé, mais l’invitation du premier admin a échoué. Renvoyez-la ci-dessous."
           }
+        }
+      }
+    },
+    "platformAdmins": {
+      "list": {
+        "title": "Admins plateforme",
+        "subtitle": "Personnel Givernance avec accès super-admin. Les nouveaux admins reçoivent un email de réinitialisation et choisissent leur mot de passe à la première connexion.",
+        "createCta": "Inviter un admin plateforme",
+        "search": {
+          "label": "Recherche",
+          "placeholder": "Rechercher par nom ou email"
+        },
+        "includeDeleted": "Afficher les admins retirés",
+        "columns": {
+          "name": "Nom",
+          "email": "Email",
+          "createdAt": "Créé le",
+          "lastLoginAt": "Dernière connexion",
+          "status": "Statut",
+          "actions": "Actions"
+        },
+        "status": {
+          "active": "Actif",
+          "removed": "Retiré"
+        },
+        "lastLoginNever": "Jamais",
+        "empty": "Aucun admin plateforme pour le moment."
+      },
+      "new": {
+        "back": "← Admins plateforme",
+        "title": "Inviter un admin plateforme",
+        "subtitle": "Provisionne un compte Keycloak avec le rôle super-admin et envoie un email de réinitialisation pour que le nouvel admin choisisse son mot de passe.",
+        "fields": {
+          "firstName": "Prénom",
+          "lastName": "Nom",
+          "email": "Email"
+        },
+        "submit": "Envoyer l'invitation",
+        "submitting": "Envoi…",
+        "cancel": "Annuler",
+        "errors": {
+          "emailTakenByTenant": "Cet email appartient à un membre d'un tenant ; la même personne Keycloak ne peut pas être à la fois admin plateforme et utilisateur tenant.",
+          "emailTakenByAdmin": "Un admin plateforme existe déjà avec cet email.",
+          "emailTakenByKeycloak": "Un utilisateur Keycloak existe déjà avec cet email. Un opérateur doit le supprimer avant de réessayer.",
+          "keycloakMisconfig": "Le realm Keycloak est mal configuré (le rôle super_admin ou l'Organization plateforme est absent). Ré-importez le realm.",
+          "generic": "Une erreur est survenue. Veuillez réessayer."
+        },
+        "success": "Invitation envoyée — le nouvel admin recevra un email de réinitialisation."
+      },
+      "detail": {
+        "back": "← Admins plateforme",
+        "title": "{firstName} {lastName}",
+        "subtitleActive": "Admin plateforme actif.",
+        "subtitleRemoved": "Cet admin a été retiré le {date} et n'a plus accès.",
+        "fields": {
+          "email": "Email",
+          "createdAt": "Créé le",
+          "lastLoginAt": "Dernière connexion",
+          "lastLoginNever": "Jamais",
+          "removedAt": "Retiré",
+          "keycloakId": "Sujet Keycloak"
+        },
+        "actions": {
+          "editName": "Modifier le nom",
+          "resetPassword": "Renvoyer la réinitialisation",
+          "remove": "Retirer l'admin",
+          "saving": "Enregistrement…",
+          "sending": "Envoi…",
+          "removing": "Suppression…"
+        },
+        "editDialog": {
+          "title": "Modifier le nom de l'admin",
+          "description": "Met à jour le nom affiché. Le changement est répercuté dans Keycloak immédiatement.",
+          "save": "Enregistrer",
+          "cancel": "Annuler"
+        },
+        "resetDialog": {
+          "title": "Renvoyer la réinitialisation",
+          "description": "Envoie un nouvel email UPDATE_PASSWORD à {email}. Le lien précédent est invalidé.",
+          "confirm": "Envoyer l'email",
+          "cancel": "Annuler"
+        },
+        "removeDialog": {
+          "title": "Retirer l'admin plateforme",
+          "description": "Effectue un soft-delete de l'admin dans la base, supprime son compte Keycloak et révoque ses tokens existants en quelques secondes. Cette action est irréversible.",
+          "confirm": "Retirer l'admin",
+          "cancel": "Annuler"
+        },
+        "toast": {
+          "renamed": "Nom de l'admin mis à jour.",
+          "passwordResetSent": "Email de réinitialisation envoyé.",
+          "removed": "Admin retiré."
+        },
+        "errors": {
+          "selfRemoval": "Vous ne pouvez pas retirer votre propre compte admin. Demandez à un autre super-admin.",
+          "lastAdmin": "Vous ne pouvez pas retirer le dernier admin plateforme actif. Invitez un autre super-admin d'abord.",
+          "notFound": "Cet admin n'existe plus.",
+          "generic": "Une erreur est survenue. Veuillez réessayer."
         }
       }
     }

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -220,6 +220,40 @@
         "keepCurrent": "Rester connecté·e"
       }
     },
+    "platformAdminAccept": {
+      "title": "Accepter votre invitation d'admin plateforme",
+      "subtitle": "Confirmez votre nom et choisissez un mot de passe pour rejoindre Givernance comme admin plateforme.",
+      "submit": "Créer mon compte admin",
+      "submitting": "Création du compte…",
+      "successTitle": "Bienvenue",
+      "successBody": "Redirection vers la connexion…",
+      "errorTitle": "Problème d'invitation",
+      "backToLogin": "Retour à la connexion",
+      "fields": {
+        "firstName": "Prénom",
+        "lastName": "Nom",
+        "password": "Choisissez un mot de passe",
+        "passwordHint": "Au moins {min} caractères. Vous l'utiliserez à l'écran suivant pour vous connecter.",
+        "passwordConfirm": "Confirmez le mot de passe"
+      },
+      "errors": {
+        "invalid": "Ce lien d'invitation n'est pas valide.",
+        "expired": "Ce lien d'invitation n'est pas valide, a expiré, ou a déjà été accepté. Demandez un nouvel envoi.",
+        "missingToken": "Aucun token d'invitation fourni.",
+        "namesRequired": "Veuillez saisir votre prénom et votre nom.",
+        "passwordTooShort": "Utilisez un mot de passe d'au moins {min} caractères.",
+        "passwordMismatch": "Les deux mots de passe ne correspondent pas.",
+        "conflict": "Un compte existe déjà avec cet email.",
+        "generic": "Nous n'avons pas pu accepter cette invitation. Réessayez ou demandez un nouvel envoi."
+      },
+      "sessionCheck": {
+        "checking": "Vérification de votre session…",
+        "title": "Déconnectez-vous pour accepter cette invitation",
+        "signedInAs": "Vous êtes actuellement connecté·e en tant que {name} ({email}).",
+        "body": "Accepter une invitation d'admin plateforme crée une nouvelle session. Déconnectez-vous d'abord pour que la prochaine connexion ouvre le bon compte.",
+        "signOut": "Se déconnecter et continuer"
+      }
+    },
     "selectOrganization": {
       "title": "Quel espace souhaitez-vous ouvrir ?",
       "subtitle": "Votre compte est associé à plusieurs associations.",
@@ -735,7 +769,7 @@
           "keycloakMisconfig": "Le realm Keycloak est mal configuré (le rôle super_admin ou l'Organization plateforme est absent). Ré-importez le realm.",
           "generic": "Une erreur est survenue. Veuillez réessayer."
         },
-        "success": "Invitation envoyée — le nouvel admin recevra un email de réinitialisation."
+        "success": "Invitation envoyée — le nouvel admin recevra un email pour définir son mot de passe et accepter."
       },
       "detail": {
         "back": "← Admins plateforme",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -699,25 +699,20 @@
         "title": "Admins plateforme",
         "subtitle": "Personnel Givernance avec accès super-admin. Les nouveaux admins reçoivent un email de réinitialisation et choisissent leur mot de passe à la première connexion.",
         "createCta": "Inviter un admin plateforme",
-        "search": {
-          "label": "Recherche",
-          "placeholder": "Rechercher par nom ou email"
-        },
-        "includeDeleted": "Afficher les admins retirés",
         "columns": {
           "name": "Nom",
           "email": "Email",
           "createdAt": "Créé le",
           "lastLoginAt": "Dernière connexion",
-          "status": "Statut",
-          "actions": "Actions"
+          "status": "Statut"
         },
         "status": {
           "active": "Actif",
           "removed": "Retiré"
         },
         "lastLoginNever": "Jamais",
-        "empty": "Aucun admin plateforme pour le moment."
+        "empty": "Aucun admin plateforme pour le moment.",
+        "fetchFailed": "Impossible de charger les admins plateforme. Rafraîchissez la page pour réessayer."
       },
       "new": {
         "back": "← Admins plateforme",
@@ -732,6 +727,8 @@
         "submitting": "Envoi…",
         "cancel": "Annuler",
         "errors": {
+          "emailRequired": "L'email est requis.",
+          "emailFormat": "Saisissez une adresse email valide.",
           "emailTakenByTenant": "Cet email appartient à un membre d'un tenant ; la même personne Keycloak ne peut pas être à la fois admin plateforme et utilisateur tenant.",
           "emailTakenByAdmin": "Un admin plateforme existe déjà avec cet email.",
           "emailTakenByKeycloak": "Un utilisateur Keycloak existe déjà avec cet email. Un opérateur doit le supprimer avant de réessayer.",

--- a/packages/web/src/models/platform-admin.ts
+++ b/packages/web/src/models/platform-admin.ts
@@ -53,6 +53,21 @@ export interface CreatePlatformAdminInput {
   lastName: string;
 }
 
+/**
+ * Response shape from `POST /v1/admin/platform-admins` (issue #254
+ * fix-commit 4 refactor). The endpoint inserts an invitation row and
+ * sends an email; the actual `platform_admins` row lands at accept time.
+ * The UI renders "invitation sent" from this — it does NOT have a real
+ * admin id to link to.
+ */
+export interface PlatformAdminInvitationSummary {
+  invitationId: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  expiresAt: string;
+}
+
 export interface UpdatePlatformAdminInput {
   firstName: string;
   lastName: string;

--- a/packages/web/src/models/platform-admin.ts
+++ b/packages/web/src/models/platform-admin.ts
@@ -1,0 +1,59 @@
+/**
+ * Platform-admin row exposed by `/v1/admin/platform-admins` (issue #254).
+ *
+ * Distinct from `Member` (tenant-scoped users): platform admins are
+ * Givernance staff with no tenant binding (ADR-022). The web UI surfaces
+ * them only inside the back-office (super-admin only) — no tenant member
+ * is ever a platform admin and vice versa.
+ */
+
+export interface PlatformAdmin {
+  id: string;
+  /** Keycloak `sub`; null for soft-deleted rows whose KC user has been removed. */
+  keycloakId: string | null;
+  email: string;
+  firstName: string;
+  lastName: string;
+  /** ISO timestamp; null until the admin first signs in (post-#254 follow-up). */
+  lastLoginAt: string | null;
+  /** ISO timestamp when the admin was soft-deleted; null for active rows. */
+  deletedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type PlatformAdminSortField = "lastName" | "email" | "createdAt" | "lastLoginAt";
+export type PlatformAdminSortOrder = "asc" | "desc";
+
+export interface PlatformAdminListQuery {
+  q?: string;
+  includeDeleted?: boolean;
+  sort?: PlatformAdminSortField;
+  order?: PlatformAdminSortOrder;
+  limit?: number;
+  offset?: number;
+}
+
+export interface PlatformAdminListResponse {
+  data: PlatformAdmin[];
+  meta: {
+    total: number;
+    limit: number;
+    offset: number;
+  };
+}
+
+export interface PlatformAdminDetailResponse {
+  data: PlatformAdmin;
+}
+
+export interface CreatePlatformAdminInput {
+  email: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface UpdatePlatformAdminInput {
+  firstName: string;
+  lastName: string;
+}

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -35,6 +35,15 @@ const PUBLIC_PREFIXES = [
   "/api/auth",
   "/_next",
   "/favicon.ico",
+  // Issue #254: the platform-admin invitation accept page lives under
+  // `/admin/platform-admins/accept` because it's adjacent to the
+  // operator-side CRUD, but it's PUBLIC by design — invitees aren't
+  // authenticated yet. Without this entry, `/admin` in
+  // `PROTECTED_PREFIXES` (one line below) catches the path and bounces
+  // the invitee to `/login`, losing the `?token=…` query and stranding
+  // them with no password set. The `isPublic` check fires before
+  // `isProtected`, so this entry takes precedence.
+  "/admin/platform-admins/accept",
 ];
 
 /**

--- a/packages/web/src/services/PlatformAdminInvitationService.ts
+++ b/packages/web/src/services/PlatformAdminInvitationService.ts
@@ -1,0 +1,70 @@
+/**
+ * Public-facing invitation accept service for platform admins (issue #254
+ * fix-commit 4 refactor). Distinct from `PlatformAdminService.ts` which
+ * targets the super-admin-gated CRUD; the endpoints here are publicly
+ * reachable so an unauthenticated invitee can validate the token and
+ * accept the invitation.
+ *
+ * No `ApiClient` dependency — these calls happen on a public page that
+ * doesn't have the operator's CSRF token. We use `fetch` directly with
+ * `credentials: include` so any pre-existing session cookie is sent
+ * (the page detects "logged in as someone else" and prompts logout).
+ */
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "/api";
+
+export interface PlatformAdminInvitationDetail {
+  email: string;
+  firstName: string;
+  lastName: string;
+  expiresAt: string;
+}
+
+export type ProbeResult =
+  | { kind: "valid"; data: PlatformAdminInvitationDetail }
+  | { kind: "invalid" };
+
+export async function probePlatformAdminInvitation(token: string): Promise<ProbeResult> {
+  try {
+    const res = await fetch(
+      `${API_URL}/v1/public/platform-admins/invitations/${encodeURIComponent(token)}`,
+      { credentials: "include" },
+    );
+    if (!res.ok) return { kind: "invalid" };
+    const body = (await res.json()) as { data?: PlatformAdminInvitationDetail };
+    if (!body.data?.email) return { kind: "invalid" };
+    return { kind: "valid", data: body.data };
+  } catch {
+    return { kind: "invalid" };
+  }
+}
+
+export type AcceptResult = { ok: true } | { ok: false; status: number; detail: string | undefined };
+
+export async function acceptPlatformAdminInvitation(
+  token: string,
+  firstName: string,
+  lastName: string,
+  password: string,
+): Promise<AcceptResult> {
+  try {
+    const res = await fetch(
+      `${API_URL}/v1/public/platform-admins/invitations/${encodeURIComponent(token)}/accept`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ firstName, lastName, password }),
+      },
+    );
+    if (res.ok) return { ok: true };
+    let detail: string | undefined;
+    try {
+      const body = (await res.json()) as { detail?: string };
+      detail = body.detail;
+    } catch {}
+    return { ok: false, status: res.status, detail };
+  } catch {
+    return { ok: false, status: 0, detail: undefined };
+  }
+}

--- a/packages/web/src/services/PlatformAdminService.ts
+++ b/packages/web/src/services/PlatformAdminService.ts
@@ -1,0 +1,67 @@
+/**
+ * PlatformAdminService — ADR-011 Layer 2 (services).
+ *
+ * Wraps `/v1/admin/platform-admins` (issue #254). Super-admin only;
+ * non-super-admins receive 404 (anti-disclosure) at the API. Errors are
+ * RFC 9457 ProblemDetails; the call sites map `status` to a user-facing
+ * toast / inline form-error message.
+ */
+
+import type { ApiClient } from "@/lib/api";
+import type {
+  CreatePlatformAdminInput,
+  PlatformAdmin,
+  PlatformAdminDetailResponse,
+  PlatformAdminListQuery,
+  PlatformAdminListResponse,
+  UpdatePlatformAdminInput,
+} from "@/models/platform-admin";
+
+export const PlatformAdminService = {
+  async list(
+    client: ApiClient,
+    query: PlatformAdminListQuery = {},
+  ): Promise<PlatformAdminListResponse> {
+    const params: Record<string, string | number | boolean | undefined> = {
+      q: query.q,
+      includeDeleted: query.includeDeleted,
+      sort: query.sort,
+      order: query.order,
+      limit: query.limit,
+      offset: query.offset,
+    };
+    return client.get<PlatformAdminListResponse>("/v1/admin/platform-admins", { params });
+  },
+
+  async getById(client: ApiClient, id: string): Promise<PlatformAdmin> {
+    const res = await client.get<PlatformAdminDetailResponse>(
+      `/v1/admin/platform-admins/${encodeURIComponent(id)}`,
+    );
+    return res.data;
+  },
+
+  async create(client: ApiClient, input: CreatePlatformAdminInput): Promise<PlatformAdmin> {
+    const res = await client.post<PlatformAdminDetailResponse>("/v1/admin/platform-admins", input);
+    return res.data;
+  },
+
+  async updateName(
+    client: ApiClient,
+    id: string,
+    input: UpdatePlatformAdminInput,
+  ): Promise<PlatformAdmin> {
+    const res = await client.patch<PlatformAdminDetailResponse>(
+      `/v1/admin/platform-admins/${encodeURIComponent(id)}`,
+      input,
+    );
+    return res.data;
+  },
+
+  async resetPassword(client: ApiClient, id: string): Promise<void> {
+    await client.post<void>(`/v1/admin/platform-admins/${encodeURIComponent(id)}/reset-password`);
+  },
+
+  async remove(client: ApiClient, id: string): Promise<void> {
+    await client.delete<void>(`/v1/admin/platform-admins/${encodeURIComponent(id)}`);
+  },
+};

--- a/packages/web/src/services/PlatformAdminService.ts
+++ b/packages/web/src/services/PlatformAdminService.ts
@@ -12,6 +12,7 @@ import type {
   CreatePlatformAdminInput,
   PlatformAdmin,
   PlatformAdminDetailResponse,
+  PlatformAdminInvitationSummary,
   PlatformAdminListQuery,
   PlatformAdminListResponse,
   UpdatePlatformAdminInput,
@@ -40,8 +41,20 @@ export const PlatformAdminService = {
     return res.data;
   },
 
-  async create(client: ApiClient, input: CreatePlatformAdminInput): Promise<PlatformAdmin> {
-    const res = await client.post<PlatformAdminDetailResponse>("/v1/admin/platform-admins", input);
+  /**
+   * POST /v1/admin/platform-admins — issue an invitation. Post fix-commit-4
+   * refactor (PR #253), this returns an invitation summary, NOT a
+   * `PlatformAdmin` row — the row materialises at accept time when the
+   * invitee submits their password. (Issue #254.)
+   */
+  async create(
+    client: ApiClient,
+    input: CreatePlatformAdminInput,
+  ): Promise<PlatformAdminInvitationSummary> {
+    const res = await client.post<{ data: PlatformAdminInvitationSummary }>(
+      "/v1/admin/platform-admins",
+      input,
+    );
     return res.data;
   },
 

--- a/packages/worker/src/lib/email-templates.ts
+++ b/packages/worker/src/lib/email-templates.ts
@@ -246,3 +246,91 @@ const TEAM_INVITE_TEMPLATES: Record<Locale, (input: TeamInviteTemplateInput) => 
 export function renderTeamInviteEmail(input: TeamInviteTemplateInput): RenderedEmail {
   return TEAM_INVITE_TEMPLATES[input.locale](input);
 }
+
+// ─── Platform-admin invite templates (issue #254 fix-commit 4) ──────────────
+
+export interface PlatformAdminInviteTemplateInput {
+  /** Pre-filled at invite time; the invitee can edit it on the accept page. */
+  inviteeFirstName: string;
+  acceptUrl: string;
+  expiresAt: Date;
+  locale: Locale;
+}
+
+function renderPlatformAdminInviteEn(input: PlatformAdminInviteTemplateInput): RenderedEmail {
+  const expires = input.expiresAt.toUTCString();
+  const safeUrl = escapeHtml(input.acceptUrl);
+  const greeting = input.inviteeFirstName ? `Hi ${escapeHtml(input.inviteeFirstName)},` : `Hello,`;
+  return {
+    subject: "You're invited to join Givernance as a platform admin",
+    text: [
+      `${input.inviteeFirstName ? `Hi ${input.inviteeFirstName},` : "Hello,"}`,
+      ``,
+      `You've been invited to join Givernance as a platform admin (super-admin staff).`,
+      ``,
+      `Accept the invitation by clicking this link and choosing your password:`,
+      ``,
+      input.acceptUrl,
+      ``,
+      `This link expires on ${expires}.`,
+      ``,
+      `If you weren't expecting this invitation, ignore this message — nothing has been activated.`,
+    ].join("\n"),
+    html: `<!doctype html><html lang="en"><body style="font-family:-apple-system,system-ui,sans-serif;line-height:1.6;color:#111;max-width:560px;margin:32px auto;padding:0 16px">
+<h1 style="font-size:20px;margin:0 0 16px">Join Givernance as a platform admin</h1>
+<p>${greeting}</p>
+<p>You've been invited to join Givernance as a <strong>platform admin</strong> (super-admin staff).</p>
+<p style="margin:24px 0"><a href="${safeUrl}" style="display:inline-block;padding:12px 20px;background:#1a56db;color:#fff;border-radius:6px;text-decoration:none;font-weight:500">Accept the invitation</a></p>
+<p style="font-size:13px;color:#555">Or copy this link into your browser:<br><span style="word-break:break-all">${safeUrl}</span></p>
+<p style="font-size:13px;color:#555">This link expires on ${expires}.</p>
+<p style="font-size:12px;color:#888;margin-top:32px;border-top:1px solid #eee;padding-top:16px">If you weren't expecting this invitation, ignore this message — nothing has been activated.</p>
+</body></html>`,
+  };
+}
+
+function renderPlatformAdminInviteFr(input: PlatformAdminInviteTemplateInput): RenderedEmail {
+  const expires = input.expiresAt.toUTCString();
+  const safeUrl = escapeHtml(input.acceptUrl);
+  const greeting = input.inviteeFirstName
+    ? `Bonjour ${escapeHtml(input.inviteeFirstName)},`
+    : `Bonjour,`;
+  return {
+    subject: "Vous êtes invité·e à rejoindre Givernance comme admin plateforme",
+    text: [
+      `${input.inviteeFirstName ? `Bonjour ${input.inviteeFirstName},` : "Bonjour,"}`,
+      ``,
+      `Vous avez été invité·e à rejoindre Givernance en tant qu'admin plateforme (équipe super-admin).`,
+      ``,
+      `Acceptez l'invitation en cliquant sur ce lien et en choisissant votre mot de passe :`,
+      ``,
+      input.acceptUrl,
+      ``,
+      `Ce lien expire le ${expires}.`,
+      ``,
+      `Si vous n'attendiez pas cette invitation, ignorez ce message — aucune action n'a été effectuée.`,
+    ].join("\n"),
+    html: `<!doctype html><html lang="fr"><body style="font-family:-apple-system,system-ui,sans-serif;line-height:1.6;color:#111;max-width:560px;margin:32px auto;padding:0 16px">
+<h1 style="font-size:20px;margin:0 0 16px">Rejoindre Givernance comme admin plateforme</h1>
+<p>${greeting}</p>
+<p>Vous avez été invité·e à rejoindre Givernance en tant qu'<strong>admin plateforme</strong> (équipe super-admin).</p>
+<p style="margin:24px 0"><a href="${safeUrl}" style="display:inline-block;padding:12px 20px;background:#1a56db;color:#fff;border-radius:6px;text-decoration:none;font-weight:500">Accepter l'invitation</a></p>
+<p style="font-size:13px;color:#555">Ou copiez ce lien dans votre navigateur :<br><span style="word-break:break-all">${safeUrl}</span></p>
+<p style="font-size:13px;color:#555">Ce lien expire le ${expires}.</p>
+<p style="font-size:12px;color:#888;margin-top:32px;border-top:1px solid #eee;padding-top:16px">Si vous n'attendiez pas cette invitation, ignorez ce message — aucune action n'a été effectuée.</p>
+</body></html>`,
+  };
+}
+
+const PLATFORM_ADMIN_INVITE_TEMPLATES: Record<
+  Locale,
+  (input: PlatformAdminInviteTemplateInput) => RenderedEmail
+> = {
+  en: renderPlatformAdminInviteEn,
+  fr: renderPlatformAdminInviteFr,
+};
+
+export function renderPlatformAdminInviteEmail(
+  input: PlatformAdminInviteTemplateInput,
+): RenderedEmail {
+  return PLATFORM_ADMIN_INVITE_TEMPLATES[input.locale](input);
+}

--- a/packages/worker/src/processors/platform-admin-invite-email.ts
+++ b/packages/worker/src/processors/platform-admin-invite-email.ts
@@ -1,0 +1,83 @@
+/**
+ * Platform-admin invite email processor (issue #254 fix-commit 4 refactor).
+ *
+ * Handles `platform_admin.invited` outbox events. Same SEC-7 posture as
+ * `team-invite-email.ts`: the raw token is NOT in the outbox payload —
+ * we look it up here by invitation id, inside the SMTP relay's trust
+ * boundary. Unknown / already-accepted invitations are terminal no-ops
+ * so a stale event after a token rotation doesn't retry forever.
+ *
+ * Distinct from team-invite because:
+ *   - The accept URL points at `/admin/platform-admins/accept` (super-admin
+ *     onboarding), not `/invite/accept` (tenant member).
+ *   - The email template emphasises "platform / Givernance staff", not
+ *     "join <tenant>".
+ *   - No tenant/inviter personalisation needed (operator emails are
+ *     internal).
+ */
+
+import { invitations } from "@givernance/shared/schema";
+import { and, eq } from "drizzle-orm";
+import { env } from "../env.js";
+import { db } from "../lib/db.js";
+import { defaultEmailSender, type EmailSender } from "../lib/email.js";
+import { ensureLocale, renderPlatformAdminInviteEmail } from "../lib/email-templates.js";
+
+export interface PlatformAdminInviteEmailJobPayload {
+  invitationId: string;
+  /** BCP-47 — resolved at enqueue time. */
+  locale: string;
+}
+
+export interface PlatformAdminInviteEmailDeps {
+  sender?: EmailSender;
+}
+
+export async function processPlatformAdminInviteEmail(
+  payload: PlatformAdminInviteEmailJobPayload,
+  deps: PlatformAdminInviteEmailDeps = {},
+): Promise<{ sent: boolean; reason?: "not_found" | "already_accepted" }> {
+  const sender = deps.sender ?? defaultEmailSender;
+
+  const [row] = await db
+    .select({
+      id: invitations.id,
+      email: invitations.email,
+      firstName: invitations.firstName,
+      lastName: invitations.lastName,
+      token: invitations.token,
+      acceptedAt: invitations.acceptedAt,
+      expiresAt: invitations.expiresAt,
+    })
+    .from(invitations)
+    .where(
+      and(
+        eq(invitations.id, payload.invitationId),
+        eq(invitations.purpose, "platform_admin_invite"),
+      ),
+    )
+    .limit(1);
+
+  if (!row) return { sent: false, reason: "not_found" };
+  if (row.acceptedAt) return { sent: false, reason: "already_accepted" };
+
+  const acceptUrl = `${env.APP_URL.replace(
+    /\/$/,
+    "",
+  )}/admin/platform-admins/accept?token=${encodeURIComponent(row.token)}`;
+  const rendered = renderPlatformAdminInviteEmail({
+    inviteeFirstName: row.firstName ?? "",
+    acceptUrl,
+    expiresAt: row.expiresAt,
+    locale: ensureLocale(payload.locale),
+  });
+
+  await sender.send({
+    to: row.email,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
+  });
+
+  return { sent: true };
+}

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -11,6 +11,7 @@ import { extractTraceId } from "./lib/trace-context.js";
 import { processGenerateCampaignDocuments } from "./processors/campaign-documents.js";
 import { processGdprErasure } from "./processors/gdpr-erasure.js";
 import { processGenerateReceipt } from "./processors/generate-receipt.js";
+import { processPlatformAdminInviteEmail } from "./processors/platform-admin-invite-email.js";
 import { processSendBulkEmail } from "./processors/send-bulk-email.js";
 import {
   processSignupVerificationEmail,
@@ -158,6 +159,19 @@ async function processDomainEvent(job: Job): Promise<void> {
     };
     const result = await processTeamInviteEmail(emailPayload);
     log.info({ invitationId, eventType: type, ...result }, "Team-invite email dispatched");
+    return;
+  }
+
+  // Issue #254 — platform-admin invitation. Distinct from `team_invite`
+  // because the accept URL points at `/admin/platform-admins/accept`
+  // (super-admin onboarding), not `/invite/accept`.
+  if (type === "platform_admin.invited") {
+    const invitationId = payload.invitationId as string;
+    const result = await processPlatformAdminInviteEmail({
+      invitationId,
+      locale: resolvePayloadLocale(payload),
+    });
+    log.info({ invitationId, eventType: type, ...result }, "Platform-admin invite dispatched");
     return;
   }
 


### PR DESCRIPTION
## Summary

Two cohesive identity-surface changes shipped on the same branch so they can be validated end-to-end:

**Part 1 — `platform_admins` table (issue #252).** Models Givernance super-admins as a first-class identity surface disjoint from tenant `users`. Drops the `PLATFORM_TENANT_ID` sentinel UUID from the impersonation guard in favour of an indexed `platform_admins.keycloak_id` lookup. Documented in **ADR-022**. Closes the dev-seed collision where org-admins inside the demo NPO were tripping the nested-impersonation guard.

**Part 2 — Platform-admin CRUD back-office (issue #254).** A super-admin-only page under `/admin/platform-admins` for managing platform admins: list / detail / create / rename / re-send password reset / soft-delete. Behind the existing `(admin)/layout.tsx` 404 anti-disclosure gate. Hard guards: self-removal forbidden, last-admin guard (atomic via SERIALIZABLE + FOR UPDATE), identity invariant (refuses creates that would collide with a tenant `users` email). Direct Keycloak provisioning: `kc.createUser` (temporary: true) → assign `super_admin` realm role → attach to "Givernance Platform" Organization → trigger UPDATE_PASSWORD email with `client_id` + `redirect_uri` so the new admin lands on the back-office login.

close #252
close #254

## What changes

### Part 1 — `platform_admins` table
- New table `platform_admins` (migration 0034, soft-delete + partial-unique indexes, no RLS, defensive REVOKE on app role).
- `PLATFORM_TENANT_ID` constant deleted from `@givernance/shared/constants`.
- Impersonation guard becomes a single indexed `platform_admins` lookup.
- `/v1/users/me` branches on `super_admin` realm role.
- Seed: super-admin → `platform_admins`. "Givernance Demo NPO" moves to fresh UUID `…c1` (carries the realistic data). "Demo Workspace" (`…b1`) stays the empty playground.
- ADR-022 added with amendment for the sentinel platform tenant (the FK target for `audit_logs.org_id` on platform-level events).

### Part 2 — Platform-admin CRUD
- 5 new endpoints under `/v1/admin/platform-admins/*`.
- Keycloak client extended with `getRealmRole`, `assignRealmRoleToUser`, `sendExecuteActionsEmail`.
- 3 web routes (`list`, `new`, `[id]`) + edit-name / reset-password / remove dialogs (built on the design-system Form/FormField provider for proper a11y).
- New sidebar entry under the back-office nav (super-admin only).
- Full en + fr i18n.
- 14 backend integration tests + 3 frontend form tests.

## Multi-agent review pass

5 specialist agents reviewed the PR in parallel (security, data architect, frontend / a11y, QA, platform / Keycloak integration). Synthesis comment is in this PR thread; 3 scoped fix-commits applied; lower-priority findings tracked in **#255**.

Critical findings fixed in this PR:
- Sentinel platform tenant now seeded by migration 0034 (was launch blocker).
- Edit-name dialog rebuilt on Form/FormField provider for a11y.
- Email validation message no longer empty (was leaving aria-invalid without descriptive text).
- Compensating-delete logs orphan KC users at error level (was silent).

Major findings fixed:
- Last-admin guard now SERIALIZABLE + FOR UPDATE (closes TOCTOU race).
- `sendExecuteActionsEmail` failure preserves the KC user; operator can retry via `/reset-password`.
- Email link passes `client_id` + `redirect_uri` (lands on app, not KC bare account console).
- Server-fetch failures render distinct error banner (not "empty list" misdirection).
- KC user created with `temporary: true` (defense-in-depth password handling).
- Soft-deleted rows hidden from `getPlatformAdminById` by default.
- RFC 9457 body shape locked on all 5 error paths.

## Manual acceptance checklist

Run on dev stack (`pnpm db:migrate` then `pnpm db:seed`):

### Part 1 — `platform_admins`
- [ ] Login as `admin@givernance.org` — `/v1/users/me` returns `orgSlug: 'platform'`, `orgName: 'Givernance Platform'`, `role: 'super_admin'`.
- [ ] Create an org_admin user inside "Givernance Demo NPO" via the existing flow.
- [ ] Start a delegation impersonation against that org_admin → succeeds (no `TARGET_NESTED_SUPER_ADMIN` 400).
- [ ] Try to impersonate `admin@givernance.org` → 400 + `TARGET_NESTED_SUPER_ADMIN`.
- [ ] `SELECT email, deleted_at FROM platform_admins;` shows the seeded super-admin.

### Part 2 — Platform-admin CRUD
- [ ] Sidebar shows "Platform admins" entry (super-admin only).
- [ ] List page renders the seeded super-admin; sort by name / created / last login works via column headers.
- [ ] Create form: invite a new admin → KC user provisioned, `super_admin` role assigned, platform Organization membership added, UPDATE_PASSWORD email triggered (check Mailpit).
- [ ] Click the email link → KC password-reset → set password → land on `/admin/platform-admins`.
- [ ] Detail page: edit name → `kc.updateUser` fires + audit row written.
- [ ] Detail page: re-send password reset → fresh email + audit row.
- [ ] Detail page: remove admin (operator must not be self) → KC user deleted, sub blocklisted, row soft-deleted.
- [ ] Self-removal: try to delete your own admin row → 400 + clear toast message.
- [ ] Last-admin guard: try to remove the only remaining admin → 400 + clear toast.
- [ ] Identity invariant: try to invite an email that belongs to a tenant member → 409 + inline form error.

### Automated
- [x] `pnpm typecheck` clean across all packages.
- [x] `pnpm lint` clean (no errors; pre-existing warnings unchanged).
- [x] `pnpm test` — **656/656** API + **70/70** web + **26/26** worker.

## Architecture references

- **ADR-022** — `docs/adrs/adr-022-platform-admins-disjoint-from-tenant-users.md` (Part 1).
- **ADR-021** — User Lifecycle / soft-delete + KC hard-delete + blocklist (the pattern Part 2 mirrors for platform admins).
- **ADR-016** — Keycloak Organizations + super-admin identity (the platform Organization the new admin gets membership in).
- **#255** — Follow-up backlog from the multi-agent review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)