### PR TITLE
feat(multi-currency): P1 — robustesse FX, UX boutons don, composant Money, allocations %

### DIFF
--- a/docs/planning/multi-currency-hardening-230.md
+++ b/docs/planning/multi-currency-hardening-230.md
@@ -1,0 +1,653 @@
+# Multi-Currency Hardening — Plan d'implémentation (issue #230)
+
+> Document de planification temporaire — basé sur l'[audit détaillé du 2026-05-01](https://github.com/purposestack/givernance/issues/230#issuecomment-4359667892) (4 agents, commit `28fed20`).
+>
+> **Branches et PRs :** trois branches créées, une par phase, en draft.
+
+---
+
+## TL;DR
+
+| Phase | Criticité | Contenu | Migration |
+|-------|-----------|---------|-----------|
+| **P0** — Critical fixes | 🔴 Bloquant | Bug devise, dashboard faux, staging rate=1, colonnes DB manquantes | `0037` |
+| **P1** — Robustesse + UX | 🟡 Requis | CRON job, cache Redis, `<Money>`, boutons "Nouveau don", allocations en % | `0038` |
+| **P2** — Gouvernance | 🟢 Important | ADR multi-devise, docs, tests de régression, CHECKs SQL | aucune |
+
+---
+
+## Phase P0 — Correctifs critiques
+
+**Branch:** `feat/multi-currency-p0-critical-fixes`
+**Ferme :** issue #230 (partiellement)
+
+### Périmètre
+
+Cinq correctifs indépendants, tous bloquants pour un usage multi-devise fiable :
+
+#### P0-1 — `EXCHANGE_RATE_API_KEY` absente du staging
+
+| Fichier | Changement |
+|---------|-----------|
+| `config/deploy-staging.yml` | Ajouter `EXCHANGE_RATE_API_KEY` à `env.secret` |
+| `.github/workflows/deploy-staging.yml` | Ajouter `EXCHANGE_RATE_API_KEY: ${{ secrets.EXCHANGE_RATE_API_KEY }}` dans le step `Setup Kamal Secrets` |
+
+> **Effet :** staging tourne actuellement en `default_fallback` rate=1 sur toute donation en devise étrangère → corruption silencieuse des données.
+
+#### P0-2 — Bug symbole devise `€` hardcodé dans `<AmountInput>`
+
+**Cause racine :** `packages/web/src/components/shared/amount-input.tsx:38` — `currencySymbol = "€"` par défaut. Les deux call-sites dans `donation-form.tsx` (lignes 345 et 546) n'passent pas la prop.
+
+**Correctifs :**
+
+1. **`packages/web/src/lib/format.ts`** — ajouter `getCurrencySymbol(currency: string): string` (switch sur les 8 devises supportées).
+
+2. **`packages/web/src/components/shared/amount-input.tsx:38`** — rendre `currencySymbol` prop required (supprimer le default `"€"`).
+
+3. **`packages/web/src/components/donations/donation-form.tsx`** — passer `currencySymbol={getCurrencySymbol(form.watch("currency"))}` aux deux call-sites (lignes 345 et 546).
+
+#### P0-3 — Migration `0037_multi_currency_hardening.sql`
+
+Colonnes manquantes sur `donations` et corrections sur `exchange_rates` :
+
+**Table `donations`** :
+
+```sql
+-- Ajouter :
+exchange_rate_at       DATE         NOT NULL DEFAULT CURRENT_DATE
+base_currency_at_donation VARCHAR(3) NOT NULL (backfill depuis tenants.base_currency)
+exchange_rate_source   VARCHAR(32)  NOT NULL DEFAULT 'unknown'
+-- Rendre NOT NULL :
+exchange_rate NUMERIC(18,8) NOT NULL (patch NULL → 1.0 avant ALTER)
+```
+
+**Table `exchange_rates`** :
+
+```sql
+-- Ajouter :
+source VARCHAR(32) NOT NULL DEFAULT 'unknown'
+-- Ajouter contrainte :
+CHECK (rate > 0)
+-- Ajouter index composite :
+CREATE INDEX exchange_rates_lookup_idx ON exchange_rates (currency, base_currency, date DESC)
+```
+
+**SQL complet de migration :**
+
+```sql
+-- Migration: 0037_multi_currency_hardening
+
+-- ─── exchange_rates — source ───────────────────────────────────────────────
+ALTER TABLE exchange_rates
+  ADD COLUMN IF NOT EXISTS source VARCHAR(32) NOT NULL DEFAULT 'unknown';
+
+-- ─── exchange_rates — rate > 0 ────────────────────────────────────────────
+DO $$
+DECLARE bad_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO bad_count FROM exchange_rates WHERE rate <= 0;
+  IF bad_count > 0 THEN
+    RAISE EXCEPTION '0037: % exchange_rates rows have rate <= 0. Fix before migrating.', bad_count;
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE exchange_rates
+  ADD CONSTRAINT exchange_rates_rate_positive CHECK (rate > 0);
+
+-- ─── exchange_rates — index composite ─────────────────────────────────────
+CREATE INDEX IF NOT EXISTS exchange_rates_lookup_idx
+  ON exchange_rates (currency, base_currency, date DESC);
+
+-- ─── donations — exchange_rate_at ─────────────────────────────────────────
+ALTER TABLE donations
+  ADD COLUMN IF NOT EXISTS exchange_rate_at DATE NOT NULL DEFAULT CURRENT_DATE;
+
+-- ─── donations — base_currency_at_donation ────────────────────────────────
+ALTER TABLE donations
+  ADD COLUMN IF NOT EXISTS base_currency_at_donation VARCHAR(3);
+--> statement-breakpoint
+DO $$
+DECLARE backfilled_from_tenant INTEGER; fallback_to_eur INTEGER;
+BEGIN
+  UPDATE donations d
+    SET base_currency_at_donation = t.base_currency
+    FROM tenants t WHERE d.org_id = t.id AND d.base_currency_at_donation IS NULL;
+  GET DIAGNOSTICS backfilled_from_tenant = ROW_COUNT;
+  UPDATE donations SET base_currency_at_donation = 'EUR' WHERE base_currency_at_donation IS NULL;
+  GET DIAGNOSTICS fallback_to_eur = ROW_COUNT;
+  RAISE NOTICE '0037: backfill base_currency_at_donation — % from tenants, % fallback EUR',
+    backfilled_from_tenant, fallback_to_eur;
+END $$;
+--> statement-breakpoint
+ALTER TABLE donations ALTER COLUMN base_currency_at_donation SET NOT NULL;
+
+-- ─── donations — exchange_rate_source ─────────────────────────────────────
+ALTER TABLE donations
+  ADD COLUMN IF NOT EXISTS exchange_rate_source VARCHAR(32) NOT NULL DEFAULT 'unknown';
+
+-- ─── donations — exchange_rate NOT NULL ───────────────────────────────────
+DO $$
+DECLARE parity_fixed INTEGER; foreign_nulls INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO foreign_nulls
+    FROM donations
+   WHERE exchange_rate IS NULL AND currency <> COALESCE(base_currency_at_donation, 'EUR');
+  IF foreign_nulls > 0 THEN
+    RAISE NOTICE '0037 WARNING: % foreign-currency donations have NULL exchange_rate → setting to 1.0 sentinel — audit required.', foreign_nulls;
+  END IF;
+  UPDATE donations SET exchange_rate = 1.0, exchange_rate_source = 'parity'
+   WHERE exchange_rate IS NULL AND currency = base_currency_at_donation;
+  GET DIAGNOSTICS parity_fixed = ROW_COUNT;
+  UPDATE donations SET exchange_rate = 1.0 WHERE exchange_rate IS NULL;
+  RAISE NOTICE '0037: set exchange_rate — % parity rows (source=parity)', parity_fixed;
+END $$;
+--> statement-breakpoint
+ALTER TABLE donations ALTER COLUMN exchange_rate SET NOT NULL;
+```
+
+**Drizzle schema — `donations` (nouveaux champs) :**
+
+```typescript
+// packages/shared/src/schema/index.ts — donations table
+exchangeRate: numeric("exchange_rate", { precision: 18, scale: 8 }).notNull(), // NOT NULL depuis 0037
+exchangeRateAt: date("exchange_rate_at").notNull().defaultNow(),
+baseCurrencyAtDonation: varchar("base_currency_at_donation", { length: 3 }).notNull().default("EUR"),
+exchangeRateSource: varchar("exchange_rate_source", { length: 32 }).notNull().default("unknown"),
+```
+
+**Drizzle schema — `exchangeRates` (champs ajoutés) :**
+
+```typescript
+source: varchar("source", { length: 32 }).notNull().default("unknown"),
+// + index composite exchange_rates_lookup_idx
+```
+
+**Application layer — `donations/service.ts:508-522` :** passer les 3 nouveaux champs à l'INSERT :
+
+```typescript
+exchangeRateAt: new Date().toISOString().slice(0, 10), // ISO date
+baseCurrencyAtDonation: baseCurrency,
+exchangeRateSource: convertedAmount.source, // 'api' | 'local_fallback' | etc.
+```
+
+#### P0-4 — Dashboard "Total levé" utilise `amountBaseCents`
+
+**Backend `packages/api/src/modules/dashboard/service.ts:47-48`** :
+```typescript
+// AVANT:
+SUM(${donations.amountCents})
+// APRÈS:
+SUM(${donations.amountBaseCents})
+```
+
+Ajouter `baseCurrency` dans le retour du service (lecture depuis `tenants.baseCurrency`).
+
+**API schema `dashboard/routes.ts`** : ajouter `baseCurrency: Type.String()` dans `DashboardStatsSchema`.
+
+**Frontend `dashboard/page.tsx:78-79`** :
+```typescript
+// AVANT:
+const primaryCurrency = kpiDonations?.data[0]?.currency ?? "EUR";
+// APRÈS:
+const baseCurrency = stats?.baseCurrency ?? "EUR";
+// Utiliser baseCurrency dans formatCurrency() / <Money>
+```
+
+#### P0-5 — Filtres `amountMin`/`amountMax` et sort `amountCents` sur devise pivot
+
+**`packages/api/src/modules/donations/service.ts:306-307`** — filtrer sur `amountBaseCents` par défaut :
+
+```typescript
+// Ajouter amountField?: "donor" | "base" à ListDonationsQuery
+const amountCol = amountField === "donor" ? donations.amountCents : donations.amountBaseCents;
+if (amountMin !== undefined) conditions.push(gte(amountCol, amountMin));
+if (amountMax !== undefined) conditions.push(lte(amountCol, amountMax));
+```
+
+**`service.ts:159`** — sort `amountCents` → colonne `amountBaseCents` :
+
+```typescript
+if (sort === "amountCents") return [dir(donations.amountBaseCents), asc(donations.id)];
+```
+
+**`donations/routes.ts`** : ajouter `amountField: Type.Optional(Type.Union([...]))` au `ListQuery`.
+
+---
+
+### Risques P0
+
+| Risque | Mitigation |
+|--------|-----------|
+| Backfill `base_currency_at_donation` incorrect si tenant a changé de devise | NOTICE dans la migration ; requête de réconciliation fournie |
+| `exchange_rate_at = CURRENT_DATE` pour les dons historiques (approximation) | Documenté dans migration ; possible backfill post-déploiement |
+| `exchange_rate NOT NULL` avec sentinel 1.0 sur dons en devise étrangère | NOTICE WARNING + audit manuel requis |
+
+---
+
+## Phase P1 — Robustesse et UX
+
+**Branch:** `feat/multi-currency-p1-robustness-ux`
+**Dépend de :** P0 mergé
+
+### Périmètre (6 fonctionnalités)
+
+#### P1-1 — Job BullMQ CRON `refresh-exchange-rates`
+
+**Nouveau fichier :** `packages/worker/src/processors/refresh-exchange-rates.ts`
+
+- Cron `"0 2 * * *"` UTC (02:00 chaque nuit)
+- Récupère les paires `(donation.currency, tenant.base_currency)` distinctes actives sur 90 jours
+- Appelle `ExchangeRateService.getRate()` pour chaque paire non-parity
+- Logs structurés : `exchange_rate.refresh_start`, `exchange_rate.refresh_complete`, `exchange_rate.refresh_failed_pair`
+- Aucun throw global — les erreurs par paire sont loguées et le reste continue
+
+**`packages/worker/src/worker.ts`** :
+```typescript
+// Ajouter queue "exchange_rates"
+// Ajouter dans scheduleRepeatableJobs():
+await exchangeRatesQueue.add(
+  EXCHANGE_RATE_JOBS.REFRESH,
+  {},
+  { jobId: "exchange-rates-refresh-nightly", repeat: { pattern: "0 2 * * *", tz: "UTC" }, ... },
+);
+```
+
+**`packages/shared/src/jobs/index.ts`** : ajouter `EXCHANGE_RATES: "exchange_rates"` à `QUEUE_NAMES`.
+
+#### P1-2 — Cache Redis pour `ExchangeRateService`
+
+Remplacer `Map` process-local (`exchange-rate-service.ts:39`) par un cache Redis injecté via le constructeur.
+
+**Interface injectable :**
+```typescript
+export interface ExchangeRateCache {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttlSeconds: number): Promise<void>;
+  del(key: string): Promise<void>;
+}
+```
+
+**Clé Redis :** `fx:{src}:{tgt}:{date}` — TTL : 3600s.
+
+Le shared package ne doit pas importer `ioredis` directement (ADR-013 type boundary). Le cache est injecté depuis l'API et le worker :
+
+```typescript
+// packages/api/src/modules/finance/exchange-rate-service.ts
+cache: {
+  get: (key) => redis.get(key),
+  set: (key, value, ttl) => redis.set(key, value, "EX", ttl).then(() => undefined),
+  del: (key) => redis.del(key).then(() => undefined),
+},
+```
+
+#### P1-3 — Constantes devises unifiées
+
+**Nouveau fichier :** `packages/shared/src/constants/currencies.ts`
+
+```typescript
+export const SUPPORTED_CURRENCIES = ["EUR","GBP","CHF","SEK","NOK","DKK","PLN","CZK"] as const;
+export type Currency = (typeof SUPPORTED_CURRENCIES)[number];
+export const BASE_CURRENCIES = [...SUPPORTED_CURRENCIES] as const;
+export type BaseCurrency = (typeof BASE_CURRENCIES)[number];
+
+export function getCurrencySymbol(currency: Currency, locale = "en-US"): string {
+  const parts = new Intl.NumberFormat(locale, { style: "currency", currency,
+    minimumFractionDigits: 0, maximumFractionDigits: 0 }).formatToParts(0);
+  return parts.find(p => p.type === "currency")?.value ?? currency;
+}
+
+export function isSupportedCurrency(value: string): value is Currency { ... }
+export function isBaseCurrency(value: string): value is BaseCurrency { ... }
+```
+
+**`packages/shared/src/validators/index.ts`** :
+- Importer `SUPPORTED_CURRENCIES`, `BASE_CURRENCIES` depuis `constants/currencies`
+- Remplacer les unions inline dans `DonationCreateSchema.currency` et `MultiCurrencySchema`
+- Deprecate `MULTI_CURRENCY_VALUES` → re-exporter `BASE_CURRENCIES` avec jsdoc `@deprecated`
+
+#### P1-4 — Migration `0038_allocation_enrichment.sql`
+
+**Table `donation_allocations`** :
+
+```sql
+-- Ajouter :
+amount_base_cents INTEGER  -- nullable, backfill progressif
+percentage_bp     INTEGER  -- nullable, CHECK (BETWEEN 1 AND 10000)
+
+-- Rendre amount_cents nullable (pour les splits en %) :
+ALTER TABLE donation_allocations ALTER COLUMN amount_cents DROP NOT NULL;
+
+-- Contrainte XOR (exactly one of amount_cents or percentage_bp) :
+ADD CONSTRAINT donation_allocations_amount_or_bp
+  CHECK (
+    (amount_cents IS NOT NULL AND percentage_bp IS NULL) OR
+    (amount_cents IS NULL AND percentage_bp IS NOT NULL)
+  );
+```
+
+**Trigger `check_allocation_sum` rewrite** : mode A (amount_cents), mode B (percentage_bp = 10000 bp), rejet mixed-mode.
+
+**Drizzle schema** :
+```typescript
+amountCents: integer("amount_cents"),           // nullable depuis 0038
+percentageBp: integer("percentage_bp"),          // nullable
+amountBaseCents: integer("amount_base_cents"),   // nullable
+```
+
+**Validator `DonationAllocationSchema`** : exposer `percentageBp` optionnel.
+
+**UI — Allocation toggle** : ajouter un toggle "montant fixe / pourcentage" par ligne d'allocation dans `donation-form.tsx` + helper "répartir équitablement".
+
+#### P1-5 — Boutons "Nouveau don" sur fiches détail
+
+**`packages/web/src/app/(app)/constituents/[id]/page.tsx:358`** — dans `ProfileActions` (gated `donations:write`) :
+```tsx
+<Button asChild variant="secondary" size="sm">
+  <Link href={`/donations/new?constituentId=${constituentId}`}>
+    <Banknote size={16} aria-hidden="true" />
+    {t("actions.newDonation")}
+  </Link>
+</Button>
+```
+
+**`packages/web/src/app/(app)/campaigns/[id]/page.tsx`** — dans le header de `DonationBreakdownCard` :
+```tsx
+<Button asChild variant="secondary" size="sm">
+  <Link href={`/donations/new?campaignId=${campaign.id}`}>
+    <Gift size={16} aria-hidden="true" />
+    {tDonations("newDonation")}
+  </Link>
+</Button>
+```
+
+Ajouter les clés de traduction `fr.json` / `en.json`.
+
+#### P1-6 — Pré-remplissage `/donations/new?constituentId=X&campaignId=Y`
+
+**`packages/web/src/app/(app)/donations/new/page.tsx`** : lire `searchParams`, résoudre `campaign.defaultCurrency`, passer à `<DonationForm>` :
+```tsx
+interface NewDonationPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+// ...
+<DonationForm
+  mode="create"
+  initialConstituentId={constituentId}
+  initialCampaignId={campaignId}
+  initialCurrency={campaignDefaultCurrency}
+/>
+```
+
+**`DonationForm`** : étendre `CreateMode` type + `buildDefaultValues` + `useEffect` pour charger le constituent via `ConstituentService.getConstituent()`.
+
+#### P1-7 — Composant `<Money>` + migration `formatCurrency` 2-args
+
+**Nouveau fichier :** `packages/web/src/components/shared/money.tsx`
+
+```tsx
+"use client";
+export function Money({ cents, currency, locale: localeProp }: MoneyProps) {
+  const localeFromHook = useLocale();
+  const baseCurrency = useTenantBaseCurrency();
+  return (
+    <span className="font-mono tabular-nums">
+      {formatCurrency(cents, localeProp ?? localeFromHook, currency ?? baseCurrency)}
+    </span>
+  );
+}
+```
+
+**`packages/web/src/lib/hooks/use-tenant-base-currency.ts`** + **`packages/web/src/lib/context/tenant-context.ts`** + **`TenantProvider`** dans `(app)/layout.tsx`.
+
+Migrer les 12+ call-sites `formatCurrency(x, locale)` sans 3ème argument vers `<Money cents={x} />` ou `<Money cents={x} currency={donation.currency} />`.
+
+#### P1-8 — Settings → onglet Currency (8 devises)
+
+**`packages/web/src/components/settings/settings-navigation.tsx`** : ajouter onglet `currency` → `/settings/currency`.
+
+**`packages/web/src/components/settings/tenant-settings-form.tsx:23`** : étendre de 3 à 8 devises :
+```typescript
+const TENANT_CURRENCIES = ["EUR","GBP","CHF","SEK","NOK","DKK","PLN","CZK"] as const;
+```
+
+**Nouveau :** `packages/web/src/app/(app)/settings/currency/page.tsx`.
+
+**API side :** vérifier que `PATCH /v1/tenants/:id` accepte les 8 devises dans `CurrencySchema`.
+
+---
+
+## Phase P2 — Gouvernance et documentation
+
+**Branch:** `feat/multi-currency-p2-governance-docs`
+**Dépend de :** P1 mergé (ou peut être parallèle)
+
+### Périmètre
+
+#### P2-1 — ADR multi-devise dans `docs/15-infra-adr.md`
+
+Rédiger un ADR numéroté (suite des ADRs existants) couvrant :
+- Problème : amountCents multi-devise additionnés sans conversion = KPIs faux
+- Décision : `amountBaseCents` (pivot tenant), snapshot `baseCurrencyAtDonation`, `exchangeRateAt`, `exchangeRateSource`
+- Fournisseur : exchangerate-api.com, granularité `DATE`, `NUMERIC(18,8)`
+- Fallback : DB local → dernier taux connu → rate=1 (toujours loggué)
+- Interaction Stripe : utiliser `intent.amount` (pas `amount_received`)
+- Alternatives rejetées : conversion à la volée, colonne devise par montant, ECB uniquement
+- Critères de révision : passage à NATS JetStream (Phase 4+), support XOF/XAF
+
+#### P2-2 — Mettre à jour `docs/03-data-model.md`
+
+- Ajouter table `exchange_rates` (colonnes, PK/UNIQUE, index composite)
+- Mettre à jour `donations` : documenter `exchange_rate_at`, `base_currency_at_donation`, `exchange_rate_source`, noter `exchange_rate NOT NULL`
+- Mettre à jour `donation_allocations` : `amount_base_cents`, `percentage_bp`, `amount_cents` nullable
+- Mettre à jour `diagrams/core-erd.mmd` : ajouter `exchange_rates` comme entité
+
+#### P2-3 — Documenter `EXCHANGE_RATE_API_KEY`
+
+- **`README.md`** : section Variables d'environnement — source, fallback, lien signup
+- **`.env.example:117`** : décommenter la ligne
+- **`docs/dev/` (si fichier existe)** : ajouter au guide de setup local
+
+#### P2-4 — Renommer migrations en collision `0023_*`
+
+Les deux fichiers `0023_onboarding_runtime.sql` et `0023_multi_currency_schema.sql` coexistent. Pour P2, documenter dans un commentaire en tête de chaque fichier l'ordre d'application (par timestamp). Ne pas renommer les fichiers sur `main` (Drizzle suit par hash de nom) — créer un ADR ou une note dans `docs/infra/README.md` expliquant la collision.
+
+#### P2-5 — CHECKs ISO 4217 SQL
+
+```sql
+-- Optionnel (validé côté app) mais défensif :
+ALTER TABLE tenants ADD CONSTRAINT tenants_base_currency_iso
+  CHECK (base_currency ~ '^[A-Z]{3}$');
+ALTER TABLE donations ADD CONSTRAINT donations_currency_iso
+  CHECK (currency ~ '^[A-Z]{3}$');
+-- etc.
+```
+
+Ou créer une table `currencies` seedée + FK (plus robuste mais plus lourd).
+
+#### P2-6 — Tests d'intégration
+
+Voir la section **Tests** ci-dessous.
+
+---
+
+## Spécifications des tests par phase
+
+### P0 — Tests d'intégration à ajouter
+
+**Nouveau fichier :** `packages/api/src/tests/integration/multi-currency-p0.test.ts`
+
+```
+describe("P0-1: EXCHANGE_RATE_API_KEY env wiring")
+  it("boots without key (Optional in dev)")
+  it("utilise la clé pour le header Authorization dans les appels API")
+
+describe("P0-3: Colonnes DB nouvelles + exchange_rate NOT NULL")
+  it("rejects NULL exchange_rate on INSERT → pg error 23502")
+  it("exchange_rate_at column accepts DATE value")
+  it("base_currency_at_donation stores tenant base currency")
+  it("exchange_rate_source stores 'api' or 'local_fallback'")
+
+describe("P0-4: Dashboard totalRaisedCents uses amountBaseCents")
+  it("CHF tenant: SUM(amountBaseCents) ≠ SUM(amountCents)")
+  it("GET /v1/dashboard/stats returns baseCurrency field")
+  it("previousMonth also uses amountBaseCents")
+
+describe("P0-5: Filters and sort on amountBaseCents")
+  it("?amountMin/amountMax filters by amountBaseCents for CHF tenant")
+  it("?sort=amountCents&order=asc orders by amountBaseCents")
+  it("?amountMin alone works as lower bound")
+  it("?amountMax alone works as upper bound")
+```
+
+**Régressions à vérifier :**
+- `exchange-rate-service.test.ts` — 5 tests existants passent
+- `donations.test.ts:142-176` — EUR→CHF, `amountBaseCents=9500`
+- `stripe-webhook.test.ts:239-296` — USD→JPY rate 150
+- `dashboard-stats.test.ts` — tenant EUR inchangé
+- `list-sort.test.ts` — tous les tris passent
+- `schema-parity.test.ts` — aucune dérive Drizzle/SQL
+
+### P1 — Tests d'intégration à ajouter
+
+| Fichier | Nb tests |
+|---------|---------|
+| `packages/worker/src/tests/integration/exchange-rate-refresh.test.ts` | 5 |
+| `packages/api/src/tests/integration/exchange-rate-redis-cache.test.ts` | 5 |
+| `packages/api/src/tests/integration/donations-prefill.test.ts` | 4 |
+| `packages/web/src/components/shared/money.test.tsx` | 8 |
+| `packages/api/src/tests/integration/settings-currency.test.ts` | 8 |
+
+**Régressions :** Worker boot pas en erreur après ajout queue, `receipt-processor.test.ts` inchangé, `stripe-webhook.test.ts` inchangé.
+
+### P2 — Tests d'intégration à ajouter
+
+| Fichier | Nb tests |
+|---------|---------|
+| `packages/api/src/tests/integration/multi-currency-dashboard.test.ts` | 5 |
+| `packages/worker/src/tests/integration/rate-refresh-job.test.ts` | 4 |
+| `packages/api/src/tests/integration/exchange-rate-api-down-fallback.test.ts` | 3 |
+| `packages/api/src/tests/integration/concurrent-rate-fetch.test.ts` | 3 |
+| `packages/api/src/tests/integration/donation-re-rate.test.ts` | 6 |
+
+---
+
+## Procédures de test manuelles
+
+### P0
+
+**T-P0-1 : EXCHANGE_RATE_API_KEY dans staging**
+1. Vérifier la clé est présente sur le host staging (`printenv EXCHANGE_RATE_API_KEY | head -c 8`)
+2. Redémarrer l'API
+3. Vérifier les logs de boot : aucun warning `EXCHANGE_RATE_API_KEY`
+4. Créer un don en CHF dans un org base-CHF
+5. `SELECT exchange_rate_source, exchange_rate FROM donations ORDER BY created_at DESC LIMIT 1` → `source = 'api'`
+6. ✅ Pass si `exchange_rate_source = 'api'`
+
+**T-P0-2 : Symbole devise mis à jour en temps réel**
+1. Naviguer vers `/donations/new`
+2. Observer le symbole dans `AmountInput` → `€`
+3. Changer la devise → `GBP` → observer le symbole → `£`
+4. Changer → `CHF` → observer → `CHF`
+5. Changer → `EUR` → observer → `€`
+6. ✅ Pass si le symbole se met à jour sans rechargement
+
+**T-P0-3 : Colonnes DB après migration**
+1. `\d donations` → confirmer `exchange_rate_at DATE`, `base_currency_at_donation VARCHAR`, `exchange_rate_source VARCHAR`, `exchange_rate NOT NULL`
+2. Tenter INSERT avec `exchange_rate = NULL` → erreur `23502`
+3. `pnpm --filter @givernance/shared run db:check` → aucune dérive de schéma
+4. ✅ Pass si tous les champs présents et NOT NULL enforced
+
+**T-P0-4 : Dashboard "Total levé" en devise pivot**
+1. Se connecter sur org à base CHF
+2. Créer 2 dons : 100 EUR (→ 95 CHF), 50 EUR (→ 47.50 CHF)
+3. Dashboard → "Total levé" = 142.50 CHF (pas 150 EUR)
+4. Le label/symbole est `CHF`
+5. ✅ Pass si valeur = sum(amountBaseCents)/100 dans la bonne devise
+
+**T-P0-5 : Filtres et tri sur devise pivot**
+1. Org CHF. Dons : A=190 CHF, B=47.50 CHF, C=95 CHF
+2. `GET /donations?amountMin=7000&amountMax=15000` → seul C apparaît (9500 CHF-cents)
+3. `GET /donations?sort=amountCents&order=asc` → ordre B→C→A
+4. ✅ Pass si filtres appliqués sur amountBaseCents
+
+### P1
+
+**T-P1-1 : Job CRON refresh-exchange-rates**
+1. Démarrer le worker (`pnpm --filter @givernance/worker dev`)
+2. Confirmer dans les logs : `Scheduled repeatable job: exchange-rates.refresh`
+3. Déclencher manuellement via Bull Board ou Redis CLI
+4. `SELECT * FROM exchange_rates WHERE date = CURRENT_DATE ORDER BY currency` → rows présentes
+5. ✅ Pass si le job existe et populate la table
+
+**T-P1-2 : Cache Redis pour les taux**
+1. Vider les clés `redis-cli KEYS "fx:*" | xargs redis-cli DEL`
+2. Créer 2 dons back-to-back en devise étrangère (même org)
+3. Logs API : 1er appel `source: 'api'`, 2ème `source: 'api_cache'` ou `source: 'db'`
+4. `redis-cli GET "fx:EUR:CHF:2026-05-04"` → valeur non vide
+5. ✅ Pass si 1 seul appel externe par fenêtre TTL
+
+**T-P1-3 : Bouton "Nouveau don" sur fiche Constituent**
+1. Naviguer sur `/constituents/:id`
+2. Localiser le bouton "Nouveau don"
+3. Cliquer → URL `/donations/new?constituentId=:id`
+4. Champ Constituent pré-rempli avec le nom du constituent
+5. Soumettre → don lié au constituent dans l'onglet Donations
+6. ✅ Pass si pré-remplissage OK et don correctement lié
+
+**T-P1-4 : Bouton "Nouveau don" sur fiche Campaign**
+1. Naviguer sur `/campaigns/:id`
+2. Localiser le bouton "Nouveau don"
+3. Cliquer → URL `/donations/new?campaignId=:id`
+4. Champ Campaign pré-rempli + devise = `campaign.defaultCurrency`
+5. Soumettre → don lié à la campagne
+6. ✅ Pass si pré-remplissage OK et don correctement lié
+
+**T-P1-5 : `/donations/new` dual pré-remplissage**
+1. Naviguer vers `/donations/new?constituentId=C1&campaignId=CAM1`
+2. Deux champs pré-remplis simultanément
+3. Devise = `CAM1.defaultCurrency`
+4. Soumettre → `constituentId=C1` + `campaignId=CAM1`
+5. ✅ Pass si les deux FK sont correctement persistées
+
+**T-P1-6 : Composant `<Money>` — aucun appel `formatCurrency` 2-args**
+1. `grep -r "formatCurrency" packages/web/src --include="*.tsx" --include="*.ts"` → 0 appels sans 3ème argument
+2. Dashboard : montants affichés dans la bonne devise
+3. Liste des dons : symbole correct par devise de chaque don
+4. ✅ Pass si grep retourne 0 résultats à 2 args et UI correcte
+
+**T-P1-7 : Settings → onglet Currency (8 devises)**
+1. Naviguer sur `/settings` → onglet "Devise" visible
+2. Sélecteur affiche exactement 8 options : EUR, GBP, CHF, SEK, NOK, DKK, PLN, CZK
+3. Sélectionner CHF → Sauvegarder → toast succès
+4. Recharger la page → CHF affiché
+5. Viewer → sélecteur disabled ou bouton absent
+6. ✅ Pass si 8 options, persistance, et viewer bloqué
+
+---
+
+## Dépendances inter-phases
+
+```
+P0 (migration 0037, bug fixes)
+  └─► P1 (migration 0038, robustesse)
+        └─► P2 (docs, ADR, tests, CHECKs)
+```
+
+P2 peut être lancé en parallèle de P1 pour les parties documentation pure (ADR, README, data-model).
+
+---
+
+## Checklist CI avant chaque merge
+
+Conformément à `CLAUDE.md` :
+
+```bash
+pnpm install
+pnpm build
+pnpm run format
+pnpm run lint
+pnpm typecheck
+pnpm test
+```
+
+Aucun merge si l'une de ces commandes échoue.

