### PR TITLE
chore(staging-redis): enforce auth, drop public host port, wrapper-script the requirepass

### DIFF
--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -240,9 +240,19 @@ accessories:
     # but no password is set on the 'default' user"). Setting requirepass
     # here makes every connection require the password from the bag, which
     # `setup-kamal-secrets` already wires into REDIS_URL for every app.
-    # `$REDIS_PASSWORD` is expanded by docker's implicit `/bin/sh -c` since
-    # `cmd:` is a string scalar.
-    cmd: redis-server --requirepass "$REDIS_PASSWORD"
+    #
+    # Array form (NOT a string scalar) is load-bearing: kamal serialises a
+    # string-form `cmd:` such that `$REDIS_PASSWORD` gets shell-expanded on
+    # the GH Actions runner — where REDIS_PASSWORD is NOT exported (only
+    # POSTGRES_PASSWORD lands in runner env via `setup-kamal-secrets`) — so
+    # the literal `$REDIS_PASSWORD` resolves to empty BEFORE reaching docker
+    # and Redis ends up booting with `--requirepass ""` (== no auth).
+    # Passing an array delegates to docker's exec form, the inner `sh -c`
+    # then runs INSIDE the container where REDIS_PASSWORD IS in env.
+    cmd:
+      - sh
+      - -c
+      - exec redis-server --requirepass "$REDIS_PASSWORD"
     directories:
       - data/redis:/data
   minio:

--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -224,7 +224,25 @@ accessories:
   redis:
     image: redis:8
     host: <%= ENV["STAGING_VPS_IP"] %>
-    port: 6379
+    # No `port:` publishing — Redis is reachable only on the internal `kamal`
+    # Docker network at `givernance-redis:6379`. Closes the public 0.0.0.0:6379
+    # exposure that combined with an empty `requirepass` let any internet-side
+    # actor read/write BullMQ queues + session cache. App services
+    # (api/web/worker/relay) keep reaching Redis via the kamal network with
+    # no change. Operator access via `docker exec givernance-redis redis-cli`
+    # over SSH, or a sidecar container on the kamal network — RedisInsight /
+    # Beekeeper need either of those paths now (no host port to tunnel to).
+    env:
+      secret:
+        - REDIS_PASSWORD
+    # Enforce authentication. Redis 8's default startup has `requirepass`
+    # empty, so AUTH commands are accepted-then-ignored ("Client sent AUTH,
+    # but no password is set on the 'default' user"). Setting requirepass
+    # here makes every connection require the password from the bag, which
+    # `setup-kamal-secrets` already wires into REDIS_URL for every app.
+    # `$REDIS_PASSWORD` is expanded by docker's implicit `/bin/sh -c` since
+    # `cmd:` is a string scalar.
+    cmd: redis-server --requirepass "$REDIS_PASSWORD"
     directories:
       - data/redis:/data
   minio:

--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -235,24 +235,24 @@ accessories:
     env:
       secret:
         - REDIS_PASSWORD
+    files:
+      # Boot wrapper that invokes `redis-server --requirepass "$REDIS_PASSWORD"`
+      # from INSIDE the container, where REDIS_PASSWORD is in env. We can't
+      # put that string directly in `cmd:` below because kamal serialises a
+      # string-form cmd in a way that shell-expands `$REDIS_PASSWORD` on the
+      # GH Actions runner first (where the var is NOT set), turning it into
+      # `--requirepass ""`. Array-form cmd would dodge that, but kamal
+      # rejects it for accessories (`should be a string` ConfigurationError).
+      # See `infra/redis/start.sh` and the issue-#283 follow-up PR for the
+      # full debug trace.
+      - infra/redis/start.sh:/usr/local/bin/start-redis.sh
     # Enforce authentication. Redis 8's default startup has `requirepass`
     # empty, so AUTH commands are accepted-then-ignored ("Client sent AUTH,
-    # but no password is set on the 'default' user"). Setting requirepass
-    # here makes every connection require the password from the bag, which
-    # `setup-kamal-secrets` already wires into REDIS_URL for every app.
-    #
-    # Array form (NOT a string scalar) is load-bearing: kamal serialises a
-    # string-form `cmd:` such that `$REDIS_PASSWORD` gets shell-expanded on
-    # the GH Actions runner — where REDIS_PASSWORD is NOT exported (only
-    # POSTGRES_PASSWORD lands in runner env via `setup-kamal-secrets`) — so
-    # the literal `$REDIS_PASSWORD` resolves to empty BEFORE reaching docker
-    # and Redis ends up booting with `--requirepass ""` (== no auth).
-    # Passing an array delegates to docker's exec form, the inner `sh -c`
-    # then runs INSIDE the container where REDIS_PASSWORD IS in env.
-    cmd:
-      - sh
-      - -c
-      - exec redis-server --requirepass "$REDIS_PASSWORD"
+    # but no password is set on the 'default' user"). The wrapper script
+    # mounted above sets `--requirepass` from `$REDIS_PASSWORD` (sourced from
+    # `.kamal/secrets` via the `env.secret` block) and `exec`s redis-server
+    # so it ends up as PID 1.
+    cmd: sh /usr/local/bin/start-redis.sh
     directories:
       - data/redis:/data
   minio:

