### PR TITLE
debug(migrate-staging-postgres): add set -x to trace silent failure

### DIFF
--- a/scripts/migrate-staging-postgres.sh
+++ b/scripts/migrate-staging-postgres.sh
@@ -43,6 +43,13 @@
 
 set -euo pipefail
 
+# Trace every command to stderr. The first end-to-end CI run of this
+# script (PR #280 cutover) failed with no captured output, even though
+# `set -e` should propagate any error to the runner. Tracing makes the
+# failing line visible regardless of whether the failing command itself
+# prints. Remove this line once CI has had a clean run.
+set -x
+
 PHASE="${1:-}"
 TARGET_VERSION="${2:-}"
 


### PR DESCRIPTION
## Why

Previous rehearsal dispatch ([run 25508579953](https://github.com/purposestack/givernance/actions/runs/25508579953/job/74861225654)) failed with exit code 1 in 5 seconds. **Zero captured stdout/stderr** from the migrate script.

`set -e` should propagate errors but the runner log shows neither `bundle exec kamal server exec` errors nor the script's own `echo "could not detect..." >&2` fallback. The artifact upload step's "No files were found" warning confirms `pre` exits before writing anything.

## Fix

Adds `set -x` to `scripts/migrate-staging-postgres.sh`. Every command echoes to stderr before execution; the first traced line that doesn't appear identifies the silent failure.

## Disposition

**Temporary.** Remove once a clean rehearsal run identifies the root cause.