### PR TITLE
fix(migrate-staging-postgres): add -d postgres to server_version detection psql call

### DIFF
--- a/scripts/migrate-staging-postgres.sh
+++ b/scripts/migrate-staging-postgres.sh
@@ -244,7 +244,16 @@ wait_for_pg_ready() {
 
 case "$PHASE" in
   pre)
-    SRC_VERSION=$(vps_exec "docker exec ${CONTAINER_NAME} psql -U ${PG_USER} -tAc \"SELECT (current_setting('server_version_num')::int / 10000)\"" \
+    # Connect to the `postgres` bootstrap DB (always exists on every
+    # cluster) to read `server_version_num` — that GUC is cluster-wide,
+    # so any DB works. We can't use `${APP_DB}` here either: a fresh
+    # cluster after the cut hasn't created it yet (only the bootstrap
+    # `postgres` DB exists until the dump's `CREATE DATABASE` runs).
+    # Without the explicit `-d`, psql defaults to a DB named after the
+    # user (`givernance`), which doesn't exist on staging — `${APP_DB}`
+    # is `givernance_staging`. That mismatch is why the previous
+    # rehearsal failed with `FATAL: database "givernance" does not exist`.
+    SRC_VERSION=$(vps_exec "docker exec ${CONTAINER_NAME} psql -U ${PG_USER} -d postgres -tAc \"SELECT (current_setting('server_version_num')::int / 10000)\"" \
       | clean_kamal_output)
     if [ -z "$SRC_VERSION" ]; then
       echo "could not detect source PG major from ${CONTAINER_NAME}" >&2


### PR DESCRIPTION
## Root cause (revealed by #312's `set -x` trace + #313's ANSI strip)

[Run 25509618985](https://github.com/purposestack/givernance/actions/runs/25509618985/job/74865238872) traced this:

```
+ SRC_VERSION='...stderr:psql:error:...FATAL:database"givernance"doesnotexist'
```

Decoded: `psql: error: ... FATAL: database "givernance" does not exist`.

Cause: `psql -U givernance` with no `-d` flag defaults to a database named after the user. Staging's actual app DB is `givernance_staging` per `config/deploy-staging.yml:172` (`POSTGRES_DB: givernance_staging`). Every other `psql` call in the script has `-d ${APP_DB}` explicit; this one slipped past.

(I hit the exact same gotcha during my ad-hoc check earlier in the cutover session and forgot to apply the lesson to the script.)

## Fix

Use `-d postgres` for `current_setting('server_version_num')` — that GUC is cluster-wide, any DB works. Choosing `postgres` rather than `${APP_DB}` so the same query works on a fresh post-cut cluster too (where `${APP_DB}` hasn't been created yet).

## Acceptance

- [ ] CI green
- [ ] Post-merge: re-dispatch rehearsal, observe `+ SRC_VERSION=16` in trace, full rehearsal completes