--- a/infra/redis/start.sh
+++ b/infra/redis/start.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Boot wrapper for the staging Redis accessory (Kamal — config/deploy-staging.yml).
+#
+# Why a wrapper instead of putting `redis-server --requirepass "$REDIS_PASSWORD"`
+# directly in `cmd:` of deploy-staging.yml: kamal serialises a string-form `cmd:`
+# such that any `$VAR` reference gets shell-expanded on the GH Actions runner
+# BEFORE reaching docker. REDIS_PASSWORD is only injected into `.kamal/secrets`
+# (i.e. into the container's env), never into the runner's shell — so the
+# literal `$REDIS_PASSWORD` resolves to empty on the runner side and Redis
+# boots with `--requirepass ""` (effectively unauthenticated). We discovered
+# this on 2026-05-10 during the issue-#283-follow-up redis hardening; see the
+# PR description for the full debug trace.
+#
+# Array-form `cmd:` would route through docker's exec form and dodge the
+# runner-side expansion, but kamal explicitly rejects it for accessories
+# (`accessories/redis/cmd: should be a string` ConfigurationError).
+#
+# This script is mounted via `accessories.redis.files:` and invoked as
+# `sh /usr/local/bin/start-redis.sh` from the kamal config — the env var
+# `REDIS_PASSWORD` is supplied by `accessories.redis.env.secret:` which
+# resolves it from `.kamal/secrets` at boot time, INSIDE the container,
+# where the expansion below works correctly.
+
+set -eu
+
+if [ -z "${REDIS_PASSWORD:-}" ]; then
+  echo "[start-redis] REDIS_PASSWORD is empty — refusing to boot Redis without auth." >&2
+  echo "[start-redis] Check accessories.redis.env.secret in config/deploy-staging.yml." >&2
+  exit 1
+fi
+
+# `exec` makes redis-server PID 1 (proper signal handling for SIGTERM stop).
+exec redis-server --requirepass "$REDIS_PASSWORD"


### PR DESCRIPTION
Brings staging Redis into a non-embarrassing security posture. Discovered during the issue #283 cutover that staging Redis was running with **no `requirepass`** AND **published on `0.0.0.0:6379`** — i.e., anyone on the internet who knew the staging VPS IP could read/write the BullMQ queues + session cache anonymously.

## What changed

1. **`requirepass` is now enforced** via `infra/redis/start.sh` (a boot wrapper mounted as `/usr/local/bin/start-redis.sh` via the redis accessory's `files:` block). The script `exec`s `redis-server --requirepass "$REDIS_PASSWORD"` from the container's env.
2. **`port: 6379` removed** from the redis accessory — Redis is no longer published to the VPS host. App services (api / web / worker / relay) keep reaching it via the kamal Docker network at `givernance-redis:6379`. Operator access via `docker exec givernance-redis redis-cli` over SSH, or a sidecar container on the kamal network (RedisInsight / Beekeeper need either of those paths now — no host port to tunnel to).
3. **`env.secret: - REDIS_PASSWORD` added** to the redis accessory so the `.kamal/secrets` bag entry actually reaches the container's env (the previous config had no `env:` block at all, so the bag's `REDIS_PASSWORD` was unused on the redis side — apps' AUTH commands were sent into the void).

## Pre-PR rotation already done

- Generated a fresh URL-safe (hex) `REDIS_PASSWORD` and saved it to the `staging` GitHub Environment + 1Password (`Givernance · Staging` → `Redis`) before pushing this branch. Apps got the new value via the `mode=deploy` workflow run that landed before the redis accessory reboot.
- Live state confirmed:
  - `redis-cli PING` (anonymous) → `NOAUTH Authentication required` ✓
  - `redis-cli -a <password> PING` → `PONG` ✓
  - `CONFIG GET requirepass` returns the rotated value ✓
  - `docker ps --filter name=givernance-redis --format '{{.Ports}}'` → `6379/tcp` (no `0.0.0.0:6379->6379/tcp`) ✓
  - `https://api.staging.givernance.org/healthz` / `auth.staging OIDC` / `staging /login` → 200 / 200 / 200

## Why a wrapper script and not just `cmd: redis-server --requirepass "$REDIS_PASSWORD"`

The branch's [first attempt](https://github.com/purposestack/givernance/pull/_/commits/a896636) tried exactly that string-form `cmd:`. Result: Redis booted with `--requirepass ""` (literal empty string), confirmed by `docker inspect givernance-redis --format '{{.Config.Cmd}}'` returning `[redis-server --requirepass ]`. **Why?** Kamal serialises a string-form `cmd:` such that `$VAR` references get shell-expanded **on the GH Actions runner** before reaching docker. `REDIS_PASSWORD` is only injected into `.kamal/secrets` (consumed by kamal at boot to build the container's env), never into the runner's shell — so the literal `$REDIS_PASSWORD` resolved to the empty string before docker even saw it.

