### PR TITLE
fix(session): cross-tenant queries must run on owner role (BYPASSRLS)

### DIFF
--- a/packages/api/src/modules/session/service.ts
+++ b/packages/api/src/modules/session/service.ts
@@ -19,7 +19,7 @@ import { auditLogs, outboxEvents, tenants, users } from "@givernance/shared/sche
 import { and, eq, sql } from "drizzle-orm";
 import pino from "pino";
 import { env } from "../../env.js";
-import { db, withTenantContext } from "../../lib/db.js";
+import { systemDb, withTenantContext } from "../../lib/db.js";
 import { redis } from "../../lib/redis.js";
 
 const logger = pino({ name: "session", level: env.LOG_LEVEL });
@@ -41,9 +41,16 @@ export interface OrgMembership {
 /**
  * List every tenant the user belongs to (by Keycloak `sub`). Suspended /
  * archived tenants are excluded so a revoked org never shows in the picker.
+ *
+ * Cross-tenant by design — runs on the owner role (`systemDb`, BYPASSRLS).
+ * Using the app-role pool would silently return zero rows because no
+ * `app.current_organization_id` is set: the whole point of this query is
+ * to enumerate ALL tenants the caller belongs to, before any single
+ * tenant context exists. The `keycloakSub` is the security boundary
+ * (sourced from a verified JWT in the route handler), not RLS.
  */
 export async function listUserOrganizations(keycloakSub: string): Promise<OrgMembership[]> {
-  const rows = await db
+  const rows = await systemDb
     .select({
       orgId: tenants.id,
       slug: tenants.slug,
@@ -116,7 +123,13 @@ export async function recordOrgSwitch(input: SwitchOrgInput): Promise<SwitchOrgR
     return { ok: false, error: "not_a_member" };
   }
 
-  const [target] = await db
+  // Cross-tenant membership probe — same rationale as `listUserOrganizations`
+  // above: the caller hasn't entered the target tenant yet, so we have no
+  // `app.current_organization_id` to set. The `(keycloakSub, targetOrgId)`
+  // pair is the authority gate. Subsequent writes use `withTenantContext`
+  // once the tenant is resolved, so RLS still isolates the audit/outbox
+  // inserts.
+  const [target] = await systemDb
     .select({
       orgId: tenants.id,
       slug: tenants.slug,

--- a/packages/api/src/tests/integration/onboarding-runtime.test.ts
+++ b/packages/api/src/tests/integration/onboarding-runtime.test.ts
@@ -35,6 +35,7 @@ import { redis } from "../../lib/redis.js";
 import { openDispute, resolveDispute, runExpireJob } from "../../modules/disputes/service.js";
 import {
   isSessionBlocklisted,
+  listUserOrganizations,
   recordOrgSwitch,
   sessionBlocklistKey,
 } from "../../modules/session/service.js";
@@ -46,7 +47,7 @@ import {
   verifyDomain,
 } from "../../modules/tenant-admin/service.js";
 import { createServer } from "../../server.js";
-import { authHeader, ensureTestTenants, signToken } from "../helpers/auth.js";
+import { authHeader, ensureTestTenants, ORG_A, ORG_B, signToken } from "../helpers/auth.js";
 
 let app: FastifyInstance;
 
@@ -609,6 +610,70 @@ describe("runExpireJob", () => {
     const res = await runExpireJob(new Date());
     expect(res.skippedOrgIds).toContain(orgId);
     expect(res.confirmedOrgIds).not.toContain(orgId);
+  });
+});
+
+// ─── listUserOrganizations — cross-tenant semantics ────────────────────────
+
+/**
+ * Lock the cross-tenant contract: `listUserOrganizations` must return EVERY
+ * tenant the caller belongs to, regardless of any current tenant context.
+ * The function runs on `systemDb` (BYPASSRLS) by design — without that, a
+ * deployment with `DATABASE_URL_APP` set hits the app role's RLS policy
+ * (`org_id = app_current_organization_id()`) on a query with no
+ * `set_config` GUC, returning ZERO rows for every authenticated user. PR
+ * #253 surfaced this latent bug via the `(app)/layout.tsx` fail-loud
+ * guard (gilbert.durand@croix-rouge.org first-login regression).
+ *
+ * This suite asserts the SEMANTIC contract (multi-tenant return + archive
+ * filter); the test runner can't directly exercise the RLS-block branch
+ * because tests/setup.ts intentionally uses the owner role for fixture
+ * setup (see `tests/setup.ts:11-13`). The matching source-code comment
+ * on `listUserOrganizations` calls out the BYPASSRLS requirement
+ * explicitly so future refactors can't silently swap `systemDb` for `db`.
+ */
+describe("listUserOrganizations — cross-tenant semantics", () => {
+  it("returns every tenant the user belongs to (multi-tenant)", async () => {
+    const sub = randomUUID();
+    const userA = randomUUID();
+    const userB = randomUUID();
+    const email = `multi-tenant-${sub}@example.org`;
+    await db.execute(sql`
+      INSERT INTO users (id, org_id, keycloak_id, email, first_name, last_name, role)
+      VALUES
+        (${userA}, ${ORG_A}, ${sub}, ${email}, 'Multi', 'Tenant', 'org_admin'),
+        (${userB}, ${ORG_B}, ${sub}, ${email}, 'Multi', 'Tenant', 'viewer')
+    `);
+    try {
+      const orgs = await listUserOrganizations(sub);
+      expect(orgs.map((o) => o.orgId).sort()).toEqual([ORG_A, ORG_B].sort());
+      expect(orgs.find((o) => o.orgId === ORG_A)?.role).toBe("org_admin");
+      expect(orgs.find((o) => o.orgId === ORG_B)?.role).toBe("viewer");
+    } finally {
+      await db.execute(sql`DELETE FROM users WHERE id IN (${userA}, ${userB})`);
+    }
+  });
+
+  it("excludes archived tenants (revoked-org never shows in picker)", async () => {
+    const sub = randomUUID();
+    const userId = randomUUID();
+    const archivedTenantId = randomUUID();
+    const archivedSlug = slug(`arch-${sub.slice(0, 6)}`);
+    await db.execute(sql`
+      INSERT INTO tenants (id, name, slug, status)
+      VALUES (${archivedTenantId}, 'Archived', ${archivedSlug}, 'archived')
+    `);
+    createdTenantIds.add(archivedTenantId);
+    await db.execute(sql`
+      INSERT INTO users (id, org_id, keycloak_id, email, first_name, last_name, role)
+      VALUES (${userId}, ${archivedTenantId}, ${sub}, ${`arch-${sub}@example.org`}, 'Arch', 'User', 'org_admin')
+    `);
+    try {
+      const orgs = await listUserOrganizations(sub);
+      expect(orgs.find((o) => o.orgId === archivedTenantId)).toBeUndefined();
+    } finally {
+      await db.execute(sql`DELETE FROM users WHERE id = ${userId}`);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

\`listUserOrganizations\` and \`recordOrgSwitch\`'s membership probe were using \`db\` (app role, NOBYPASSRLS) for queries that span every tenant the caller belongs to. With \`DATABASE_URL_APP\` set, the app role's \`tenant_isolation\` policy on \`users\` evaluates \`org_id = app_current_organization_id()\` against a NULL GUC and returns **zero rows** for every authenticated user.

## How it surfaced

PR #253's [\`(app)/layout.tsx\` fail-loud guard](packages/web/src/app/(app)/layout.tsx#L64-L69) caught a real first-login regression: gilbert.durand@croix-rouge.org accepted a team invitation, logged in (auth plugin's active-row check uses \`withTenantContext\` which sets the GUC), but \`/v1/users/me/organizations\` returned \`[]\` → \`membershipCount === 0\` → throw.

Both functions are **cross-tenant by design** — the \`keycloakSub\` (sourced from a verified JWT in the route handler) is the security boundary, not RLS. The header comment in [\`session/service.ts:6-7\`](packages/api/src/modules/session/service.ts#L6-L7) already said _\"Cross-tenant query → owner role\"_; the implementation just imported the wrong client.

## Why tests missed it

[\`tests/setup.ts:11-13\`](packages/api/src/tests/setup.ts#L11-L13) intentionally leaves \`DATABASE_URL_APP\` unset so fixture inserts can bypass RLS. Tests therefore run as the owner role, never exercising the app-role's RLS policy on this code path. Existing tests would have passed even with \`db\` in place — and did, until #253 wired a fail-loud guard.

## Changes

### [packages/api/src/modules/session/service.ts](packages/api/src/modules/session/service.ts)
- \`listUserOrganizations\`: \`db\` → \`systemDb\`. Added a header note explaining the BYPASSRLS requirement and the security boundary.
- \`recordOrgSwitch\` initial \`(keycloakSub, targetOrgId)\` membership probe: same swap. The subsequent audit/outbox writes still go through \`withTenantContext\` (RLS-isolated), which is correct.

### [packages/api/src/tests/integration/onboarding-runtime.test.ts](packages/api/src/tests/integration/onboarding-runtime.test.ts)
New \`listUserOrganizations — cross-tenant semantics\` describe block:
1. **multi-tenant return**: user with rows in BOTH \`ORG_A\` + \`ORG_B\` (same \`keycloak_id\`) gets both back, with the right per-tenant role.
2. **archived filter**: a tenant flipped to \`archived\` is excluded from the picker.

These can't directly exercise the RLS-block path (test setup uses owner role), but they lock the SEMANTIC contract — a future refactor that filters by current tenant context would fail the multi-tenant test.

## Why not fix in PR #251

This is unrelated to the impersonation step-up MFA work — it's a latent bug that ADR-022's first new-tenant-onboarding flow exposed. Shipping as a focused hotfix off \`main\` so it can land without waiting for #251 review.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm run lint\` clean (existing warnings only)
- [x] \`pnpm run format\` no changes
- [x] \`pnpm test\`: 659 API + 81 web + 26 worker pass (was 657 / 81 / 26 — +2 regression tests)
- [x] After merge: confirm gilbert.durand@croix-rouge.org first-login on dev no longer throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)