### PR TITLE
fix(migrate-staging-postgres): query lc_collate/lc_ctype from pg_database (not SHOW)

### DIFF
--- a/scripts/migrate-staging-postgres.sh
+++ b/scripts/migrate-staging-postgres.sh
@@ -287,8 +287,14 @@ case "$PHASE" in
     # all read via the bootstrap superuser, which bypasses RLS — that's
     # intentional, we want the actual catalog state, not a tenant view.
     echo "Capturing source-side encoding / locale / policy / extension state"
-    SRC_LC_COLLATE=$(vps_exec "docker exec ${CONTAINER_NAME} psql -U ${PG_USER} -d ${APP_DB} -tAc 'SHOW lc_collate'" | clean_kamal_output)
-    SRC_LC_CTYPE=$(vps_exec "docker exec ${CONTAINER_NAME} psql -U ${PG_USER} -d ${APP_DB} -tAc 'SHOW lc_ctype'" | clean_kamal_output)
+    # `lc_collate` and `lc_ctype` are NOT runtime GUCs — they're per-database
+    # properties set at CREATE DATABASE time and stored in pg_database. PG 16
+    # returns `ERROR: unrecognized configuration parameter "lc_collate"` for
+    # `SHOW lc_collate`. Query pg_database directly. `server_encoding` IS a
+    # GUC (read-only, derived from the connected DB's encoding), so SHOW
+    # works for it — kept for consistency with PG documentation.
+    SRC_LC_COLLATE=$(vps_exec "docker exec ${CONTAINER_NAME} psql -U ${PG_USER} -d ${APP_DB} -tAc \"SELECT datcollate FROM pg_database WHERE datname = current_database()\"" | clean_kamal_output)
+    SRC_LC_CTYPE=$(vps_exec "docker exec ${CONTAINER_NAME} psql -U ${PG_USER} -d ${APP_DB} -tAc \"SELECT datctype FROM pg_database WHERE datname = current_database()\"" | clean_kamal_output)
     SRC_ENCODING=$(vps_exec "docker exec ${CONTAINER_NAME} psql -U ${PG_USER} -d ${APP_DB} -tAc 'SHOW server_encoding'" | clean_kamal_output)
     SRC_POLICY_COUNT=$(vps_exec "docker exec ${CONTAINER_NAME} psql -U ${PG_USER} -d ${APP_DB} -tAc \"SELECT count(*) FROM pg_policies WHERE schemaname='public'\"" | clean_kamal_output)
     SRC_EXTENSION_COUNT=$(vps_exec "docker exec ${CONTAINER_NAME} psql -U ${PG_USER} -d ${APP_DB} -tAc \"SELECT count(*) FROM pg_extension WHERE extname IN ('pg_trgm')\"" | clean_kamal_output)


### PR DESCRIPTION
## Root cause (next layer revealed by trace)

[Run 25510068577](https://github.com/purposestack/givernance/actions/runs/25510068577/job/74866852652) cleared `SRC_VERSION=16` ✅ (#314 fix worked) and `BIND_PATH=/root/givernance-postgres/data/postgres` ✅, then died on:

```
SRC_LC_COLLATE='...stderr:ERROR:unrecognizedconfigurationparameter"lc_collate"'
```

`lc_collate` and `lc_ctype` are **not runtime GUCs** — they're per-database properties set at `CREATE DATABASE` time and stored in `pg_database`. PG 16 rejects `SHOW` for them. `server_encoding` IS a runtime GUC so `SHOW` works for it.

## Fix

```sql
-- Before
SHOW lc_collate
SHOW lc_ctype
-- After
SELECT datcollate FROM pg_database WHERE datname = current_database()
SELECT datctype   FROM pg_database WHERE datname = current_database()
```

`SHOW server_encoding` retained — it's a real GUC.

## Acceptance

- [ ] CI green
- [ ] Post-merge: re-dispatch rehearsal, full `pre` phase completes through `pg_dumpall` and the rehearse-restore step
