### PR TITLE
fix(setup-kamal-secrets): URL-encode passwords in DATABASE_URL / REDIS_URL

### DIFF
--- a/.github/actions/setup-kamal-secrets/action.yml
+++ b/.github/actions/setup-kamal-secrets/action.yml
@@ -81,6 +81,19 @@ runs:
           exit 1
         fi
 
+        # URL-encode passwords before interpolating them into URIs (issue #335).
+        # `pg-connection-string` (used by drizzle-kit AND `pg.Pool`) and
+        # `ioredis` parse the URI strictly: any `/`, `?`, `#`, `@`, `:`, `+`,
+        # `=`, `[`, `]` in the password segment splits the URL at the wrong
+        # boundary. Discovered the hard way during the issue #283 staging
+        # cutover when `openssl rand -base64 24` produced a `/`-containing
+        # POSTGRES_PASSWORD and drizzle-kit migrate exit 1'd silently with
+        # `applying migrations…` (the underlying `TypeError: Invalid URL`
+        # got swallowed). `jq -sRr @uri` is RFC 3986 percent-encoding;
+        # available on every GH Actions runner via the standard image.
+        PG_PASS_ENC=$(printf '%s' "$PG_PASS" | jq -sRr @uri)
+        REDIS_PASS_ENC=$(printf '%s' "$REDIS_PASS" | jq -sRr @uri)
+
         cat <<EOF > .kamal/secrets
         GITHUB_TOKEN=${GITHUB_TOKEN}
         POSTGRES_PASSWORD=$PG_PASS
@@ -90,9 +103,9 @@ runs:
         KEYCLOAK_ADMIN_PASSWORD=$KC_PASS
         SESSION_SECRET=$SESSION_SEC
         KC_DB_PASSWORD=$KEYCLOAK_DB_PASS
-        DATABASE_URL=postgres://givernance:$PG_PASS@givernance-postgres:5432/givernance_staging
-        DATABASE_URL_APP=postgres://givernance:$PG_PASS@givernance-postgres:5432/givernance_staging
-        REDIS_URL=redis://:$REDIS_PASS@givernance-redis:6379
+        DATABASE_URL=postgres://givernance:$PG_PASS_ENC@givernance-postgres:5432/givernance_staging
+        DATABASE_URL_APP=postgres://givernance:$PG_PASS_ENC@givernance-postgres:5432/givernance_staging
+        REDIS_URL=redis://:$REDIS_PASS_ENC@givernance-redis:6379
         S3_SECRET_ACCESS_KEY=$MINIO_PASS
         KEYCLOAK_ADMIN_CLIENT_SECRET=$KC_CLIENT_SECRET
         RESEND_API_KEY=$RESEND_KEY


### PR DESCRIPTION
Fixes the latent bug surfaced during the 2026-05-10 issue #283 staging cutover: `setup-kamal-secrets/action.yml` constructs `DATABASE_URL`, `DATABASE_URL_APP`, and `REDIS_URL` by raw string concatenation, so any URI-special character in the password segment (`/`, `?`, `#`, `@`, `:`, `+`, `=`, `[`, `]`) splits the URL at the wrong boundary when `pg-connection-string` / `ioredis` parses it.

Closes #335.

## How the bug manifested

Initial POSTGRES_PASSWORD rotation used `openssl rand -base64 24`, which produced `p8Fb6ezFDr6LsBE13G9/1n02PZEpcKeO`. The `/` made:

```
DATABASE_URL=postgres://givernance:p8Fb6ezFDr6LsBE13G9/1n02PZEpcKeO@givernance-postgres:5432/givernance_staging
```

…parse as `path = /1n02PZEpcKeO@givernance-postgres:5432/givernance_staging` (or similar, depending on the parser). `pg-connection-string` throws `TypeError: Invalid URL` at `new URL(...)` time, **before** any connection attempt.

`drizzle-kit migrate` swallowed the stderr and exited 1 with `applying migrations…` as the last visible output. Took two failed deploys before `node -e "new (require('pg')).Pool({connectionString: process.env.DATABASE_URL})"` surfaced the actual error.

Workaround at the time was to re-rotate to `openssl rand -hex 24` (URL-safe charset by construction). That's what's currently running. This PR removes the need for the workaround going forward.

## Fix

Pipe each password through `jq -sRr @uri` (RFC 3986 percent-encoding) before interpolating:

\`\`\`bash
PG_PASS_ENC=$(printf '%s' "$PG_PASS" | jq -sRr @uri)
REDIS_PASS_ENC=$(printf '%s' "$REDIS_PASS" | jq -sRr @uri)
# then use $PG_PASS_ENC / $REDIS_PASS_ENC in DATABASE_URL / REDIS_URL
\`\`\`

`jq` is available on every standard GitHub Actions runner image — no install step needed.

## Why only PG and Redis (not the other secrets)

Only these three values are interpolated into URIs:
- `DATABASE_URL`, `DATABASE_URL_APP` (`postgres://user:$PG_PASS@…`)
- `REDIS_URL` (`redis://:$REDIS_PASS@…`)

Other entries (`POSTGRES_PASSWORD`, `KC_DB_PASSWORD`, `MINIO_KMS_SECRET_KEY`, etc.) are written to `.kamal/secrets` as bare key=value pairs and consumed as env vars by their respective services — no URI parsing involved. `S3_SECRET_ACCESS_KEY` is a separate AWS-SDK header, not a URI segment.

`KEYCLOAK_ADMIN_CLIENT_SECRET` lives in URLs constructed by the api's KC client at runtime, but those URLs use `application/x-www-form-urlencoded` form bodies (where the secret is a body field, not a URI segment) — not affected.

## No regression for current values

Hex passwords (which is what's currently running for POSTGRES_PASSWORD and REDIS_PASSWORD after the #340 audit) become no-ops through `@uri` — the charset `[0-9a-f]` is unchanged by percent-encoding.

\`\`\`
$ printf '%s' "c8c2a73fab44e81af6fdec54eeb5aee158131768e743d62a" | jq -sRr @uri
c8c2a73fab44e81af6fdec54eeb5aee158131768e743d62a    # ← unchanged

$ printf '%s' "p8Fb6ezFDr6LsBE13G9/1n02PZEpcKeO" | jq -sRr @uri
p8Fb6ezFDr6LsBE13G9%2F1n02PZEpcKeO    # ← / encoded as %2F
\`\`\`

## Pre-merge acceptance

- [ ] On merge, the post-merge `deploy-staging` run is green (the rebuilt `.kamal/secrets` has the now-percent-encoded URIs; `pg-connection-string` accepts both unencoded and percent-encoded values, so existing hex passwords keep working)
- [ ] Optional sanity test (after merge): rotate a low-blast-radius secret like `RESEND_API_KEY` to a value containing a `/` and confirm the deploy still goes green (the URI construction code path doesn't touch RESEND_API_KEY, but proves the broader hardening posture)

## Out of scope

- The runbook (`docs/runbooks/migrate-staging-keycloak-db.md`) recommends `openssl rand -base64 24` in the pre-flight. With this PR, the recommendation can drop the strict-charset constraint — but hex is still the simpler default. Tracked in #340's post-mortem follow-up; trivial PR can land later.
- Drop the `:-staging_X_123` fallbacks from this same composite action so a missing GH staging-env secret fails fast at deploy time instead of silently using a known-public default. Now that #340's audit confirmed every fallback has been rotated off, this is the natural next step. Will file as a follow-up issue.