### PR TITLE
fix(migrate-staging-postgres): add GITHUB_TOKEN to migrate job env

### DIFF
--- a/.github/workflows/migrate-staging-postgres.yml
+++ b/.github/workflows/migrate-staging-postgres.yml
@@ -79,6 +79,13 @@ jobs:
       # config/deploy-staging.yml's ERB template reads STAGING_VPS_IP
       # from the runner env — same convention as deploy-staging.yml.
       STAGING_VPS_IP: ${{ secrets.VPS_IP }}
+      # `setup-kamal-secrets` composite action runs with `set -u` and
+      # writes `GITHUB_TOKEN=${GITHUB_TOKEN}` into `.kamal/secrets` so
+      # Kamal can pull the ghcr.io-hosted Keycloak image. Without this
+      # job-env, the composite action fails with `GITHUB_TOKEN: unbound
+      # variable` before any migration phase runs. Same pattern as
+      # `deploy-staging.yml`.
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
       src_version: ${{ steps.read-state.outputs.src_version }}


### PR DESCRIPTION
## Why

Second YAML hygiene bug surfaced when dispatching the rehearsal workflow ([run 25507709787](https://github.com/purposestack/givernance/actions/runs/25507709787)). The \`Setup Kamal Secrets\` step failed with:

\`\`\`
GITHUB_TOKEN: unbound variable
\`\`\`

The \`setup-kamal-secrets\` composite action runs under \`set -u\` and references \`\${GITHUB_TOKEN}\` to write \`GITHUB_TOKEN=…\` into \`.kamal/secrets\` — Kamal needs it for the ghcr.io-hosted Keycloak image pull on staging.

\`deploy-staging.yml:44\` provides \`GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}\` at the job level. My migrate workflow's job-env block was missing it (dropped during the workflow split when I narrowed permissions to \`contents: read\`).

## Fix

Add \`GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}\` to the migrate job's \`env:\` block. Same pattern as deploy-staging. \`contents: read\` permission is unaffected — the token is read-only at that scope.

## Acceptance

- [ ] CI green (compliance gate runs unchanged)
- [ ] Post-merge: \`gh workflow run migrate-staging-postgres.yml -f mode=rehearsal …\` reaches the \`PRE\` phase

🤖 Surfaced while resuming the ADR-026 cutover after #309 landed.