### PR TITLE
chore(staging): bump postgres accessory to PG 17 (post-migration)

### DIFF
--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -182,14 +182,12 @@ builder:
 # Use accessories for external services
 accessories:
   postgres:
-    # Pinned to PG 16 until `migrate-staging-postgres` workflow has run
-    # against the live VPS (it dumps the PG 16 datadir, rotates it aside,
-    # and restores into PG 17). Bumping this in advance would make the
-    # auto-deploy on this PR's merge boot a PG 17 container against a
-    # PG 16 datadir → "FATAL: incompatible". The migrate workflow opens
-    # a follow-up PR to bump this line once the cutover succeeds. See
-    # ADR-026.
-    image: postgres:16
+    # Major version anchored to Scaleway Managed PostgreSQL EU's ceiling
+    # via `infra/compliance-versions.yml` (ADR-026). Cutover from PG 16
+    # to PG 17 ran via `migrate-staging-postgres.yml` on 2026-05-07
+    # (run 25511200127); this line aligns the checked-in config with
+    # the running PG 17 accessory.
+    image: postgres:17
     host: <%= ENV["STAGING_VPS_IP"] %>
     port: 5432
     env:


### PR DESCRIPTION
Aligns `config/deploy-staging.yml` with the live staging Postgres major after a successful migration via [`migrate-staging-postgres.yml`](https://github.com/purposestack/givernance/actions/runs/25511200127) on 2026-05-07.

## What changed

- `config/deploy-staging.yml`: `accessories.postgres.image` bumped from `postgres:16` to `postgres:17`
- Replaces the now-obsolete "Pinned to PG 16 until …" comment (the two-stage rollout described there has completed) with a short pointer to ADR-026 and the run ID

## Why this is a separate PR (not the cutover PR #280)

Per [ADR-026](docs/15-infra-adr.md#adr-026), the cutover PR landed dev/CI on PG 17 and the manifest+gate, but left staging on PG 16 so that PR's auto-deploy didn't try to boot PG 17 against the existing PG 16 datadir.

## Why this PR is opened by hand (not by the workflow's `open-pr` job)

The workflow's `open-pr` job ([job 74870701031](https://github.com/purposestack/givernance/actions/runs/25511200127/job/74870701031)) failed on a separate workflow bug:

1. `actions/upload-artifact@v4` defaults `include-hidden-files: false`. Our `path: .migrate-staging-postgres/*.sql` starts with a dot, so the upload silently matched zero files (logged as `##[warning] No files were found`, no artifact created).
2. `open-pr`'s `download-artifact` step then failed hard on `Artifact not found`. The download was actually redundant — `SRC` and `TARGET` are already passed via `needs.migrate.outputs.*`, so the artifact was never needed at runtime.

The `migrate` job itself was green; staging is healthy on PG 17. Filing the workflow fix as a separate small PR.

## What's been verified on staging post-cutover

From the live run's `verify` phase (job 74870132295):

| Check | Source (PG 16) | Target (PG 17) | Status |
|---|---|---|---|
| `pg_policies` (public) | 23 | 23 | matches ✅ |
| `pg_trgm` extension | 1 | 1 | matches ✅ |
| Keycloak `databasechangelog` (in `givernance_staging`) | 187 | 187 | matches ✅ |
| `givernance_staging.users` | 8 | 8 | rows |
| `givernance_staging.tenants` | 3 | 3 | rows |
| `givernance_staging.donations` | 43,110 | 43,110 | rows |
| `givernance_staging.audit_logs` | 104 | 104 | rows |
| `https://api.staging.givernance.org/healthz` | — | 200 | passed |
| Keycloak OIDC discovery | — | 200 | passed |

## Manual acceptance checklist

**Reality vs. config**
- [x] `ssh givernance-staging 'docker inspect givernance-postgres --format "{{ .Config.Image }}"'` → `postgres:17` (verified pre-merge from the run)
- [ ] After merge: `kamal accessory details postgres -c config/deploy-staging.yml` reports `postgres:17` (kamal setup post-merge will be a no-op for the accessory since image already matches)

**Live behaviour** (verified at the workflow's `verify` step; re-confirm after merge)
- [ ] `https://api.staging.givernance.org/healthz` returns 200
- [ ] `https://auth.staging.givernance.org/realms/givernance/.well-known/openid-configuration` returns 200
- [ ] Sign in to `https://staging.givernance.org` as the seeded NPO admin and confirm RLS still works
- [ ] Create a test donation; verify the receipt PDF + audit-log entry land

**Operational hygiene**
- [ ] Rotated PG 16 datadir is on the VPS for ~7 days as rollback insurance — confirm `ssh givernance-staging 'ls /root/givernance-postgres/data/'` shows the timestamped `data-pg16-...` directory
- [ ] Pre-flight snapshot from earlier (`/root/preflight-pg-bind-20260507T153234Z.tar.gz` + `.sql`) is also on the VPS as second-line insurance
- [ ] Followup workflow-fix PR opens (separately) for `include-hidden-files: true` + remove redundant `download-artifact` step

**Policy hygiene**
- [x] `infra/compliance-versions.yml` has `postgres.max_major: 17` — gate accepts this bump

🤖 Opened by hand because the workflow's `open-pr` job failed on a separate artifact-upload bug; staging is healthy regardless.