The branch's [second attempt](https://github.com/purposestack/givernance/pull/_/commits/5975502) tried array-form `cmd: ["sh","-c", …]`, which would dodge runner-side expansion by routing through docker's exec form. Kamal explicitly rejects this for accessories: `accessories/redis/cmd: should be a string` (`Kamal::ConfigurationError`).

The [final approach](https://github.com/purposestack/givernance/pull/_/commits/fdf9031) — wrapper script mounted via `files:`, invoked from a string-form `cmd:` that has no `$VAR` references — sidesteps both. The script reads `$REDIS_PASSWORD` at runtime **inside the container** and refuses to boot if it's empty (defense in depth). The full debug trace is in the script's header comment + the YAML comments + the commit messages on this branch — kept verbose because this is exactly the kind of footgun that re-bites in 6 months.

## Pre-merge acceptance checklist

**Smoke (live cluster after this PR's branch was reboot-applied — should still hold)**
- [ ] `curl -sI https://api.staging.givernance.org/healthz` → 200
- [ ] `curl -sI https://auth.staging.givernance.org/realms/givernance/.well-known/openid-configuration` → 200
- [ ] `curl -sI https://staging.givernance.org/login` → 200/302/307
- [ ] Sign in to `https://staging.givernance.org/login` and confirm the dashboard renders (BullMQ + sessions are healthy)

**Redis-side verification (via SSH)**
- [ ] `ssh givernance-staging "docker exec givernance-redis redis-cli PING"` → `NOAUTH Authentication required` (anonymous fails)
- [ ] `ssh givernance-staging "docker exec givernance-redis redis-cli -a '<REDIS_PASSWORD>' --no-auth-warning PING"` → `PONG` (auth works)
- [ ] `ssh givernance-staging "docker ps --filter name=givernance-redis --format '{{.Ports}}'"` → `6379/tcp` (no `0.0.0.0:` prefix; no host-port mapping)

**Config + script**
- [ ] `yq -r '.accessories.redis.env.secret[]' config/deploy-staging.yml` → `REDIS_PASSWORD`
- [ ] `yq -r '.accessories.redis.files[]' config/deploy-staging.yml` → `infra/redis/start.sh:/usr/local/bin/start-redis.sh`
- [ ] `yq -r '.accessories.redis.cmd' config/deploy-staging.yml` → `sh /usr/local/bin/start-redis.sh`
- [ ] `yq -r '.accessories.redis | has("port")' config/deploy-staging.yml` → `false`
- [ ] `infra/redis/start.sh` is mode 0755 (executable) — verify with `ls -la infra/redis/start.sh`
- [ ] `gh secret list --env staging --repo purposestack/givernance | grep REDIS_PASSWORD` shows the secret is set

**After merge**
- [ ] The post-merge `deploy-staging` run is green (rebuilds `.kamal/secrets` from GH staging-env, runs `kamal setup` if config diff detected — both idempotent against the already-running redis accessory at the matching env)
- [ ] No regressions in BullMQ throughput / session lifetime (this is essentially a credential-only change for the apps; nothing else moves)

## Out of scope (still pending — separate hygiene audit)

The remaining staging fallbacks in `setup-kamal-secrets/action.yml` that are likely still load-bearing:

- `KEYCLOAK_ADMIN_PASSWORD` (= `staging_keycloak_123`) — confirmed during issue #283 cutover
- `MINIO_ROOT_PASSWORD` / `MINIO_KMS_SECRET_KEY` / `SESSION_SECRET` / `IMPERSONATION_JWT_SECRET` / `KEYCLOAK_ADMIN_CLIENT_SECRET` — assumed similar pattern; verify by `docker inspect <accessory>` env grep

Plus network-side hardening:
- Postgres on `0.0.0.0:5432` — strong password is in place but should narrow to kamal-network-only
- Mailpit / MinIO host-port mappings — audit similar to redis above

These are **not** blockers for this PR; will file as a single hygiene-audit issue after this lands.

## Source-of-truth chain for `REDIS_PASSWORD`

- 1Password vault `Givernance · Staging` → `Redis` (canonical)
- GitHub Environments → staging → Environment secrets (`REDIS_PASSWORD`, set 2026-05-10 09:30 UTC)
- `.kamal/secrets` (rebuilt every CI run by `setup-kamal-secrets` from the GH secret)
- Container env (read at boot time by `infra/redis/start.sh`)

🤖 Generated alongside Claude Code while triaging the Redis hygiene findings from issue #283. See the script header + YAML comments for the full debug trace.