### PR TITLE
chore(setup-kamal-secrets): drop staging dev fallbacks + add prod launch runbook

### DIFF
--- a/.github/actions/setup-kamal-secrets/action.yml
+++ b/.github/actions/setup-kamal-secrets/action.yml
@@ -21,17 +21,27 @@ runs:
         set -euo pipefail
         mkdir -p .kamal
 
-        # Apply non-load-bearing fallbacks for staging-only credentials so
-        # a fresh fork or accidentally-deleted secret doesn't block the
-        # deploy. These match the values the local docker-compose stack
-        # uses; production must override every one of them via a real
-        # secret.
-        PG_PASS="${POSTGRES_PASSWORD:-staging_postgres_123}"
-        REDIS_PASS="${REDIS_PASSWORD:-staging_redis_123}"
-        MINIO_PASS="${MINIO_ROOT_PASSWORD:-staging_minio_123}"
-        KC_PASS="${KEYCLOAK_ADMIN_PASSWORD:-staging_keycloak_123}"
-        KC_CLIENT_SECRET="${KEYCLOAK_ADMIN_CLIENT_SECRET:-staging_keycloak_client_secret_123}"
-        SESSION_SEC="${SESSION_SECRET:-staging_session_secret_123}"
+        # Every secret below is required — `:?` aborts the step with a
+        # clear error if the matching GH-Environment secret is unset
+        # (issue #343). The previous `:-staging_X_123` fallbacks were a
+        # foot-gun: they were committed in plaintext, framed as "non-
+        # load-bearing", and turned out to be load-bearing on the
+        # 2026-05-10 hygiene audit (#340). Now a missing secret fails
+        # at deploy time with a clear pointer instead of silently
+        # rebooting onto a known-public default.
+        #
+        # Adding a new caller (e.g. a future production environment, see
+        # `docs/runbooks/launch-prod.md`)? Every name listed here must
+        # exist in that environment's secret bag, generated via
+        # `openssl rand -hex 24` (URL-safe by construction; #335 fix
+        # makes other charsets work too but hex stays the recommendation).
+        # Fork-developer setup steps live in `docs/dev/staging-secrets-setup.md`.
+        PG_PASS="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required — set it in Settings → Environments → staging → Secrets. See docs/dev/staging-secrets-setup.md.}"
+        REDIS_PASS="${REDIS_PASSWORD:?REDIS_PASSWORD is required — set it in Settings → Environments → staging → Secrets. See docs/dev/staging-secrets-setup.md.}"
+        MINIO_PASS="${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required — set it in Settings → Environments → staging → Secrets. See docs/dev/staging-secrets-setup.md.}"
+        KC_PASS="${KEYCLOAK_ADMIN_PASSWORD:?KEYCLOAK_ADMIN_PASSWORD is required — set it in Settings → Environments → staging → Secrets. See docs/dev/staging-secrets-setup.md.}"
+        KC_CLIENT_SECRET="${KEYCLOAK_ADMIN_CLIENT_SECRET:?KEYCLOAK_ADMIN_CLIENT_SECRET is required — set it in Settings → Environments → staging → Secrets. See docs/dev/staging-secrets-setup.md.}"
+        SESSION_SEC="${SESSION_SECRET:?SESSION_SECRET is required — set it in Settings → Environments → staging → Secrets. See docs/dev/staging-secrets-setup.md.}"
         # Resend API key — required because deploy-staging.yml sets
         # EMAIL_PROVIDER=resend; missing key crashes the worker on first
         # send. No fallback: an unset secret here is a deploy bug.
@@ -46,10 +56,8 @@ runs:
         # check in packages/api/src/env.ts requires this be present and
         # ≥32 chars — without it the api container exits 1 on boot, which
         # was the regression from 1e49f8e that took staging down on every
-        # push to main. Staging fallback is non-load-bearing, exactly 32
-        # ASCII chars (HS256 doesn't care about charset). Production must
-        # override; rotate by setting the GH secret and redeploying.
-        IMPERSONATION_JWT="${IMPERSONATION_JWT_SECRET:-staging_impersonation_jwt_secret_32}"
+        # push to main.
+        IMPERSONATION_JWT="${IMPERSONATION_JWT_SECRET:?IMPERSONATION_JWT_SECRET is required — set it in Settings → Environments → staging → Secrets. See docs/dev/staging-secrets-setup.md.}"
         # Keycloak's dedicated DB role password (ADR-017). Wired into:
         #   - the postgres accessory's init script on first cluster init
         #     (provisions the `keycloak` role + `givernance_keycloak` DB —
@@ -59,20 +67,16 @@ runs:
         #     `KC_DB_USERNAME` flips from `givernance` (bootstrap superuser
         #     used by the legacy co-located KC) to `keycloak` (least-priv
         #     role owning only the KC DB).
