### PR TITLE
fix(ci): shorten infra/version-skew label description to fit 100-char cap

### DIFF
--- a/.github/workflows/check-staging-version-skew.yml
+++ b/.github/workflows/check-staging-version-skew.yml
@@ -338,7 +338,7 @@ jobs:
         run: |
           gh label create infra/version-skew \
             --color B60205 \
-            --description "Staging accessory's running major has drifted from the dev/CI pin (auto-managed by check-staging-version-skew.yml)" \
+            --description "Staging accessory drifted from dev/CI pin (managed by check-staging-version-skew.yml)" \
             --force
 
       # Drift detected: open a new issue, or rewrite the body of every


### PR DESCRIPTION
The `Ensure infra/version-skew label exists` step in [`check-staging-version-skew.yml`](https://github.com/purposestack/givernance/blob/main/.github/workflows/check-staging-version-skew.yml) was failing with:

\`\`\`
HTTP 422: Validation Failed (https://api.github.com/repos/purposestack/givernance/labels)
description is too long (maximum is 100 characters)
\`\`\`

(see [run 25625680340](https://github.com/purposestack/givernance/actions/runs/25625680340/job/75220289084)). The label description was 114 chars; GitHub caps at 100. The whole workflow then exited 1 even on green-drift runs.

## Fix

Trim the description from 114 → 85 chars:

| Before | After |
|---|---|
| \`Staging accessory's running major has drifted from the dev/CI pin (auto-managed by check-staging-version-skew.yml)\` | \`Staging accessory drifted from dev/CI pin (managed by check-staging-version-skew.yml)\` |

Drops the redundant "running major has" + "auto-" qualifiers; keeps the audit-managed-by hint that points future readers at the workflow file.

## Pre-merge acceptance

- [ ] On merge, the next scheduled run of \`check-staging-version-skew.yml\` (or the next push to staging-config paths) gets past the \`Ensure label exists\` step
- [ ] The label \`infra/version-skew\` ends up at the new description (visible at \`Settings → Labels\` or via \`gh label list --search infra/version-skew\`)

## Origin

Bug landed in #281 (scheduled skew-detection). Surfaced 2026-05-10 on the first scheduled run since the staging cluster's redis cutover (PR #338).

🤖 Spotted while watching the post-merge deploy of PR #338.