--- a/packages/api/migrations/0038_allocation_enrichment.sql
+++ b/packages/api/migrations/0038_allocation_enrichment.sql
@@ -1,0 +1,95 @@
+-- Migration: 0038_allocation_enrichment
+-- Extends donation_allocations to support:
+--   1. amount_base_cents — pre-converted amount in the tenant's pivot currency
+--   2. percentage_bp     — basis-points split (10000 bp = 100%) for proportional allocations
+--   3. amount_cents nullable — supports percentage-mode rows (no fixed amount)
+--   4. XOR constraint — every row is either fixed-amount OR percentage, never both
+--   5. Trigger rewrite — check_allocation_sum enforces mode A (sum = donation) or
+--                         mode B (sum = 10000 bp), and rejects mixed-mode allocations
+
+-- ─── amount_base_cents ────────────────────────────────────────────────────────
+ALTER TABLE donation_allocations
+  ADD COLUMN IF NOT EXISTS amount_base_cents INTEGER;
+
+-- ─── percentage_bp ────────────────────────────────────────────────────────────
+ALTER TABLE donation_allocations
+  ADD COLUMN IF NOT EXISTS percentage_bp INTEGER
+  CONSTRAINT donation_allocations_percentage_bp_range CHECK (percentage_bp BETWEEN 1 AND 10000);
+
+-- ─── amount_cents nullable (percentage-mode rows have no fixed amount) ────────
+ALTER TABLE donation_allocations
+  ALTER COLUMN amount_cents DROP NOT NULL;
+
+-- ─── XOR: exactly one of amount_cents / percentage_bp must be set ─────────────
+--> statement-breakpoint
+ALTER TABLE donation_allocations
+  ADD CONSTRAINT donation_allocations_amount_or_bp CHECK (
+    (amount_cents IS NOT NULL AND percentage_bp IS NULL) OR
+    (amount_cents IS NULL     AND percentage_bp IS NOT NULL)
+  );
+
+-- ─── Trigger rewrite ─────────────────────────────────────────────────────────
+-- Mode A: all rows have amount_cents, sum must equal donations.amount_cents
+-- Mode B: all rows have percentage_bp, sum must equal 10000 (100 %)
+-- Mixed-mode (rows with both types within the same donation) is rejected.
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION check_allocation_sum()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_donation_id   UUID;
+  v_amount_sum    INTEGER;
+  v_bp_sum        INTEGER;
+  v_donation_amt  INTEGER;
+  v_amount_count  INTEGER;
+  v_bp_count      INTEGER;
+  v_total_rows    INTEGER;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_donation_id := OLD.donation_id;
+  ELSE
+    v_donation_id := NEW.donation_id;
+  END IF;
+
+  SELECT
+    COUNT(*)                            INTO v_total_rows,
+    COUNT(amount_cents)                 INTO v_amount_count,
+    COUNT(percentage_bp)                INTO v_bp_count,
+    COALESCE(SUM(amount_cents), 0)      INTO v_amount_sum,
+    COALESCE(SUM(percentage_bp), 0)     INTO v_bp_sum
+  FROM donation_allocations
+  WHERE donation_id = v_donation_id;
+
+  -- Zero rows = no allocations, always valid
+  IF v_total_rows = 0 THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    RETURN NEW;
+  END IF;
+
+  -- Reject mixed-mode within the same donation
+  IF v_amount_count > 0 AND v_bp_count > 0 THEN
+    RAISE EXCEPTION 'Mixed allocation modes (amount_cents and percentage_bp) on donation %',
+      v_donation_id
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF v_amount_count = v_total_rows THEN
+    -- Mode A: sum of amounts must equal donation.amount_cents
+    SELECT amount_cents INTO v_donation_amt FROM donations WHERE id = v_donation_id;
+    IF v_amount_sum <> v_donation_amt THEN
+      RAISE EXCEPTION 'Allocation sum (%) does not equal donation amount (%) for donation %',
+        v_amount_sum, v_donation_amt, v_donation_id
+        USING ERRCODE = 'check_violation';
+    END IF;
+  ELSE
+    -- Mode B: sum of basis points must equal 10000 (100 %)
+    IF v_bp_sum <> 10000 THEN
+      RAISE EXCEPTION 'Percentage allocation sum (% bp) must equal 10000 bp for donation %',
+        v_bp_sum, v_donation_id
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -260,6 +260,20 @@
       "when": 1777800000000,
       "tag": "0036_platform_admins_sort_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1778000000000,
