### PR TITLE
fix(migrate-staging-postgres): strip ANSI escape codes in clean_kamal_output

### DIFF
--- a/scripts/migrate-staging-postgres.sh
+++ b/scripts/migrate-staging-postgres.sh
@@ -96,19 +96,34 @@ fi
 
 mkdir -p "$WORKDIR"
 
-# Run a command on the VPS host shell. Kamal pipes stdout faithfully, which
-# lets us capture the output of `docker inspect` / `cat <file>` etc.
+# Run a command on the VPS host shell. Kamal pipes stdout to us, but it
+# colorises everything (ANSI escape codes around per-host headers and
+# command output) — `clean_kamal_output` below strips those so callers
+# can compare the result as a clean scalar.
 vps_exec() {
   bundle exec kamal server exec -c "$KAMAL_CONFIG" "$1"
 }
 
-# Strip kamal's status-line prefix ("App Host: <ip>") and trailing whitespace
-# so callers can use the result as a clean scalar. NOTE: this strips ALL
-# whitespace via tr — only safe for values that don't contain legitimate
-# internal whitespace (versions, byte counts, container names, single-token
-# paths).
+# Strip ANSI escape codes, kamal's "App Host: <ip>" header line, and
+# trailing whitespace so callers can use the result as a clean scalar.
+#
+# Kamal wraps each line with CSI codes (e.g. `\e[33m...\e[0m` for yellow
+# warnings, `\e[34m  App Host: 185.186.76.104\e[0m` for the per-host
+# header). Our previous version only stripped whitespace, so when
+# `awk 'NF { line=$0 }'` picked "the last non-empty line", that line was
+# often a bare `\e[0m` reset code — yielding a non-numeric scalar that
+# tripped the next `[ -gt ]` comparison silently under `set -e`.
+#
+# Strip ANSI escapes FIRST, then awk picks the actual last data line,
+# then tr removes residual whitespace. NOTE: still only safe for values
+# that don't contain legitimate internal whitespace (versions, byte
+# counts, container names, single-token paths).
 clean_kamal_output() {
-  awk 'NF { line=$0 } END { sub(/^App Host:[[:space:]]*[0-9.]+[[:space:]]*/, "", line); print line }' \
+  # ANSI CSI sequences: \e[ <params> <final byte 0x40-0x7E>. The common
+  # ones we hit are SGR (color) endings in [mGKHJ]; the broader range
+  # below is defensive against future kamal output additions.
+  sed -E $'s/\x1b\\[[0-9;]*[A-Za-z]//g' \
+    | awk 'NF { line=$0 } END { sub(/^[[:space:]]*App Host:[[:space:]]*[0-9.]+[[:space:]]*/, "", line); print line }' \
     | tr -d '[:space:]'
 }
 


### PR DESCRIPTION
## Root cause (found via #312's `set -x` trace)

[Run 25509172819](https://github.com/purposestack/givernance/actions/runs/25509172819/job/74863601634) traced this:

```
++ bundle exec kamal server exec -c config/deploy-staging.yml '...'
++ clean_kamal_output
++ awk 'NF { line=$0 } END { ... print line }'
++ tr -d '[:space:]'
+ SRC_VERSION='[0m'
##[error]Process completed with exit code 1.
```

`bundle exec kamal server exec` colorises everything: per-host headers (`\e[34m  App Host: 185.186.76.104\e[0m`) AND command-output values (`\e[33m16\e[0m`). The previous `clean_kamal_output` only stripped **whitespace** via `tr -d '[:space:]'`, so when awk picked "the last non-empty line", that line was the trailing bare `\e[0m` reset code. `SRC_VERSION` ended up as the literal escape character + `[0m`, and `set -e + pipefail` fired silently on the next operation.

## Fix

Prepend a `sed` filter that strips ANSI CSI sequences (`\e[<params><final-byte>`) **before** awk:

```bash
clean_kamal_output() {
  sed -E $'s/\x1b\\[[0-9;]*[A-Za-z]//g' \
    | awk 'NF { line=$0 } END { sub(/^[[:space:]]*App Host:[[:space:]]*[0-9.]+[[:space:]]*/, "", line); print line }' \
    | tr -d '[:space:]'
}
```

Unit-tested locally: simulated `\e[34m  App Host: ...\e[0m\n\e[33m16\e[0m` → cleaned = `16`. ✅

## Why not just use `--no-color`

Kamal's `server exec` doesn't expose a flag to disable color. SSHKit (which kamal uses) auto-detects TTY and tries to add color even on non-TTY runners.

## Followups (deferred)

- `set -x` debug trace from #312 is still in place; one more clean rehearsal run and I'll remove it in a separate cleanup PR.
- The same ANSI-stripping issue could exist in `scripts/rehearse-pg-restore.sh` and other future scripts. Worth extracting `clean_kamal_output` into `scripts/lib/kamal.sh` once we hit it a second time.

## Acceptance

- [ ] CI green
- [ ] Post-merge: re-dispatch rehearsal, observe `SRC_VERSION=16` in trace, full pre/cut/verify completes