-        # Until that cutover lands, this value is unused at runtime — the
-        # live keycloak accessory still authenticates via POSTGRES_PASSWORD
-        # through KC_DB_PASSWORD below. Staging fallback non-load-bearing;
-        # production must override via `gh secret set KEYCLOAK_DB_PASSWORD
-        # --env staging` (matched to the value the operator generates +
-        # records during the runbook).
-        KEYCLOAK_DB_PASS="${KEYCLOAK_DB_PASSWORD:-staging_keycloak_db_123}"
+        # After PR #336 cutover (2026-05-10), staging keycloak runs as
+        # the dedicated `keycloak` role with this password.
+        KEYCLOAK_DB_PASS="${KEYCLOAK_DB_PASSWORD:?KEYCLOAK_DB_PASSWORD is required — set it in Settings → Environments → staging → Secrets. See docs/dev/staging-secrets-setup.md.}"
         # MinIO server-side AES256 encryption key. Format
         # `<key-name>:<base64-32-byte-secret>`; generate with
-        # `openssl rand -base64 32`. The base64 portion MUST decode to
-        # *exactly* 32 bytes — the validation step below enforces this so
-        # a future maintainer who edits the fallback can't silently
-        # reproduce the 2026-04-29 outage (issue #211).
-        MINIO_KMS="${MINIO_KMS_SECRET_KEY:-staging-kms:p3wiREaVf4VXPFYGTbdyrk5kVzqCrd9jEpw1EgEl/Qg=}"
+        # `openssl rand -base64 32` and prefix with `<keyname>:`. The
+        # base64 portion MUST decode to exactly 32 bytes — the validation
+        # step below enforces this; the 2026-04-29 outage (#211) was
+        # caused by a wrong-length value masquerading as valid.
+        MINIO_KMS="${MINIO_KMS_SECRET_KEY:?MINIO_KMS_SECRET_KEY is required — set it in Settings → Environments → staging → Secrets. Format: <key-name>:<base64-32-byte-secret>. See docs/dev/staging-secrets-setup.md.}"
 
         KMS_BASE64="${MINIO_KMS#*:}"
         KMS_LEN=$(printf '%s' "$KMS_BASE64" | base64 -d 2>/dev/null | wc -c | tr -d ' ')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,9 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── 23-postal-campaigns.md      — Postal campaigns + QR reconciliation (Epic #274): user flow, domain, readiness gates, attribution
 │   ├── 24-branding-assets.md       — Organisation branding (Epic #286): logo upload, sharp variants, bucket topology, Keycloak sync, PDF embedding
 │   ├── adrs/                       — Individual ADR files (incl. ADR-023 bucket topology, ADR-024 image pipeline, ADR-025 PDF code boundary)
-│   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283); each file is plan + live journal + post-mortem
+│   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283; launch-prod.md for the production-environment launch — issue #344); each file is plan + live journal + post-mortem
+│   ├── dev/
+│   │   └── staging-secrets-setup.md — Reference for fork developers + the prod-launch runbook: every GH-Environment secret the deploy needs, how to generate it, how to rotate it (#343)
 │   ├── vision/
 │   │   └── conversational-mode.md — Future conversational AI mode (2026-2028)
 │   ├── security/                  — Security audits & RBAC matrices (non-numbered, dated; e.g. rbac-audit-2026-04-27.md)

--- a/docs/dev/staging-secrets-setup.md
+++ b/docs/dev/staging-secrets-setup.md
@@ -1,0 +1,100 @@
+# Setting up the staging GitHub Environment secret bag
+
+Reference for fork developers and for the production-launch runbook ([`docs/runbooks/launch-prod.md`](../runbooks/launch-prod.md)).
+
+> **Why this exists.** [`.github/actions/setup-kamal-secrets/action.yml`](../../.github/actions/setup-kamal-secrets/action.yml) is the single source of truth for the secret bag every staging deploy + accessory reboot consumes (`deploy-staging.yml`, `staging-accessory-reboot.yml`, `migrate-staging-postgres.yml`). Until #340/#343 it had `:-staging_X_123` fallbacks committed in plaintext for every secret, which were load-bearing in practice and showed up in container envs ([#340](https://github.com/purposestack/givernance/issues/340) audit). Since #343 (2026-05-10) the action requires every secret listed below; missing any one fails the deploy at the `Setup Kamal Secrets` step with a clear error pointing here.
+
+## Required secrets
+
+Set every entry in **Settings → Environments → staging → Environment secrets** (NOT repo-level secrets, NOT environment variables).
+
+| Secret name | Generate via | Used by | Notes |
+|---|---|---|---|
+| `POSTGRES_PASSWORD` | `openssl rand -hex 24` | bootstrap-superuser pw for the postgres accessory; runtime auth for api / web / worker / relay via `DATABASE_URL` | Hex is the recommended charset (URL-safe by construction). #335 fix makes other charsets work via percent-encoding, but hex stays simpler. |
+| `REDIS_PASSWORD` | `openssl rand -hex 24` | `redis-server --requirepass` (via `infra/redis/start.sh`) AND apps' `REDIS_URL` | Same charset reasoning. |
+| `KEYCLOAK_DB_PASSWORD` | `openssl rand -hex 24` | dedicated `keycloak` role (#336) — KC connects to its own database with this | Set this BEFORE running the staging Keycloak DB cutover runbook on a fresh cluster. Bootstrap-superuser path: the postgres accessory's init script (`infra/postgres/init/01-init-keycloak-db.sh`) provisions the role + `givernance_keycloak` DB on first cluster boot. |
+| `KEYCLOAK_ADMIN_PASSWORD` | `openssl rand -hex 24` | KC master-realm admin user. **Important:** KC reads this only on first realm bootstrap; after that, the admin user's password is stored inside KC and ignores the env. To rotate later: `kcadm.sh set-password` on the running KC, THEN update the GH secret + reboot the accessory (so the env matches if a future fresh-init happens). | |
+| `KEYCLOAK_ADMIN_CLIENT_SECRET` | `openssl rand -hex 32` | `givernance-admin` confidential client in the `givernance` realm — used by the api for tenant-onboarding admin operations | `scripts/keycloak-sync-realm.sh` (called as the deploy's "Sync Keycloak realm" step) reconciles the realm-side value from this env on every deploy. |
+| `MINIO_ROOT_PASSWORD` | `openssl rand -hex 32` | MinIO admin user. Apps connect to MinIO **as root** via `S3_ACCESS_KEY_ID=admin` + `S3_SECRET_ACCESS_KEY=$MINIO_ROOT_PASSWORD`. To rotate: reboot the minio accessory (it picks up the new env on container restart), then redeploy apps so their S3_SECRET_ACCESS_KEY env matches. | |
+| `MINIO_KMS_SECRET_KEY` | `KEY=$(openssl rand -base64 32) && printf 'staging-kms:%s' "$KEY"` | MinIO server-side AES256 KMS — apps upload PDF receipts with `ServerSideEncryption: AES256` which requires this | **Format MUST be `<key-name>:<base64-32-byte-secret>`** (e.g. `staging-kms:<value>`). Base64 portion MUST decode to exactly 32 bytes — the composite action's `KMS_LEN` check enforces this. The 2026-04-29 staging outage (#211) was caused by a wrong-length value here. |
+| `SESSION_SECRET` | `openssl rand -hex 32` | Next.js session cookie signing | Rotation invalidates all live sessions (everyone gets logged out). |
+| `IMPERSONATION_JWT_SECRET` | `openssl rand -hex 32` | Symmetric HS256 secret signing the api's app-layer impersonation JWTs (and the web SSR's verification of them — issue #24) | Production env check in `packages/api/src/env.ts` requires this to be present and ≥32 chars on boot. |
+| `RESEND_API_KEY` | from Resend dashboard | Worker email sender (transactional sends — signup verification, team invitations) | Set as the dedicated staging Resend API key (scoped to the verified `givernance.org` apex). |
+| `STRIPE_SECRET_KEY` | from Stripe dashboard | api Stripe Connect platform key | Empty allowed — surfaces "Stripe is not configured" UX message instead of crashing. See [`docs/dev/stripe-local-setup.md`](stripe-local-setup.md) → Staging deployment. |
+| `STRIPE_WEBHOOK_SECRET` | from Stripe dashboard webhook config | api Stripe webhook signature verification | Empty allowed (same reasoning as STRIPE_SECRET_KEY). |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | from Stripe dashboard | Web Stripe.js init (baked into Next.js bundle at build time via `builder.args`) | Empty allowed. **Resolved at workflow level** in `deploy-staging.yml`'s root `env:` block, NOT in this composite action — but listed here for completeness because operators shouldn't have to chase it. |
+| `VPS_IP` | Scaleway console | Kamal config's ERB template (`STAGING_VPS_IP`); also exported to runner env for `ssh -L` style operator commands | One-time set per VPS provisioning. |
+| `SSH_PRIVATE_KEY` | dedicated key generated by operator (NOT personal) | webfactory/ssh-agent in every staging-touching workflow | Recommended: rotate at every operator-team change. |
+
+> **Total: 15 entries** — 12 application/infra secrets + 3 deploy-time identifiers (`VPS_IP`, `SSH_PRIVATE_KEY`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`).
+
+## Bulk-setup recipe
+
+For a fresh staging environment (or a fork), run something like this from a local checkout (assumes `gh` CLI authenticated against your fork):
+
+```bash
+# 1. Generate every secret (URL-safe hex by default, special-cased MINIO_KMS).
+declare -A SECRETS=(
+  [POSTGRES_PASSWORD]="$(openssl rand -hex 24)"
+  [REDIS_PASSWORD]="$(openssl rand -hex 24)"
+  [KEYCLOAK_DB_PASSWORD]="$(openssl rand -hex 24)"
+  [KEYCLOAK_ADMIN_PASSWORD]="$(openssl rand -hex 24)"
+  [KEYCLOAK_ADMIN_CLIENT_SECRET]="$(openssl rand -hex 32)"
+  [MINIO_ROOT_PASSWORD]="$(openssl rand -hex 32)"
+  [MINIO_KMS_SECRET_KEY]="staging-kms:$(openssl rand -base64 32)"
+  [SESSION_SECRET]="$(openssl rand -hex 32)"
+  [IMPERSONATION_JWT_SECRET]="$(openssl rand -hex 32)"
+)
+
+# 2. Print them all so you can save to your password manager BEFORE setting them in GH.
+#    (The `gh secret set` step below makes them write-only — you can't read them back from GH.)
+for k in "${(@k)SECRETS}"; do
+  printf '%-30s %s\n' "$k" "${SECRETS[$k]}"
+done
+echo
+read -k '?Saved every value to 1Password (or your secret manager)? Press any key to continue, Ctrl-C to abort: '
+echo
+
+# 3. Set each in the staging GH Environment.
+for k in "${(@k)SECRETS}"; do
+  printf '%s' "${SECRETS[$k]}" | gh secret set "$k" --env staging --repo <your-org>/<your-fork>
+done
+
+# 4. Set the externally-sourced ones manually (Stripe / Resend / VPS / SSH key).
+gh secret set STRIPE_SECRET_KEY --env staging --repo <your-org>/<your-fork>          # paste from Stripe dashboard
+gh secret set STRIPE_WEBHOOK_SECRET --env staging --repo <your-org>/<your-fork>     # paste from Stripe dashboard
+gh secret set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY --env staging --repo <your-org>/<your-fork>
+gh secret set RESEND_API_KEY --env staging --repo <your-org>/<your-fork>            # paste from Resend dashboard
+gh secret set VPS_IP --env staging --repo <your-org>/<your-fork>                    # the staging VPS public IP
+gh secret set SSH_PRIVATE_KEY --env staging --repo <your-org>/<your-fork>           # paste your dedicated staging key
+
+# 5. Sanity-check.
+gh secret list --env staging --repo <your-org>/<your-fork> | sort
+
+# 6. Clear the in-memory map.
+unset SECRETS
+```
+
+> The above is zsh syntax (associative arrays). For bash 4+ replace `${(@k)SECRETS}` with `${!SECRETS[@]}` and `read -k '?…'` with `read -p '…' -n 1`.
+
+## How rotations work
+
+Each secret has a different rotation procedure depending on whether the running service caches it post-startup. See the runbooks under `docs/runbooks/` for per-secret recipes — the [`migrate-staging-keycloak-db.md`](../runbooks/migrate-staging-keycloak-db.md) journal documents the patterns that emerged during the 2026-05-10 audit.
+
+Quick reference:
+
+| Secret | What "rotation" needs |
+|---|---|
+| `POSTGRES_PASSWORD` | `ALTER ROLE givernance WITH PASSWORD 'new'` on the live cluster (auth as the role first), THEN `gh secret set`, THEN `gh workflow run deploy-staging.yml -f mode=deploy`. The postgres container's env stays stale until the accessory itself is rebooted (which doesn't happen on plain `kamal deploy`); that's fine because POSTGRES_PASSWORD is only used at first init. |
+| `REDIS_PASSWORD` | `gh secret set`, then `gh workflow run deploy-staging.yml -f mode=deploy`, then `gh workflow run staging-accessory-reboot.yml -f accessory=redis -f confirm=redis`. Redis rebooted with the new env picks up `requirepass` from the bag (via `infra/redis/start.sh`). |
+| `KEYCLOAK_ADMIN_PASSWORD` | `kcadm.sh set-password -r master --username admin --new-password '<new>'` on the running KC (auth with the OLD password first), THEN `gh secret set`, THEN reboot keycloak accessory (cosmetic — KC ignores the env post-bootstrap). |
+| `KEYCLOAK_ADMIN_CLIENT_SECRET` | `gh secret set`, then `gh workflow run deploy-staging.yml -f mode=deploy`. The deploy's "Sync Keycloak realm" step calls `scripts/keycloak-sync-realm.sh` which reconciles the realm-side value from env. |
+| `MINIO_ROOT_PASSWORD` | `gh secret set`, then reboot minio accessory (picks up new env on restart), then deploy mode=deploy (apps' S3_SECRET_ACCESS_KEY env updates). |
+| `SESSION_SECRET` / `IMPERSONATION_JWT_SECRET` | `gh secret set`, then `gh workflow run deploy-staging.yml -f mode=deploy`. Side effect: existing sessions / impersonation tokens invalidated. |
+
+## Anti-patterns to avoid
+
+- **Don't** set these as **repo-level** secrets — `deploy-staging.yml` declares `environment: staging` and only resolves env-scoped secrets.
+- **Don't** set them as GH **Variables** — they need to be marked as Secrets so they're masked in workflow logs.
+- **Don't** reuse the same value across staging and production. Generate per-environment.
+- **Don't** revert to the `staging_X_123` strings that lived in the action's fallbacks pre-#343 — those values are still in the git history and are public.

--- a/docs/runbooks/launch-prod.md
+++ b/docs/runbooks/launch-prod.md
@@ -1,0 +1,204 @@
+# Runbook — Launch the Givernance production environment
+
+> Tracking issue: [#344](https://github.com/purposestack/givernance/issues/344). Captures every hygiene lesson from the 2026-05-10 staging audit (#340) so prod doesn't reproduce them. Filled in as a journal during the actual launch (same pattern as [`migrate-staging-keycloak-db.md`](migrate-staging-keycloak-db.md)).
+>
+> **One-shot.** Runs once, when the production environment is provisioned for the first time. Subsequent rotations / image bumps / migrations get their own per-task runbooks (or extend this one's "Day 2" section).
+>
+> **What this runbook delivers.** A staging-equivalent cluster on prod hardware (Scaleway VM + Managed PostgreSQL or self-hosted PG depending on Phase 1 vs Phase 4+ posture per [ADR-009](../adrs/adr-009-…)) with: every secret rotated off committed defaults from day 1; every infra service kamal-network-only (no public 0.0.0.0:* listeners); Redis enforcing `requirepass`; ADR-017 DB topology in place from the start (no separate keycloak-DB cutover needed because we boot fresh); auth on `auth.givernance.org`; the app on `givernance.org` / `app.givernance.org`.
+>
+> **What this runbook does NOT cover.** Stripe live-mode onboarding (separate runbook, blocking on the Connect platform setup ADR); per-tenant onboarding (driven by the in-app signup flow, not infra); the SaaS marketing site at `givernance.org/{en,fr}/marketing`. Out of scope here.
+
+---
+
+## Plan (forward)
+
+```
+                                    Day 0 — Provision                                       Day 1 — Launch
+   ┌──────────────────────────┐                                              ┌───────────────────────────────┐
+   │ Operator local           │                                              │ Operator local                │
+   │  - generate every secret │                                              │  - dispatch deploy-prod.yml   │
+   │  - save to 1Password     │                                              │  - watch first kamal setup    │
+   │  - populate GH `prod` env│   GH `prod` Environment secret bag full      │  - run smoke + first-login    │
+   └──────────────────────────┘                                              └───────────────┬───────────────┘
+                                                                                             │
+                                                                                             ▼
+                                                                ┌──────────────────────────────────────────┐
+                                                                │ Scaleway prod VM                         │
+                                                                │  - kamal-proxy (HTTPS via Let's Encrypt) │
+                                                                │  - postgres (kamal-network-only)         │
+                                                                │  - redis (kamal-network-only, requirepass│
+                                                                │  - minio (kamal-network-only)            │
+                                                                │  - keycloak (proxied; givernance_keycloak│
+                                                                │    DB from day 1 via init script)        │
+                                                                │  - api / web / worker / relay            │
+                                                                └──────────────────────────────────────────┘
+                                                                Public listeners on the host: 22 / 80 / 443
+                                                                Everything else on the kamal Docker network.
+```
+
+### Pre-flight checklist (Day 0 — before the deploy workflow ever fires)
+
+- [ ] **VPS provisioned**: Scaleway VM in PAR (Paris) or AMS (Amsterdam) per ADR-009. Sized per `docs/infra/README.md` Phase 1 cost estimates.
+- [ ] **DNS records added** at the registrar pointing to the VPS public IP:
+  - [ ] `givernance.org` (web)
+  - [ ] `app.givernance.org` (web — same VHost, separated for tenant-app traffic)
+  - [ ] `api.givernance.org` (api via kamal-proxy)
+  - [ ] `auth.givernance.org` (keycloak via kamal-proxy)
+- [ ] **Scaleway security group** on the prod VM allows inbound only on:
+  - `22/tcp` — SSH; consider IP allowlist for operator team + GH Actions runner ranges (the latter is harder to pin reliably; use a dedicated bastion instead if feasible)
+  - `80/tcp` — HTTP (only for kamal-proxy ACME challenges; kamal-proxy auto-redirects to 443)
+  - `443/tcp` — HTTPS
+  - **Explicitly deny** `5432`, `6379`, `8080`, `9000`. Belt-and-suspenders alongside the kamal-network-only configuration in `config/deploy-prod.yml` (when it lands; same shape as staging post-#341).
+- [ ] **SSH dedicated key** generated locally (NOT operator personal key). Save private key to 1Password vault `Givernance · Production` → item `SSH key (deploy)`. Public key added to the VM's `~/.ssh/authorized_keys` for the deploy user.
+- [ ] **`config/deploy-prod.yml` exists** in the repo, mirroring the structure of `config/deploy-staging.yml` post-#341 (no `port:` mapping on any infra accessory, redis uses `infra/redis/start.sh`, postgres mounts the `01-init-keycloak-db.sh` init script via `files:`). DNS hostnames swapped for prod values. Image references same as staging unless explicitly version-pinned per Scaleway's compliance ceiling (see `infra/compliance-versions.yml` + ADR-026).
+- [ ] **`production` GH Environment created** (`Settings → Environments → New environment → production`). Recommended: required-reviewer protection (the operator team), branch policy `Selected branches → main`.
+- [ ] **Every secret listed in `docs/dev/staging-secrets-setup.md` is set in the `production` GH Environment** with freshly-generated values (DO NOT reuse staging values). Use the bulk-setup script there with `--env production` instead of `--env staging`.
+- [ ] **`deploy-prod.yml` workflow exists** (mirror of `deploy-staging.yml`, swapping `staging` → `production` for environment + secrets refs). Wired into `setup-kamal-secrets` composite action — which is required-secrets-only since #343, so a missing `production` secret fails the deploy at the `Setup Kamal Secrets` step with a clear error.
+- [ ] **Coordination**: announce launch window in the team channel. Estimate ~1 hour for the initial deploy + smoke; subsequent ops are fast.
+
+### Day 1 — Launch sequence
+
+#### Step 1 — Trigger the first prod deploy
+
+```bash
+# From a checkout of main with all the prerequisites above met.
+gh workflow run deploy-prod.yml --ref main --repo purposestack/givernance -f mode=setup
+sleep 8
+RUN_ID=$(gh run list --repo purposestack/givernance --workflow=deploy-prod.yml --limit=1 --json databaseId -q '.[0].databaseId')
+gh run watch --repo purposestack/givernance --exit-status "$RUN_ID"
+```
+
+The first run uses `mode=setup` (full kamal bootstrap), not the routine `mode=deploy`. This:
+- Sets up kamal-proxy on the VM with TLS via Let's Encrypt (auto-acquires certs for the four DNS names above on first start)
+- Boots all four accessories (postgres, redis, minio, keycloak) — postgres's first init runs `infra/postgres/init/01-init-keycloak-db.sh`, provisioning the dedicated `keycloak` role + `givernance_keycloak` DB AND hardening the public schema in both databases
+- Builds and pushes the keycloak image
+- Builds and pushes the app image
+- Boots the api / web / worker / relay containers
+- Runs DB migrations
+- Runs DB seed (the seed for prod should be a no-op or minimal — TBD per the seed script's prod handling; verify in advance)
+- Reconciles the Keycloak realm via `scripts/keycloak-sync-realm.sh`
+
+> **If the deploy fails partway through:** the `Dump Keycloak logs on failure` and `Dump API logs on failure` steps surface logs to the run summary. Most likely failure modes on a first run: a missing GH secret (now fail-fast with a clear error since #343), a DNS record not yet propagated (rerun once propagation completes), a Scaleway-firewall rule blocking 80/443.
+
+#### Step 2 — Smoke
+
+```bash
+curl -fsSI https://api.givernance.org/healthz
+curl -fsSI https://auth.givernance.org/realms/givernance/.well-known/openid-configuration
+curl -fsSI https://givernance.org/
+curl -fsSI https://app.givernance.org/login
+```
+
+All four should return 200 (or 200/302 for the web hostnames depending on the locale-redirect logic).
+
+#### Step 3 — First admin login
+
+```bash
+# Open in incognito to avoid caching from staging:
+open "https://app.givernance.org/login"
+# Sign in as the seeded admin user; credentials match what the realm-import created.
+# If the seed didn't create one, use the master-realm admin (KEYCLOAK_ADMIN/KEYCLOAK_ADMIN_PASSWORD)
+# to log into https://auth.givernance.org/admin/master/console/ and create the first user manually.
+```
+
+#### Step 4 — Confirm DB topology is ADR-017 compliant from the start
+
+```bash
+ssh givernance-prod "docker exec -e PGPASSWORD='<POSTGRES_PASSWORD from 1Password>' givernance-postgres psql -U givernance -d postgres -tAc \"SELECT datname, pg_get_userbyid(datdba) AS owner FROM pg_database WHERE datname IN ('givernance', 'givernance_keycloak') ORDER BY datname\""
+# Expected:
+#   givernance|givernance
+#   givernance_keycloak|keycloak
+```
+
+(Note: prod DB name is `givernance`, not `givernance_staging`. Adjust if your `config/deploy-prod.yml` uses a different `POSTGRES_DB`.)
+
+#### Step 5 — Confirm Redis enforces auth + no public ports
+
+```bash
+# Redis anonymous PING must FAIL (Redis container has --requirepass set via infra/redis/start.sh).
+ssh givernance-prod "docker exec givernance-redis redis-cli PING 2>&1" || echo "  ✓ rejected"
+
+# Authenticated PING must SUCCEED.
+ssh givernance-prod "docker exec givernance-redis redis-cli -a '<REDIS_PASSWORD>' --no-auth-warning PING"
+
+# No public ports beyond 22/80/443.
+ssh givernance-prod "ss -tln | awk 'NR>1 {print \$4}' | sort -u"
+# Expected: only *:22, *:80, *:443 (plus the IPv6 [::]: variants).
+```
+
+#### Step 6 — Post-launch journal
+
+Fill in the **Journal** section below with actual outcomes — same pattern as `docs/runbooks/migrate-staging-keycloak-db.md`. Commit the filled journal as part of the first prod-config PR (or directly to main if the launch was a single push).
+
+---
+
+## Day 2 onward
+
+Once the cluster is alive, day-to-day ops parallel staging. Reuse:
+
+- **Routine deploys**: `deploy-prod.yml` triggers on push to main + manual dispatch. Same `mode=auto/deploy/setup` semantics as staging.
+- **Accessory reboots / rotations**: `prod-accessory-reboot.yml` (mirror of `staging-accessory-reboot.yml`).
+- **Rotation runbooks**: every recipe in `docs/dev/staging-secrets-setup.md` "How rotations work" applies to prod with the obvious env-name swap. **Always rotate prod secrets independently of staging** — never reuse a value across environments.
+
+### Recommended cadences
+
+- `SESSION_SECRET` / `IMPERSONATION_JWT_SECRET`: rotate quarterly, or on any operator-team change.
+- `POSTGRES_PASSWORD` / `REDIS_PASSWORD` / `KEYCLOAK_DB_PASSWORD`: rotate yearly, or on any infrastructure-team change.
+- `KEYCLOAK_ADMIN_PASSWORD` / `KEYCLOAK_ADMIN_CLIENT_SECRET`: rotate on any operator-team change.
+- `MINIO_ROOT_PASSWORD`: rotate yearly. **Never** rotate MINIO_KMS_SECRET_KEY without a re-encryption migration — encrypted objects become unreadable otherwise.
+- `SSH_PRIVATE_KEY`: rotate per the org's normal cadence.
+
+---
+
+## Journal (fill in during the launch)
+
+| Field | Value |
+|---|---|
+| Operator | _____ |
+| VPS provider / region | Scaleway / _____ |
+| VPS public IP | _____ |
+| Launch start (UTC) | _____ |
+| Launch end (UTC) | _____ |
+| Total operator-on-keyboard time | _____ |
+| First `deploy-prod.yml` run (run #) | _____ |
+| `kamal setup` wall-clock | _____ s |
+| First Let's Encrypt cert acquisition | OK / fail (which DNS name first) |
+| First admin login | OK / fail |
+| ADR-017 DB topology check | givernance owner=_____ ; givernance_keycloak owner=_____ |
+| Redis auth check (anonymous rejected) | OK / fail |
+| Public port audit (only 22/80/443) | OK / fail |
+| Deviations from plan | _____ |
+| Decisions made on the fly | _____ |
+
+## Post-mortem (fill in after launch — first 48 hours)
+
+- [ ] All four public endpoints return 200 in continuous monitoring (api healthz, auth OIDC, web home, web /login)
+- [ ] Sign-in flow works end-to-end (KC login → app dashboard → at least one DB-touching navigation)
+- [ ] Stripe webhook signature verification works (test webhook from the Stripe dashboard)
+- [ ] Receipt PDF generation works (create a test donation, verify PDF lands in MinIO with KMS encryption)
+- [ ] Worker email delivery works (send a test invitation, verify receipt via Resend dashboard)
+- [ ] Logs flow into Scaleway Cockpit (Loki ingest + Grafana panels)
+- [ ] First nightly DB backup completes (Scaleway Managed PG handles this if applicable; otherwise verify your `pg_dump` cron)
+
+### What went well
+
+_____
+
+### What went wrong / surprised us
+
+_____
+
+### Follow-up items
+
+- [ ] _____
+
+---
+
+## Related
+
+- [`docs/runbooks/migrate-staging-keycloak-db.md`](migrate-staging-keycloak-db.md) — the staging Keycloak DB cutover (issue #283). Doesn't apply to prod (we boot ADR-017 compliant from day 1) but the journal/post-mortem structure is the model.
+- [`docs/dev/staging-secrets-setup.md`](../dev/staging-secrets-setup.md) — secret bag reference (works for prod too with the obvious env swap).
+- [`docs/infra/README.md`](../infra/README.md) — infrastructure topology (Scaleway services, sizing, GDPR posture).
+- [`docs/15-infra-adr.md`](../15-infra-adr.md) — Architecture Decision Records, esp. ADR-009 (Scaleway), ADR-017 (one DB per tool), ADR-023 (PG 17 cutover policy).
+- [`config/deploy-staging.yml`](../../config/deploy-staging.yml) — template for `config/deploy-prod.yml`. Diff between them after launch should be minimal: hostname swaps, possibly different image pins per the compliance manifest, possibly different sizing flags on the VM accessories.
+- Tracking issue: [#344](https://github.com/purposestack/givernance/issues/344).


### PR DESCRIPTION
Closes #343, partially addresses #344. Bundles the two issues per the post-#340 cleanup plan — they're a natural pair (the prod-launch runbook depends on the fallbacks-already-dropped property to make sense).

## #343 — fail fast on missing GH-env secrets

### Before

Every staging "secret" in [`setup-kamal-secrets/action.yml`](.github/actions/setup-kamal-secrets/action.yml) had a `:-staging_X_123`-style fallback, committed in plaintext, framed as "non-load-bearing":

\`\`\`bash
PG_PASS="${POSTGRES_PASSWORD:-staging_postgres_123}"
REDIS_PASS="${REDIS_PASSWORD:-staging_redis_123}"
# ... etc, 9 of them
\`\`\`

The 2026-05-10 staging hygiene audit (#340) discovered the cost: every one of these was **load-bearing** on the running staging cluster — none of the GH staging-env secrets had been set, so the committed defaults were the actual credentials. Each fallback was the actual password protecting that service, visible to anyone with read access to this repo.

### After

\`:-fallback\` → \`:?<error message>\`:

\`\`\`bash
PG_PASS="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required — set it in Settings → Environments → staging → Secrets. See docs/dev/staging-secrets-setup.md.}"
\`\`\`

Bash's \`:?\` writes the message to stderr and exits the (non-interactive) shell when the variable is unset OR empty. Combined with the composite action's existing \`set -euo pipefail\`, a missing GH staging-env secret now aborts the \`Setup Kamal Secrets\` step with a clear error pointing at the right place, instead of silently rebooting the cluster onto a known-public default.

### Kept as empty fallbacks (intentional)

| Secret | Why empty is fine |
|---|---|
| \`RESEND_API_KEY\` | Worker handles unset by skipping outbound mail (would be set in any env that does email send) |
| \`STRIPE_SECRET_KEY\` | Empty surfaces user-facing "Stripe is not configured" message instead of crashing the donation route |
| \`STRIPE_WEBHOOK_SECRET\` | Same reasoning |

### Safe to land now

Every fallback's matching staging GH-env secret has been set (verified against \`gh secret list --env staging\` after #340 closed). After this PR merges, the next deploy resolves every required secret successfully — no breakage.

## #344 — codify the prod-launch hygiene baseline

Two new docs:

### \`docs/dev/staging-secrets-setup.md\`

Reference for every secret the deploy needs, with:
- Generation recipe per secret (\`openssl rand -hex 24\` for service passwords, \`-hex 32\` for app-layer signing secrets, \`base64\` only for the \`MINIO_KMS_SECRET_KEY\` because of its 32-byte-decoded format constraint)
- Rotation procedure per secret (which differ — Postgres needs ALTER ROLE on the live cluster, Keycloak admin password needs kcadm.sh set-password, etc.)
- Anti-patterns (don't use repo-level secrets, don't reuse across environments, don't revert to the \`staging_X_123\` strings still in git history)
- A bulk-setup zsh script for fork developers

Closes the "docs for fork developers" TODO from #343. Doubles as the prod secret-population reference (swap \`--env staging\` for \`--env production\`).

### \`docs/runbooks/launch-prod.md\`

The production launch runbook itself. Same plan + journal + post-mortem structure as [\`docs/runbooks/migrate-staging-keycloak-db.md\`](docs/runbooks/migrate-staging-keycloak-db.md).

Captures:

- **Pre-flight (Day 0)**: VPS provisioned, DNS records added, Scaleway security group narrowed to \`22/80/443\`, dedicated SSH key, \`config/deploy-prod.yml\` exists in the shape of \`config/deploy-staging.yml\` post-#341, \`production\` GH Environment created with required-reviewer protection, every secret populated.
- **Day 1 launch**: \`gh workflow run deploy-prod.yml -f mode=setup\` (full kamal bootstrap), smoke, first admin login, ADR-017 DB topology check, redis-auth check, public-port audit.
- **Day 2 onward**: routine deploys via \`deploy-prod.yml\`, accessory reboots via \`prod-accessory-reboot.yml\`, recommended rotation cadences per secret class.

Future operator running this gets every learning from the 2026-05-10 staging audit baked in: no committed defaults (this PR), no public host ports beyond \`22/80/443\` (#341 + #338), redis with \`requirepass\` from day 1 via \`infra/redis/start.sh\` (#338), ADR-017 DB topology from day 1 via \`infra/postgres/init/01-init-keycloak-db.sh\` (#334).

### Why these two issues are bundled

They're a natural pair: the prod-launch runbook is only meaningful if the composite action is fail-fast on missing secrets — otherwise a "fresh prod" deploy could silently boot onto staging fallbacks, which is exactly the failure mode #344 is designed to prevent. Land them atomically.

## Pre-merge acceptance

**Action.yml change**
- [ ] \`grep -c ':?' .github/actions/setup-kamal-secrets/action.yml\` returns 9 (all the previously-fallback'd required secrets)
- [ ] \`grep -c ':-}' .github/actions/setup-kamal-secrets/action.yml\` returns 3 (RESEND, STRIPE_SECRET, STRIPE_WEBHOOK — intentionally kept)
- [ ] \`grep -c 'staging_.*_123' .github/actions/setup-kamal-secrets/action.yml\` returns 0 (the dev defaults are gone from the action; they remain in git history as expected)

**Behavior**
- [ ] Post-merge \`deploy-staging\` run is green (every required GH staging-env secret is set; verified pre-PR via \`gh secret list --env staging\`)
- [ ] Negative regression test (manual, optional): in a temporary fork, deliberately unset one secret; the resulting workflow run should fail at \`Setup Kamal Secrets\` with the specific error message pointing at \`docs/dev/staging-secrets-setup.md\`

**Docs**
- [ ] [\`docs/dev/staging-secrets-setup.md\`](docs/dev/staging-secrets-setup.md) renders cleanly on GitHub
- [ ] [\`docs/runbooks/launch-prod.md\`](docs/runbooks/launch-prod.md) renders cleanly on GitHub
- [ ] Both new files appear in the \`docs/\` tree section of [CLAUDE.md](CLAUDE.md)

**CI**
- [ ] \`pnpm run format\` clean
- [ ] \`pnpm run lint\` clean (no new warnings beyond the 50 pre-existing)
- [ ] No TypeScript / build / test changes (this PR is YAML + markdown only)

## What stays open after this merges

- **#344** stays OPEN as the prod-launch tracking issue. The doc + tooling parts are addressed by this PR; the rest are operator-time checkboxes that get checked off when prod is actually provisioned.
- **#343** closes on this PR's merge.

## Sequence note

This PR + #341 (postgres bind, already merged) + #342 (URL-encoding, already merged) + the in-place rotations from #340 close the entire 2026-05-10 staging hygiene audit. After merge:

- Zero committed-default credentials are load-bearing on staging
- Zero non-essential public host listeners (only 22 / 80 / 443 remain)
- Missing-GH-secret fails fast at deploy time
- The prod-launch path is documented end-to-end

🤖 Bundled from #343 + #344 per the operator's request.