### PR TITLE
fix(migrate-staging-postgres): use scp for dump pull (not kamal server exec)

### DIFF
--- a/scripts/migrate-staging-postgres.sh
+++ b/scripts/migrate-staging-postgres.sh
@@ -342,9 +342,22 @@ case "$PHASE" in
     echo "Remote dump size: ${REMOTE_BYTES} bytes"
 
     echo "Pulling dump back to runner → ${LOCAL_DUMP}"
-    bundle exec kamal server exec -c "$KAMAL_CONFIG" "cat ${REMOTE_DUMP}" \
-      | sed -E '1s/^App Host:[[:space:]]*[0-9.]+[[:space:]]*//' \
-      > "${LOCAL_DUMP}"
+    # Use scp (not `kamal server exec "cat ..."`) so the local file is
+    # raw bytes, not contaminated with kamal's status output. Kamal
+    # interleaves "Running '...' on <host>..." / "Finished '...' on
+    # <host>" lines in its stdout — the previous version stripped only
+    # the leading "App Host:" prefix and let the rest through, which
+    # produced an invalid SQL file (psql halted on "syntax error at
+    # or near 'Running'"). The SSH agent + STAGING_VPS_IP are already
+    # set up by the workflow's setup-kamal-secrets / ssh-agent steps.
+    if [ -z "${STAGING_VPS_IP:-}" ]; then
+      echo "STAGING_VPS_IP env var not set — workflow must export it" >&2
+      exit 1
+    fi
+    scp -o StrictHostKeyChecking=accept-new \
+        -o UserKnownHostsFile=/dev/null \
+        -o LogLevel=ERROR \
+        "root@${STAGING_VPS_IP}:${REMOTE_DUMP}" "${LOCAL_DUMP}"
 
     LOCAL_BYTES=$(wc -c < "${LOCAL_DUMP}" | tr -d '[:space:]')
     if [ -z "$LOCAL_BYTES" ] || [ "$LOCAL_BYTES" -lt 1000 ]; then


### PR DESCRIPTION
## Root cause (we got REALLY far this time)

[Run 25510638321](https://github.com/purposestack/givernance/actions/runs/25510638321/job/74868157948) cleared the entire `pre` phase, booted the ephemeral PG 17 container in the rehearse step, then died on:

```
psql:/tmp/restore.sql:11: ERROR: syntax error at or near "Running"
LINE 1: Running 'cat /root/migrate-pg16-to-17-...sql' on 185.186.76.104...
```

The dump file isn't pure SQL — `kamal server exec "cat $REMOTE_DUMP"` interleaves status lines like:

```
App Host: 185.186.76.104
Running 'cat /root/migrate-pg16-to-17-...sql' on 185.186.76.104...
<actual SQL content>
Finished 'cat ...' on 185.186.76.104
```

Previous version stripped only the leading `App Host:` prefix on line 1; the `Running '...'` / `Finished '...'` status lines survived. psql halted on the first non-SQL line.

## Fix

Replace the kamal-cat-pipe-sed pipeline with `scp`:

```bash
scp -o StrictHostKeyChecking=accept-new \
    -o UserKnownHostsFile=/dev/null \
    -o LogLevel=ERROR \
    "root@${STAGING_VPS_IP}:${REMOTE_DUMP}" "${LOCAL_DUMP}"
```

Raw bytes, no kamal formatting, no ANSI codes, no status headers. The SSH agent + STAGING_VPS_IP are already wired by `setup-kamal-secrets` + `webfactory/ssh-agent` in the workflow.

Added an explicit `STAGING_VPS_IP` guard so a future invocation without it gets a clear error.

## Why not also rewrite the value-capture vps_exec calls?

We could replace ALL `kamal server exec` with raw `ssh root@$VPS …` to dodge the entire output-formatting class of bugs. Tempting but risky to bundle into this PR — every call would need re-testing. The remaining `vps_exec` callers capture single short scalars where the ANSI strip + `awk 'last non-empty line'` works in practice (proven by this run reaching the rehearse step). File-content transfers — only one of those — needed scp.

If output-parsing bugs continue surfacing, a follow-up PR can extract a `vps_exec_raw` helper that uses ssh directly.

## Acceptance

- [ ] CI green
- [ ] Post-merge: re-dispatch rehearsal, full `pre` + rehearse-restore both complete; counts match source state
