### PR TITLE
chore(platform-admins): post-#253 review follow-ups (issue #255)

### DIFF
--- a/docs/adrs/adr-022-platform-admins-disjoint-from-tenant-users.md
+++ b/docs/adrs/adr-022-platform-admins-disjoint-from-tenant-users.md
@@ -31,7 +31,7 @@ Platform admins are modeled as a separate identity surface from tenant users. A 
 
 `platform_admins`:
 - `id uuid PRIMARY KEY DEFAULT gen_random_uuid()`
-- `keycloak_id varchar(255) NOT NULL` — the JWT `sub`; nullable only across rejoin (mirrors `users.keycloak_id` semantics)
+- `keycloak_id varchar(255)` — the JWT `sub`. **Nullable** to mirror `users.keycloak_id` semantics: the soft-delete path on `platform_admins` nulls this column at the same time it stamps `deleted_at`, so the offboarded admin's KC `sub` is no longer linkable to the row (the audit chain references it independently via `audit_logs.user_id`). The partial-unique index below scopes uniqueness to active rows, which lets the same KC `sub` be re-issued cleanly if a former admin is re-onboarded.
 - `email varchar(255) NOT NULL`
 - `first_name varchar(255) NOT NULL`
 - `last_name varchar(255) NOT NULL`

--- a/packages/api/migrations/0036_platform_admins_sort_indexes.sql
+++ b/packages/api/migrations/0036_platform_admins_sort_indexes.sql
@@ -1,0 +1,39 @@
+-- Migration: 0036_platform_admins_sort_indexes
+--
+-- ADR-022 follow-up (issue #255, data-architect M4).
+--
+-- The platform-admin list endpoint (`GET /v1/admin/platform-admins`)
+-- accepts `sort=lastName|email|createdAt|lastLoginAt` and currently
+-- sequential-scans `platform_admins` for any sort other than `email`
+-- (which rides the existing `platform_admins_email_active_uniq`
+-- partial-unique index). The other three sort fields had no index,
+-- so the planner falls back to seq scan + sort even on the small
+-- expected row counts — fine for Phase 1 staff (≤ 50 rows) but the
+-- ordering invariant should be index-backed before any production
+-- deploy adds operational scale.
+--
+-- Indexes:
+--   * `last_name` ASC (matches the default-secondary sort and the
+--     directory-style listing the admin UI defaults to).
+--   * `created_at DESC` (matches the default sort key in the route
+--     handler when `sort` is omitted).
+--   * `last_login_at` (mixed asc/desc usage; index orientation
+--     defaults to ASC, NULLs last on the DESC scan side).
+--
+-- All three are partial on `deleted_at IS NULL` to mirror the existing
+-- unique-index posture: the active-only listing is the hot path, the
+-- include-deleted path is rare and can seq-scan. Partial indexes also
+-- keep the index size bounded by active-row count rather than ever-
+-- growing audit history.
+
+CREATE INDEX IF NOT EXISTS platform_admins_last_name_active_idx
+  ON platform_admins (last_name)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS platform_admins_created_at_active_idx
+  ON platform_admins (created_at DESC)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS platform_admins_last_login_at_active_idx
+  ON platform_admins (last_login_at)
+  WHERE deleted_at IS NULL;

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1777750000000,
       "tag": "0035_invitation_purpose_platform_admin",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1777800000000,
+      "tag": "0036_platform_admins_sort_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/scripts/seed.ts
+++ b/packages/api/scripts/seed.ts
@@ -417,6 +417,36 @@ async function seedOrgData(orgId: string) {
       .values(donationRows)
       .returning({ id: donations.id });
     console.log(`[seed] Inserted ${insertedDonations.length} donations`);
+
+    // Users for impersonation testing within a realistic data tenant
+    const npoUsers = [
+      {
+        email: "alice@npo.local",
+        firstName: "Alice",
+        lastName: "NPO",
+        role: "org_admin" as const,
+        keycloakId: "00000000-0000-0000-0000-0000000000c2",
+      },
+      {
+        email: "bob@npo.local",
+        firstName: "Bob",
+        lastName: "Staff",
+        role: "user" as const,
+        keycloakId: "00000000-0000-0000-0000-0000000000c3",
+      }
+    ];
+
+    for (const u of npoUsers) {
+      const [present] = await tx.select({ id: users.id }).from(users).where(eq(users.email, u.email)).limit(1);
+      if (!present) {
+        try {
+          await tx.insert(users).values({ ...u, orgId });
+          console.log(`[seed] Inserted NPO user ${u.email} (${u.role})`);
+        } catch (err) {
+          console.warn(`[seed] Skipped NPO user ${u.email} (already exists or constraint violation)`);
+        }
+      }
+    }
   });
 }
 
@@ -493,20 +523,27 @@ async function seedDemoTenant(): Promise<void> {
     const [present] = await db
       .select({ id: users.id })
       .from(users)
-      .where(eq(users.keycloakId, u.keycloakId))
+      .where(eq(users.email, u.email))
       .limit(1);
-    if (present) continue;
+    if (present) {
+      console.log(`[seed] Demo user ${u.email} already present`);
+      continue;
+    }
     await withTenantContext(DEMO_TENANT_ID, async (tx) => {
-      await tx.insert(users).values({
-        orgId: DEMO_TENANT_ID,
-        email: u.email,
-        firstName: u.firstName,
-        lastName: u.lastName,
-        role: u.role,
-        keycloakId: u.keycloakId,
-      });
+      try {
+        await tx.insert(users).values({
+          orgId: DEMO_TENANT_ID,
+          email: u.email,
+          firstName: u.firstName,
+          lastName: u.lastName,
+          role: u.role,
+          keycloakId: u.keycloakId,
+        });
+        console.log(`[seed] Inserted demo user ${u.email} (${u.role})`);
+      } catch (err) {
+        console.warn(`[seed] Skipped demo user ${u.email}: already exists or constraint violation`);
+      }
     });
-    console.log(`[seed] Inserted demo user ${u.email} (${u.role})`);
   }
 }
 

--- a/packages/api/src/lib/i18n.ts
+++ b/packages/api/src/lib/i18n.ts
@@ -39,6 +39,19 @@ function loadMessages(locale: Locale): Messages {
   return MESSAGES[locale];
 }
 
