### PR TITLE
fix(staging-workflows): share concurrency group across all VPS-touching flows

### DIFF
--- a/.github/workflows/migrate-staging-postgres.yml
+++ b/.github/workflows/migrate-staging-postgres.yml
@@ -51,12 +51,19 @@ on:
         type: string
         required: true
 
-# No concurrent migrations, ever. Two parallel runs against the same VPS
-# would stomp each other's rotated datadir / dump / accessory boot.
-# `cancel-in-progress: false` keeps the in-flight run safe even if a
-# second dispatch lands.
+# Share the `deploy-staging` concurrency group with `deploy-staging.yml`
+# and `staging-accessory-reboot.yml`. All three workflows acquire the same
+# Kamal lock on the VPS at some point — a routine deploy mid-`kamal deploy`
+# colliding with `kamal accessory boot postgres` from this workflow's `cut`
+# phase would cause lock contention and unpredictable retries. Serialising
+# at the GitHub-Actions level removes that race.
+#
+# `cancel-in-progress: false` keeps an in-flight migration safe from being
+# cancelled by a routine push to main, and vice versa — every workflow in
+# this group can take many minutes and aborting mid-flight would leave
+# staging in a half-state.
 concurrency:
-  group: migrate-staging-postgres
+  group: deploy-staging
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Why

Three workflows acquire the same staging VPS Kamal lock at some point:

- [\`deploy-staging.yml\`](.github/workflows/deploy-staging.yml) — every push to \`main\` + manual dispatch
- [\`staging-accessory-reboot.yml\`](.github/workflows/staging-accessory-reboot.yml) — out-of-band accessory env / image rotation
- [\`migrate-staging-postgres.yml\`](.github/workflows/migrate-staging-postgres.yml) — Postgres major-version cutover (added in #280)

\`staging-accessory-reboot.yml\` already declares its job-level concurrency in the shared \`deploy-staging\` group ([line 47](.github/workflows/staging-accessory-reboot.yml#L47), with a comment explaining the rationale). \`migrate-staging-postgres.yml\` shipped with a private \`migrate-staging-postgres\` group — meaning GitHub Actions would NOT serialise it against deploys or reboots, even though they all eventually fight for the same Kamal lock on the VPS.

Surfaced this morning while running through the ADR-026 cutover: the operator had to manually wait for the post-merge \`deploy-staging\` run to complete before dispatching \`migrate-staging-postgres\` in rehearsal mode. With this fix, GitHub Actions queues the dispatch automatically — no operator timing judgment.

## Fix

Single-file change: \`migrate-staging-postgres.yml\` joins the existing \`deploy-staging\` concurrency group. Comment updated to name all three workflows that share it.

\`cancel-in-progress: false\` retained — every workflow in this group can take many minutes and aborting mid-flight would leave staging in a half-state.

## Why \`group: deploy-staging\` and not a renamed-for-clarity group

The name is mildly misleading (it's now used by deploy + reboot + migrate, not just deploy), but renaming would mean editing all three workflows just for clarity. The comment already explains the convention. Worth following up if a fourth VPS-touching workflow ever lands; not worth doing today.

## Acceptance

- [ ] CI green
- [ ] Post-merge: dispatching \`migrate-staging-postgres.yml\` while \`deploy-staging.yml\` is in progress shows the migrate run as \`queued\` (not \`in_progress\`) until deploy completes

🤖 Surfaced during the ADR-026 cutover.