### PR TITLE
fix(migrate-staging-postgres): merge duplicate env block in open-pr job

### DIFF
--- a/.github/workflows/migrate-staging-postgres.yml
+++ b/.github/workflows/migrate-staging-postgres.yml
@@ -311,6 +311,7 @@ jobs:
         env:
           TARGET: ${{ needs.migrate.outputs.target_version }}
           SRC: ${{ needs.migrate.outputs.src_version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           BRANCH="chore/staging-pg${TARGET}-accessory-bump-${GITHUB_RUN_ID}"
@@ -389,8 +390,6 @@ jobs:
             --head "$BRANCH" \
             --title "chore(staging): bump postgres accessory to PG ${TARGET} (post-migration)" \
             --body-file "$PR_BODY"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clean up branch on failure
         if: failure() || cancelled()


### PR DESCRIPTION
## Why

Dispatching \`migrate-staging-postgres.yml\` immediately after merging #280 fails at the GitHub API:

\`\`\`
HTTP 422: Invalid Argument - failed to parse workflow:
(Line: 392, Col: 9): 'env' is already defined
\`\`\`

The \`Apply postgres image bump on a fresh branch\` step in the \`open-pr\` job had two \`env:\` keys at the same step level — one before \`run:\` (\`TARGET\`/\`SRC\`) and one after (\`GH_TOKEN\`). GitHub's workflow parser is stricter than local \`yq\` and rejects this.

## Fix

Merged \`GH_TOKEN\` into the single \`env:\` block alongside \`TARGET\`/\`SRC\`. One line removed, one line added; no logic change.

## Why a separate PR (not amending #280)

#280 was already squash-merged. This is a one-line YAML hygiene fix surfaced only at dispatch time — not catchable by CI's biome/typecheck/test lanes, and \`yq -P\` parses it cleanly so my pre-push validation missed it. Branching from current main per the project's "branch from main" rule.

## Acceptance

- [ ] CI green (the gate runs unchanged on this PR)
- [ ] Post-merge: \`gh workflow run migrate-staging-postgres.yml -f mode=rehearsal -f target_version=17 -f confirm=MIGRATE-PG-STAGING\` actually creates a dispatch event without the 422

🤖 Surfaced while dispatching the cutover from #280; ADR-026 cutover continues after this lands.