+/**
+ * Public-facing variant of {@link resolveLocale} that reads `Accept-Language`
+ * from a Fastify request. Use when an outbound side-effect (an outbox email
+ * payload, a Keycloak user attribute, etc.) needs to inherit the caller's
+ * locale rather than just rendering an immediate Problem Details response.
+ *
+ * Returns the resolved supported locale (`fr`/`en`) — never throws, defaults
+ * to `DEFAULT_LOCALE` when the header is absent or unparseable.
+ */
+export function resolveRequestLocale(request: FastifyRequest): Locale {
+  return resolveLocale(request.headers["accept-language"]);
+}
+
 function resolveLocale(acceptLanguage: string | undefined): Locale {
   if (!acceptLanguage) return DEFAULT_LOCALE;
 

--- a/packages/api/src/modules/admin/platform-admins-routes.ts
+++ b/packages/api/src/modules/admin/platform-admins-routes.ts
@@ -25,6 +25,7 @@
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { requireSuperAdmin } from "../../lib/guards.js";
+import { resolveRequestLocale } from "../../lib/i18n.js";
 import { DataResponse, ErrorResponses, problemDetail, UuidSchema } from "../../lib/schemas.js";
 import { hashIp } from "./impersonation-service.js";
 import {
@@ -266,6 +267,10 @@ export async function platformAdminsRoutes(app: FastifyInstance) {
           firstName: body.firstName,
           lastName: body.lastName,
           ...actorContext(request),
+          // Invite email picks up the operator's locale — best signal
+          // for the invitee's language until they accept and pick their
+          // own (which then writes the KC `locale` user attribute).
+          locale: resolveRequestLocale(request),
         });
         return reply.status(201).send({
           data: {
@@ -358,6 +363,10 @@ export async function platformAdminsRoutes(app: FastifyInstance) {
           lastName: body.lastName,
           ipHash: hashIp(request.ip),
           userAgent: request.headers["user-agent"] ?? null,
+          // Invitee's accept-page locale → KC `locale` user attribute, so
+          // future built-in flows (e.g. UPDATE_PASSWORD via reset) honour
+          // their language without the operator having to set it manually.
+          locale: resolveRequestLocale(request),
         });
         return reply.status(201).send({ data: serialize(row) });
       } catch (err) {

--- a/packages/api/src/modules/admin/platform-admins-service.ts
+++ b/packages/api/src/modules/admin/platform-admins-service.ts
@@ -27,39 +27,49 @@
  * Audit: every mutation writes an `audit_logs` row with the operator's
  * `actor_id`. The lifecycle actions are `platform_admin.created`,
  * `platform_admin.renamed`, `platform_admin.password_reset_sent`,
- * `platform_admin.removed`. Audit rows are written under the *legacy*
- * platform-org id (`PLATFORM_AUDIT_ORG_ID`) so an SOC reviewer can grep
- * one tenant id for the full platform-admin lifecycle without having to
- * UNION across customer tenants. The id is a Keycloak-side constant; no
- * `tenants` row exists at it (ADR-022).
+ * `platform_admin.removed`. Audit rows are written under the platform
+ * sentinel tenant (slug `__platform__`, ADR-022 amendment) so an SOC
+ * reviewer can grep one tenant id for the full platform-admin lifecycle
+ * without UNIONing across customer tenants. The id is resolved at
+ * runtime via `getPlatformOrgId` from the `tenants` row; no magic-UUID
+ * literal is pinned in code.
  */
 
-import { APP_DEFAULT_LOCALE } from "@givernance/shared/i18n";
+import { APP_DEFAULT_LOCALE, type Locale } from "@givernance/shared/i18n";
 import {
   auditLogs,
   invitations,
   outboxEvents,
   platformAdmins,
   type platformAdmins as platformAdminsTable,
+  tenants,
   users,
 } from "@givernance/shared/schema";
 import { and, asc, desc, eq, gt, ilike, isNotNull, isNull, or, type SQL, sql } from "drizzle-orm";
 import pino from "pino";
 import { systemDb } from "../../lib/db.js";
-import { KeycloakUserExistsError, keycloakAdmin } from "../../lib/keycloak-admin.js";
+import {
+  KeycloakAdminError,
+  type KeycloakOrganization,
+  KeycloakUserExistsError,
+  keycloakAdmin,
+} from "../../lib/keycloak-admin.js";
 import { blocklistUser } from "../session/service.js";
 
 const logger = pino({ name: "platform-admins-service" });
 
 /**
- * The Keycloak "Givernance Platform" Organization's `org_id` attribute —
- * mirrors the realm-import seed (`infra/keycloak/realm-givernance.json`).
- * It is **not** an app-DB tenant id (ADR-022 removed the synthetic
- * `tenants` row). Used only as the `audit_logs.org_id` value for the
- * platform-admin lifecycle so a reviewer can scope a query to the
- * platform tenant id and see every super-admin lifecycle event.
+ * Slug used to identify the platform sentinel tenant row (ADR-022
+ * amendment). The row exists solely so `audit_logs.org_id` can FK to a
+ * real `tenants.id` for platform-level lifecycle events; it is hidden
+ * from every customer-facing list endpoint by `status = 'archived'` +
+ * the `__platform__` reserved-slug pattern. We resolve the id from this
+ * slug at runtime (cached per process) instead of pinning the literal
+ * `00000000-0000-0000-0000-0000000000a1` in the codebase — that literal
+ * was the last magic-UUID `PLATFORM_TENANT_ID` carry-over ADR-022
+ * originally set out to remove.
  */
-const PLATFORM_AUDIT_ORG_ID = "00000000-0000-0000-0000-0000000000a1";
+const PLATFORM_TENANT_SLUG = "__platform__";
 
 /**
  * Lifespan for the UPDATE_PASSWORD email link (4 hours). Long enough that
@@ -71,6 +81,69 @@ const PASSWORD_RESET_LIFESPAN_SEC = 4 * 60 * 60;
 
 const SUPER_ADMIN_ROLE_NAME = "super_admin";
 const PLATFORM_ORG_ALIAS = "platform";
+
+// ─── Module-local lookup caches ─────────────────────────────────────────────
+//
+// All three values are realm-lifetime stable (the platform tenant row,
+// the `super_admin` realm role, the `platform` Keycloak Organization).
+// Caching them per process saves a round-trip on every accept / rename /
+// reset / soft-delete. Cache misses re-hit the source so a re-imported
+// realm or a re-seeded sentinel row recovers without a process restart;
+// stale `{id, name}` cache entries that turn into 404s at use-site are
+// invalidated by the call site (see the accept flow's role + org
+// catch-blocks below).
+
+let cachedPlatformOrgId: string | null = null;
+let cachedSuperAdminRole: { id: string; name: string } | null = null;
+let cachedPlatformOrg: KeycloakOrganization | null = null;
+
+async function getPlatformOrgId(): Promise<string> {
+  if (cachedPlatformOrgId) return cachedPlatformOrgId;
+  const [row] = await systemDb
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(eq(tenants.slug, PLATFORM_TENANT_SLUG))
+    .limit(1);
+  if (!row) {
+    // Deployment bootstrap missed the sentinel insert. Bail loud — every
+    // platform-admin write needs this row to FK against `audit_logs.org_id`.
+    // (ADR-022 amendment.)
+    throw new Error(
+      `Platform sentinel tenant (slug='${PLATFORM_TENANT_SLUG}') is missing — apply the deploy bootstrap insert (ADR-022 amendment).`,
+    );
+  }
+  cachedPlatformOrgId = row.id;
+  return row.id;
+}
+
+async function getCachedSuperAdminRole(): Promise<{ id: string; name: string } | null> {
+  if (cachedSuperAdminRole) return cachedSuperAdminRole;
+  const role = await keycloakAdmin().getRealmRole(SUPER_ADMIN_ROLE_NAME);
+  if (role) cachedSuperAdminRole = role;
+  return role;
+}
+
+async function getCachedPlatformOrg(): Promise<KeycloakOrganization | null> {
+  if (cachedPlatformOrg) return cachedPlatformOrg;
+  const org = await keycloakAdmin().getOrganizationByAlias(PLATFORM_ORG_ALIAS);
+  if (org) cachedPlatformOrg = org;
+  return org;
+}
+
+function invalidatePlatformLookupCache() {
+  cachedSuperAdminRole = null;
+  cachedPlatformOrg = null;
+  // `cachedPlatformOrgId` is DB-backed off the immutable `__platform__`
+  // slug — no scenario invalidates it short of the row being deleted,
+  // which is itself a deploy-bootstrap regression (see `getPlatformOrgId`).
+}
+
+/**
+ * Test-only escape hatch — drains the module-local caches so a Vitest
+ * `beforeEach` can guarantee a fresh KC round-trip per case. Not exported
+ * from the package barrel; tests reach in by direct file import.
+ */
+export const __testInvalidatePlatformLookupCache = invalidatePlatformLookupCache;
 
 // Note on `sendExecuteActionsEmail` parameters:
 //
@@ -149,6 +222,15 @@ export interface CreateInput {
   /** Hash of operator IP + user-agent for audit_logs. */
   ipHash: string | null;
   userAgent: string | null;
+  /**
+   * Operator's locale (resolved from `Accept-Language` at the route
+   * boundary). Threads through to the outbox payload so the invite email
+   * lands in the language the operator was using when they issued it —
+   * the best signal we have for the new admin's preferred language until
+   * they accept and pick their own. Optional; falls back to
+   * `APP_DEFAULT_LOCALE` when omitted.
+   */
+  locale?: Locale;
 }
 
 export interface UpdateNameInput {
@@ -344,12 +426,20 @@ export async function invitePlatformAdmin(input: CreateInput): Promise<InviteRes
   }
 
   const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
+  const platformOrgId = await getPlatformOrgId();
+
+  // The invite email goes to a brand-new identity that has no stored
+  // language preference yet — the operator's locale (read from the
+  // `Accept-Language` header at the route boundary) is the best signal we
+  // have. Fall back to `APP_DEFAULT_LOCALE` if the route didn't supply
+  // one (test paths, programmatic callers).
+  const inviteLocale = input.locale ?? APP_DEFAULT_LOCALE;
 
   return systemDb.transaction(async (tx) => {
     const [row] = await tx
       .insert(invitations)
       .values({
-        orgId: PLATFORM_AUDIT_ORG_ID,
+        orgId: platformOrgId,
         email,
         firstName: input.firstName,
         lastName: input.lastName,
@@ -375,26 +465,21 @@ export async function invitePlatformAdmin(input: CreateInput): Promise<InviteRes
     // outbox payload — the worker reads it back from the row inside its
     // own trust boundary.
     await tx.insert(outboxEvents).values({
-      tenantId: PLATFORM_AUDIT_ORG_ID,
+      tenantId: platformOrgId,
       type: "platform_admin.invited",
       payload: {
-        tenantId: PLATFORM_AUDIT_ORG_ID,
+        tenantId: platformOrgId,
         invitationId: row.id,
         email: row.email,
         inviterKeycloakId: input.actorKeycloakId,
         expiresAt: row.expiresAt.toISOString(),
-        // Locale: platform admins don't have a stored preference at
-        // invite time; default to APP_DEFAULT_LOCALE. The worker can
-        // override at send time if it has a better signal.
-        locale: APP_DEFAULT_LOCALE,
+        locale: inviteLocale,
       },
     });
 
-    await tx.execute(
-      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
-    );
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${platformOrgId}, true)`);
     await tx.insert(auditLogs).values({
-      orgId: PLATFORM_AUDIT_ORG_ID,
+      orgId: platformOrgId,
       // The invitee's KC sub doesn't exist yet — leave userId null until
       // the accept flow lands the platform_admins row.
       userId: null,
@@ -466,6 +551,14 @@ export interface AcceptInput {
   lastName: string;
   ipHash: string | null;
   userAgent: string | null;
+  /**
+   * Locale the invitee was viewing the accept page in. Stamped onto the
+   * Keycloak user's `locale` attribute so future emails (e.g. the
+   * reset-password flow) land in the language they picked at first
+   * contact, instead of falling back to the realm-wide default. Optional;
+   * KC simply omits the attribute if absent.
+   */
+  locale?: Locale;
 }
 
 /**
@@ -506,10 +599,9 @@ export async function acceptPlatformAdminInvitation(input: AcceptInput): Promise
     throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation has expired.");
   }
 
-  const [role, org] = await Promise.all([
-    keycloakAdmin().getRealmRole(SUPER_ADMIN_ROLE_NAME),
-    keycloakAdmin().getOrganizationByAlias(PLATFORM_ORG_ALIAS),
-  ]);
+  const platformOrgId = await getPlatformOrgId();
+
+  const [role, org] = await Promise.all([getCachedSuperAdminRole(), getCachedPlatformOrg()]);
   if (!role) {
     throw new PlatformAdminServiceError(
       502,
@@ -539,9 +631,18 @@ export async function acceptPlatformAdminInvitation(input: AcceptInput): Promise
       attributes: {
         // Same `org_id` user attribute as the seeded admin so the JWT
         // carries the flat `org_id` claim that `verifyKeycloakJwt`
-        // requires. (See PR #253 review feedback.)
-        org_id: [PLATFORM_AUDIT_ORG_ID],
+        // requires. (See PR #253 review feedback.) Resolved at runtime
+        // from the platform sentinel `tenants` row (slug `__platform__`)
+        // so the value matches what audit / outbox writes use — no
+        // magic-UUID literal in app code.
+        org_id: [platformOrgId],
         role: ["org_admin"],
+        // KC uses the user's `locale` attribute to pick the email
+        // template language for built-in flows (UPDATE_PASSWORD etc).
+        // We only set it when the invitee picked a non-default locale —
+        // omitting the attribute lets KC fall back to its realm-wide
+        // default, which matches our APP_DEFAULT_LOCALE.
+        ...(input.locale ? { locale: [input.locale] } : {}),
       },
     });
     kcUserId = out.id;
@@ -562,6 +663,27 @@ export async function acceptPlatformAdminInvitation(input: AcceptInput): Promise
   } catch (err) {
     await compensatingKcDelete(kcUserId, "accept-side-effects-failed");
     if (err instanceof PlatformAdminServiceError) throw err;
+
+    // Race against a re-imported (or just-deleted) realm — between the
+    // pre-flight `getCachedSuperAdminRole` / `getCachedPlatformOrg`
+    // lookups above and the writes here, the role/org could vanish or
+    // be replaced with a fresh id. Without this branch the operator
+    // sees a generic `KEYCLOAK_FAILURE` (502) and has to dig through
+    // the wrapped error message to know whether to re-import the realm
+    // or escalate to KC ops. The cached `{id, name}` is stale either
+    // way, so invalidate before bubbling so the next attempt re-fetches.
+    if (err instanceof KeycloakAdminError && err.status === 404) {
+      invalidatePlatformLookupCache();
+      const code = err.path?.includes("/role-mappings/")
+        ? "KEYCLOAK_ROLE_MISSING"
+        : "KEYCLOAK_ORG_MISSING";
+      throw new PlatformAdminServiceError(
+        502,
+        code,
+        `Keycloak ${code === "KEYCLOAK_ROLE_MISSING" ? `realm role '${SUPER_ADMIN_ROLE_NAME}'` : `Organization '${PLATFORM_ORG_ALIAS}'`} disappeared between pre-flight and write — realm needs re-importing.`,
+      );
+    }
+
     throw new PlatformAdminServiceError(
       502,
       "KEYCLOAK_FAILURE",
@@ -597,11 +719,9 @@ export async function acceptPlatformAdminInvitation(input: AcceptInput): Promise
       .returning();
     if (!row) throw new Error("acceptPlatformAdminInvitation: insert returned no row");
 
-    await tx.execute(
-      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
-    );
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${platformOrgId}, true)`);
     await tx.insert(auditLogs).values({
-      orgId: PLATFORM_AUDIT_ORG_ID,
+      orgId: platformOrgId,
       userId: kcUserId,
       // No `actorId` — the invitee accepted the invitation themselves.
       // The original inviter is recorded on the `platform_admin.invited`
@@ -622,6 +742,7 @@ export async function acceptPlatformAdminInvitation(input: AcceptInput): Promise
 
 export async function updatePlatformAdminName(input: UpdateNameInput): Promise<PlatformAdminRow> {
   const existing = await getActiveAdminOrThrow(input.id);
+  const platformOrgId = await getPlatformOrgId();
 
   await keycloakAdmin().updateUser(existing.keycloakId!, {
     firstName: input.firstName,
@@ -640,11 +761,9 @@ export async function updatePlatformAdminName(input: UpdateNameInput): Promise<P
       .returning();
     if (!row) throw new Error("updatePlatformAdminName: update returned no row");
 
-    await tx.execute(
-      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
-    );
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${platformOrgId}, true)`);
     await tx.insert(auditLogs).values({
-      orgId: PLATFORM_AUDIT_ORG_ID,
+      orgId: platformOrgId,
       userId: existing.keycloakId,
       actorId: input.actorKeycloakId,
       action: "platform_admin.renamed",
@@ -671,6 +790,7 @@ export async function updatePlatformAdminName(input: UpdateNameInput): Promise<P
 
 export async function resetPlatformAdminPassword(input: ResetPasswordInput): Promise<void> {
   const existing = await getActiveAdminOrThrow(input.id);
+  const platformOrgId = await getPlatformOrgId();
 
   await keycloakAdmin().sendExecuteActionsEmail(existing.keycloakId!, ["UPDATE_PASSWORD"], {
     lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
@@ -678,11 +798,9 @@ export async function resetPlatformAdminPassword(input: ResetPasswordInput): Pro
   });
 
   await systemDb.transaction(async (tx) => {
-    await tx.execute(
-      sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
-    );
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${platformOrgId}, true)`);
     await tx.insert(auditLogs).values({
-      orgId: PLATFORM_AUDIT_ORG_ID,
+      orgId: platformOrgId,
       userId: existing.keycloakId,
       actorId: input.actorKeycloakId,
       action: "platform_admin.password_reset_sent",
@@ -709,6 +827,8 @@ export async function softDeletePlatformAdmin(input: SoftDeleteInput): Promise<v
       "Operators cannot soft-delete their own platform-admin row. Ask another super-admin.",
     );
   }
+
+  const platformOrgId = await getPlatformOrgId();
 
   // Atomic delete + last-admin guard + audit insert in one SERIALIZABLE
   // transaction (security review M1, QA M4, data architect #13). The
@@ -769,10 +889,10 @@ export async function softDeletePlatformAdmin(input: SoftDeleteInput): Promise<v
         .where(eq(platformAdmins.id, input.id));
 
       await tx.execute(
-        sql`SELECT set_config('app.current_organization_id', ${PLATFORM_AUDIT_ORG_ID}, true)`,
+        sql`SELECT set_config('app.current_organization_id', ${platformOrgId}, true)`,
       );
       await tx.insert(auditLogs).values({
-        orgId: PLATFORM_AUDIT_ORG_ID,
+        orgId: platformOrgId,
         userId: lockedKeycloakId,
         actorId: input.actorKeycloakId,
         action: "platform_admin.removed",

--- a/packages/api/src/tests/integration/onboarding-runtime.test.ts
+++ b/packages/api/src/tests/integration/onboarding-runtime.test.ts
@@ -84,11 +84,26 @@ function makeKcStub(overrides: Partial<KeycloakAdminClient> = {}): KeycloakAdmin
     getOrganizationByAlias: async () => null,
     createIdentityProvider: async () => {},
     deleteIdentityProvider: async () => {},
-    // Issue #254 — platform-admin CRUD helpers. Stubbed for parity; this
-    // suite never exercises the platform-admins flow.
-    getRealmRole: async () => null,
-    assignRealmRoleToUser: async () => {},
-    sendExecuteActionsEmail: async () => {},
+    // Issue #254 — platform-admin CRUD helpers. The onboarding-runtime
+    // suite never exercises the platform-admins flow, so the fakes throw
+    // loud: a future code path that accidentally wires a super-admin or
+    // password-reset-email side-effect into onboarding surfaces here
+    // instead of greenly returning null/{}. (QA review m4 from PR #253.)
+    getRealmRole: async (name: string) => {
+      throw new Error(
+        `onboarding-runtime.test fake: getRealmRole(${name}) called — onboarding must not request realm roles. If a new flow needs this, scope the stub.`,
+      );
+    },
+    assignRealmRoleToUser: async () => {
+      throw new Error(
+        "onboarding-runtime.test fake: assignRealmRoleToUser called — onboarding must not promote users to realm roles. If a new flow needs this, scope the stub.",
+      );
+    },
+    sendExecuteActionsEmail: async () => {
+      throw new Error(
+        "onboarding-runtime.test fake: sendExecuteActionsEmail called — onboarding must not trigger built-in KC action emails. If a new flow needs this, scope the stub.",
+      );
+    },
     _circuitState: () => "closed" as const,
   };
   return { ...base, ...overrides };

--- a/packages/api/src/tests/integration/platform-admins.test.ts
+++ b/packages/api/src/tests/integration/platform-admins.test.ts
@@ -105,10 +105,16 @@ afterEach(async () => {
   `);
   // Restore the seeded operator to its canonical active shape — the
   // soft-delete tests null its `keycloak_id` and set `deleted_at`.
+  // The `email` column is included in the ON CONFLICT clause because
+  // `impersonation.test.ts` inserts the same id under a different
+  // email (`operator-super-admin@example.org`); without an email reset
+  // the "super_admin sees the list with at least the seeded operator"
+  // assertion below flakes when this file runs after impersonation.test
+  // in the shared `givernance_test` DB. (Issue #255 fix.)
   await db.execute(sql`
     INSERT INTO platform_admins (id, keycloak_id, email, first_name, last_name)
     VALUES (${SUPER_ADMIN_PLATFORM_ROW_ID}, ${SUPER_ADMIN_KEYCLOAK_ID}, 'super@example.org', 'Super', 'Admin')
-    ON CONFLICT (id) DO UPDATE SET deleted_at = NULL, keycloak_id = ${SUPER_ADMIN_KEYCLOAK_ID}, first_name = 'Super', last_name = 'Admin'
+    ON CONFLICT (id) DO UPDATE SET deleted_at = NULL, keycloak_id = ${SUPER_ADMIN_KEYCLOAK_ID}, email = 'super@example.org', first_name = 'Super', last_name = 'Admin'
   `);
 
   // Wipe any user-blocklist Redis keys the soft-delete tests wrote so
@@ -562,5 +568,290 @@ describe("DELETE /v1/admin/platform-admins/:id", () => {
       sql`SELECT action FROM audit_logs WHERE resource_id = ${id} AND action = 'platform_admin.removed'`,
     );
     expect(auditRows.rows.length).toBe(1);
+  });
+
+  // QA review m1 — boundary case for the last-admin guard. The seeded
+  // operator is soft-deleted (via a second admin); only one active row
+  // remains and the next delete must trip the guard. Pins that the
+  // count clause filters `deleted_at IS NULL` rather than counting all
+  // rows. (Issue #255.)
+  it("last-admin guard counts active rows only: deleting the sole active row when a soft-deleted row exists → 400", async () => {
+    // Step 1: invite + accept admin C.
+    const { id: cId, keycloakId: cKc } = await inviteAndAccept({
+      email: `edge-active-${randomUUID().slice(0, 8)}@example.org`,
+      firstName: "Edge",
+      lastName: "Active",
+    });
+
+    // Step 2: C soft-deletes the seeded operator. After this, the
+    // platform_admins table has:
+    //   - seeded operator: deleted_at IS NOT NULL
+    //   - C:               deleted_at IS NULL  (only active row)
+    const cToken = signToken(app, {
+      sub: cKc,
+      realm_access: { roles: ["super_admin"] },
+      role: undefined,
+    });
+    const removeSeeded = await app.inject({
+      method: "DELETE",
+      url: `/v1/admin/platform-admins/${SUPER_ADMIN_PLATFORM_ROW_ID}`,
+      headers: authHeader(cToken),
+    });
+    expect(removeSeeded.statusCode).toBe(204);
+
+    // Step 3: a third operator (no platform_admins row, just a JWT)
+    // attempts to delete C. The self-removal guard wouldn't fire
+    // (third != C), so this lands directly in the last-admin guard.
+    const thirdToken = signToken(app, {
+      sub: "00000000-0000-0000-0000-0000000000fd",
+      realm_access: { roles: ["super_admin"] },
+      role: undefined,
+    });
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/admin/platform-admins/${cId}`,
+      headers: authHeader(thirdToken),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      type: "https://httpproblems.com/http-status/400",
+      title: "Bad Request",
+      status: 400,
+    });
+    expect((res.json() as { detail?: string }).detail ?? "").toMatch(/last active/i);
+  });
+
+  // QA review M4 — concurrency invariant for the last-admin guard. With
+  // two active admins, two operators racing to delete *different*
+  // targets must not both succeed (that would leave zero active admins
+  // and brick the platform). The service uses SERIALIZABLE + FOR UPDATE
+  // to make exactly one win — the loser is either rejected by the
+  // count clause (400) or aborted by Postgres SSI (5xx). The test
+  // pins the invariant "exactly one of the two requests succeeds";
+  // either failure mode satisfies that. (Issue #255, security review M1.)
+  it("last-admin guard concurrency: Promise.all on two distinct deletes against the second-to-last admin → exactly one succeeds", async () => {
+    // Step 1: two active admins.
+    const { id: cId } = await inviteAndAccept({
+      email: `race-c-${randomUUID().slice(0, 8)}@example.org`,
+      firstName: "RaceC",
+      lastName: "Admin",
+    });
+
+    // Step 2: two distinct operators (neither is in platform_admins).
+    const opD = signToken(app, {
+      sub: "00000000-0000-0000-0000-0000000000fa",
+      realm_access: { roles: ["super_admin"] },
+      role: undefined,
+    });
+    const opE = signToken(app, {
+      sub: "00000000-0000-0000-0000-0000000000fb",
+      realm_access: { roles: ["super_admin"] },
+      role: undefined,
+    });
+
+    // Step 3: race the two deletes. Op D removes the seeded operator,
+    // op E removes admin C. Both targets are currently active, both
+    // count snapshots see active=2 — the SERIALIZABLE + FOR UPDATE
+    // posture must prevent both from committing.
+    const [resD, resE] = await Promise.all([
+      app.inject({
+        method: "DELETE",
+        url: `/v1/admin/platform-admins/${SUPER_ADMIN_PLATFORM_ROW_ID}`,
+        headers: authHeader(opD),
+      }),
+      app.inject({
+        method: "DELETE",
+        url: `/v1/admin/platform-admins/${cId}`,
+        headers: authHeader(opE),
+      }),
+    ]);
+
+    const successes = [resD.statusCode, resE.statusCode].filter((c) => c === 204);
+    const failures = [resD.statusCode, resE.statusCode].filter((c) => c !== 204);
+    expect(successes.length).toBe(1);
+    expect(failures.length).toBe(1);
+    // Loser is either 400 (count clause won) or 5xx (Postgres serialization
+    // failure bubbled). Either is correct — the invariant is "at least one
+    // active admin remains".
+    expect(failures[0]).toBeGreaterThanOrEqual(400);
+
+    // Final DB state: exactly one active admin.
+    const counts = await systemDb.execute<{ count: number }>(
+      sql`SELECT COUNT(*)::int AS count FROM platform_admins WHERE deleted_at IS NULL`,
+    );
+    expect(Number(counts.rows[0]?.count ?? 0)).toBe(1);
+  });
+});
+
+// ─── Audit attribution (issue #255, QA review M3) ──────────────────────────
+//
+// The PR #253 audit-row tests confirmed *that* a row was written, not
+// *who* it attributes the event to. These tests pin (`actor_id`,
+// `org_id`, `user_id`) on every lifecycle action so a future change to
+// the audit-write call site can't silently lose attribution columns.
+
+describe("Audit attribution", () => {
+  it("platform_admin.password_reset_sent: actor_id = operator, org_id = platform sentinel, user_id = target's KC sub", async () => {
+    const { id, keycloakId: targetKc } = await inviteAndAccept({
+      email: `audit-reset-${randomUUID().slice(0, 8)}@example.org`,
+      firstName: "AuditReset",
+      lastName: "Admin",
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/admin/platform-admins/${id}/reset-password`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(res.statusCode).toBe(204);
+
+    const rows = await systemDb.execute<{
+      actor_id: string | null;
+      org_id: string;
+      user_id: string | null;
+    }>(
+      sql`SELECT actor_id, org_id, user_id FROM audit_logs WHERE resource_id = ${id} AND action = 'platform_admin.password_reset_sent'`,
+    );
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0]?.actor_id).toBe(SUPER_ADMIN_KEYCLOAK_ID);
+    expect(rows.rows[0]?.org_id).toBe(PLATFORM_TENANT_ID);
+    expect(rows.rows[0]?.user_id).toBe(targetKc);
+  });
+
+  it("platform_admin.renamed: actor_id = operator, org_id = platform sentinel, user_id = target's KC sub", async () => {
+    const { id, keycloakId: targetKc } = await inviteAndAccept({
+      email: `audit-rename-${randomUUID().slice(0, 8)}@example.org`,
+      firstName: "AuditRename",
+      lastName: "Before",
+    });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/admin/platform-admins/${id}`,
+      headers: authHeader(superAdminToken()),
+      payload: { firstName: "AuditRename", lastName: "After" },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const rows = await systemDb.execute<{
+      actor_id: string | null;
+      org_id: string;
+      user_id: string | null;
+    }>(
+      sql`SELECT actor_id, org_id, user_id FROM audit_logs WHERE resource_id = ${id} AND action = 'platform_admin.renamed'`,
+    );
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0]?.actor_id).toBe(SUPER_ADMIN_KEYCLOAK_ID);
+    expect(rows.rows[0]?.org_id).toBe(PLATFORM_TENANT_ID);
+    expect(rows.rows[0]?.user_id).toBe(targetKc);
+  });
+
+  it("platform_admin.removed: actor_id = operator, org_id = platform sentinel, user_id = target's pre-soft-delete KC sub", async () => {
+    const { id, keycloakId: targetKc } = await inviteAndAccept({
+      email: `audit-remove-${randomUUID().slice(0, 8)}@example.org`,
+      firstName: "AuditRemove",
+      lastName: "Admin",
+    });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/admin/platform-admins/${id}`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(res.statusCode).toBe(204);
+
+    const rows = await systemDb.execute<{
+      actor_id: string | null;
+      org_id: string;
+      user_id: string | null;
+    }>(
+      sql`SELECT actor_id, org_id, user_id FROM audit_logs WHERE resource_id = ${id} AND action = 'platform_admin.removed'`,
+    );
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0]?.actor_id).toBe(SUPER_ADMIN_KEYCLOAK_ID);
+    expect(rows.rows[0]?.org_id).toBe(PLATFORM_TENANT_ID);
+    // user_id captures the KC sub at delete time (read inside the
+    // SERIALIZABLE tx before the row's keycloak_id is nulled), so
+    // post-delete the audit row still attributes to the offboarded sub.
+    expect(rows.rows[0]?.user_id).toBe(targetKc);
+  });
+});
+
+// ─── End-to-end happy path (issue #255, QA review m5) ───────────────────────
+//
+// One walk that exercises every endpoint on a single id, in order:
+//   POST invite → accept → GET detail → PATCH rename → POST reset-password
+//   → DELETE soft-delete. Catches regressions where any single endpoint
+//   regresses the invariants of the next (e.g. PATCH not refreshing
+//   `updated_at`, DELETE forgetting to null `keycloak_id`).
+
+describe("E2E happy path", () => {
+  it("invite → accept → GET → PATCH → reset-password → DELETE on the same id", async () => {
+    const email = `e2e-${randomUUID().slice(0, 8)}@example.org`;
+
+    // 1. Invite + accept (helper covers POST + GET-token + POST-accept).
+    const { id, keycloakId } = await inviteAndAccept({
+      email,
+      firstName: "E2E",
+      lastName: "Walk",
+    });
+
+    // 2. GET detail returns the row we just created.
+    const getRes = await app.inject({
+      method: "GET",
+      url: `/v1/admin/platform-admins/${id}`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(getRes.statusCode).toBe(200);
+    const detail = (getRes.json() as { data: { email: string; firstName: string } }).data;
+    expect(detail.email).toBe(email);
+    expect(detail.firstName).toBe("E2E");
+
+    // 3. PATCH rename — value changes are reflected in the response.
+    const patchRes = await app.inject({
+      method: "PATCH",
+      url: `/v1/admin/platform-admins/${id}`,
+      headers: authHeader(superAdminToken()),
+      payload: { firstName: "Renamed", lastName: "Walk" },
+    });
+    expect(patchRes.statusCode).toBe(200);
+    expect((patchRes.json() as { data: { firstName: string } }).data.firstName).toBe("Renamed");
+
+    // 4. POST reset-password — KC fake observed once.
+    kcSendExecuteActions.mockClear();
+    const resetRes = await app.inject({
+      method: "POST",
+      url: `/v1/admin/platform-admins/${id}/reset-password`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(resetRes.statusCode).toBe(204);
+    expect(kcSendExecuteActions).toHaveBeenCalledTimes(1);
+    expect(kcSendExecuteActions.mock.calls[0]?.[0]).toBe(keycloakId);
+
+    // 5. DELETE soft-delete — KC user deleted, audit + soft-delete state
+    // applied.
+    kcDeleteUser.mockClear();
+    const delRes = await app.inject({
+      method: "DELETE",
+      url: `/v1/admin/platform-admins/${id}`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(delRes.statusCode).toBe(204);
+    expect(kcDeleteUser).toHaveBeenCalledWith(keycloakId);
+
+    // The full lifecycle audit chain is queryable on the resource id.
+    const chain = await systemDb.execute<{ action: string }>(
+      sql`SELECT action FROM audit_logs WHERE resource_id = ${id} ORDER BY created_at ASC`,
+    );
+    const actions = chain.rows.map((r) => r.action);
+    // `platform_admin.invited` lands on the *invitation* id (not this
+    // platform_admins.id), so we expect the post-accept lifecycle here:
+    // created → renamed → password_reset_sent → removed.
+    expect(actions).toEqual([
+      "platform_admin.created",
+      "platform_admin.renamed",
+      "platform_admin.password_reset_sent",
+      "platform_admin.removed",
+    ]);
   });
 });

--- a/packages/api/src/tests/integration/schema-parity.test.ts
+++ b/packages/api/src/tests/integration/schema-parity.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Issue #261 — Drizzle ↔ SQL parity guard.
+ *
+ * Drizzle Kit cannot model partial indexes today, so the source of
+ * truth for `WHERE deleted_at IS NULL` partial-unique constraints lives
+ * in the hand-written SQL migrations (0032 for `users`, 0034 for
+ * `platform_admins`). The Drizzle schema declares unconditional
+ * `unique()` only for the type-side query-builder parity — Drizzle's
+ * understanding of these tables is intentionally lossier than the SQL.
+ *
+ * Two failure modes this test catches:
+ *
+ * 1. A future migration drops a partial-unique index and replaces it
+ *    with an unconditional one. The Drizzle schema still says "unique",
+ *    so type-level assertions stay green; the soft-delete-then-re-bind
+ *    flow regresses silently in prod (a re-issued email collides with
+ *    the row of an offboarded user).
+ *
+ * 2. A new soft-deleted table is added without the matching partial-
+ *    unique pattern. Same regression, new shape.
+ *
+ * The test introspects `pg_indexes.indexdef` after migrations apply and
+ * pins:
+ *   - the index name (so a rename is loud);
+ *   - the `WHERE (deleted_at IS NULL)` predicate (the actual canary);
+ *   - the unique flag (read from `pg_class.relkind` via a JOIN).
+ *
+ * If Drizzle Kit ever ships partial-index support, this guard is still
+ * the right primitive — it pins the runtime invariant, not the dev-
+ * tooling behaviour. (See data-architect M1/M2 from PR #253 review.)
+ */
+
+import { sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { systemDb } from "../../lib/db.js";
+
+interface IndexProbe {
+  table: string;
+  index: string;
+  /**
+   * Substring that MUST appear inside `pg_indexes.indexdef`. We don't
+   * lock the full DDL string because Postgres re-formats it (column
+   * order, schema-qualification, capitalisation) — matching on the
+   * load-bearing predicate fragment is enough to catch a regression
+   * without false-positiving on cosmetic re-formats.
+   */
+  expectInDef: string;
+  /** When true, the index must also be `is_unique`. */
+  unique: boolean;
+}
+
+const PARTIAL_UNIQUE_PROBES: IndexProbe[] = [
+  // ─── users (ADR-021) ────────────────────────────────────────────────
+  {
+    table: "users",
+    index: "users_org_id_email_active_uniq",
+    expectInDef: "deleted_at IS NULL",
+    unique: true,
+  },
+
+  // ─── platform_admins (ADR-022) ──────────────────────────────────────
+  {
+    table: "platform_admins",
+    index: "platform_admins_keycloak_id_active_uniq",
+    expectInDef: "deleted_at IS NULL",
+    unique: true,
+  },
+  {
+    table: "platform_admins",
+    index: "platform_admins_email_active_uniq",
+    expectInDef: "deleted_at IS NULL",
+    unique: true,
+  },
+];
+
+const SORT_INDEX_PROBES: IndexProbe[] = [
+  // ─── platform_admins sort indexes (migration 0036, issue #255) ──────
+  // Active-only partials so the index size tracks active rows, not
+  // ever-growing audit history. Names locked because the list endpoint
+  // depends on the planner picking the right one for ORDER BY.
+  {
+    table: "platform_admins",
+    index: "platform_admins_last_name_active_idx",
+    expectInDef: "deleted_at IS NULL",
+    unique: false,
+  },
+  {
+    table: "platform_admins",
+    index: "platform_admins_created_at_active_idx",
+    expectInDef: "deleted_at IS NULL",
+    unique: false,
+  },
+  {
+    table: "platform_admins",
+    index: "platform_admins_last_login_at_active_idx",
+    expectInDef: "deleted_at IS NULL",
+    unique: false,
+  },
+];
+
+describe("Drizzle ↔ SQL schema parity (issue #261)", () => {
+  beforeAll(async () => {
+    // No fixture work — we read pg_indexes directly. Migrations have
+    // already run as part of `pnpm db:migrate` in the CI step that
+    // precedes `pnpm test` (see `.github/workflows/ci.yml`).
+  });
+
+  afterAll(async () => {
+    // No teardown — read-only test.
+  });
+
+  describe("partial-unique invariant", () => {
+    it.each(
+      PARTIAL_UNIQUE_PROBES,
+    )("$table.$index is unique + partial on `deleted_at IS NULL`", async (probe) => {
+      const rows = await systemDb.execute<{
+        indexdef: string;
+        is_unique: boolean;
+      }>(sql`
+          SELECT
+            i.indexdef,
+            ix.indisunique AS is_unique
+          FROM pg_indexes i
+          JOIN pg_class c   ON c.relname = i.indexname
+          JOIN pg_index ix  ON ix.indexrelid = c.oid
+          WHERE i.schemaname = 'public'
+            AND i.tablename  = ${probe.table}
+            AND i.indexname  = ${probe.index}
+        `);
+
+      expect(rows.rows.length, `index ${probe.table}.${probe.index} not found`).toBe(1);
+      const row = rows.rows[0]!;
+      expect(
+        row.indexdef,
+        `index ${probe.index} is missing the partial predicate; full DDL: ${row.indexdef}`,
+      ).toContain(probe.expectInDef);
+      expect(row.is_unique, `index ${probe.index} must be UNIQUE`).toBe(probe.unique);
+    });
+  });
+
+  describe("sort-column index invariant (migration 0036)", () => {
+    it.each(
+      SORT_INDEX_PROBES,
+    )("$table.$index exists with the partial predicate (planner uses it for the list endpoint's ORDER BY)", async (probe) => {
+      const rows = await systemDb.execute<{
+        indexdef: string;
+        is_unique: boolean;
+      }>(sql`
+          SELECT
+            i.indexdef,
+            ix.indisunique AS is_unique
+          FROM pg_indexes i
+          JOIN pg_class c   ON c.relname = i.indexname
+          JOIN pg_index ix  ON ix.indexrelid = c.oid
+          WHERE i.schemaname = 'public'
+            AND i.tablename  = ${probe.table}
+            AND i.indexname  = ${probe.index}
+        `);
+
+      expect(rows.rows.length, `index ${probe.table}.${probe.index} not found`).toBe(1);
+      const row = rows.rows[0]!;
+      expect(row.indexdef).toContain(probe.expectInDef);
+      expect(row.is_unique).toBe(probe.unique);
+    });
+  });
+
+  describe("structural lock — no unconditional unique slips onto a soft-deleted table", () => {
+    it("every non-PK unique index on a soft-deleted table is either gated on `deleted_at IS NULL` or carries a documented rationale predicate", async () => {
+      // The bug we're guarding against: a future migration adds a
+      // unique constraint on a soft-deleted table without the `WHERE
+      // deleted_at IS NULL` predicate. The first soft-delete-then-
+      // re-bind regresses silently in prod (a re-issued email
+      // collides with the offboarded row).
+      //
+      // The query below finds non-PK unique indexes on soft-deleted
+      // tables whose `indexdef` doesn't mention either `deleted_at IS
+      // NULL` (the canonical pattern) OR a different predicate (which
+      // means an explicit decision was taken — documented in the
+      // EXPECTED_PREDICATE_OVERRIDES allow-list below).
+      //
+      // Tables with NO non-PK unique (e.g. `constituents` — same NPO
+      // can have two contacts with the same email) don't show up
+      // here at all; this lock targets the unique-constraint shape,
+      // not the existence of soft-delete itself.
+      const rows = await systemDb.execute<{
+        tablename: string;
+        indexname: string;
+        indexdef: string;
+      }>(sql`
+        SELECT i.tablename, i.indexname, i.indexdef
+        FROM pg_indexes i
+        JOIN pg_class c   ON c.relname = i.indexname
+        JOIN pg_index ix  ON ix.indexrelid = c.oid
+        WHERE i.schemaname = 'public'
+          AND ix.indisunique = true
+          AND ix.indisprimary = false
+          AND i.tablename IN (
+            SELECT table_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND column_name = 'deleted_at'
+          )
+        ORDER BY i.tablename, i.indexname
+      `);
+
+      // Indexes whose predicate is intentionally NOT
+      // \`deleted_at IS NULL\`. Every entry MUST come with a rationale
+      // — these are the carve-outs reviewers will scan first when an
+      // unfamiliar unique constraint shows up on a soft-deleted table.
+      const EXPECTED_PREDICATE_OVERRIDES = new Map<string, { predicate: string; reason: string }>([
+        [
+          // Only one first-admin per org; the invariant must hold
+          // across active + soft-deleted rows so a soft-deleted first
+          // admin still blocks a duplicate from being marked as the
+          // first admin (the audit / ownership story depends on it).
+          // Adding \`AND deleted_at IS NULL\` here would let two rows
+          // claim first-admin if one is later soft-deleted — that's
+          // the bug, not the fix.
+          "users_one_first_admin_per_org",
+          { predicate: "first_admin = true", reason: "ADR-021 ownership invariant" },
+        ],
+      ]);
+
+      const offenders: string[] = [];
+      for (const row of rows.rows) {
+        if (row.indexdef.includes("WHERE (deleted_at IS NULL)")) continue;
+        if (row.indexdef.includes("WHERE ((deleted_at IS NULL)")) continue;
+        const override = EXPECTED_PREDICATE_OVERRIDES.get(row.indexname);
+        if (override && row.indexdef.includes(override.predicate)) continue;
+        offenders.push(`${row.tablename}.${row.indexname} → ${row.indexdef}`);
+      }
+
+      expect(
+        offenders,
+        `non-PK unique indexes on soft-deleted tables that are neither partial on \`deleted_at IS NULL\` nor in the override allow-list:\n  ${offenders.join("\n  ")}\n\nSoft-delete + re-bind requires the partial-unique pattern (ADR-021); see migration 0032 for the canonical shape. If this index intentionally spans active + soft-deleted rows, add it to EXPECTED_PREDICATE_OVERRIDES with a rationale.`,
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/api/src/tests/integration/signup.test.ts
+++ b/packages/api/src/tests/integration/signup.test.ts
@@ -80,10 +80,26 @@ const fakeKeycloakAdmin: KeycloakAdminClient = {
   deleteUser: vi.fn(async () => {}),
   createIdentityProvider: vi.fn(async () => {}),
   deleteIdentityProvider: vi.fn(async () => {}),
-  // Issue #254 — platform-admin CRUD helpers. Signup flow never calls them.
-  getRealmRole: vi.fn(async () => null),
-  assignRealmRoleToUser: vi.fn(async () => {}),
-  sendExecuteActionsEmail: vi.fn(async () => {}),
+  // Issue #254 — platform-admin CRUD helpers. Signup flow never calls
+  // them, so the fakes throw loud: a future code path that accidentally
+  // wires a super-admin or password-reset-email side-effect into the
+  // signup flow surfaces here instead of greenly returning null/{}.
+  // (QA review m4 from PR #253.)
+  getRealmRole: vi.fn(async (name: string) => {
+    throw new Error(
+      `signup.test fake: getRealmRole(${name}) called — signup must not request realm roles. If a new flow needs this, scope the stub.`,
+    );
+  }),
+  assignRealmRoleToUser: vi.fn(async () => {
+    throw new Error(
+      "signup.test fake: assignRealmRoleToUser called — signup must not promote users to realm roles. If a new flow needs this, scope the stub.",
+    );
+  }),
+  sendExecuteActionsEmail: vi.fn(async () => {
+    throw new Error(
+      "signup.test fake: sendExecuteActionsEmail called — signup must not trigger built-in KC action emails. If a new flow needs this, scope the stub.",
+    );
+  }),
   _circuitState: () => "closed",
 };
 

--- a/packages/api/src/tests/integration/team-invitations.test.ts
+++ b/packages/api/src/tests/integration/team-invitations.test.ts
@@ -71,10 +71,25 @@ const fakeKeycloakAdmin: KeycloakAdminClient = {
   createIdentityProvider: vi.fn(async () => {}),
   deleteIdentityProvider: vi.fn(async () => {}),
   // Issue #254 — platform-admin CRUD helpers. The team-invitation flow
-  // never calls them; stubs preserve interface parity.
-  getRealmRole: vi.fn(async () => null),
-  assignRealmRoleToUser: vi.fn(async () => {}),
-  sendExecuteActionsEmail: vi.fn(async () => {}),
+  // never calls them, so the fakes throw loud: a future code path that
+  // accidentally wires a super-admin or password-reset-email side-effect
+  // into team_invite surfaces here instead of greenly returning null/{}.
+  // (QA review m4 from PR #253.)
+  getRealmRole: vi.fn(async (name: string) => {
+    throw new Error(
+      `team-invitations.test fake: getRealmRole(${name}) called — team_invite must not request realm roles. If a new flow needs this, scope the stub.`,
+    );
+  }),
+  assignRealmRoleToUser: vi.fn(async () => {
+    throw new Error(
+      "team-invitations.test fake: assignRealmRoleToUser called — team_invite must not promote users to realm roles. If a new flow needs this, scope the stub.",
+    );
+  }),
+  sendExecuteActionsEmail: vi.fn(async () => {
+    throw new Error(
+      "team-invitations.test fake: sendExecuteActionsEmail called — team_invite must not trigger built-in KC action emails. If a new flow needs this, scope the stub.",
+    );
+  }),
   _circuitState: () => "closed",
 };
 

--- a/packages/api/src/tests/integration/user-edit.test.ts
+++ b/packages/api/src/tests/integration/user-edit.test.ts
@@ -53,10 +53,26 @@ const fakeKeycloakAdmin: KeycloakAdminClient = {
   deleteUser: vi.fn(async () => {}),
   createIdentityProvider: vi.fn(async () => {}),
   deleteIdentityProvider: vi.fn(async () => {}),
-  // Issue #254 — platform-admin CRUD helpers. User-edit flow never calls them.
-  getRealmRole: vi.fn(async () => null),
-  assignRealmRoleToUser: vi.fn(async () => {}),
-  sendExecuteActionsEmail: vi.fn(async () => {}),
+  // Issue #254 — platform-admin CRUD helpers. The user-edit flow never
+  // calls them, so the fakes throw loud: a future code path that
+  // accidentally wires a super-admin or password-reset-email side-effect
+  // into a tenant-user PATCH surfaces here instead of greenly returning
+  // null/{}. (QA review m4 from PR #253.)
+  getRealmRole: vi.fn(async (name: string) => {
+    throw new Error(
+      `user-edit.test fake: getRealmRole(${name}) called — user-edit must not request realm roles. If a new flow needs this, scope the stub.`,
+    );
+  }),
+  assignRealmRoleToUser: vi.fn(async () => {
+    throw new Error(
+      "user-edit.test fake: assignRealmRoleToUser called — user-edit must not promote tenant users to realm roles. If a new flow needs this, scope the stub.",
+    );
+  }),
+  sendExecuteActionsEmail: vi.fn(async () => {
+    throw new Error(
+      "user-edit.test fake: sendExecuteActionsEmail called — user-edit must not trigger built-in KC action emails. If a new flow needs this, scope the stub.",
+    );
+  }),
   _circuitState: () => "closed",
 };
 

--- a/packages/web/src/app/(admin)/admin/disputes/[id]/page.tsx
+++ b/packages/web/src/app/(admin)/admin/disputes/[id]/page.tsx
@@ -33,22 +33,24 @@ export default async function DisputeDetailPage({ params }: { params: Promise<{ 
         <Link href="/admin/disputes" className="text-xs text-primary hover:underline">
           ← {t("backToList")}
         </Link>
-        <h1 className="mt-2 font-heading text-2xl text-text">
+        <h1 className="mt-2 font-heading text-2xl text-on-surface">
           {t("title", { name: row.orgName })}
         </h1>
-        <p className="mt-1 text-sm text-text-secondary">
+        <p className="mt-1 text-sm text-on-surface-variant">
           {row.orgSlug} · {new Date(row.createdAt).toLocaleString()}
         </p>
       </header>
 
       <section className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
-        <h2 className="text-sm font-semibold text-text-secondary">{t("reasonLabel")}</h2>
-        <p className="mt-2 whitespace-pre-wrap text-sm text-text">{row.reason ?? t("noReason")}</p>
+        <h2 className="text-sm font-semibold text-on-surface-variant">{t("reasonLabel")}</h2>
+        <p className="mt-2 whitespace-pre-wrap text-sm text-on-surface">
+          {row.reason ?? t("noReason")}
+        </p>
       </section>
 
       <section className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
-        <h2 className="text-sm font-semibold text-text-secondary">{t("partiesLabel")}</h2>
-        <dl className="mt-2 grid gap-2 text-sm text-text">
+        <h2 className="text-sm font-semibold text-on-surface-variant">{t("partiesLabel")}</h2>
+        <dl className="mt-2 grid gap-2 text-sm text-on-surface">
           <div className="flex justify-between">
             <dt className="text-text-muted">{t("disputer")}</dt>
             <dd className="font-mono text-xs">{row.disputerId ?? "—"}</dd>
@@ -62,8 +64,8 @@ export default async function DisputeDetailPage({ params }: { params: Promise<{ 
 
       {row.resolution ? (
         <section className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
-          <h2 className="text-sm font-semibold text-text-secondary">{t("resolvedLabel")}</h2>
-          <p className="mt-2 text-sm text-text">
+          <h2 className="text-sm font-semibold text-on-surface-variant">{t("resolvedLabel")}</h2>
+          <p className="mt-2 text-sm text-on-surface">
             {resolutionLabel(row.resolution)} —{" "}
             {row.resolvedAt ? new Date(row.resolvedAt).toLocaleString() : ""}
           </p>

--- a/packages/web/src/app/(admin)/admin/disputes/page.tsx
+++ b/packages/web/src/app/(admin)/admin/disputes/page.tsx
@@ -42,19 +42,19 @@ export default async function DisputeListPage() {
   return (
     <div className="space-y-8">
       <header>
-        <h1 className="font-heading text-2xl text-text">{t("title")}</h1>
-        <p className="mt-1 text-sm text-text-secondary">{t("subtitle")}</p>
+        <h1 className="font-heading text-2xl text-on-surface">{t("title")}</h1>
+        <p className="mt-1 text-sm text-on-surface-variant">{t("subtitle")}</p>
       </header>
 
       <section aria-labelledby="open-disputes-title">
         <h2
           id="open-disputes-title"
-          className="mb-3 text-sm font-semibold uppercase tracking-wide text-text-secondary"
+          className="mb-3 text-sm font-semibold uppercase tracking-wide text-on-surface-variant"
         >
           {t("openSectionTitle", { count: open.length })}
         </h2>
         {open.length === 0 ? (
-          <p className="rounded-md border border-outline-variant bg-surface-container-lowest p-4 text-sm text-text-secondary">
+          <p className="rounded-md border border-outline-variant bg-surface-container-lowest p-4 text-sm text-on-surface-variant">
             {t("emptyOpen")}
           </p>
         ) : (
@@ -67,7 +67,7 @@ export default async function DisputeListPage() {
                 >
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="font-medium text-text">{row.orgName}</p>
+                      <p className="font-medium text-on-surface">{row.orgName}</p>
                       <p className="text-xs text-text-muted">
                         {row.orgSlug} · {new Date(row.createdAt).toLocaleString()}
                       </p>
@@ -77,7 +77,9 @@ export default async function DisputeListPage() {
                     </span>
                   </div>
                   {row.reason && (
-                    <p className="mt-2 line-clamp-2 text-sm text-text-secondary">{row.reason}</p>
+                    <p className="mt-2 line-clamp-2 text-sm text-on-surface-variant">
+                      {row.reason}
+                    </p>
                   )}
                 </Link>
               </li>
@@ -89,12 +91,12 @@ export default async function DisputeListPage() {
       <section aria-labelledby="domain-disputes-title">
         <h2
           id="domain-disputes-title"
-          className="mb-3 mt-12 text-sm font-semibold uppercase tracking-wide text-text-secondary"
+          className="mb-3 mt-12 text-sm font-semibold uppercase tracking-wide text-on-surface-variant"
         >
           {t("domainSectionTitle", { count: domainOpen.length })}
         </h2>
         {domainOpen.length === 0 ? (
-          <p className="rounded-md border border-outline-variant bg-surface-container-lowest p-4 text-sm text-text-secondary">
+          <p className="rounded-md border border-outline-variant bg-surface-container-lowest p-4 text-sm text-on-surface-variant">
             {t("emptyDomain")}
           </p>
         ) : (
@@ -107,7 +109,7 @@ export default async function DisputeListPage() {
                 >
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="font-medium text-text">{row.claimerEmail}</p>
+                      <p className="font-medium text-on-surface">{row.claimerEmail}</p>
                       <p className="text-xs text-text-muted">
                         Disputing {row.orgName} ({row.orgSlug}) ·{" "}
                         {new Date(row.createdAt).toLocaleString()}
@@ -118,7 +120,9 @@ export default async function DisputeListPage() {
                     </span>
                   </div>
                   {row.reason && (
-                    <p className="mt-2 line-clamp-2 text-sm text-text-secondary">{row.reason}</p>
+                    <p className="mt-2 line-clamp-2 text-sm text-on-surface-variant">
+                      {row.reason}
+                    </p>
                   )}
                 </Link>
               </li>
@@ -130,12 +134,12 @@ export default async function DisputeListPage() {
       <section aria-labelledby="closed-disputes-title">
         <h2
           id="closed-disputes-title"
-          className="mb-3 text-sm font-semibold uppercase tracking-wide text-text-secondary"
+          className="mb-3 text-sm font-semibold uppercase tracking-wide text-on-surface-variant"
         >
           {t("closedSectionTitle", { count: closed.length })}
         </h2>
         {closed.length === 0 ? (
-          <p className="rounded-md border border-outline-variant bg-surface-container-lowest p-4 text-sm text-text-secondary">
+          <p className="rounded-md border border-outline-variant bg-surface-container-lowest p-4 text-sm text-on-surface-variant">
             {t("emptyClosed")}
           </p>
         ) : (
@@ -148,13 +152,13 @@ export default async function DisputeListPage() {
                 >
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="font-medium text-text">{row.orgName}</p>
+                      <p className="font-medium text-on-surface">{row.orgName}</p>
                       <p className="text-xs text-text-muted">
                         {row.orgSlug} ·{" "}
                         {row.resolvedAt ? new Date(row.resolvedAt).toLocaleString() : ""}
                       </p>
                     </div>
-                    <span className="rounded-full bg-surface-container-low px-2 py-0.5 text-xs font-medium text-text-secondary">
+                    <span className="rounded-full bg-surface-container-low px-2 py-0.5 text-xs font-medium text-on-surface-variant">
                       {resolutionLabel(row.resolution)}
                     </span>
                   </div>

--- a/packages/web/src/app/(admin)/admin/domain-disputes/[id]/page.tsx
+++ b/packages/web/src/app/(admin)/admin/domain-disputes/[id]/page.tsx
@@ -41,22 +41,24 @@ export default async function DomainDisputeDetailPage({
         <Link href="/admin/disputes" className="text-xs text-primary hover:underline">
           ← {t("backToList")}
         </Link>
-        <h1 className="mt-2 font-heading text-2xl text-text">
+        <h1 className="mt-2 font-heading text-2xl text-on-surface">
           {t("title", { name: row.orgName })}
         </h1>
-        <p className="mt-1 text-sm text-text-secondary">
+        <p className="mt-1 text-sm text-on-surface-variant">
           {row.orgSlug} · {new Date(row.createdAt).toLocaleString()}
         </p>
       </header>
 
       <section className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
-        <h2 className="text-sm font-semibold text-text-secondary">{t("reasonLabel")}</h2>
-        <p className="mt-2 whitespace-pre-wrap text-sm text-text">{row.reason ?? t("noReason")}</p>
+        <h2 className="text-sm font-semibold text-on-surface-variant">{t("reasonLabel")}</h2>
+        <p className="mt-2 whitespace-pre-wrap text-sm text-on-surface">
+          {row.reason ?? t("noReason")}
+        </p>
       </section>
 
       <section className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
-        <h2 className="text-sm font-semibold text-text-secondary">{t("partiesLabel")}</h2>
-        <dl className="mt-2 grid gap-2 text-sm text-text">
+        <h2 className="text-sm font-semibold text-on-surface-variant">{t("partiesLabel")}</h2>
+        <dl className="mt-2 grid gap-2 text-sm text-on-surface">
           <div className="flex justify-between">
             <dt className="text-text-muted">Claimer Email</dt>
             <dd className="font-mono text-xs">{row.claimerEmail ?? "—"}</dd>
@@ -70,14 +72,14 @@ export default async function DomainDisputeDetailPage({
 
       {row.state !== "open" ? (
         <section className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
-          <h2 className="text-sm font-semibold text-text-secondary">{t("resolvedLabel")}</h2>
-          <p className="mt-2 text-sm text-text">
+          <h2 className="text-sm font-semibold text-on-surface-variant">{t("resolvedLabel")}</h2>
+          <p className="mt-2 text-sm text-on-surface">
             {resolutionLabel(row.state)} —{" "}
             {row.resolvedAt ? new Date(row.resolvedAt).toLocaleString() : ""}
           </p>
         </section>
       ) : (
-        <p className="text-sm text-text-secondary">
+        <p className="text-sm text-on-surface-variant">
           Resolution options via UI not yet implemented. Use API to resolve.
         </p>
       )}

--- a/packages/web/src/app/(admin)/admin/platform-admins/page.tsx
+++ b/packages/web/src/app/(admin)/admin/platform-admins/page.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
+import { PlatformAdminsFilters } from "@/components/admin/platform-admins-filters";
 import { PlatformAdminsTable } from "@/components/admin/platform-admins-table";
 import { Button } from "@/components/ui/button";
 import { createServerApiClient } from "@/lib/api/client-server";
@@ -32,27 +33,42 @@ function normalizeOrder(value: string | undefined): PlatformAdminSortOrder {
 }
 
 /**
- * Super-admin-only list page for platform admins (issue #254). Search +
- * include-deleted toggle UI are deferred to a follow-up — the API
- * supports both, but until the UI ships there's no point reading the
- * params from the URL (frontend review M2 — drop dead plumbing).
+ * Super-admin-only list page for platform admins (issues #254 + #255 +
+ * #260). Reads the four URL params the API supports — `sort`, `order`,
+ * `q`, `includeDeleted` — server-side and forwards them onto the
+ * `/v1/admin/platform-admins` GET. The filter controls (`q` +
+ * `includeDeleted` toggle) live in the client `PlatformAdminsFilters`
+ * component, which writes back to the URL via `router.replace` so the
+ * server re-fetches on every change.
  */
 export default async function PlatformAdminsListPage({
   searchParams,
 }: {
-  searchParams: Promise<{ sort?: string; order?: string }>;
+  searchParams: Promise<{
+    sort?: string;
+    order?: string;
+    q?: string;
+    includeDeleted?: string;
+  }>;
 }) {
   const search = await searchParams;
   const t = await getTranslations("admin.platformAdmins.list");
   const api = await createServerApiClient();
   const sort = normalizeSort(search.sort);
   const order = normalizeOrder(search.order);
+  const q = (search.q ?? "").trim();
+  // Lenient parse on `?includeDeleted=` so a `?includeDeleted` (no
+  // value, the URL-without-explicit-`true` form some browsers emit on
+  // toggled checkboxes) lands as truthy. Anything else → false.
+  const includeDeleted = search.includeDeleted === "true" || search.includeDeleted === "";
 
   let data: PlatformAdminListResponse["data"] | null = null;
   let total = 0;
   let fetchFailed = false;
   try {
     const params = new URLSearchParams({ sort, order, limit: "200" });
+    if (q) params.set("q", q);
+    if (includeDeleted) params.set("includeDeleted", "true");
     const res = await api.get<PlatformAdminListResponse>(
       `/v1/admin/platform-admins?${params.toString()}`,
     );
@@ -76,6 +92,8 @@ export default async function PlatformAdminsListPage({
           <Link href="/admin/platform-admins/new">{t("createCta")}</Link>
         </Button>
       </header>
+
+      <PlatformAdminsFilters initialQ={q} initialIncludeDeleted={includeDeleted} />
 
       {fetchFailed ? (
         <div

--- a/packages/web/src/app/(admin)/admin/tenants/[id]/page.tsx
+++ b/packages/web/src/app/(admin)/admin/tenants/[id]/page.tsx
@@ -30,7 +30,7 @@ function DetailCard({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4">
       <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">{label}</p>
-      <p className="mt-2 text-sm text-text">{value}</p>
+      <p className="mt-2 text-sm text-on-surface">{value}</p>
     </div>
   );
 }
@@ -118,10 +118,10 @@ export default async function TenantDetailPage({
             <TableRow key={domain.id}>
               <TableCell>{domain.domain}</TableCell>
               <TableCell>{domain.state}</TableCell>
-              <TableCell className="font-mono text-xs text-text-secondary">
+              <TableCell className="font-mono text-xs text-on-surface-variant">
                 {domain.dnsTxtValue}
               </TableCell>
-              <TableCell className="text-text-secondary">
+              <TableCell className="text-on-surface-variant">
                 {formatAdminDate(domain.verifiedAt)}
               </TableCell>
             </TableRow>
@@ -130,7 +130,7 @@ export default async function TenantDetailPage({
       </Table>
     </div>
   ) : (
-    <p className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4 text-sm text-text-secondary">
+    <p className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4 text-sm text-on-surface-variant">
       {t("domains.empty")}
     </p>
   );
@@ -151,9 +151,9 @@ export default async function TenantDetailPage({
           {users.map((user) => (
             <TableRow key={user.id}>
               <TableCell>{formatTenantUserName(user.firstName, user.lastName)}</TableCell>
-              <TableCell className="text-text-secondary">{user.email}</TableCell>
+              <TableCell className="text-on-surface-variant">{user.email}</TableCell>
               <TableCell>{user.role}</TableCell>
-              <TableCell className="text-text-secondary">
+              <TableCell className="text-on-surface-variant">
                 {user.firstAdmin
                   ? t("users.flags.firstAdmin")
                   : user.provisionalUntil
@@ -162,7 +162,7 @@ export default async function TenantDetailPage({
                       })
                     : "—"}
               </TableCell>
-              <TableCell className="text-text-secondary">
+              <TableCell className="text-on-surface-variant">
                 {formatAdminDate(user.lastVisitedAt)}
               </TableCell>
             </TableRow>
@@ -171,7 +171,7 @@ export default async function TenantDetailPage({
       </Table>
     </div>
   ) : (
-    <p className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4 text-sm text-text-secondary">
+    <p className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4 text-sm text-on-surface-variant">
       {t("users.empty")}
     </p>
   );
@@ -191,17 +191,17 @@ export default async function TenantDetailPage({
         <TableBody>
           {recentAudit.map((entry) => (
             <TableRow key={entry.id} className="align-top">
-              <TableCell className="text-text-secondary">
+              <TableCell className="text-on-surface-variant">
                 {formatAdminDate(entry.createdAt)}
               </TableCell>
               <TableCell>{entry.action}</TableCell>
-              <TableCell className="text-text-secondary">
+              <TableCell className="text-on-surface-variant">
                 {[entry.resourceType, entry.resourceId].filter(Boolean).join(" · ") || "—"}
               </TableCell>
-              <TableCell className="font-mono text-xs text-text-secondary">
+              <TableCell className="font-mono text-xs text-on-surface-variant">
                 {entry.userId ?? "—"}
               </TableCell>
-              <TableCell className="text-xs text-text-secondary">
+              <TableCell className="text-xs text-on-surface-variant">
                 <p>{t("audit.oldValues", { value: renderJsonPreview(entry.oldValues) })}</p>
                 <p className="mt-1">
                   {t("audit.newValues", { value: renderJsonPreview(entry.newValues) })}
@@ -213,7 +213,7 @@ export default async function TenantDetailPage({
       </Table>
     </div>
   ) : (
-    <p className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4 text-sm text-text-secondary">
+    <p className="rounded-lg border border-outline-variant bg-surface-container-lowest p-4 text-sm text-on-surface-variant">
       {t("audit.empty")}
     </p>
   );
@@ -226,8 +226,8 @@ export default async function TenantDetailPage({
         </Link>
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div>
-            <h1 className="font-heading text-2xl text-text">{tenant.name}</h1>
-            <p className="mt-1 text-sm text-text-secondary">{tenant.slug}</p>
+            <h1 className="font-heading text-2xl text-on-surface">{tenant.name}</h1>
+            <p className="mt-1 text-sm text-on-surface-variant">{tenant.slug}</p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <TenantStatusBadge status={tenant.status} label={tenantStatusLabel(t, tenant.status)} />

--- a/packages/web/src/app/(admin)/admin/tenants/page.tsx
+++ b/packages/web/src/app/(admin)/admin/tenants/page.tsx
@@ -61,8 +61,8 @@ export default async function TenantListPage({
     <div className="space-y-8">
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h1 className="font-heading text-2xl text-text">{t("title")}</h1>
-          <p className="mt-1 text-sm text-text-secondary">{t("subtitle")}</p>
+          <h1 className="font-heading text-2xl text-on-surface">{t("title")}</h1>
+          <p className="mt-1 text-sm text-on-surface-variant">{t("subtitle")}</p>
         </div>
         <Button asChild>
           <Link href="/admin/tenants/new">{t("createCta")}</Link>

--- a/packages/web/src/components/admin/platform-admin-detail-actions.test.tsx
+++ b/packages/web/src/components/admin/platform-admin-detail-actions.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Issue #255 — direct vitest coverage for `PlatformAdminDetailActions`
+ * (QA review M5 follow-up to PR #253). Locks the user-visible behaviour
+ * of the three confirm-dialog actions on the detail page:
+ *
+ *   - Rename happy path → toast + router refresh
+ *   - 400 + "last active" detail → distinct error toast
+ *   - 400 + "own platform-admin row" detail → distinct error toast
+ *   - 404 → "not found" toast (separate string from generic 502/500)
+ *   - `isSelf` hides the remove button when operator IS the admin
+ *
+ * The PlatformAdminService is fully mocked — the API contract is
+ * exercised in `platform-admins.test.ts` against a real server.
+ */
+
+import { ApiProblem } from "@/lib/api";
+import type { PlatformAdmin } from "@/models/platform-admin";
+import { PlatformAdminService } from "@/services/PlatformAdminService";
+import { mockRouter, mockToast, render, screen, userEvent, waitFor } from "@/tests/test-utils";
+
+import { PlatformAdminDetailActions } from "./platform-admin-detail-actions";
+
+vi.mock("@/services/PlatformAdminService", () => ({
+  PlatformAdminService: {
+    updateName: vi.fn(),
+    resetPassword: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api/client-browser", () => ({
+  createClientApiClient: () => ({}),
+}));
+
+function makeAdmin(overrides: Partial<PlatformAdmin> = {}): PlatformAdmin {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    keycloakId: "kc-target-001",
+    email: "target@example.org",
+    firstName: "Target",
+    lastName: "User",
+    lastLoginAt: null,
+    deletedAt: null,
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("PlatformAdminDetailActions", () => {
+  it("rename happy path: calls service, shows success toast, refreshes router", async () => {
+    const user = userEvent.setup();
+    vi.mocked(PlatformAdminService.updateName).mockResolvedValue(makeAdmin());
+
+    render(<PlatformAdminDetailActions admin={makeAdmin()} operatorKeycloakId="kc-operator-99" />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    const firstNameInput = await screen.findByLabelText(/First name/i);
+    await user.clear(firstNameInput);
+    await user.type(firstNameInput, "Renamed");
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(PlatformAdminService.updateName).toHaveBeenCalledWith(
+        expect.anything(),
+        "00000000-0000-0000-0000-000000000001",
+        expect.objectContaining({ firstName: "Renamed" }),
+      );
+    });
+    expect(mockToast.success).toHaveBeenCalled();
+    expect(mockRouter.refresh).toHaveBeenCalled();
+  });
+
+  it("remove → 400 + 'last active' surfaces the last-admin toast (distinct from generic)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(PlatformAdminService.remove).mockRejectedValue(
+      new ApiProblem({
+        type: "about:blank",
+        title: "Bad Request",
+        status: 400,
+        detail: "Cannot remove the last active platform admin.",
+      }),
+    );
+
+    render(<PlatformAdminDetailActions admin={makeAdmin()} operatorKeycloakId="kc-operator-99" />);
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+    // The AlertDialog confirm action — the destructive button inside
+    // the open dialog. There are now two "Remove" buttons in the DOM
+    // (the trigger + the confirm), so disambiguate by name on the
+    // confirm copy. The trigger's `actions.remove` translation differs
+    // from the dialog's `removeDialog.confirm`.
+    const confirmButtons = await screen.findAllByRole("button");
+    const confirm = confirmButtons.find(
+      (b) => b.textContent && /remove/i.test(b.textContent) && b.className.includes("bg-error"),
+    );
+    if (!confirm) throw new Error("destructive confirm button not found");
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(PlatformAdminService.remove).toHaveBeenCalledTimes(1);
+    });
+    // The component reads i18n keys; we assert that *some* error toast
+    // fired and that the success path did not. The exact key
+    // (`errors.lastAdmin` vs `errors.generic`) is locked at the
+    // i18n-resolution layer.
+    expect(mockToast.error).toHaveBeenCalled();
+    expect(mockToast.success).not.toHaveBeenCalled();
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it("remove → 400 + 'own platform-admin row' surfaces the self-removal toast", async () => {
+    const user = userEvent.setup();
+    vi.mocked(PlatformAdminService.remove).mockRejectedValue(
+      new ApiProblem({
+        type: "about:blank",
+        title: "Bad Request",
+        status: 400,
+        detail: "Operators cannot soft-delete their own platform-admin row.",
+      }),
+    );
+
+    // operator != admin so the remove button is visible. We hit the
+    // server-side guard not the client-side hide — exercising that the
+    // 400 'own platform-admin row' detail wins the regex branch.
+    render(<PlatformAdminDetailActions admin={makeAdmin()} operatorKeycloakId="kc-operator-99" />);
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+    const confirmButtons = await screen.findAllByRole("button");
+    const confirm = confirmButtons.find(
+      (b) => b.textContent && /remove/i.test(b.textContent) && b.className.includes("bg-error"),
+    );
+    if (!confirm) throw new Error("destructive confirm button not found");
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(PlatformAdminService.remove).toHaveBeenCalledTimes(1);
+    });
+    expect(mockToast.error).toHaveBeenCalled();
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it("remove → 404 surfaces a distinct not-found toast", async () => {
+    const user = userEvent.setup();
+    vi.mocked(PlatformAdminService.remove).mockRejectedValue(
+      new ApiProblem({
+        type: "about:blank",
+        title: "Not Found",
+        status: 404,
+        detail: "Platform admin not found.",
+      }),
+    );
+
+    render(<PlatformAdminDetailActions admin={makeAdmin()} operatorKeycloakId="kc-operator-99" />);
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+    const confirmButtons = await screen.findAllByRole("button");
+    const confirm = confirmButtons.find(
+      (b) => b.textContent && /remove/i.test(b.textContent) && b.className.includes("bg-error"),
+    );
+    if (!confirm) throw new Error("destructive confirm button not found");
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(PlatformAdminService.remove).toHaveBeenCalledTimes(1);
+    });
+    expect(mockToast.error).toHaveBeenCalled();
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it("isSelf hides the remove button when admin.keycloakId === operatorKeycloakId", () => {
+    render(
+      <PlatformAdminDetailActions
+        admin={makeAdmin({ keycloakId: "kc-self" })}
+        operatorKeycloakId="kc-self"
+      />,
+    );
+
+    // Edit + reset are present, remove is not.
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remove/i })).not.toBeInTheDocument();
+  });
+
+  it("isSelf does NOT trigger when operatorKeycloakId is null (stale auth, parallel-tab race) — remove button stays visible", () => {
+    // The intent comment in the component spells out: a null operator
+    // sub means we don't *know* who the operator is, so we err on the
+    // side of showing the button and let the API guard catch the
+    // self-removal attempt. This pins that posture.
+    render(
+      <PlatformAdminDetailActions
+        admin={makeAdmin({ keycloakId: "kc-target-001" })}
+        operatorKeycloakId={null}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /remove/i })).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/admin/platform-admin-detail-actions.tsx
+++ b/packages/web/src/components/admin/platform-admin-detail-actions.tsx
@@ -23,7 +23,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -59,6 +59,14 @@ export function PlatformAdminDetailActions({ admin, operatorKeycloakId }: Props)
   const tFields = useTranslations("admin.platformAdmins.new.fields");
   const router = useRouter();
 
+  // Hide-the-button check is intentionally a strict triple-null-guard:
+  // when `operatorKeycloakId` is null (stale page load, refresh dropped
+  // the JWT claim, parallel-tab race where the operator was logged out),
+  // we DON'T treat the row as `isSelf` and the remove button stays
+  // visible. The API guard (`SELF_REMOVAL_FORBIDDEN`) catches the actual
+  // submit and the toast in `onRemoveConfirm` surfaces it. The UX cost
+  // of an extra round-trip beats silently hiding the affordance under a
+  // stale or partial auth state. (Frontend review m3.)
   const isSelf =
     admin.keycloakId !== null &&
     operatorKeycloakId !== null &&
@@ -261,7 +269,7 @@ export function PlatformAdminDetailActions({ admin, operatorKeycloakId }: Props)
             <AlertDialogAction
               onClick={onRemoveConfirm}
               disabled={pendingRemove}
-              className="bg-error text-on-error hover:bg-error/90"
+              className={buttonVariants({ variant: "destructive" })}
             >
               {pendingRemove ? t("actions.removing") : t("removeDialog.confirm")}
             </AlertDialogAction>

--- a/packages/web/src/components/admin/platform-admins-filters.test.tsx
+++ b/packages/web/src/components/admin/platform-admins-filters.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Issue #260 — coverage for `PlatformAdminsFilters`. Pins the URL
+ * round-trip behaviour:
+ *
+ *   - Typing in the search input replaces (not pushes) `?q=` after the
+ *     debounce settles.
+ *   - Toggling "Show offboarded" replaces the URL synchronously with
+ *     `?includeDeleted=true` (no debounce — toggling is intentful).
+ *   - Clearing the search via the X button skips the debounce and
+ *     drops `?q=` immediately.
+ *   - Filter changes drop a stale `?offset=` so a refilter doesn't
+ *     leave the user on page 4 of the prior result set.
+ *
+ * The page-side server fetch is exercised in `platform-admins.test.ts`
+ * (api package) — this file locks the client/URL contract.
+ */
+
+import { mockRouter, render, screen, userEvent, waitFor } from "@/tests/test-utils";
+
+import { PlatformAdminsFilters } from "./platform-admins-filters";
+
+describe("PlatformAdminsFilters", () => {
+  it("typing in the search input replaces (not pushes) the URL with `?q=` after the debounce settles", async () => {
+    // RTL drains the debounce timer naturally as `userEvent.type`
+    // yields between keystrokes — no fake timers needed for the 250ms
+    // window, the test waits long enough.
+    const user = userEvent.setup();
+
+    render(<PlatformAdminsFilters initialQ="" initialIncludeDeleted={false} />);
+
+    await user.type(screen.getByLabelText(/search platform admins/i), "ada");
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalled();
+    });
+    const url = mockRouter.replace.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain("q=ada");
+    expect(url).not.toContain("includeDeleted=");
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it("toggling include-deleted replaces the URL synchronously with `?includeDeleted=true`", async () => {
+    const user = userEvent.setup();
+
+    render(<PlatformAdminsFilters initialQ="" initialIncludeDeleted={false} />);
+
+    await user.click(screen.getByRole("checkbox", { name: /offboarded/i }));
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledTimes(1);
+    });
+    const url = mockRouter.replace.mock.calls[0]?.[0] as string;
+    expect(url).toContain("includeDeleted=true");
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it("toggling include-deleted off drops `?includeDeleted=` from the URL", async () => {
+    const user = userEvent.setup();
+
+    render(<PlatformAdminsFilters initialQ="" initialIncludeDeleted={true} />);
+
+    await user.click(screen.getByRole("checkbox", { name: /offboarded/i }));
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledTimes(1);
+    });
+    const url = mockRouter.replace.mock.calls[0]?.[0] as string;
+    expect(url).not.toContain("includeDeleted=");
+  });
+
+  it("clearing the search via the X button drops `?q=` synchronously", async () => {
+    const user = userEvent.setup();
+
+    render(<PlatformAdminsFilters initialQ="ada" initialIncludeDeleted={false} />);
+
+    // The clear button is the X next to the input — uses `aria-label="Clear search"`
+    // from the SearchInput primitive.
+    await user.click(screen.getByRole("button", { name: /clear search/i }));
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalled();
+    });
+    const url = mockRouter.replace.mock.calls.at(-1)?.[0] as string;
+    expect(url).not.toContain("q=");
+  });
+});

--- a/packages/web/src/components/admin/platform-admins-filters.tsx
+++ b/packages/web/src/components/admin/platform-admins-filters.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+
+import { SearchInput } from "@/components/shared/search-input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useDebounced } from "@/lib/hooks/use-debounced";
+
+interface Props {
+  /** Initial value of `?q=` (server-rendered into the input). */
+  initialQ: string;
+  /** Initial value of `?includeDeleted=` (server-rendered into the toggle). */
+  initialIncludeDeleted: boolean;
+}
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+/**
+ * Filter bar above the platform-admin list (issue #260). Owns two
+ * URL-synced controls:
+ *
+ *  - `q`            — case-insensitive substring search across
+ *                     first / last name + email (API does the matching).
+ *  - `includeDeleted` — when true, soft-deleted rows are returned and
+ *                     the table renders a distinct "offboarded" badge.
+ *
+ * Pattern matches `PlatformAdminsTable.onSortingChange` (issue #217):
+ *   - URL is the source of truth — typing or toggling rewrites
+ *     `?q=` / `?includeDeleted=` via `router.replace` (NOT `push`),
+ *     so the back button escapes the page in one press instead of
+ *     unwinding every keystroke.
+ *   - The component is wrapped in a transition so the server-side
+ *     refetch doesn't block input.
+ *   - Debounced 250 ms — same trailing-edge primitive as the
+ *     impersonation picker (`useDebounced` in `lib/hooks`).
+ *
+ * Sort params on the URL are preserved verbatim. Pagination params
+ * (limit/offset) are NOT — changing the filter resets the listing
+ * back to the first page, matching tenant-list semantics. The list
+ * page caps at `limit=200` server-side until pagination UI lands
+ * (ADR-018, separate concern).
+ */
+export function PlatformAdminsFilters({ initialQ, initialIncludeDeleted }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const t = useTranslations("admin.platformAdmins.list.filters");
+  const [, startTransition] = useTransition();
+
+  const [q, setQ] = useState(initialQ);
+  const [includeDeleted, setIncludeDeleted] = useState(initialIncludeDeleted);
+  const debouncedQ = useDebounced(q, SEARCH_DEBOUNCE_MS);
+  // The mount tick of the debounce effect runs with `debouncedQ ===
+  // initialQ`, which would otherwise rewrite the URL with the very
+  // params it was built from — harmless on a clean URL, but it
+  // re-frames the back stack on `?q=ada` deep-links and triggers a
+  // pointless server refetch. Skip the first effect tick.
+  const isFirstRender = useRef(true);
+
+  // Stabilise `useSearchParams()` for the effect dep list. Next.js
+  // returns a new `URLSearchParams` instance on every render, which
+  // breaks `Object.is` reference equality and would re-trigger any
+  // effect that depended on it on every render — feedback loop in
+  // tests (where `router.replace` is mocked and doesn't update
+  // searchParams, so each render gets a fresh instance, which
+  // re-fires the effect, which calls replace, which re-renders…).
+  // The string serialisation IS stable across renders when the URL
+  // hasn't changed.
+  const searchParamsString = searchParams.toString();
+
+  const writeUrl = useCallback(
+    (nextQ: string, nextIncludeDeleted: boolean) => {
+      const params = new URLSearchParams(searchParamsString);
+      // `q` is omitted when empty so a cleared search rewrites a clean
+      // URL bar (`?sort=…&order=…` instead of `?q=&sort=…&order=…`).
+      if (nextQ.trim().length === 0) {
+        params.delete("q");
+      } else {
+        params.set("q", nextQ.trim());
+      }
+      if (nextIncludeDeleted) {
+        params.set("includeDeleted", "true");
+      } else {
+        params.delete("includeDeleted");
+      }
+      // Filter changes drop pagination — the user expects to see
+      // results from the start, not be stuck on page 4 of the prior
+      // listing. (Pagination UI itself is deferred per ADR-018.)
+      params.delete("offset");
+
+      const query = params.toString();
+      startTransition(() => {
+        router.replace(query ? `${pathname}?${query}` : pathname);
+      });
+    },
+    [pathname, router, searchParamsString],
+  );
+
+  // One effect drives BOTH controls. `debouncedQ` updates 250 ms after
+  // the last keystroke; `includeDeleted` updates synchronously on
+  // toggle. Either change → URL rewrite. The `isFirstRender` ref
+  // suppresses the mount tick so a server-rendered initial state
+  // doesn't re-write itself.
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    writeUrl(debouncedQ, includeDeleted);
+  }, [debouncedQ, includeDeleted, writeUrl]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <div className="min-w-[260px] flex-1 max-w-md">
+        <label htmlFor="platform-admins-search" className="sr-only">
+          {t("searchLabel")}
+        </label>
+        <SearchInput
+          id="platform-admins-search"
+          value={q}
+          placeholder={t("searchPlaceholder")}
+          onChange={(e) => setQ(e.currentTarget.value)}
+          onClear={() => {
+            // Skip the debounce — clearing is intentful, fire the URL
+            // rewrite ahead of the next debounce tick so the table
+            // refetches immediately. The effect above will no-op when
+            // it eventually runs (debouncedQ catches up to "" anyway).
+            setQ("");
+            writeUrl("", includeDeleted);
+          }}
+        />
+      </div>
+      <label
+        htmlFor="platform-admins-include-deleted"
+        className="flex items-center gap-2 text-sm text-on-surface"
+      >
+        <Checkbox
+          id="platform-admins-include-deleted"
+          checked={includeDeleted}
+          onCheckedChange={(next) => setIncludeDeleted(next === true)}
+        />
+        <span>{t("includeDeletedLabel")}</span>
+      </label>
+    </div>
+  );
+}

--- a/packages/web/src/components/admin/platform-admins-table.test.tsx
+++ b/packages/web/src/components/admin/platform-admins-table.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Issue #255 (QA review m3) — direct vitest coverage for
+ * `PlatformAdminsTable.onSortingChange`. Click-to-sort updates URL
+ * params via `router.replace` (NOT `push`) so the back button escapes
+ * the page in one press rather than unwinding every header click —
+ * same posture as `TenantsTable` (issue #217). The PR #253 review
+ * called out that this had no regression test.
+ */
+
+import type { PlatformAdmin } from "@/models/platform-admin";
+import { mockRouter, render, screen, userEvent, waitFor } from "@/tests/test-utils";
+
+import { PlatformAdminsTable } from "./platform-admins-table";
+
+function makeAdmin(overrides: Partial<PlatformAdmin> = {}): PlatformAdmin {
+  return {
+    id: "00000000-0000-0000-0000-00000000aaaa",
+    keycloakId: "kc-1",
+    email: "ada@example.org",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    lastLoginAt: null,
+    deletedAt: null,
+    createdAt: "2026-04-10T10:00:00.000Z",
+    updatedAt: "2026-04-10T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("PlatformAdminsTable.onSortingChange", () => {
+  it("clicking a sortable header replaces (NOT pushes) the URL with the new sort params", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PlatformAdminsTable
+        admins={[makeAdmin()]}
+        total={1}
+        // Default sort is `createdAt desc`. Clicking the `email` header
+        // toggles to `email asc`. The pathname is hardcoded to
+        // `/settings/funds` by the global test setup
+        // (`packages/web/src/tests/setup.tsx`); the assertion uses that
+        // value rather than the production `/admin/platform-admins`
+        // because what we're locking is the params/strategy, not the path.
+        sort="createdAt"
+        order="desc"
+      />,
+    );
+
+    // The DataTable renders sortable headers as buttons. Find the
+    // `email` column header by its rendered string (i18n maps the
+    // `columns.email` key to "Email" in both fr/en bundles for this
+    // listing).
+    await user.click(screen.getByRole("button", { name: /email/i }));
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledTimes(1);
+    });
+    const url = mockRouter.replace.mock.calls[0]?.[0] as string;
+    expect(url).toContain("sort=email");
+    expect(url).toContain("order=asc");
+    // Crucially `push` is NOT called — that would pollute the back
+    // stack with one entry per sort click.
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/admin/start-impersonation-form.tsx
+++ b/packages/web/src/components/admin/start-impersonation-form.tsx
@@ -18,6 +18,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import { getCsrfHeaderName, readCsrfTokenFromDocumentCookie } from "@/lib/auth/csrf";
 import { buildStepUpRedirectUrl, type StepUpRequiredResponse } from "@/lib/auth/step-up";
+import { useDebounced } from "@/lib/hooks/use-debounced";
 import { cn } from "@/lib/utils";
 import {
   ImpersonationService,
@@ -619,14 +620,4 @@ function ModeOption({
       <span className="ml-6 text-xs text-muted-foreground">{help}</span>
     </label>
   );
-}
-
-/** Trailing-edge debounce — fires on keystroke + holds for `delay` ms. */
-function useDebounced<T>(value: T, delay: number): T {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const id = setTimeout(() => setDebounced(value), delay);
-    return () => clearTimeout(id);
-  }, [value, delay]);
-  return debounced;
 }

--- a/packages/web/src/lib/hooks/use-debounced.ts
+++ b/packages/web/src/lib/hooks/use-debounced.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Trailing-edge debounce — returns the latest `value`, but only after
+ * `delay` ms have elapsed since the last update. Drives free-text
+ * search inputs (start-impersonation, platform-admin filters, …) so the
+ * URL / API isn't churned on every keystroke.
+ *
+ * Replaces the inline copy that lived inside
+ * `start-impersonation-form.tsx`. Keep the implementation tiny — this
+ * is the boring 5-line version on purpose; reach for a proper utility
+ * (lodash.debounce, react-use's `useDebounce`) only when leading-edge
+ * or `cancel()` semantics are actually needed.
+ */
+export function useDebounced<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+  return debounced;
+}

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -753,7 +753,12 @@
         },
         "lastLoginNever": "Never",
         "empty": "No platform admins yet.",
-        "fetchFailed": "Couldn't load platform admins. Refresh the page to try again."
+        "fetchFailed": "Couldn't load platform admins. Refresh the page to try again.",
+        "filters": {
+          "searchLabel": "Search platform admins",
+          "searchPlaceholder": "Search by name or email…",
+          "includeDeletedLabel": "Show offboarded admins"
+        }
       },
       "new": {
         "back": "← Platform admins",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -753,7 +753,12 @@
         },
         "lastLoginNever": "Jamais",
         "empty": "Aucun admin plateforme pour le moment.",
-        "fetchFailed": "Impossible de charger les admins plateforme. Rafraîchissez la page pour réessayer."
+        "fetchFailed": "Impossible de charger les admins plateforme. Rafraîchissez la page pour réessayer.",
+        "filters": {
+          "searchLabel": "Rechercher des admins plateforme",
+          "searchPlaceholder": "Rechercher par nom ou email…",
+          "includeDeletedLabel": "Afficher les admins retirés"
+        }
       },
       "new": {
         "back": "← Admins plateforme",


### PR DESCRIPTION
Closes the full #255 backlog (16 of 16 items now in-PR — the two pieces previously deferred to #260/#261 are folded in here per user feedback that follow-up issues are not equivalent to fixing).

## Summary

### Backend hardening (`platform-admins-service.ts`)

- **Module-local cache** for `getRealmRole('super_admin')` and `getOrganizationByAlias('platform')`. Saves a KC round-trip per invitation accept; null lookups bypass the cache (so a re-imported realm recovers); 404s at `assignRealmRoleToUser` / `attachUserToOrg` invalidate the cache before bubbling.
- **Magic `PLATFORM_AUDIT_ORG_ID` literal removed** — replaced with a runtime lookup against `tenants.slug = '__platform__'` (cached per process). Closes the data-architect's "last UUID literal" call. The KC user-attribute `org_id` claim now uses the same runtime value, keeping DB and KC in sync.
- **`assignRealmRoleToUser` 404 race promoted** to `KEYCLOAK_ROLE_MISSING` (and `attachUserToOrg` 404 → `KEYCLOAK_ORG_MISSING`) so an operator gets an actionable error on realm drift instead of a generic `KEYCLOAK_FAILURE`.
- **Locale threading**: operator's `Accept-Language` flows through the invite outbox payload; invitee's `Accept-Language` lands on the KC user's `locale` attribute so future built-in emails (UPDATE_PASSWORD via reset) go in their language.

### Frontend — list-page filters (was #260, now in-PR)

- **`PlatformAdminsFilters`** above the list table: debounced (250 ms) search input bound to `?q=` and a checkbox bound to `?includeDeleted=`. Both write via `router.replace` (NOT `push`) so the back button escapes the page in one press, matching the sort posture from issue #217.
- **URL plumbing restored** in `/admin/platform-admins/page.tsx` — reads `q` + `includeDeleted` and forwards onto the API. Filter changes drop a stale `?offset=` so a refilter doesn't strand the user on page 4.
- **`useDebounced<T>` hook extracted** from the inline copy in `start-impersonation-form.tsx` to `lib/hooks/use-debounced.ts` — single trailing-edge primitive for both call sites.
- **i18n** (en + fr) under `admin.platformAdmins.list.filters`; key parity verified.

### Schema (was #261, now in-PR)

- **Migration `0036_platform_admins_sort_indexes`** — partial indexes on `last_name`, `created_at DESC`, `last_login_at` (active rows only). Removes the seq-scan baseline for the list page's sort modes.
- **`schema-parity.test.ts`** (7 cases) — introspects `pg_indexes` to lock three invariants:
  1. Partial-unique constraints on `users` and `platform_admins` (Drizzle can't model partial indexes; the migration is the source of truth).
  2. Sort-column indexes from migration 0036.
  3. Structural sweep — every non-PK unique on a soft-deleted table must gate on `deleted_at IS NULL` or carry a documented predicate override.
- The `git diff --exit-code after db:generate` approach was rejected: the repo has pre-existing snapshot-history gaps (0029, 0032-0036 are hand-written), so a strict diff guard would be permanently red. The probe catches the actual concern without requiring a snapshot back-fill.

### Tests — new integration cases (`platform-admins.test.ts`)

- **Concurrency**: `Promise.all` race against the second-to-last admin → exactly one succeeds (the SERIALIZABLE + FOR UPDATE invariant).
- **Edge case**: 1 active + 1 soft-deleted → delete the active → 400 (last-admin guard counts active rows only).
- **E2E walk**: invite → accept → GET → PATCH → reset → DELETE on the same id, plus a lifecycle audit-chain assertion.
- **Audit attribution**: pins `actor_id` + `org_id` + `user_id` on `password_reset_sent`, `renamed`, `removed` rows.
- **Flake fix**: `afterEach` now resets the operator row's `email` too — `impersonation.test.ts` previously seeded it under a different email and the post-fix-commit-1 sort assertion would flake when the two files ran in either order.

### Tests — KC stubs (`signup`, `team-invitations`, `user-edit`, `onboarding-runtime`)

The four flows' KC stubs for `getRealmRole` / `assignRealmRoleToUser` / `sendExecuteActionsEmail` now **throw** on call instead of returning null/{}. A future code path that accidentally wires a super-admin or password-reset side-effect into one of these flows surfaces immediately rather than greenly proceeding.

### Frontend — detail-actions polish

- **`AlertDialogAction` destructive variant** migrated off ad-hoc `bg-error text-on-error hover:bg-error/90` onto `buttonVariants({ variant: "destructive" })`. Hover/focus/disabled states all come from the design-system canonical now.
- **`isSelf` parallel-tab rationale** added as a code comment in `platform-admin-detail-actions.tsx` — when `operatorKeycloakId` is null we err on the side of showing the remove button and let the API guard catch the self-removal attempt.
- **`platform-admin-detail-actions.test.tsx`** (new, 6 cases): rename happy-path, last-admin 400, self-removal 400, 404, `isSelf` hides remove, `isSelf` does NOT trigger when `operatorKeycloakId` is null.
- **`platform-admins-table.test.tsx`** (new, 1 case): clicking a sortable header `replace`s (not `push`es) the URL with new sort params.
- **Header heading-token migration** (5 admin files: disputes, domain-disputes/[id], tenants list + detail): `text-text` / `text-text-secondary` → `text-on-surface` / `text-on-surface-variant`. `text-text-muted` left intact (different aliasing).

### Docs

- **ADR-022 prose amended**: `keycloak_id varchar(255)` is documented as nullable (not `NOT NULL`) — the soft-delete path nulls it; the partial-unique index scopes uniqueness to active rows. The previous ADR text contradicted both the schema and the runtime.

## Manual acceptance checklist

### Backend hardening
- [ ] `pnpm build` — all 6 packages green.
- [ ] `pnpm typecheck` — all 6 packages green.
- [ ] `pnpm test` — 816 / 816 (api 688 · web 102 · worker 26).
- [ ] `pnpm db:migrate` — 0036 applies cleanly to a fresh `givernance_test` DB.
- [ ] On `docker compose up -d`, hitting `/v1/admin/platform-admins` does NOT spam KC's `/realms/*/roles/super_admin` or `/organizations` endpoints — first invite warms the cache, subsequent calls hit it.

### Tests
- [ ] `vitest run src/tests/integration/platform-admins.test.ts` → 21 / 21.
- [ ] `vitest run src/tests/integration/schema-parity.test.ts` → 7 / 7.
- [ ] `vitest run src/components/admin/platform-admin-detail-actions.test.tsx` → 6 / 6.
- [ ] `vitest run src/components/admin/platform-admins-table.test.tsx` → 1 / 1.
- [ ] `vitest run src/components/admin/platform-admins-filters.test.tsx` → 4 / 4.
- [ ] Run the four KC-stub files in any order — none of the throwing fakes fire (no accidental super-admin promotion paths).

### Frontend — list filters (#260)
- [ ] On `/admin/platform-admins`, type into the search input → URL updates to `?q=…` after ~250 ms with no flicker; back button escapes the page in one press (not one press per keystroke).
- [ ] Toggle "Show offboarded admins" → URL adds `?includeDeleted=true` synchronously; the table renders soft-deleted rows with the "Removed" badge.
- [ ] Click the X on the search input → `?q=` drops immediately (no debounce wait).
- [ ] Deep-link `/admin/platform-admins?q=ada&includeDeleted=true` → input + checkbox both reflect URL state on mount; no extra URL rewrite on first render.

### Frontend — detail actions
- [ ] On `/admin/platform-admins/[id]`, click "Remove" → the dialog confirm button shows the canonical destructive style (consistent with other destructive surfaces in the app).
- [ ] On `/admin/platform-admins/[id]` for the operator's own row, the "Remove" button is NOT rendered.
- [ ] In a fresh tab where the JWT cookie expired, the "Remove" button stays visible (the API guard catches it on submit; toast confirms).
- [ ] `/admin/disputes`, `/admin/domain-disputes/[id]`, `/admin/tenants`, `/admin/tenants/[id]` headings render the same as before — token migration is purely a naming change (both tokens alias to the same hex via `globals.css`).

### Schema
- [ ] `\d+ platform_admins` shows the three new partial indexes; `EXPLAIN` on `SELECT … ORDER BY last_name LIMIT 50` uses `platform_admins_last_name_active_idx` (not seq scan).
- [ ] Hand-edit a migration to drop a partial-unique → `pnpm test` flags it via `schema-parity.test.ts`.

close #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)