### PR TITLE
chore(deps): add 7/14-day Dependabot cooldown across all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,26 @@ version: 2
 # `applies-to: version-updates` key on every group confines grouping to the
 # routine update flow and excludes Dependabot security updates. See:
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot-yml-file#groups
+#
+# `cooldown` blocks force every routine bump to soak in the wild before
+# Dependabot opens a PR — 14 days for majors (where breaking-change
+# blast-radius lives, e.g. archiver 7→8 going pure-ESM and breaking the
+# postal-export worker on the same day the version was tagged on npm),
+# 7 days for minor/patch (long enough to surface most regressions without
+# starving CVE coverage). Cooldown is per-ecosystem block — Dependabot's
+# parser does not honour YAML anchors, so the block is repeated by hand.
+# Cooldown applies to *version* updates only; Dependabot security updates
+# (CVE-driven) bypass cooldown entirely and ship same-day, which is the
+# whole point of the split.
 updates:
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
     open-pull-requests-limit: 10
     groups:
       minor-and-patch:
@@ -22,6 +37,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
     groups:
       actions:
         applies-to: version-updates
@@ -50,6 +69,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
     ignore:
       - dependency-name: node
         update-types:
@@ -59,11 +82,19 @@ updates:
     directory: /infra/keycloak
     schedule:
       interval: weekly
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
 
   - package-ecosystem: docker
     directory: /packages/api
     schedule:
       interval: weekly
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
     ignore:
       - dependency-name: node
         update-types:
@@ -73,6 +104,10 @@ updates:
     directory: /packages/worker
     schedule:
       interval: weekly
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
     ignore:
       - dependency-name: node
         update-types:
@@ -90,6 +125,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
     # Compliance-anchored dependencies (postgres, redis) are NOT ignored
     # here on purpose: Dependabot still opens major-bump PRs so the CVE
     # feed and upstream-release visibility stay intact. The


### PR DESCRIPTION
## Summary

Adds a tiered [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--) block to every Dependabot ecosystem so routine version bumps must soak upstream before a PR is opened:

- **14 days** for `semver-major` — where the breaking-change blast-radius actually lives.
- **7 days** for `semver-minor` and `semver-patch` — long enough to surface most regressions without starving routine maintenance.

**Security updates are unaffected.** Dependabot's `cooldown` only applies to *version updates*; CVE-driven security updates bypass cooldown entirely and continue to ship same-day. The split is the whole point — slow the routine churn, keep the CVE feed fast.

## Why now

Concrete trigger: #330 bumped `archiver` 7.0.1 → 8.0.0 on 2026-05-08, the same day 8.0.0 was tagged on npm. archiver 8 went pure-ESM, which broke the postal-export worker (Epic #274) on import — five integration tests failed with `TypeError: default is not a function` at [`packages/worker/src/processors/postal-export.ts:386`](https://github.com/purposestack/givernance/blob/main/packages/worker/src/processors/postal-export.ts#L386). A 14-day major-cooldown would have held that PR until the upstream regression had time to surface, sparing a CI run and a review cycle.

Same shape as the existing weekly schedule + grouped minor/patch policy: bias the routine pipeline toward signal, keep the security pipeline fast.

## Implementation note

`cooldown` is **per-`updates:` block**, not global, and Dependabot's parser does **not** honour YAML anchors — the same three-line stanza is repeated across all 7 ecosystems (npm, github-actions, four docker entries, docker-compose). That's verbose but it's the only way the parser accepts it.

## Out of scope (intentional)

- **Existing open Dependabot PRs are not retroactively closed.** `cooldown` only governs *future* PR creation. #330 (broken archiver bump) will be closed manually; #329 (minor/patch group, opened the same minute) is left as-is — it would have passed the new policy too.
- **No `include`/`exclude` carve-outs.** If a specific dependency ever needs a faster lane (e.g., a tool we co-own), we'll add it surgically; defaulting closed is safer.

## Manual acceptance checklist

- [ ] Lint: `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` returns clean (already verified locally).
- [ ] After merge, confirm Dependabot's next scheduled run honours the cooldown by checking that no PR opens for any package whose latest release is < 7 days old (no live test until next Monday).
- [ ] #330 closed with a comment pointing here.

## Risk

Lowest-blast-radius config change. `.github/dependabot.yml` only affects PR-creation cadence — no runtime, no CI, no production path touches this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)