+      "tag": "0037_multi_currency_hardening",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1778200000000,
+      "tag": "0038_allocation_enrichment",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/modules/finance/exchange-rate-service.ts
+++ b/packages/api/src/modules/finance/exchange-rate-service.ts
@@ -2,11 +2,20 @@ import { ExchangeRateService as SharedExchangeRateService } from "@givernance/sh
 import pino from "pino";
 import { env } from "../../env.js";
 import { db } from "../../lib/db.js";
+import { redis } from "../../lib/redis.js";
 
 const exchangeRateLogger = pino({
   level: env.LOG_LEVEL,
   base: { service: "givernance-api", module: "exchange-rate-service" },
 });
+
+/** Redis-backed ExchangeRateCache adapter — keys: `fx:{src}:{tgt}:{date}` */
+const redisCache = {
+  get: (key: string) => redis.get(key),
+  set: (key: string, value: string, ttlSeconds: number) =>
+    redis.set(key, value, "EX", ttlSeconds).then(() => undefined),
+  del: (key: string) => redis.del(key).then(() => undefined),
+};
 
 interface ExchangeRateServiceOptions {
   dbClient?: Pick<typeof db, "select" | "insert">;
@@ -18,6 +27,7 @@ export class ExchangeRateService extends SharedExchangeRateService {
   constructor(options: ExchangeRateServiceOptions = {}) {
     super({
       apiKey: process.env.EXCHANGE_RATE_API_KEY ?? env.EXCHANGE_RATE_API_KEY,
+      cache: redisCache,
       dbClient: options.dbClient ?? db,
       fetchImpl: options.fetchImpl,
       logger: options.logger ?? exchangeRateLogger,

--- a/packages/api/src/modules/tenants/routes.ts
+++ b/packages/api/src/modules/tenants/routes.ts
@@ -1,5 +1,6 @@
 /** Tenant routes — platform-admin CRUD for organizations */
 
+import { BASE_CURRENCIES } from "@givernance/shared/constants";
 import { SUPPORTED_LOCALES } from "@givernance/shared/i18n";
 import { outboxEvents, tenants } from "@givernance/shared/schema";
 import { Type } from "@sinclair/typebox";
@@ -25,11 +26,7 @@ const CreateTenantBody = Type.Object({
   ),
 });
 
-const TenantBaseCurrencySchema = Type.Union([
-  Type.Literal("EUR"),
-  Type.Literal("GBP"),
-  Type.Literal("CHF"),
-]);
+const TenantBaseCurrencySchema = Type.Union(BASE_CURRENCIES.map((c) => Type.Literal(c)));
 
 const TenantLocaleSchema = Type.Union(SUPPORTED_LOCALES.map((value) => Type.Literal(value)));
 
@@ -157,7 +154,7 @@ export async function tenantRoutes(app: FastifyInstance) {
     async (request, reply) => {
       const { orgId } = request.params as { orgId: string };
       const body = request.body as {
-        baseCurrency?: "EUR" | "GBP" | "CHF";
+        baseCurrency?: (typeof BASE_CURRENCIES)[number];
         defaultLocale?: "en" | "fr";
       };
       const [updated] = await db

--- a/packages/shared/src/constants/currencies.ts
+++ b/packages/shared/src/constants/currencies.ts
@@ -1,0 +1,63 @@
+/**
+ * Canonical list of currencies supported by Givernance.
+ *
+ * Single source of truth for:
+ * - donation currency validation (DonationCreateSchema)
+ * - tenant base currency (MultiCurrencySchema, PATCH /v1/tenants/:id)
+ * - UI currency selectors and symbol rendering
+ *
+ * Kept in `@givernance/shared/constants` (not the schema entry point) so the
+ * web package can import it without pulling the Drizzle schema (ADR-013).
+ */
+
+export const SUPPORTED_CURRENCIES = [
+  "EUR",
+  "GBP",
+  "CHF",
+  "SEK",
+  "NOK",
+  "DKK",
+  "PLN",
+  "CZK",
+] as const;
+export type Currency = (typeof SUPPORTED_CURRENCIES)[number];
+
+/**
+ * Currencies that can be configured as a tenant's base (pivot) currency.
+ * Currently identical to SUPPORTED_CURRENCIES — any donation currency can also
+ * be a base currency. Kept as a distinct constant so the type can diverge if
+ * XOF/XAF (non-decimal) are added in future (Phase 4+, see P2 ADR).
+ */
+export const BASE_CURRENCIES = [...SUPPORTED_CURRENCIES] as const;
+export type BaseCurrency = (typeof BASE_CURRENCIES)[number];
+
+/**
+ * Returns the currency symbol for a given ISO-4217 code using the browser/Node
+ * Intl API. Falls back to the currency code itself if Intl is unavailable.
+ *
+ * Examples: "EUR" → "€", "GBP" → "£", "CHF" → "CHF", "SEK" → "kr"
+ *
+ * Note: the exact symbol depends on the `locale`. The default "en-US" gives
+ * unambiguous symbols for European currencies (CHF stays "CHF", SEK "kr", etc.).
+ */
+export function getCurrencySymbol(currency: string, locale = "en-US"): string {
+  try {
+    const parts = new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).formatToParts(0);
+    return parts.find((p) => p.type === "currency")?.value ?? currency;
+  } catch {
+    return currency;
+  }
+}
+
+export function isSupportedCurrency(value: string): value is Currency {
+  return (SUPPORTED_CURRENCIES as readonly string[]).includes(value);
+}
+
+export function isBaseCurrency(value: string): value is BaseCurrency {
+  return (BASE_CURRENCIES as readonly string[]).includes(value);
+}

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -5,6 +5,15 @@
  */
 
 export {
+  BASE_CURRENCIES,
+  type BaseCurrency,
+  type Currency as SupportedCurrency,
+  getCurrencySymbol,
+  isBaseCurrency,
+  isSupportedCurrency,
+  SUPPORTED_CURRENCIES,
+} from "./currencies";
+export {
   IMPERSONATION_END_REASON_VALUES,
   IMPERSONATION_MODE_VALUES,
   type ImpersonationEndReason,

--- a/packages/shared/src/finance/exchange-rate-service.ts
+++ b/packages/shared/src/finance/exchange-rate-service.ts
@@ -25,8 +25,21 @@ interface ExchangeRateCacheEntry {
   rate: number | null;
 }
 
+/**
+ * Injectable Redis-backed cache so multiple API/worker processes share the same
+ * rate data instead of each keeping a separate in-process Map.
+ * The shared package must not import ioredis directly (ADR-013 type boundary);
+ * the caller (API or worker) wires in the concrete Redis commands.
+ */
+export interface ExchangeRateCache {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttlSeconds: number): Promise<void>;
+  del(key: string): Promise<void>;
+}
+
 export interface ExchangeRateServiceOptions {
   apiKey?: string;
+  cache?: ExchangeRateCache;
   cacheTtlMs?: number;
   dbClient: DbClient;
   fetchImpl?: typeof fetch;
@@ -36,7 +49,10 @@ export interface ExchangeRateServiceOptions {
 
 const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 2_000;
+/** Process-local fallback cache — used only when no Redis cache is injected */
 const exchangeRateApiCache = new Map<string, ExchangeRateCacheEntry>();
+
+const REDIS_CACHE_TTL_SECONDS = 3600;
 
 function normalizeCurrency(currency: string) {
   return currency.trim().toUpperCase();
@@ -90,6 +106,7 @@ export function clearExchangeRateApiCache() {
 
 export class ExchangeRateService {
   private readonly apiKey?: string;
+  private readonly redisCache?: ExchangeRateCache;
   private readonly cacheTtlMs: number;
   private readonly dbClient: DbClient;
   private readonly fetchImpl: typeof fetch;
@@ -98,6 +115,7 @@ export class ExchangeRateService {
 
   constructor(options: ExchangeRateServiceOptions) {
     this.apiKey = options.apiKey;
+    this.redisCache = options.cache;
     this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
     this.dbClient = options.dbClient;
     this.fetchImpl = options.fetchImpl ?? fetch;
@@ -135,7 +153,17 @@ export class ExchangeRateService {
       return { rate: localRate, source: "local_exact" };
     }
 
-    const cachedRate = readCachedRate(source, target, date);
+    // Redis cache wins over the in-process Map when available
+    if (this.redisCache) {
+      const redisKey = `fx:${source}:${target}:${date}`;
+      const redisHit = await this.redisCache.get(redisKey);
+      if (redisHit) {
+        const redisRate = parseRate(redisHit);
+        if (redisRate) return { rate: redisRate, source: "api_cache" };
+      }
+    }
+
+    const cachedRate = this.redisCache ? null : readCachedRate(source, target, date);
     if (cachedRate?.rate) {
       return { rate: cachedRate.rate, source: "api_cache" };
     }
@@ -226,17 +254,28 @@ export class ExchangeRateService {
           },
         });
 
-      exchangeRateApiCache.set(getCacheKey(source, target, date), {
-        expiresAt: Date.now() + this.cacheTtlMs,
-        rate,
-      });
+      if (this.redisCache) {
+        const redisKey = `fx:${source}:${target}:${date}`;
+        await this.redisCache
+          .set(redisKey, toStoredRate(rate), REDIS_CACHE_TTL_SECONDS)
+          .catch(() => {
+            /* non-fatal: Redis write failure degrades to DB lookup next request */
+          });
+      } else {
+        exchangeRateApiCache.set(getCacheKey(source, target, date), {
+          expiresAt: Date.now() + this.cacheTtlMs,
+          rate,
+        });
+      }
 
       return rate;
     } catch (error) {
-      exchangeRateApiCache.set(getCacheKey(source, target, date), {
-        expiresAt: Date.now() + this.cacheTtlMs,
-        rate: null,
-      });
+      if (!this.redisCache) {
+        exchangeRateApiCache.set(getCacheKey(source, target, date), {
+          expiresAt: Date.now() + this.cacheTtlMs,
+          rate: null,
+        });
+      }
 
       this.logger.warn(
         {

--- a/packages/shared/src/jobs/index.ts
+++ b/packages/shared/src/jobs/index.ts
@@ -86,9 +86,21 @@ export const QUEUE_NAMES = {
   EVENTS: "givernance_events",
   WEBHOOKS: "webhooks",
   TENANT_LIFECYCLE: "tenant_lifecycle",
+  EXCHANGE_RATES: "exchange_rates",
 } as const;
 
 /** Repeatable job names inside TENANT_LIFECYCLE queue. */
 export const TENANT_LIFECYCLE_JOBS = {
   PROVISIONAL_ADMIN_EXPIRE: "tenant.provisional-admin-expire",
 } as const;
+
+/** Repeatable job names inside EXCHANGE_RATES queue. */
+export const EXCHANGE_RATE_JOBS = {
+  REFRESH: "exchange-rates.refresh",
+} as const;
+
+/** Nightly exchange-rate refresh — no data payload needed */
+export interface RefreshExchangeRatesJob {
+  name: typeof EXCHANGE_RATE_JOBS.REFRESH;
+  data: Record<string, never>;
+}

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -678,7 +678,23 @@ export const donationAllocations = pgTable(
     fundId: uuid("fund_id")
       .notNull()
       .references(() => funds.id, { onDelete: "restrict" }),
-    amountCents: integer("amount_cents").notNull(),
+    /**
+     * Fixed amount in donor currency. Nullable since 0038 — only one of
+     * amountCents (mode A) or percentageBp (mode B) is set per row.
+     * A DB CHECK constraint (donation_allocations_amount_or_bp) enforces XOR.
+     */
+    amountCents: integer("amount_cents"),
+    /**
+     * Pre-converted amount in the tenant's pivot currency.
+     * Nullable — backfilled progressively for historical rows.
+     */
+    amountBaseCents: integer("amount_base_cents"),
+    /**
+     * Basis-points split (10 000 bp = 100 %). Used for percentage-mode
+     * allocations where the exact amount is computed at receipt time.
+     * A DB CHECK constraint enforces bp ∈ [1, 10000].
+     */
+    percentageBp: integer("percentage_bp"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -2,6 +2,7 @@
 
 import { type Static, type TSchema, Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
+import { BASE_CURRENCIES, SUPPORTED_CURRENCIES } from "../constants/currencies";
 import { isReservedSlug } from "../constants/reserved-slugs";
 
 export {
@@ -107,15 +108,32 @@ export const ConstituentUpdateSchema = Type.Object({
   tags: Type.Optional(Type.Array(Type.String())),
 });
 
-/** Schema for a fund allocation within a donation */
-export const DonationAllocationSchema = Type.Object({
-  fundId: Type.String({ format: "uuid" }),
-  amountCents: Type.Integer({ exclusiveMinimum: 0 }),
-});
+/**
+ * Schema for a fund allocation within a donation.
+ *
+ * Exactly one of `amountCents` (mode A — fixed amount) or `percentageBp`
+ * (mode B — basis-point split) must be supplied per row.
+ * The DB enforces the XOR constraint; this schema validates at API boundary.
+ */
+export const DonationAllocationSchema = Type.Union([
+  Type.Object({
+    fundId: Type.String({ format: "uuid" }),
+    amountCents: Type.Integer({ exclusiveMinimum: 0 }),
+  }),
+  Type.Object({
+    fundId: Type.String({ format: "uuid" }),
+    percentageBp: Type.Integer({ minimum: 1, maximum: 10000 }),
+  }),
+]);
 
-export const MULTI_CURRENCY_VALUES = ["EUR", "GBP", "CHF"] as const;
+/**
+ * @deprecated Use `BASE_CURRENCIES` from `@givernance/shared/constants` instead.
+ * `MULTI_CURRENCY_VALUES` only contained 3 currencies; `BASE_CURRENCIES` has all 8.
+ * This re-export is kept for backwards compatibility until all call-sites are migrated.
+ */
+export const MULTI_CURRENCY_VALUES = BASE_CURRENCIES;
 export const MultiCurrencySchema = Type.Union(
-  MULTI_CURRENCY_VALUES.map((currency) => Type.Literal(currency)),
+  BASE_CURRENCIES.map((currency) => Type.Literal(currency)),
   { default: "EUR" },
 );
 
@@ -124,16 +142,7 @@ export const DonationCreateSchema = Type.Object({
   constituentId: Type.String({ format: "uuid" }),
   amountCents: Type.Integer({ exclusiveMinimum: 0 }),
   currency: Type.Union(
-    [
-      Type.Literal("EUR"),
-      Type.Literal("GBP"),
-      Type.Literal("CHF"),
-      Type.Literal("SEK"),
-      Type.Literal("NOK"),
-      Type.Literal("DKK"),
-      Type.Literal("PLN"),
-      Type.Literal("CZK"),
-    ],
+    SUPPORTED_CURRENCIES.map((c) => Type.Literal(c)),
     { default: "EUR" },
   ),
   campaignId: Type.Optional(Type.String({ format: "uuid" })),
@@ -201,6 +210,12 @@ export type ConstituentCreate = Static<typeof ConstituentCreateSchema>;
 export type ConstituentUpdate = Static<typeof ConstituentUpdateSchema>;
 export type DonationCreate = Static<typeof DonationCreateSchema>;
 export type DonationAllocation = Static<typeof DonationAllocationSchema>;
+/** Helper to check if an allocation is in percentage mode */
+export function isPercentageAllocation(
+  a: DonationAllocation,
+): a is { fundId: string; percentageBp: number } {
+  return "percentageBp" in a;
+}
 export type CampaignCreate = Static<typeof CampaignCreateSchema>;
 export type CampaignUpdate = Static<typeof CampaignUpdateSchema>;
 export type CampaignPublicPage = Static<typeof CampaignPublicPageSchema>;

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -189,6 +189,8 @@ export default async function CampaignDetailPage({
             campaign={campaign}
             donationsResult={donationsResult}
             donationsLabel={tDonations("title")}
+            canWrite={canWrite}
+            newDonationLabel={tDonations("actions.new")}
           />
         </div>
       </div>
@@ -408,10 +410,14 @@ async function DonationBreakdownCard({
   campaign,
   donationsResult,
   donationsLabel,
+  canWrite,
+  newDonationLabel,
 }: {
   campaign: Campaign;
   donationsResult: DonationListResponse;
   donationsLabel: string;
+  canWrite: boolean;
+  newDonationLabel: string;
 }) {
   const t = await getTranslations("campaigns.detail");
   const { data: donations, pagination } = donationsResult;
@@ -425,11 +431,21 @@ async function DonationBreakdownCard({
             {t("donations.subtitle", { count: pagination.total })}
           </p>
         </div>
-        <Button asChild variant="ghost" size="sm">
-          <Link href={`/donations?campaignId=${encodeURIComponent(campaign.id)}`}>
-            {donationsLabel}
-          </Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          {canWrite ? (
+            <Button asChild variant="secondary" size="sm">
+              <Link href={`/donations/new?campaignId=${campaign.id}`}>
+                <Gift size={16} aria-hidden="true" />
+                {newDonationLabel}
+              </Link>
+            </Button>
+          ) : null}
+          <Button asChild variant="ghost" size="sm">
+            <Link href={`/donations?campaignId=${encodeURIComponent(campaign.id)}`}>
+              {donationsLabel}
+            </Link>
+          </Button>
+        </div>
       </div>
 
       {donations.length === 0 ? (

--- a/packages/web/src/app/(app)/constituents/[id]/page.tsx
+++ b/packages/web/src/app/(app)/constituents/[id]/page.tsx
@@ -1,4 +1,13 @@
-import { Download, FileText, GitMerge, Mail, Pencil, Sparkles, Trash2 } from "lucide-react";
+import {
+  Banknote,
+  Download,
+  FileText,
+  GitMerge,
+  Mail,
+  Pencil,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
@@ -101,6 +110,7 @@ export default async function ConstituentDetailPage({ params, searchParams }: De
 
   const t = await getTranslations("constituentDetail");
   const tType = await getTranslations("constituents.types");
+  const tDonations = await getTranslations("donations");
   const locale = await getLocale();
 
   const totalDonatedCents = donationsResult.data.reduce(
@@ -136,6 +146,7 @@ export default async function ConstituentDetailPage({ params, searchParams }: De
           merge: t("actions.merge"),
           exportGdpr: t("actions.exportGdpr"),
           delete: t("actions.delete"),
+          newDonation: tDonations("actions.new"),
         }}
       />
       <AiSuggestionCard
@@ -237,6 +248,7 @@ interface ProfileLabels {
   merge: string;
   exportGdpr: string;
   delete: string;
+  newDonation: string;
 }
 
 function ProfileCard({
@@ -362,6 +374,14 @@ function ProfileActions({
           <Link href={`/constituents/${constituentId}/edit`}>
             <Pencil size={16} aria-hidden="true" />
             {labels.edit}
+          </Link>
+        </Button>
+      ) : null}
+      {canWrite ? (
+        <Button asChild variant="secondary" size="sm">
+          <Link href={`/donations/new?constituentId=${constituentId}`}>
+            <Banknote size={16} aria-hidden="true" />
+            {labels.newDonation}
           </Link>
         </Button>
       ) : null}

--- a/packages/web/src/app/(app)/donations/new/page.tsx
+++ b/packages/web/src/app/(app)/donations/new/page.tsx
@@ -2,12 +2,38 @@ import { getTranslations } from "next-intl/server";
 
 import { DonationForm } from "@/components/donations/donation-form";
 import { PageHeader } from "@/components/shared/page-header";
+import { createServerApiClient } from "@/lib/api/client-server";
 import { requirePermission } from "@/lib/auth/guards";
+import { CampaignService } from "@/services/CampaignService";
 
-export default async function NewDonationPage() {
+interface NewDonationPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function extractString(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v;
+}
+
+export default async function NewDonationPage({ searchParams }: NewDonationPageProps) {
   await requirePermission("write");
   const t = await getTranslations("donations.form");
   const tDonations = await getTranslations("donations");
+
+  const sp = await searchParams;
+  const initialConstituentId = extractString(sp.constituentId);
+  const initialCampaignId = extractString(sp.campaignId);
+
+  // Resolve the campaign's defaultCurrency so the form opens in the right currency
+  let initialCurrency: string | undefined;
+  if (initialCampaignId) {
+    try {
+      const client = await createServerApiClient();
+      const campaign = await CampaignService.getCampaign(client, initialCampaignId);
+      initialCurrency = campaign.defaultCurrency ?? undefined;
+    } catch {
+      // Non-fatal: form will use the tenant default
+    }
+  }
 
   return (
     <>
@@ -20,7 +46,12 @@ export default async function NewDonationPage() {
           { label: t("breadcrumbNew") },
         ]}
       />
-      <DonationForm mode="create" />
+      <DonationForm
+        mode="create"
+        initialConstituentId={initialConstituentId}
+        initialCampaignId={initialCampaignId}
+        initialCurrency={initialCurrency}
+      />
     </>
   );
 }

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -4,6 +4,8 @@ import { Toaster } from "@/components/ui/toast";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { AuthProvider } from "@/lib/auth";
 import { requireAuth } from "@/lib/auth/guards";
+import { TenantProvider } from "@/lib/context/tenant-context";
+import { TenantService } from "@/services/TenantService";
 
 /**
  * Authenticated app layout — wraps all protected routes with:
@@ -39,13 +41,26 @@ const fetchMeWithMembership = cache(async () => {
   };
 });
 
+async function fetchTenantBaseCurrency(orgId: string): Promise<string> {
+  try {
+    const api = await createServerApiClient();
+    const tenant = await TenantService.getTenant(api, orgId);
+    return tenant.baseCurrency;
+  } catch {
+    return "EUR";
+  }
+}
+
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const auth = await requireAuth();
   const isSuperAdmin = auth.roles.includes("super_admin");
 
   const userName = auth.firstName ? `${auth.firstName} ${auth.lastName ?? ""}`.trim() : auth.email;
 
-  const { me, membershipCount } = await fetchMeWithMembership();
+  const [{ me, membershipCount }, baseCurrency] = await Promise.all([
+    fetchMeWithMembership(),
+    auth.orgId ? fetchTenantBaseCurrency(auth.orgId) : Promise.resolve("EUR"),
+  ]);
 
   // Broken state: a non-super-admin reached the authenticated layout but
   // we couldn't resolve their tenant memberships. Two failure modes:
@@ -83,16 +98,18 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 
   return (
     <AuthProvider>
-      <AppShell
-        impersonation={auth.impersonation}
-        impersonationUserName={auth.impersonation ? userName : undefined}
-        provisionalAdmin={provisionalAdmin}
-        membershipCount={membershipCount}
-        isSuperAdmin={auth.roles.includes("super_admin")}
-      >
-        {children}
-      </AppShell>
-      <Toaster />
+      <TenantProvider baseCurrency={baseCurrency}>
+        <AppShell
+          impersonation={auth.impersonation}
+          impersonationUserName={auth.impersonation ? userName : undefined}
+          provisionalAdmin={provisionalAdmin}
+          membershipCount={membershipCount}
+          isSuperAdmin={auth.roles.includes("super_admin")}
+        >
+          {children}
+        </AppShell>
+        <Toaster />
+      </TenantProvider>
     </AuthProvider>
   );
 }

--- a/packages/web/src/app/(app)/settings/currency/page.tsx
+++ b/packages/web/src/app/(app)/settings/currency/page.tsx
@@ -1,0 +1,27 @@
+import { getTranslations } from "next-intl/server";
+import { CurrencySettingsForm } from "@/components/settings/currency-settings-form";
+import { SettingsNavigation } from "@/components/settings/settings-navigation";
+import { PageHeader } from "@/components/shared/page-header";
+import { requireAuth } from "@/lib/auth/guards";
+
+export default async function CurrencySettingsPage() {
+  const auth = await requireAuth();
+  const t = await getTranslations("settings");
+  const tCurrency = await getTranslations("settings.currency");
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title={t("title")}
+        description={t("subtitle")}
+        breadcrumbs={[
+          { label: t("breadcrumbRoot"), href: "/dashboard" },
+          { label: t("title"), href: "/settings" },
+          { label: tCurrency("title") },
+        ]}
+      />
+      <SettingsNavigation />
+      <CurrencySettingsForm orgId={auth.orgId} canManageTenant={auth.roles.includes("org_admin")} />
+    </div>
+  );
+}

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -105,7 +105,16 @@ const DEFAULT_VALUES: DefaultValues<DonationFormValues> = {
   allocations: [],
 };
 
-type CreateMode = { mode: "create"; donation?: undefined };
+type CreateMode = {
+  mode: "create";
+  donation?: undefined;
+  /** Pre-select a constituent (from ?constituentId= query param) */
+  initialConstituentId?: string;
+  /** Pre-select a campaign (from ?campaignId= query param) */
+  initialCampaignId?: string;
+  /** Pre-select a currency (derived from the campaign's defaultCurrency) */
+  initialCurrency?: string;
+};
 type EditMode = { mode: "edit"; donation: DonationDetail };
 
 export type DonationFormProps = CreateMode | EditMode;
@@ -793,7 +802,12 @@ function toUpdateApiPayload(values: DonationFormValues): DonationUpdateInput {
 
 function buildDefaultValues(props: DonationFormProps): DefaultValues<DonationFormValues> {
   if (props.mode === "create") {
-    return DEFAULT_VALUES;
+    return {
+      ...DEFAULT_VALUES,
+      constituentId: props.initialConstituentId ?? DEFAULT_VALUES.constituentId,
+      campaignId: props.initialCampaignId ?? DEFAULT_VALUES.campaignId,
+      currency: (props.initialCurrency as DonationCurrency | undefined) ?? DEFAULT_VALUES.currency,
+    };
   }
 
   return {

--- a/packages/web/src/components/settings/currency-settings-form.tsx
+++ b/packages/web/src/components/settings/currency-settings-form.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { Lock } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { TenantCurrency } from "@/models/tenant";
+import { TenantService } from "@/services/TenantService";
+
+const TENANT_CURRENCIES: TenantCurrency[] = [
+  "EUR",
+  "GBP",
+  "CHF",
+  "SEK",
+  "NOK",
+  "DKK",
+  "PLN",
+  "CZK",
+];
+
+function resolveApiErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiProblem) {
+    return error.detail ?? error.title ?? fallback;
+  }
+  return fallback;
+}
+
+interface CurrencySettingsFormProps {
+  orgId?: string;
+  canManageTenant: boolean;
+}
+
+export function CurrencySettingsForm({ orgId, canManageTenant }: CurrencySettingsFormProps) {
+  const t = useTranslations("settings.currency");
+  const router = useRouter();
+  const [baseCurrency, setBaseCurrency] = useState<TenantCurrency>("EUR");
+  const [initialCurrency, setInitialCurrency] = useState<TenantCurrency>("EUR");
+  const [tenantName, setTenantName] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!orgId || !canManageTenant) {
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+
+    async function loadTenant(nextOrgId: string) {
+      try {
+        const tenant = await TenantService.getTenant(createClientApiClient(), nextOrgId);
+        if (!active) return;
+        setTenantName(tenant.name);
+        setBaseCurrency(tenant.baseCurrency);
+        setInitialCurrency(tenant.baseCurrency);
+      } catch (error) {
+        if (!active) return;
+        setErrorMessage(resolveApiErrorMessage(error, t("errors.load")));
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    void loadTenant(orgId);
+
+    return () => {
+      active = false;
+    };
+  }, [canManageTenant, t, orgId]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!orgId || !canManageTenant || saving) return;
+
+    setSaving(true);
+    setErrorMessage(null);
+
+    try {
+      if (baseCurrency !== initialCurrency) {
+        const tenant = await TenantService.updateTenant(createClientApiClient(), orgId, {
+          baseCurrency,
+        });
+        setTenantName(tenant.name);
+        setBaseCurrency(tenant.baseCurrency);
+        setInitialCurrency(tenant.baseCurrency);
+        toast.success(t("success.updated"));
+        router.refresh();
+      }
+    } catch (error) {
+      const message = resolveApiErrorMessage(error, t("errors.save"));
+      setErrorMessage(message);
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const isDirty = baseCurrency !== initialCurrency;
+
+  return (
+    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+      <div className="max-w-3xl">
+        <h2 className="font-heading text-2xl leading-tight text-on-surface">{t("title")}</h2>
+        <p className="mt-2 text-sm leading-6 text-on-surface-variant">{t("description")}</p>
+      </div>
+
+      {canManageTenant && orgId ? (
+        <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+          <div className="max-w-xs space-y-2">
+            <label htmlFor="base-currency" className="text-sm font-medium text-on-surface">
+              {t("fields.baseCurrency")}
+            </label>
+            <Select
+              value={baseCurrency}
+              onValueChange={(value) => setBaseCurrency(value as TenantCurrency)}
+              disabled={loading || saving}
+            >
+              <SelectTrigger id="base-currency" aria-label={t("fields.baseCurrency")}>
+                <SelectValue placeholder={t("fields.baseCurrencyPlaceholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                {TENANT_CURRENCIES.map((currency) => (
+                  <SelectItem key={currency} value={currency}>
+                    {currency}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-on-surface-variant">
+              {tenantName
+                ? t("fields.baseCurrencyHintWithName", { name: tenantName })
+                : t("fields.baseCurrencyHint")}
+            </p>
+          </div>
+
+          {errorMessage ? <p className="text-sm text-error">{errorMessage}</p> : null}
+
+          <div className="flex items-center justify-end gap-3">
+            <Button type="submit" disabled={loading || saving || !isDirty}>
+              {saving ? t("actions.saving") : t("actions.save")}
+            </Button>
+          </div>
+        </form>
+      ) : (
+        <div className="mt-6 inline-flex items-center gap-2 rounded-xl bg-surface-container px-4 py-3 text-sm text-on-surface-variant">
+          <Lock size={16} aria-hidden="true" />
+          <span>{t("readOnly")}</span>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/components/settings/settings-navigation.tsx
+++ b/packages/web/src/components/settings/settings-navigation.tsx
@@ -22,6 +22,11 @@ const SETTINGS_NAV_ITEMS = [
     key: "funds",
     match: (pathname: string) => pathname.startsWith("/settings/funds"),
   },
+  {
+    href: "/settings/currency",
+    key: "currency",
+    match: (pathname: string) => pathname.startsWith("/settings/currency"),
+  },
 ] as const;
 
 export function SettingsNavigation() {

--- a/packages/web/src/components/settings/tenant-settings-form.tsx
+++ b/packages/web/src/components/settings/tenant-settings-form.tsx
@@ -20,7 +20,16 @@ import { createClientApiClient } from "@/lib/api/client-browser";
 import type { TenantCurrency } from "@/models/tenant";
 import { TenantService } from "@/services/TenantService";
 
-const TENANT_CURRENCIES: TenantCurrency[] = ["EUR", "GBP", "CHF"];
+const TENANT_CURRENCIES: TenantCurrency[] = [
+  "EUR",
+  "GBP",
+  "CHF",
+  "SEK",
+  "NOK",
+  "DKK",
+  "PLN",
+  "CZK",
+];
 
 function resolveApiErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof ApiProblem) {

--- a/packages/web/src/components/shared/money.tsx
+++ b/packages/web/src/components/shared/money.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useLocale } from "next-intl";
+import { useTenantBaseCurrency } from "@/lib/hooks/use-tenant-base-currency";
+import { formatCurrency } from "@/lib/format";
+
+interface MoneyProps {
+  /** Amount in cents */
+  cents: number;
+  /**
+   * ISO-4217 currency code. When omitted the tenant's base currency is used
+   * (provided by `TenantProvider` in the app layout).
+   */
+  currency?: string;
+  /** BCP-47 locale override. Falls back to the active next-intl locale. */
+  locale?: string;
+  className?: string;
+}
+
+/**
+ * Renders a monetary amount in the correct currency and locale.
+ *
+ * When no `currency` prop is passed the tenant's base currency is resolved from
+ * `TenantContext` — eliminating the "EUR hardcoded" bug on multi-currency tenants.
+ *
+ * Usage:
+ *   <Money cents={12345} />                         → "123,45 €" (tenant EUR)
+ *   <Money cents={9500} currency="CHF" />           → "CHF 95.00" (explicit)
+ *   <Money cents={5000} currency={donation.currency} /> → donor currency
+ */
+export function Money({ cents, currency, locale: localeProp, className }: MoneyProps) {
+  const localeFromHook = useLocale();
+  const baseCurrency = useTenantBaseCurrency();
+
+  return (
+    <span className={`font-mono tabular-nums${className ? ` ${className}` : ""}`}>
+      {formatCurrency(cents, localeProp ?? localeFromHook, currency ?? baseCurrency)}
+    </span>
+  );
+}

--- a/packages/web/src/lib/context/tenant-context.tsx
+++ b/packages/web/src/lib/context/tenant-context.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+interface TenantContextValue {
+  /** ISO-4217 base currency of the current tenant (e.g. "EUR", "CHF"). */
+  baseCurrency: string;
+}
+
+const TenantContext = createContext<TenantContextValue>({ baseCurrency: "EUR" });
+
+export function TenantProvider({
+  children,
+  baseCurrency,
+}: {
+  children: React.ReactNode;
+  baseCurrency: string;
+}) {
+  return <TenantContext.Provider value={{ baseCurrency }}>{children}</TenantContext.Provider>;
+}
+
+export function useTenantContext(): TenantContextValue {
+  return useContext(TenantContext);
+}

--- a/packages/web/src/lib/hooks/use-tenant-base-currency.ts
+++ b/packages/web/src/lib/hooks/use-tenant-base-currency.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useTenantContext } from "@/lib/context/tenant-context";
+
+/**
+ * Returns the ISO-4217 base currency configured for the current tenant.
+ * Defaults to "EUR" when no TenantProvider is in the tree (e.g. in tests).
+ *
+ * Usage: const baseCurrency = useTenantBaseCurrency();
+ */
+export function useTenantBaseCurrency(): string {
+  return useTenantContext().baseCurrency;
+}

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -844,7 +844,8 @@
       "label": "Organisation settings navigation",
       "organization": "Organisation",
       "members": "Members",
-      "funds": "Funds"
+      "funds": "Funds",
+      "currency": "Currency"
     },
     "members": {
       "title": "Members",
@@ -1180,6 +1181,28 @@
         "load": "Unable to load Stripe status right now.",
         "start": "Unable to start Stripe onboarding right now."
       }
+    },
+    "currency": {
+      "title": "Base Currency",
+      "description": "Set the pivot currency used for reporting and multi-currency aggregates.",
+      "fields": {
+        "baseCurrency": "Base currency",
+        "baseCurrencyPlaceholder": "Choose a currency",
+        "baseCurrencyHint": "Used to aggregate donations received in different currencies.",
+        "baseCurrencyHintWithName": "{name} will use this currency as the pivot for converted amounts."
+      },
+      "actions": {
+        "save": "Save",
+        "saving": "Saving…"
+      },
+      "success": {
+        "updated": "Base currency updated."
+      },
+      "errors": {
+        "load": "Failed to load currency settings.",
+        "save": "Error saving base currency."
+      },
+      "readOnly": "Only an administrator can change the base currency."
     }
   },
   "profile": {

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -844,7 +844,8 @@
       "label": "Navigation des paramètres de l'organisation",
       "organization": "Organisation",
       "members": "Membres",
-      "funds": "Fonds"
+      "funds": "Fonds",
+      "currency": "Devise"
     },
     "members": {
       "title": "Membres",
@@ -1180,6 +1181,28 @@
         "load": "Impossible de charger le statut Stripe pour le moment.",
         "start": "Impossible de démarrer l'onboarding Stripe pour le moment."
       }
+    },
+    "currency": {
+      "title": "Devise de base",
+      "description": "Définissez la devise pivot utilisée pour les rapports et les agrégats multi-devises.",
+      "fields": {
+        "baseCurrency": "Devise de base",
+        "baseCurrencyPlaceholder": "Choisissez une devise",
+        "baseCurrencyHint": "Cette devise est utilisée pour agréger les dons en devises différentes.",
+        "baseCurrencyHintWithName": "{name} utilisera cette devise comme pivot pour les montants convertis."
+      },
+      "actions": {
+        "save": "Enregistrer",
+        "saving": "Enregistrement…"
+      },
+      "success": {
+        "updated": "Devise de base mise à jour."
+      },
+      "errors": {
+        "load": "Impossible de charger les paramètres de devise.",
+        "save": "Erreur lors de la sauvegarde de la devise."
+      },
+      "readOnly": "Seul un administrateur peut modifier la devise."
     }
   },
   "profile": {

--- a/packages/web/src/models/tenant.ts
+++ b/packages/web/src/models/tenant.ts
@@ -1,6 +1,7 @@
+import type { BaseCurrency } from "@givernance/shared/constants";
 import type { Locale } from "@givernance/shared/i18n";
 
-export type TenantCurrency = "EUR" | "GBP" | "CHF";
+export type TenantCurrency = BaseCurrency;
 
 export interface Tenant {
   id: string;

--- a/packages/worker/src/lib/cache-redis.ts
+++ b/packages/worker/src/lib/cache-redis.ts
@@ -1,0 +1,19 @@
+/** Dedicated Redis connection for application-level caching (not BullMQ queues) */
+
+import Redis from "ioredis";
+import { env } from "../env.js";
+
+/**
+ * Separate connection from the BullMQ queue connections — BullMQ requires
+ * `maxRetriesPerRequest: null` which is a BullMQ-internal contract; the
+ * cache connection uses default ioredis settings for clean error propagation.
+ */
+export const cacheRedis = new Redis(env.REDIS_URL);
+
+/** ExchangeRateCache adapter for injection into ExchangeRateService */
+export const exchangeRateRedisCache = {
+  get: (key: string) => cacheRedis.get(key),
+  set: (key: string, value: string, ttlSeconds: number) =>
+    cacheRedis.set(key, value, "EX", ttlSeconds).then(() => undefined),
+  del: (key: string) => cacheRedis.del(key).then(() => undefined),
+};

--- a/packages/worker/src/processors/refresh-exchange-rates.ts
+++ b/packages/worker/src/processors/refresh-exchange-rates.ts
@@ -1,0 +1,79 @@
+/** Job processor — nightly exchange-rate refresh */
+
+import { ExchangeRateService } from "@givernance/shared";
+import { donations, tenants } from "@givernance/shared/schema";
+import type { Job } from "bullmq";
+import { and, eq, gte, ne } from "drizzle-orm";
+import { env } from "../env.js";
+import { exchangeRateRedisCache } from "../lib/cache-redis.js";
+import { db } from "../lib/db.js";
+import { jobLogger } from "../lib/logger.js";
+
+/**
+ * Refresh exchange rates for all (donation_currency, tenant_base_currency)
+ * pairs active in the last 90 days.
+ *
+ * Runs nightly at 02:00 UTC so the DB always has a fresh rate available before
+ * the European business day starts, reducing reliance on the real-time API
+ * fallback during donation processing.
+ *
+ * Error handling: per-pair failures are logged and swallowed — one bad currency
+ * pair should not abort the entire refresh. The job itself succeeds if it
+ * completes iteration.
+ */
+export async function processRefreshExchangeRates(job: Job): Promise<void> {
+  const log = jobLogger({ jobId: job.id, traceId: "exchange-rate-refresh" });
+
+  log.info("exchange_rate.refresh_start");
+
+  // Collect distinct (donation_currency, tenant_base_currency) pairs from
+  // donations in the last 90 days. We join through donations → tenants to get
+  // the tenant's current base currency as the pivot.
+  // NOTE: Once P0 lands and donations gain a `baseCurrencyAtDonation` snapshot
+  // column, this query should switch to that field for historical accuracy.
+  const since = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+  const pairs = await db
+    .selectDistinct({
+      currency: donations.currency,
+      baseCurrency: tenants.baseCurrency,
+    })
+    .from(donations)
+    .innerJoin(tenants, eq(donations.orgId, tenants.id))
+    .where(
+      and(
+        gte(donations.donatedAt, since),
+        ne(donations.currency, tenants.baseCurrency),
+      ),
+    );
+
+  log.info({ pairCount: pairs.length }, "exchange_rate.refresh_pairs_found");
+
+  const exchangeRateService = new ExchangeRateService({
+    apiKey: env.EXCHANGE_RATE_API_KEY,
+    dbClient: db,
+    cache: exchangeRateRedisCache,
+    logger: log,
+  });
+
+  let refreshed = 0;
+  let failed = 0;
+
+  for (const { currency, baseCurrency } of pairs) {
+    try {
+      await exchangeRateService.getRate(currency, baseCurrency);
+      refreshed++;
+    } catch (err) {
+      failed++;
+      log.warn(
+        {
+          currency,
+          baseCurrency,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "exchange_rate.refresh_failed_pair",
+      );
+    }
+  }
+
+  log.info({ refreshed, failed, total: pairs.length }, "exchange_rate.refresh_complete");
+}

--- a/packages/worker/src/processors/stripe-webhook.ts
+++ b/packages/worker/src/processors/stripe-webhook.ts
@@ -15,6 +15,7 @@ import type { Job } from "bullmq";
 import { and, eq, sql } from "drizzle-orm";
 import type Stripe from "stripe";
 import { env } from "../env.js";
+import { exchangeRateRedisCache } from "../lib/cache-redis.js";
 import { db, withWorkerContext } from "../lib/db.js";
 import { jobLogger } from "../lib/logger.js";
 
@@ -137,6 +138,7 @@ async function handlePaymentIntentSucceeded(
   await withWorkerContext(orgId, async (tx) => {
     const exchangeRateService = new ExchangeRateService({
       apiKey: env.EXCHANGE_RATE_API_KEY,
+      cache: exchangeRateRedisCache,
       dbClient: tx,
       logger: log,
     });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1,6 +1,6 @@
 /** BullMQ Worker entry point — registers all job processors */
 
-import { QUEUE_NAMES, TENANT_LIFECYCLE_JOBS } from "@givernance/shared/jobs";
+import { EXCHANGE_RATE_JOBS, QUEUE_NAMES, TENANT_LIFECYCLE_JOBS } from "@givernance/shared/jobs";
 import type { Job } from "bullmq";
 import { Queue, Worker } from "bullmq";
 import Redis from "ioredis";
@@ -12,6 +12,7 @@ import { processGenerateCampaignDocuments } from "./processors/campaign-document
 import { processGdprErasure } from "./processors/gdpr-erasure.js";
 import { processGenerateReceipt } from "./processors/generate-receipt.js";
 import { processPlatformAdminInviteEmail } from "./processors/platform-admin-invite-email.js";
+import { processRefreshExchangeRates } from "./processors/refresh-exchange-rates.js";
 import { processSendBulkEmail } from "./processors/send-bulk-email.js";
 import {
   processSignupVerificationEmail,
@@ -39,6 +40,7 @@ const campaignsQueue = new Queue(QUEUE_NAMES.CAMPAIGNS, { connection: queueConne
 const tenantLifecycleQueue = new Queue(QUEUE_NAMES.TENANT_LIFECYCLE, {
   connection: queueConnection,
 });
+const exchangeRatesQueue = new Queue(QUEUE_NAMES.EXCHANGE_RATES, { connection: queueConnection });
 
 /**
  * Register the nightly provisional-admin expire job.
@@ -58,6 +60,21 @@ async function scheduleRepeatableJobs() {
       removeOnFail: { count: 50 },
     },
   );
+
+  // Nightly exchange-rate refresh at 02:00 UTC — runs before the EU business
+  // day starts. Fixed jobId prevents duplicate schedules across worker restarts.
+  await exchangeRatesQueue.add(
+    EXCHANGE_RATE_JOBS.REFRESH,
+    {},
+    {
+      jobId: "exchange-rates-refresh-nightly",
+      repeat: { pattern: "0 2 * * *", tz: "UTC" },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 50 },
+    },
+  );
+
+  logger.info("Scheduled repeatable job: exchange-rates.refresh (daily 02:00 UTC)");
 }
 
 /**
@@ -228,6 +245,12 @@ function startWorkers() {
     ...defaultJobOpts,
   });
 
+  const exchangeRatesWorker = new Worker(QUEUE_NAMES.EXCHANGE_RATES, processRefreshExchangeRates, {
+    connection: createRedisConnection(),
+    concurrency: 1,
+    ...defaultJobOpts,
+  });
+
   const workers = [
     receiptsWorker,
     emailsWorker,
@@ -236,6 +259,7 @@ function startWorkers() {
     eventsWorker,
     webhooksWorker,
     tenantLifecycleWorker,
+    exchangeRatesWorker,
   ];
 
   for (const w of workers) {


### PR DESCRIPTION
## Contexte

Suite à l'[audit multi-devise du 2026-05-01](https://github.com/purposestack/givernance/issues/230#issuecomment-4359667892), cette PR implémente les **fonctionnalités P1** — robustesse du sous-système FX et améliorations UX demandées dans l'issue.

**Dépend de :** `feat/multi-currency-p0-critical-fixes` (doit être mergée en premier).

Plan de planification complet : `docs/planning/multi-currency-hardening-230.md`

---

## Périmètre

### P1-1 — Job BullMQ CRON `refresh-exchange-rates`

- Nouveau : `packages/worker/src/processors/refresh-exchange-rates.ts`
  - Cron `"0 2 * * *"` UTC
  - Récupère les paires `(donation.currency, tenant.base_currency)` distinctes actives sur 90 jours
  - Appelle `ExchangeRateService.getRate()` par paire, skip les parity (même devise)
  - Aucun throw global — erreurs par paire loguées, reste continue
- `packages/shared/src/jobs/index.ts` : ajouter `EXCHANGE_RATES: "exchange_rates"` à `QUEUE_NAMES`
- `packages/worker/src/worker.ts` : enregistrer la queue et le job repeatable

### P1-2 — Cache Redis pour `ExchangeRateService`

Remplacer `Map` process-local (`exchange-rate-service.ts:39`) par un cache Redis injecté.

- `packages/shared/src/finance/exchange-rate-service.ts` : interface `ExchangeRateCache { get, set, del }` injectable via le constructeur
- `packages/api/src/modules/finance/exchange-rate-service.ts` : injecter le client Redis existant
- `packages/worker/src/services/exchange-rate-service.ts` : idem pour le worker
- Clé : `fx:{src}:{tgt}:{date}` — TTL : 3600s

> Conforme à ADR-013 : le shared package n'importe pas `ioredis` directement.

### P1-3 — Constantes devises unifiées

- Nouveau : `packages/shared/src/constants/currencies.ts`
  - `SUPPORTED_CURRENCIES = ["EUR","GBP","CHF","SEK","NOK","DKK","PLN","CZK"]`
  - `BASE_CURRENCIES` (idem), types `Currency`, `BaseCurrency`
  - `getCurrencySymbol(currency, locale)` via `Intl.NumberFormat.formatToParts`
  - `isSupportedCurrency()`, `isBaseCurrency()`
- `packages/shared/src/validators/index.ts` : consommer `SUPPORTED_CURRENCIES` / `BASE_CURRENCIES` — supprimer les unions inline ; `MULTI_CURRENCY_VALUES` → `@deprecated`, re-export de `BASE_CURRENCIES`

### P1-4 — Migration `0038_allocation_enrichment.sql`

- `donation_allocations` : ajouter `amount_base_cents INTEGER` (nullable), `percentage_bp INTEGER CHECK (BETWEEN 1 AND 10000)` (nullable), rendre `amount_cents` nullable
- Contrainte XOR : `amount_cents IS NOT NULL XOR percentage_bp IS NOT NULL`
- Réécriture trigger `check_allocation_sum` : mode A (amount_cents), mode B (percentage_bp=10000), rejet mixed-mode
- Drizzle schema + validator `DonationAllocationSchema` : exposer `percentageBp` optionnel
- UI `donation-form.tsx` : toggle "montant fixe / pourcentage" par ligne d'allocation

### P1-5 — Boutons "Nouveau don" sur fiches détail

- `packages/web/src/app/(app)/constituents/[id]/page.tsx:358` — `ProfileActions` (gated `donations:write`) : bouton `→ /donations/new?constituentId=:id`
- `packages/web/src/app/(app)/campaigns/[id]/page.tsx` — `DonationBreakdownCard` : bouton `→ /donations/new?campaignId=:id`
- Traductions `fr.json` / `en.json` : clé `actions.newDonation`

### P1-6 — Pré-remplissage `/donations/new?constituentId=X&campaignId=Y`

- `packages/web/src/app/(app)/donations/new/page.tsx` : lire `searchParams`, résoudre `campaign.defaultCurrency`, passer à `<DonationForm initialConstituentId initialCampaignId initialCurrency>`
- `DonationForm` : étendre type `CreateMode` + `buildDefaultValues` + `useEffect` pour charger le constituent

### P1-7 — Composant `<Money>` + migration `formatCurrency` 2-args

- Nouveau : `packages/web/src/components/shared/money.tsx` — résout la devise via `useTenantBaseCurrency()` ou prop `currency` explicite
- Nouveau : `packages/web/src/lib/hooks/use-tenant-base-currency.ts` + `TenantContext`
- Nouveau : `packages/web/src/components/shared/tenant-provider.tsx` — wiring dans `(app)/layout.tsx`
- Migrer les **12+ call-sites** `formatCurrency(cents, locale)` sans 3ème argument vers `<Money cents={…} />`

### P1-8 — Settings → onglet Currency (8 devises)

- `packages/web/src/components/settings/settings-navigation.tsx` : ajouter onglet `currency` → `/settings/currency`
- `packages/web/src/components/settings/tenant-settings-form.tsx:23` : élargir de 3 → 8 devises
- Nouveau : `packages/web/src/app/(app)/settings/currency/page.tsx`
- API : vérifier que `PATCH /v1/tenants/:id` accepte les 8 devises dans `CurrencySchema`

---

## Plan de test — étape par étape

### Prérequis

```bash
pnpm install && pnpm build && pnpm run format && pnpm run lint && pnpm typecheck && pnpm test
```

### Nouveaux tests d'intégration à écrire

**`packages/worker/src/tests/integration/exchange-rate-refresh.test.ts`**
- `it("job repeatable enregistré au boot avec le bon cron pattern")`
- `it("processRefreshExchangeRates upsert les taux pour toutes les paires distinctes actives")`
- `it("skip les paires EUR/EUR (parity)")`
- `it("fallback gracieux si l'API externe est down")`
- `it("ré-exécution = upsert, pas de duplication de rows")`

**`packages/api/src/tests/integration/exchange-rate-redis-cache.test.ts`**
- `it("2ème appel dans le TTL = hit cache Redis, 0 appel externe")`
- `it("paires différentes ne partagent pas le cache")`
- `it("expiration TTL → nouvel appel externe")`
- `it("écriture Redis en échec → lookup continue sans crash")`

**`packages/api/src/tests/integration/donations-prefill.test.ts`**
- `it("GET /v1/constituents/:id retourne le constituent pour le pré-remplissage")`
- `it("GET /v1/campaigns/:id retourne la campagne + defaultCurrency")`
- `it("POST /v1/donations avec constituentId+campaignId → don lié aux deux")`
- `it("constituentId d'un autre tenant → 404 (RLS)")`

**`packages/web/src/components/shared/money.test.tsx`**
- `it("1234 cents EUR fr locale → '12,34 €'")`
- `it("CHF → 'CHF 9.99'")`
- `it("GBP → '£5.00'")`
- `it("0 cents → '0,00 €'")`
- `it("valeur négative (remboursement) → affiche le signe moins")`
- `it("applique classe font-mono par défaut")`
- `it("formatCurrency 2-args sans currency = EUR silencieux — deprecated")`
- `it("currency=undefined résout depuis useTenantBaseCurrency")`

**`packages/api/src/tests/integration/settings-currency.test.ts`**
- `it("GET /v1/tenants/settings retourne baseCurrency")`
- `it("PATCH baseCurrency='CHF' → 200, persisté")`
- `it("PATCH baseCurrency='JPY' → 400 (hors liste)")`
- `it("PATCH baseCurrency='eur' (minuscule) → 400")`
- `it("PATCH viewer → 403")`
- `it("PATCH user → 403")`
- `it("changement baseCurrency ne modifie pas les amount_base_cents existants")`
- `it("8 devises sont toutes acceptées — test paramétrique")`

### Tests manuels

**T-P1-1 : Job CRON refresh-exchange-rates**
1. Démarrer le worker : `pnpm --filter @givernance/worker dev`
2. Logs boot → confirmation `Scheduled repeatable job: exchange-rates.refresh`
3. Bull Board (ou `redis-cli HGETALL "bull:exchange-rates:repeat:..."`) → job visible avec cron `0 2 * * *`
4. Déclencher manuellement via Bull Board ou script de test
5. `SELECT * FROM exchange_rates WHERE date = CURRENT_DATE ORDER BY currency` → rows présentes
6. ✅ Pass si job enregistré et rows de taux créées pour aujourd'hui

**T-P1-2 : Cache Redis — 1 seul appel externe par TTL**
1. `redis-cli KEYS "fx:*" | xargs redis-cli DEL` (vider le cache)
2. Créer 2 dons back-to-back en GBP pour un org base-EUR (< 1 seconde d'écart)
3. Logs API : 1er don `source: 'api'`, 2ème `source: 'api_cache'`
4. `redis-cli GET "fx:GBP:EUR:$(date +%F)"` → valeur non vide
5. ✅ Pass si seul 1 appel externe visible dans les logs pour les 2 dons

**T-P1-3 : Bouton "Nouveau don" sur fiche Constituent**
1. Aller sur `/constituents/:id`
2. Localiser le bouton "Nouveau don" (près de Edit, Merge, etc.)
3. Cliquer → URL `/donations/new?constituentId=:id`
4. Champ Constituent pré-rempli avec le nom du constituent
5. Champ non modifiable (readonly ou disabled)
6. Remplir montant + soumettre
7. Don visible dans l'onglet Donations de la fiche constituent
8. ✅ Pass si pré-remplissage correct et don lié

**T-P1-4 : Bouton "Nouveau don" sur fiche Campaign**
1. Aller sur `/campaigns/:id`
2. Localiser le bouton "Nouveau don" dans la card Donations
3. Cliquer → URL `/donations/new?campaignId=:id`
4. Champ Campaign pré-rempli + devise = `campaign.defaultCurrency`
5. Soumettre → don visible dans la card Donations de la campagne
6. ✅ Pass si pré-remplissage correct (campaign + devise) et don lié

**T-P1-5 : Dual pré-remplissage `/donations/new?constituentId=X&campaignId=Y`**
1. Naviguer vers `/donations/new?constituentId=C1_ID&campaignId=CAM1_ID`
2. Constituent = C1 (nom affiché, champ non modifiable)
3. Campaign = CAM1 (nom affiché)
4. Devise = `CAM1.defaultCurrency`
5. Soumettre → `SELECT constituent_id, campaign_id FROM donations ORDER BY created_at DESC LIMIT 1`
6. ✅ Pass si les 2 FK correctement persistées

**T-P1-6 : Composant `<Money>` — aucun appel `formatCurrency` 2-args**
1. `grep -r "formatCurrency" packages/web/src --include="*.tsx" --include="*.ts"` → 0 appel sans 3ème argument
2. Dashboard : "Total levé" avec bon symbole devise
3. Liste dons : chaque montant avec sa devise propre
4. Changer la locale du navigateur → format change (fr: `1 234,56 €`, en: `€1,234.56`)
5. ✅ Pass si grep = 0 résultats à 2 args, UI correcte multi-locale

**T-P1-7 : Settings → onglet Currency (8 devises)**
1. Aller sur `/settings`
2. Onglet "Devise" visible dans la navigation settings
3. Sélecteur de devise affiche exactement 8 options : EUR, GBP, CHF, SEK, NOK, DKK, PLN, CZK
4. Aucune autre devise (ex. JPY, USD) dans la liste
5. Sélectionner `PLN` → Sauvegarder → toast succès
6. Recharger → `PLN` toujours sélectionné
7. Se connecter en `viewer` → sélecteur disabled ou bouton Save absent
8. ✅ Pass si exactement 8 options, persistance OK, viewer bloqué

**T-P1-8 : Allocations en pourcentage**
1. Créer un nouveau don via `/donations/new`
2. Ajouter 2 lignes d'allocation
3. Activer le mode "pourcentage" sur chaque ligne
4. Saisir 60% sur Fund A, 40% sur Fund B → total = 100%
5. Essayer 60% + 50% → erreur de validation avant soumission
6. Soumettre le don avec 60/40 → vérifier `percentage_bp = 6000 / 4000` en DB
7. ✅ Pass si le toggle %, la validation, et la persistance fonctionnent

### Régressions à vérifier

- [ ] Worker boot sans erreur avec la nouvelle queue `exchange_rates`
- [ ] `exchange-rate-service.test.ts` — 5 tests passent avec la couche Redis injectée (tests utilisent Map par défaut)
- [ ] `stripe-webhook.test.ts` — 9 tests passent inchangés
- [ ] `donations.test.ts:142-176` — EUR→CHF inchangé
- [ ] `receipt-processor.test.ts` — génération reçus inchangée
- [ ] `donations.test.ts` — trigger `check_allocation_sum` : tests existants avec `amount_cents` passent (mode A du trigger reécrit)
- [ ] `pnpm typecheck` — `MULTI_CURRENCY_VALUES @deprecated`, pas d'erreur de type

---

## Architecture References

- **ADR-013** : type boundary — `ExchangeRateCache` interface dans shared, implémentation Redis dans api/worker
- **ADR-011** : `NEXT_PUBLIC_API_URL` pour le client Next.js server-side

## Liens

- Audit : relates to #230
- Plan : `docs/planning/multi-currency-hardening-230.md`
- P0 (prérequis) : `feat/multi-currency-p0-critical-fixes`
- P2 (suite) : `feat/multi-currency-p2-governance-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)