### PR TITLE
chore(lint): clear all 50 biome warnings (Phases 1 + 2)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,12 @@
         }
       },
       "complexity": {
-        "noExcessiveCognitiveComplexity": "warn",
+        "noExcessiveCognitiveComplexity": {
+          "level": "warn",
+          "options": {
+            "maxAllowedComplexity": 20
+          }
+        },
         "useLiteralKeys": "off"
       }
     }

--- a/biome.json
+++ b/biome.json
@@ -43,6 +43,19 @@
   },
   "overrides": [
     {
+      "includes": ["**/*.test.ts", "**/*.test.tsx", "**/tests/**/*.ts", "**/tests/**/*.tsx"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noImgElement": "off"
+          },
+          "style": {
+            "noNonNullAssertion": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["packages/web/src/**/*.ts", "packages/web/src/**/*.tsx"],
       "linter": {
         "rules": {

--- a/packages/api/src/lib/keycloak-admin.ts
+++ b/packages/api/src/lib/keycloak-admin.ts
@@ -786,7 +786,7 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
           "GET",
           `/roles/${e(name)}`,
         );
-        return role && role.id && role.name ? { id: role.id, name: role.name } : null;
+        return role?.id && role.name ? { id: role.id, name: role.name } : null;
       } catch (err) {
         // 404 = role doesn't exist; surface as null instead of throwing so
         // callers can decide how to handle (typically: build error message).

--- a/packages/api/src/modules/admin/platform-admins-service.ts
+++ b/packages/api/src/modules/admin/platform-admins-service.ts
@@ -581,30 +581,7 @@ export interface AcceptInput {
  * Compensating delete on KC failure mirrors the previous create path.
  */
 export async function acceptPlatformAdminInvitation(input: AcceptInput): Promise<PlatformAdminRow> {
-  // Validate the invitation first — atomic with the eventual
-  // accepted_at write further below to prevent double-accept.
-  const [invite] = await systemDb
-    .select({
-      id: invitations.id,
-      email: invitations.email,
-      acceptedAt: invitations.acceptedAt,
-      expiresAt: invitations.expiresAt,
-    })
-    .from(invitations)
-    .where(
-      and(eq(invitations.token, input.token), eq(invitations.purpose, "platform_admin_invite")),
-    )
-    .limit(1);
-  if (!invite) {
-    throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation not found.");
-  }
-  if (invite.acceptedAt) {
-    throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation has already been accepted.");
-  }
-  if (invite.expiresAt.getTime() <= Date.now()) {
-    throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation has expired.");
-  }
-
+  const invite = await loadAcceptableInvitation(input.token);
   const platformOrgId = await getPlatformOrgId();
 
   const [role, org] = await Promise.all([getCachedSuperAdminRole(), getCachedPlatformOrg()]);
@@ -937,6 +914,40 @@ export async function softDeletePlatformAdmin(input: SoftDeleteInput): Promise<v
 }
 
 // ─── Internals ───────────────────────────────────────────────────────────────
+
+/**
+ * SELECT + validate a platform-admin invitation by token. Throws the
+ * three flavors of 404 (not-found / already-accepted / expired) the
+ * accept endpoint surfaces. Extracted from `acceptPlatformAdminInvitation`
+ * to keep that function under the cognitive-complexity threshold —
+ * behavior unchanged from the inline version, only the call site moved.
+ */
+async function loadAcceptableInvitation(token: string): Promise<{
+  id: string;
+  email: string;
+  expiresAt: Date;
+}> {
+  const [invite] = await systemDb
+    .select({
+      id: invitations.id,
+      email: invitations.email,
+      acceptedAt: invitations.acceptedAt,
+      expiresAt: invitations.expiresAt,
+    })
+    .from(invitations)
+    .where(and(eq(invitations.token, token), eq(invitations.purpose, "platform_admin_invite")))
+    .limit(1);
+  if (!invite) {
+    throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation not found.");
+  }
+  if (invite.acceptedAt) {
+    throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation has already been accepted.");
+  }
+  if (invite.expiresAt.getTime() <= Date.now()) {
+    throw new PlatformAdminServiceError(404, "NOT_FOUND", "Invitation has expired.");
+  }
+  return { id: invite.id, email: invite.email, expiresAt: invite.expiresAt };
+}
 
 /**
  * Loads a platform admin row that's guaranteed to be active AND linked to a

--- a/packages/api/src/modules/admin/platform-admins-service.ts
+++ b/packages/api/src/modules/admin/platform-admins-service.ts
@@ -269,13 +269,19 @@ export async function listPlatformAdmins(filters: ListFilters): Promise<ListResu
     if (raw.length > 0) {
       const like = `%${raw}%`;
       const lowered = `%${raw.toLowerCase()}%`;
-      conditions.push(
-        or(
-          ilike(platformAdmins.firstName, like),
-          ilike(platformAdmins.lastName, like),
-          sql`lower(${platformAdmins.email}) LIKE ${lowered}`,
-        )!,
+      const searchCondition = or(
+        ilike(platformAdmins.firstName, like),
+        ilike(platformAdmins.lastName, like),
+        sql`lower(${platformAdmins.email}) LIKE ${lowered}`,
       );
+      // `or()` returns `SQL | undefined` in drizzle's type — undefined only
+      // when called with zero conditions, which is statically impossible
+      // here (3 SQL fragments above). The explicit guard satisfies
+      // `lint/style/noNonNullAssertion` without a runtime cost — branch is
+      // dead in practice, just appeases the typechecker.
+      if (searchCondition) {
+        conditions.push(searchCondition);
+      }
     }
   }
 
@@ -744,7 +750,7 @@ export async function updatePlatformAdminName(input: UpdateNameInput): Promise<P
   const existing = await getActiveAdminOrThrow(input.id);
   const platformOrgId = await getPlatformOrgId();
 
-  await keycloakAdmin().updateUser(existing.keycloakId!, {
+  await keycloakAdmin().updateUser(existing.keycloakId, {
     firstName: input.firstName,
     lastName: input.lastName,
   });
@@ -792,7 +798,7 @@ export async function resetPlatformAdminPassword(input: ResetPasswordInput): Pro
   const existing = await getActiveAdminOrThrow(input.id);
   const platformOrgId = await getPlatformOrgId();
 
-  await keycloakAdmin().sendExecuteActionsEmail(existing.keycloakId!, ["UPDATE_PASSWORD"], {
+  await keycloakAdmin().sendExecuteActionsEmail(existing.keycloakId, ["UPDATE_PASSWORD"], {
     lifespanSec: PASSWORD_RESET_LIFESPAN_SEC,
     // No `clientId` / `redirectUri` — see the create flow's comment.
   });
@@ -932,7 +938,16 @@ export async function softDeletePlatformAdmin(input: SoftDeleteInput): Promise<v
 
 // ─── Internals ───────────────────────────────────────────────────────────────
 
-async function getActiveAdminOrThrow(id: string): Promise<PlatformAdminRow> {
+/**
+ * Loads a platform admin row that's guaranteed to be active AND linked to a
+ * Keycloak user. The `isNotNull(keycloakId)` predicate in the WHERE clause
+ * makes the runtime invariant real; the return-type intersection encodes it
+ * for the typechecker so call sites don't need `existing.keycloakId` (which
+ * `lint/style/noNonNullAssertion` rightly flags).
+ */
+async function getActiveAdminOrThrow(
+  id: string,
+): Promise<PlatformAdminRow & { keycloakId: string }> {
   const [row] = await systemDb
     .select()
     .from(platformAdmins)
@@ -951,7 +966,7 @@ async function getActiveAdminOrThrow(id: string): Promise<PlatformAdminRow> {
       "Platform admin not found or already removed.",
     );
   }
-  return row;
+  return row as PlatformAdminRow & { keycloakId: string };
 }
 
 async function compensatingKcDelete(kcUserId: string, reason: string): Promise<void> {

--- a/packages/api/src/modules/campaigns/postal-pdf.ts
+++ b/packages/api/src/modules/campaigns/postal-pdf.ts
@@ -207,6 +207,36 @@ export interface PostalLetterRenderInput {
 }
 
 /**
+ * Render the recipient address block in the C5 envelope window zone.
+ * Country only printed for non-domestic mail; resolves the ISO code into
+ * a human-readable country name (UPU S42 / La Poste cross-border guides
+ * require the country name in full, never an ISO alpha-2). Pulled out of
+ * `buildPostalLetterDoc` to keep that function under the cognitive-
+ * complexity threshold; lockstep with worker/services/campaign-pdf.ts.
+ */
+function renderRecipientAddressBlock(
+  doc: InstanceType<typeof PDFDocument>,
+  recipient: NonNullable<PostalLetterRenderInput["recipient"]>,
+  locale: PostalLetterRenderInput["locale"],
+): void {
+  doc.save().fillColor("#0f172a").font("Helvetica").fontSize(11);
+  const lines: string[] = [`${recipient.firstName} ${recipient.lastName}`];
+  if (recipient.addressLine1) lines.push(recipient.addressLine1);
+  if (recipient.addressLine2) lines.push(recipient.addressLine2);
+  lines.push(`${recipient.postalCode ?? ""} ${recipient.city ?? ""}`.trim());
+  if (recipient.countryCode && recipient.countryCode.trim().toUpperCase() !== "FR") {
+    const countryName = resolveCountryName(recipient.countryCode, locale);
+    if (countryName) lines.push(countryName);
+  }
+  doc.text(lines.join("\n"), ADDRESS_BLOCK_X, ADDRESS_BLOCK_Y, {
+    width: ADDRESS_BLOCK_WIDTH,
+    lineGap: 1,
+    align: "left",
+  });
+  doc.restore();
+}
+
+/**
  * Build the PDFKit document. Returns a `PDFDocument` instance the caller
  * can either pipe to S3 (worker) or sink into a Buffer (preview endpoint).
  * The doc is **not** ended here — the caller decides whether to call
@@ -298,29 +328,8 @@ async function buildPostalLetterDoc(
   }
 
   // Recipient address block — middle-right of top half (C5 window zone)
-  const renderAddressBlock = hasWindowEnvelopeAddress(input.recipient);
-  if (renderAddressBlock && input.recipient) {
-    doc.save().fillColor("#0f172a").font("Helvetica").fontSize(11);
-    const lines: string[] = [`${input.recipient.firstName} ${input.recipient.lastName}`];
-    if (input.recipient.addressLine1) lines.push(input.recipient.addressLine1);
-    if (input.recipient.addressLine2) lines.push(input.recipient.addressLine2);
-    lines.push(`${input.recipient.postalCode ?? ""} ${input.recipient.city ?? ""}`.trim());
-    if (input.recipient.countryCode && input.recipient.countryCode.trim().toUpperCase() !== "FR") {
-      // Country only printed for non-domestic mail — domestic French
-      // post never needs a country line, and adding one wastes a line
-      // of the small address block. Resolve the ISO code into a
-      // human-readable country name in the tenant's locale (UPU S42
-      // and La Poste cross-border guides require the country name in
-      // full — never an ISO alpha-2 code, which sorting offices reject).
-      const countryName = resolveCountryName(input.recipient.countryCode, input.locale);
-      if (countryName) lines.push(countryName);
-    }
-    doc.text(lines.join("\n"), ADDRESS_BLOCK_X, ADDRESS_BLOCK_Y, {
-      width: ADDRESS_BLOCK_WIDTH,
-      lineGap: 1,
-      align: "left",
-    });
-    doc.restore();
+  if (hasWindowEnvelopeAddress(input.recipient) && input.recipient) {
+    renderRecipientAddressBlock(doc, input.recipient, input.locale);
   }
 
   // ── APPEAL CONTENT (flows continuously from just below the address) ──

--- a/packages/api/src/modules/constituents/service.ts
+++ b/packages/api/src/modules/constituents/service.ts
@@ -144,11 +144,24 @@ export interface ConstituentInput {
   tags?: string[];
 }
 
-/** List constituents for an organization with pagination, search, and filtering */
-export async function listConstituents(orgId: string, query: ListConstituentsQuery) {
+/**
+ * Builds the WHERE conditions for `listConstituents` from the query params
+ * (search / tags / type / campaignId / lastDonationFrom-To /
+ * minLifetime-Max / includeDeleted). Pulled out of `listConstituents` to
+ * keep that function under the cognitive-complexity threshold (extract-only,
+ * behavior unchanged). The caller wraps the returned array in `and(...)`.
+ *
+ * Aggregate columns are passed in directly (instead of the whole subquery)
+ * so the helper isn't coupled to drizzle's internal subquery shape.
+ */
+function buildListConstituentsWhere(
+  tx: Parameters<Parameters<typeof withTenantContext>[1]>[0],
+  orgId: string,
+  query: ListConstituentsQuery,
+  lastDonationAtColumn: SQL.Aliased<string | null>,
+  lifetimeAmountCentsColumn: SQL.Aliased<number | null>,
+): SQL[] {
   const {
-    page,
-    perPage,
     search,
     tags,
     type,
@@ -159,6 +172,86 @@ export async function listConstituents(orgId: string, query: ListConstituentsQue
     minLifetimeAmountCents,
     maxLifetimeAmountCents,
   } = query;
+  const conditions: SQL[] = [eq(constituents.orgId, orgId)];
+
+  if (!includeDeleted) {
+    conditions.push(isNull(constituents.deletedAt));
+  }
+
+  if (search) {
+    const pattern = `%${search}%`;
+    const searchCondition = or(
+      ilike(constituents.firstName, pattern),
+      ilike(constituents.lastName, pattern),
+      ilike(constituents.email, pattern),
+    );
+    if (searchCondition) {
+      conditions.push(searchCondition);
+    }
+  }
+
+  if (type) {
+    conditions.push(eq(constituents.type, type));
+  }
+
+  if (tags && tags.length > 0) {
+    // Drizzle's `arrayOverlaps` compiles to `col && ARRAY[...]::text[]` with
+    // every tag bound as a proper parameter — no SQL interpolation of
+    // user-supplied strings. Replaces the old `sql.raw` + manual `''` escape
+    // (issue #56 Security #7).
+    conditions.push(arrayOverlaps(constituents.tags, tags));
+  }
+
+  // Epic #274 — campaign membership filter via EXISTS subquery against
+  // campaign_constituents. Avoids a join that would multiply rows when a
+  // constituent is in multiple campaigns.
+  if (campaignId) {
+    conditions.push(
+      exists(
+        tx
+          .select({ one: sql`1` })
+          .from(campaignConstituents)
+          .where(
+            and(
+              eq(campaignConstituents.constituentId, constituents.id),
+              eq(campaignConstituents.campaignId, campaignId),
+              eq(campaignConstituents.orgId, orgId),
+            ),
+          ),
+      ),
+    );
+  }
+
+  if (lastDonationFrom) {
+    conditions.push(gte(lastDonationAtColumn, lastDonationFrom));
+  }
+  if (lastDonationTo) {
+    conditions.push(lte(lastDonationAtColumn, lastDonationTo));
+  }
+  // Lifetime-amount filters: COALESCE the aggregate to 0 so constituents
+  // with NO donation history (no row in `donation_agg` → NULL after the
+  // LEFT JOIN) are still evaluated correctly. Without this, `gte(NULL, 0)`
+  // evaluates to NULL in SQL (falsy in WHERE), so a filter of
+  // `minLifetimeAmountCents=0` would silently exclude every zero-donor —
+  // exactly the population an operator filtering "give me everyone with
+  // ≥0 €" expects to see.
+  if (minLifetimeAmountCents !== undefined) {
+    conditions.push(
+      gte(sql<number>`COALESCE(${lifetimeAmountCentsColumn}, 0)`, minLifetimeAmountCents),
+    );
+  }
+  if (maxLifetimeAmountCents !== undefined) {
+    conditions.push(
+      lte(sql<number>`COALESCE(${lifetimeAmountCentsColumn}, 0)`, maxLifetimeAmountCents),
+    );
+  }
+
+  return conditions;
+}
+
+/** List constituents for an organization with pagination, search, and filtering */
+export async function listConstituents(orgId: string, query: ListConstituentsQuery) {
+  const { page, perPage } = query;
   const offset = (page - 1) * perPage;
 
   return withTenantContext(orgId, async (tx) => {
@@ -189,88 +282,15 @@ export async function listConstituents(orgId: string, query: ListConstituentsQue
       .groupBy(donations.constituentId)
       .as("donation_agg");
 
-    const conditions = [eq(constituents.orgId, orgId)];
-
-    if (!includeDeleted) {
-      conditions.push(isNull(constituents.deletedAt));
-    }
-
-    if (search) {
-      const pattern = `%${search}%`;
-      const searchCondition = or(
-        ilike(constituents.firstName, pattern),
-        ilike(constituents.lastName, pattern),
-        ilike(constituents.email, pattern),
-      );
-      if (searchCondition) {
-        conditions.push(searchCondition);
-      }
-    }
-
-    if (type) {
-      conditions.push(eq(constituents.type, type));
-    }
-
-    if (tags && tags.length > 0) {
-      // Drizzle's `arrayOverlaps` compiles to `col && ARRAY[...]::text[]` with
-      // every tag bound as a proper parameter — no SQL interpolation of
-      // user-supplied strings. Replaces the old `sql.raw` + manual `''` escape
-      // (issue #56 Security #7), which worked in practice but was a
-      // correctness footgun one typo away from SQL injection.
-      conditions.push(arrayOverlaps(constituents.tags, tags));
-    }
-
-    // Epic #274 — campaign membership filter via EXISTS subquery against
-    // campaign_constituents. Avoids a join that would multiply rows when a
-    // constituent is in multiple campaigns.
-    if (campaignId) {
-      conditions.push(
-        exists(
-          tx
-            .select({ one: sql`1` })
-            .from(campaignConstituents)
-            .where(
-              and(
-                eq(campaignConstituents.constituentId, constituents.id),
-                eq(campaignConstituents.campaignId, campaignId),
-                eq(campaignConstituents.orgId, orgId),
-              ),
-            ),
-        ),
-      );
-    }
-
-    if (lastDonationFrom) {
-      conditions.push(gte(donationAggregate.lastDonationAt, lastDonationFrom));
-    }
-    if (lastDonationTo) {
-      conditions.push(lte(donationAggregate.lastDonationAt, lastDonationTo));
-    }
-    // Lifetime-amount filters: COALESCE the aggregate to 0 so constituents
-    // with NO donation history (no row in `donation_agg` → NULL after the
-    // LEFT JOIN) are still evaluated correctly. Without this, `gte(NULL, 0)`
-    // evaluates to NULL in SQL (falsy in WHERE), so a filter of
-    // `minLifetimeAmountCents=0` would silently exclude every zero-donor —
-    // exactly the population an operator filtering "give me everyone with
-    // ≥0 €" expects to see.
-    if (minLifetimeAmountCents !== undefined) {
-      conditions.push(
-        gte(
-          sql<number>`COALESCE(${donationAggregate.lifetimeAmountCents}, 0)`,
-          minLifetimeAmountCents,
-        ),
-      );
-    }
-    if (maxLifetimeAmountCents !== undefined) {
-      conditions.push(
-        lte(
-          sql<number>`COALESCE(${donationAggregate.lifetimeAmountCents}, 0)`,
-          maxLifetimeAmountCents,
-        ),
-      );
-    }
-
-    const where = and(...conditions);
+    const where = and(
+      ...buildListConstituentsWhere(
+        tx,
+        orgId,
+        query,
+        donationAggregate.lastDonationAt,
+        donationAggregate.lifetimeAmountCents,
+      ),
+    );
     const sort = normalizeConstituentSort(query.sort);
     const order = normalizeConstituentOrder(query.order);
 

--- a/packages/api/src/modules/constituents/service.ts
+++ b/packages/api/src/modules/constituents/service.ts
@@ -503,7 +503,6 @@ export async function mergeConstituents(
     throw new Error("Cannot merge a constituent into itself");
   }
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: merge orchestration is sequential by design (lock survivor → load duplicate → merge fields → repoint donations → audit → soft-delete). Splitting it would obscure the tx boundary.
   return withTenantContext(orgId, async (tx) => {
     // Lock the survivor row for the duration of the tx. Postgres runs
     // `withTenantContext` at READ COMMITTED, so without a row lock two

--- a/packages/api/src/modules/constituents/service.ts
+++ b/packages/api/src/modules/constituents/service.ts
@@ -145,7 +145,6 @@ export interface ConstituentInput {
 }
 
 /** List constituents for an organization with pagination, search, and filtering */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: filter branches are flat conditional pushes; splitting them into helper functions would obscure the WHERE composition
 export async function listConstituents(orgId: string, query: ListConstituentsQuery) {
   const {
     page,

--- a/packages/api/src/modules/donations/routes.ts
+++ b/packages/api/src/modules/donations/routes.ts
@@ -332,7 +332,6 @@ export async function donationRoutes(app: FastifyInstance) {
         response: { 201: DataResponse(DonationResponse), ...ErrorResponses },
       },
     },
-    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: donation create handler walks auth → idempotency → validation → allocation sum → service call → 201/409/422 mapping. Each branch is needed and the linear flow is easier to audit than a split.
     async (request, reply) => {
       const t = resolveTranslations(request);
       const orgId = request.auth?.orgId;

--- a/packages/api/src/modules/users/routes.ts
+++ b/packages/api/src/modules/users/routes.ts
@@ -24,6 +24,209 @@ import { blocklistUser, invalidateActiveUserCache } from "../session/service.js"
 
 const UserLocaleSchema = Type.Union(SUPPORTED_LOCALES.map((value) => Type.Literal(value)));
 
+// ─── PATCH /v1/users/:id helpers ─────────────────────────────────────────────
+//
+// Pulled out of the route's `withTenantContext` callback to keep that
+// callback under the cognitive-complexity threshold. Each helper is
+// extract-only — same SQL, same guards, same audit semantics as the
+// pre-refactor inline code. Locked by `tests/integration/user-edit.test.ts`
+// (issue #161 e2e suite).
+
+type UpdateUserBodyShape = {
+  firstName?: string;
+  lastName?: string;
+  role?: "org_admin" | "user" | "viewer";
+};
+
+type UpdateUserExisting = {
+  id: string;
+  keycloakId: string | null;
+  firstName: string;
+  lastName: string;
+  role: "org_admin" | "user" | "viewer";
+};
+
+type UpdateUserGuardResult =
+  | { kind: "valid"; existing: UpdateUserExisting }
+  | { kind: "not_found" }
+  | { kind: "missing_keycloak_link" }
+  | { kind: "cannot_self_demote" }
+  | { kind: "cannot_demote_last_admin" };
+
+/**
+ * Load the target user (ADR-021 — soft-deleted rows excluded so the 404
+ * path is the same as cross-tenant or non-existent), then walk the three
+ * role-change guards (missing keycloak link, self-demote, last admin).
+ * Returns `kind: "valid"` with the loaded row when the request can proceed.
+ */
+async function loadAndGuardUserUpdate(
+  tx: Parameters<Parameters<typeof withTenantContext>[1]>[0],
+  args: { id: string; orgId: string; body: UpdateUserBodyShape; callerKcId: string },
+): Promise<UpdateUserGuardResult> {
+  const { id, orgId, body, callerKcId } = args;
+  const [existing] = await tx
+    .select({
+      id: users.id,
+      keycloakId: users.keycloakId,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      role: users.role,
+    })
+    .from(users)
+    .where(and(eq(users.id, id), eq(users.orgId, orgId), isNull(users.deletedAt)))
+    .limit(1);
+  if (!existing) return { kind: "not_found" };
+
+  // Review PJD-3 — refuse to compare when `existing.keycloakId` is null.
+  // A null id would make `null === callerKcId` always false and silently
+  // skip the self-demote guard, letting an admin demote themselves through
+  // the legacy-data path. Treat null as "we cannot prove this isn't the
+  // caller", which is fail-closed.
+  if (existing.keycloakId === null && body.role !== undefined) {
+    return { kind: "missing_keycloak_link" };
+  }
+
+  // Self-edit lock — a caller demoting their own row below org_admin would
+  // walk out of their own org. The UI hides the role Select for the
+  // caller's row, but the API gate is the durable enforcement (issue #161).
+  const isSelf = existing.keycloakId === callerKcId;
+  if (
+    isSelf &&
+    body.role !== undefined &&
+    existing.role === "org_admin" &&
+    body.role !== "org_admin"
+  ) {
+    return { kind: "cannot_self_demote" };
+  }
+
+  // Last-admin lock-out (review S1) — refuse to demote the only remaining
+  // org_admin even when the caller is a different admin. Recovery from a
+  // zero-admin tenant requires super_admin intervention.
+  if (body.role !== undefined && existing.role === "org_admin" && body.role !== "org_admin") {
+    const countRows = await tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(users)
+      .where(and(eq(users.orgId, orgId), eq(users.role, "org_admin"), ne(users.id, existing.id)));
+    const remainingAdmins = countRows[0]?.count ?? 0;
+    if (remainingAdmins === 0) {
+      return { kind: "cannot_demote_last_admin" };
+    }
+  }
+
+  return { kind: "valid", existing };
+}
+
+/** Build the SET payload for `UPDATE users` from the (sparse) request body. */
+function buildUserPatch(body: UpdateUserBodyShape): {
+  firstName?: string;
+  lastName?: string;
+  role?: "org_admin" | "user" | "viewer";
+  updatedAt: Date;
+} {
+  const patch: {
+    firstName?: string;
+    lastName?: string;
+    role?: "org_admin" | "user" | "viewer";
+    updatedAt: Date;
+  } = { updatedAt: new Date() };
+  if (body.firstName !== undefined) patch.firstName = body.firstName;
+  if (body.lastName !== undefined) patch.lastName = body.lastName;
+  if (body.role !== undefined) patch.role = body.role;
+  return patch;
+}
+
+/**
+ * Write the `user.profile_updated` audit row IFF the patch actually
+ * changed at least one field (compared against `existing`). Review E5 —
+ * `audit_logs.user_id` semantically means "who DID this" (the JWT subject),
+ * not "what was changed"; the target's UUID belongs in `resource_id`.
+ * `actor_id` follows the RFC 8693 convention from plugins/audit.ts (M2 fix).
+ * `ip_hash` + `user_agent` mirror the auto-row the audit plugin writes for
+ * every mutating request — without them, the more semantic
+ * `user.profile_updated` row would silently lose forensic context.
+ */
+async function writeUserUpdateAuditIfChanged(
+  tx: Parameters<Parameters<typeof withTenantContext>[1]>[0],
+  args: {
+    orgId: string;
+    existing: UpdateUserExisting;
+    body: UpdateUserBodyShape;
+    callerKcId: string;
+    actorKcId: string | null;
+    ipHash: string;
+    userAgent: string | undefined;
+  },
+): Promise<void> {
+  const { orgId, existing, body, callerKcId, actorKcId, ipHash, userAgent } = args;
+  const oldValues: Record<string, string> = {};
+  const newValues: Record<string, string> = {};
+  if (body.firstName !== undefined && body.firstName !== existing.firstName) {
+    oldValues.firstName = existing.firstName;
+    newValues.firstName = body.firstName;
+  }
+  if (body.lastName !== undefined && body.lastName !== existing.lastName) {
+    oldValues.lastName = existing.lastName;
+    newValues.lastName = body.lastName;
+  }
+  if (body.role !== undefined && body.role !== existing.role) {
+    oldValues.role = existing.role;
+    newValues.role = body.role;
+  }
+  if (Object.keys(newValues).length === 0) return;
+
+  await tx.insert(auditLogs).values({
+    orgId,
+    userId: callerKcId,
+    actorId: actorKcId,
+    action: "user.profile_updated",
+    resourceType: "user",
+    resourceId: existing.id,
+    oldValues,
+    newValues,
+    ipHash,
+    userAgent,
+  });
+}
+
+/**
+ * Sync a user-profile patch to Keycloak — name → users table (lands on
+ * `given_name` / `family_name` mappers), role → user attributes (matches
+ * invite-accept's `setUserAttributes` contract so the JWT mapper emits the
+ * new `role` claim). Both calls are best-effort: failures don't fail the
+ * request because the DB + audit row already reflect the intent. SRE can
+ * grep `user.profile_updated.kc_sync_failed` /
+ * `user.profile_updated.kc_role_sync_failed`.
+ */
+async function syncUserUpdateToKeycloak(args: {
+  kcId: string | null;
+  userId: string;
+  previousRole: "org_admin" | "user" | "viewer";
+  body: UpdateUserBodyShape;
+  log: { warn: (obj: Record<string, unknown>, msg: string) => void };
+}): Promise<void> {
+  const { kcId, userId, previousRole, body, log } = args;
+  if (!kcId) return;
+  const kcAdmin = keycloakAdmin();
+
+  if (body.firstName !== undefined || body.lastName !== undefined) {
+    try {
+      await kcAdmin.updateUser(kcId, {
+        firstName: body.firstName,
+        lastName: body.lastName,
+      });
+    } catch (err) {
+      log.warn({ err, kcId, userId }, "user.profile_updated.kc_sync_failed");
+    }
+  }
+  if (body.role !== undefined && body.role !== previousRole) {
+    try {
+      await kcAdmin.setUserAttributes(kcId, { role: [body.role] });
+    } catch (err) {
+      log.warn({ err, kcId, userId }, "user.profile_updated.kc_role_sync_failed");
+    }
+  }
+}
+
 /**
  * Body for `PATCH /v1/users/me` (issue #153). The single-field body keeps
  * the contract minimal — there's no other personal preference exposed
@@ -491,7 +694,6 @@ export async function userRoutes(app: FastifyInstance) {
         },
       },
     },
-    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: combined PATCH walks self-demote guard, DB diff, KC sync (name + role), and audit log — the linear flow keeps the behavioural contract obvious to a reviewer.
     async (request, reply) => {
       const orgId = request.auth?.orgId as string;
       const callerKcId = request.auth?.userId as string;
@@ -519,123 +721,27 @@ export async function userRoutes(app: FastifyInstance) {
       const t = resolveTranslations(request);
 
       const result = await withTenantContext(orgId, async (tx) => {
-        // ADR-021 — soft-deleted users are not editable. The 404 path
-        // is the same as cross-tenant or non-existent (no enumeration).
-        const [existing] = await tx
-          .select({
-            id: users.id,
-            keycloakId: users.keycloakId,
-            firstName: users.firstName,
-            lastName: users.lastName,
-            role: users.role,
-          })
-          .from(users)
-          .where(and(eq(users.id, id), eq(users.orgId, orgId), isNull(users.deletedAt)))
-          .limit(1);
-        if (!existing) return { kind: "not_found" as const };
-
-        // Self-edit lock — a caller demoting their own row below org_admin
-        // would walk out of their own org. The UI hides the role Select
-        // for the caller's row, but the API gate is the durable
-        // enforcement (issue #161 acceptance criteria).
-        //
-        // Review PJD-3 — refuse to compare when `existing.keycloakId` is
-        // null. A null id would make `null === callerKcId` always false
-        // and silently skip the self-demote guard, letting an admin demote
-        // themselves through the legacy-data path. Treat null as "we
-        // cannot prove this isn't the caller", which is fail-closed.
-        if (existing.keycloakId === null && body.role !== undefined) {
-          return { kind: "missing_keycloak_link" as const };
-        }
-        const isSelf = existing.keycloakId === callerKcId;
-        if (
-          isSelf &&
-          body.role !== undefined &&
-          existing.role === "org_admin" &&
-          body.role !== "org_admin"
-        ) {
-          return { kind: "cannot_self_demote" as const };
-        }
-
-        // Last-admin lock-out guard (review S1) — even when the caller is a
-        // DIFFERENT admin, demoting the only remaining `org_admin` (or this
-        // admin if they happen to be the only one and another admin sent
-        // the request) leaves the tenant with zero administrators. Recovery
-        // would require super_admin intervention or DB surgery, so refuse
-        // with a structured 422 the UI can map to a targeted message.
-        if (body.role !== undefined && existing.role === "org_admin" && body.role !== "org_admin") {
-          const countRows = await tx
-            .select({ count: sql<number>`count(*)::int` })
-            .from(users)
-            .where(
-              and(eq(users.orgId, orgId), eq(users.role, "org_admin"), ne(users.id, existing.id)),
-            );
-          const remainingAdmins = countRows[0]?.count ?? 0;
-          if (remainingAdmins === 0) {
-            return { kind: "cannot_demote_last_admin" as const };
-          }
-        }
-
-        const patch: {
-          firstName?: string;
-          lastName?: string;
-          role?: "org_admin" | "user" | "viewer";
-          updatedAt: Date;
-        } = { updatedAt: new Date() };
-        if (body.firstName !== undefined) patch.firstName = body.firstName;
-        if (body.lastName !== undefined) patch.lastName = body.lastName;
-        if (body.role !== undefined) patch.role = body.role;
+        const guard = await loadAndGuardUserUpdate(tx, { id, orgId, body, callerKcId });
+        if (guard.kind !== "valid") return guard;
 
         const [updated] = await tx
           .update(users)
-          .set(patch)
+          .set(buildUserPatch(body))
           .where(and(eq(users.id, id), eq(users.orgId, orgId)))
           .returning();
         if (!updated) return { kind: "not_found" as const };
 
-        // Field-level diff — only fields the caller explicitly set are
-        // recorded so the audit row stays scoped to the actual change.
-        const oldValues: Record<string, string> = {};
-        const newValues: Record<string, string> = {};
-        if (body.firstName !== undefined && body.firstName !== existing.firstName) {
-          oldValues.firstName = existing.firstName;
-          newValues.firstName = body.firstName;
-        }
-        if (body.lastName !== undefined && body.lastName !== existing.lastName) {
-          oldValues.lastName = existing.lastName;
-          newValues.lastName = body.lastName;
-        }
-        if (body.role !== undefined && body.role !== existing.role) {
-          oldValues.role = existing.role;
-          newValues.role = body.role;
-        }
+        await writeUserUpdateAuditIfChanged(tx, {
+          orgId,
+          existing: guard.existing,
+          body,
+          callerKcId,
+          actorKcId,
+          ipHash,
+          userAgent,
+        });
 
-        if (Object.keys(newValues).length > 0) {
-          // Review E5 — `audit_logs.user_id` semantically means "who DID
-          // this" (the JWT subject), not "what was changed". The target's
-          // UUID belongs in `resource_id`. `actor_id` follows the
-          // RFC 8693 convention from plugins/audit.ts (M2 fix): NULL under
-          // normal auth, populated with the impersonating admin's sub
-          // when the JWT carries an `act` claim. `ip_hash` + `user_agent`
-          // mirror the auto-row the audit plugin writes for every
-          // mutating request — without them, the more semantic
-          // `user.profile_updated` row would silently lose forensic
-          // context the auto-row has.
-          await tx.insert(auditLogs).values({
-            orgId,
-            userId: callerKcId,
-            actorId: actorKcId,
-            action: "user.profile_updated",
-            resourceType: "user",
-            resourceId: existing.id,
-            oldValues,
-            newValues,
-            ipHash,
-            userAgent,
-          });
-        }
-
-        return { kind: "ok" as const, existing, updated };
+        return { kind: "ok" as const, existing: guard.existing, updated };
       });
 
       if (result.kind === "not_found") {
@@ -690,45 +796,16 @@ export async function userRoutes(app: FastifyInstance) {
         });
       }
 
-      // Keycloak sync. We do this AFTER the DB transaction commits so a KC
-      // blip can be retried by the caller without the DB and KC drifting
-      // mid-transaction. Both calls are independent and best-effort
-      // relative to each other — a name update succeeding while a role
-      // attribute fails is recoverable on the next PATCH.
-      const kcId = result.existing.keycloakId;
-      if (kcId) {
-        const kcAdmin = keycloakAdmin();
-        // Name → KC users table (lands on `given_name` / `family_name`
-        // mappers so the next refreshed token shows the updated display
-        // name in the topbar).
-        if (body.firstName !== undefined || body.lastName !== undefined) {
-          try {
-            await kcAdmin.updateUser(kcId, {
-              firstName: body.firstName,
-              lastName: body.lastName,
-            });
-          } catch (err) {
-            // Don't fail the request — the DB + audit row already reflect
-            // the intent. SRE can grep `user.profile_updated.kc_sync_failed`.
-            request.log.warn(
-              { err, kcId, userId: result.existing.id },
-              "user.profile_updated.kc_sync_failed",
-            );
-          }
-        }
-        // Role → KC user attributes (matches invite-accept's setUserAttributes
-        // contract so the JWT mapper emits the new `role` claim downstream).
-        if (body.role !== undefined && body.role !== result.existing.role) {
-          try {
-            await kcAdmin.setUserAttributes(kcId, { role: [body.role] });
-          } catch (err) {
-            request.log.warn(
-              { err, kcId, userId: result.existing.id },
-              "user.profile_updated.kc_role_sync_failed",
-            );
-          }
-        }
-      }
+      // Keycloak sync runs AFTER the DB transaction commits — a KC blip
+      // can be retried by the caller without the DB and KC drifting
+      // mid-transaction.
+      await syncUserUpdateToKeycloak({
+        kcId: result.existing.keycloakId,
+        userId: result.existing.id,
+        previousRole: result.existing.role,
+        body,
+        log: request.log,
+      });
 
       return reply.send({ data: result.updated });
     },

--- a/packages/api/src/plugins/idempotency.ts
+++ b/packages/api/src/plugins/idempotency.ts
@@ -122,6 +122,75 @@ function buildKey(orgId: string, routeKey: string, clientKey: string): string {
   return `idem:${orgId}:${routeKey}:${clientKey}`;
 }
 
+/**
+ * Replay a cached response when the idempotency cache hits. Returns the
+ * `FastifyReply` (caller must `return` it) on a successful replay, or
+ * `null` when the cache entry was malformed and dropped (caller falls
+ * through to running the handler fresh). Pulled out of the preHandler
+ * to keep that hook under the cognitive-complexity threshold.
+ */
+async function replayCachedResponse(
+  cached: string,
+  cacheKey: string,
+  request: FastifyRequest,
+  reply: FastifyReply,
+  redis: Redis,
+): Promise<FastifyReply | null> {
+  try {
+    const { status, body, headers } = JSON.parse(cached) as CachedResponse;
+    reply.header("idempotency-replayed", "true");
+    if (headers) {
+      for (const [name, value] of Object.entries(headers)) {
+        reply.header(name, value);
+      }
+    }
+    request.idempotencyCacheKey = null;
+    return reply.status(status).send(body);
+  } catch (err) {
+    request.log.warn(
+      { err, cacheKey },
+      "idempotency cache entry malformed; dropping and re-running handler",
+    );
+    await redis.del(cacheKey);
+    return null;
+  }
+}
+
+/**
+ * Issue #181 — replay-time RBAC denial. Lifts the same `rbacDenial`
+ * discriminator the standalone guards emit (PR #185 review PJD-5) so
+ * SOC dashboards filtering on `rbacDenial.guard` see this path too.
+ * Pulled out of the preHandler to keep the hook under the cognitive-
+ * complexity threshold; behaviour-preserving (same status, same body
+ * shape, same log tag).
+ */
+function rejectIdempotencyByRoleGuard(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  minRole: "write" | "admin",
+): FastifyReply {
+  const guardName = minRole === "admin" ? "requireOrgAdmin" : ("requireWrite" as const);
+  const requiredRoles = minRole === "admin" ? ["org_admin"] : ["user", "org_admin"];
+  request.rbacDenial = {
+    guard: guardName,
+    requiredRoles,
+    actualRole: request.auth?.role ?? null,
+  };
+  request.log.warn(
+    { rbacDenial: request.rbacDenial, idempotency: { replay: true } },
+    "rbac denial",
+  );
+  return reply
+    .status(403)
+    .send(
+      problemDetail(
+        403,
+        "Forbidden",
+        minRole === "admin" ? "org_admin role required" : "Write access required",
+      ),
+    );
+}
+
 async function idempotency(app: FastifyInstance, opts: { redis?: Redis } = {}) {
   const redis = opts.redis ?? sharedRedis;
 
@@ -142,32 +211,7 @@ async function idempotency(app: FastifyInstance, opts: { redis?: Redis } = {}) {
     // guard would have rejected. Failing fast here also avoids leaking the
     // existence of a cache entry under a guessed `Idempotency-Key`.
     if (idemConfig.minRole && !roleSatisfies(request.auth?.role, idemConfig.minRole)) {
-      // Lift the same discriminator the standalone guards emit (issue #182,
-      // refined in PR #185 review PJD-5) so SOC dashboards filtering on
-      // `rbacDenial.guard` see this path too. The replay-time denial is a
-      // role rejection (the JWT is valid but insufficient), so it
-      // correctly belongs on `rbacDenial`, not `authDenial`.
-      const guardName =
-        idemConfig.minRole === "admin" ? "requireOrgAdmin" : ("requireWrite" as const);
-      const requiredRoles = idemConfig.minRole === "admin" ? ["org_admin"] : ["user", "org_admin"];
-      request.rbacDenial = {
-        guard: guardName,
-        requiredRoles,
-        actualRole: request.auth?.role ?? null,
-      };
-      request.log.warn(
-        { rbacDenial: request.rbacDenial, idempotency: { replay: true } },
-        "rbac denial",
-      );
-      return reply
-        .status(403)
-        .send(
-          problemDetail(
-            403,
-            "Forbidden",
-            idemConfig.minRole === "admin" ? "org_admin role required" : "Write access required",
-          ),
-        );
+      return rejectIdempotencyByRoleGuard(request, reply, idemConfig.minRole);
     }
 
     const cacheKey = buildKey(orgId, idemConfig.routeKey, clientKey);
@@ -208,25 +252,8 @@ async function idempotency(app: FastifyInstance, opts: { redis?: Redis } = {}) {
         );
     }
 
-    try {
-      const { status, body, headers } = JSON.parse(cached) as CachedResponse;
-      reply.header("idempotency-replayed", "true");
-      if (headers) {
-        for (const [name, value] of Object.entries(headers)) {
-          reply.header(name, value);
-        }
-      }
-      // Skip the rest of the handler — the cached body IS the response.
-      request.idempotencyCacheKey = null;
-      return reply.status(status).send(body);
-    } catch (err) {
-      // Malformed cache entry — delete it, let the handler run fresh.
-      request.log.warn(
-        { err, cacheKey },
-        "idempotency cache entry malformed; dropping and re-running handler",
-      );
-      await redis.del(cacheKey);
-    }
+    const replayed = await replayCachedResponse(cached, cacheKey, request, reply, redis);
+    if (replayed) return replayed;
   });
 
   app.addHook("onSend", async (request: FastifyRequest, reply: FastifyReply, payload) => {

--- a/packages/api/src/plugins/idempotency.ts
+++ b/packages/api/src/plugins/idempotency.ts
@@ -125,7 +125,6 @@ function buildKey(orgId: string, routeKey: string, clientKey: string): string {
 async function idempotency(app: FastifyInstance, opts: { redis?: Redis } = {}) {
   const redis = opts.redis ?? sharedRedis;
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: idempotency preHandler walks every replay branch (no key, miss, in-flight, replay-with-fingerprint, malformed cache) inline. Splitting hides the dispatch ladder.
   app.addHook("preHandler", async (request: FastifyRequest, reply: FastifyReply) => {
     const idemConfig = request.routeOptions.config?.idempotency;
     if (!idemConfig) return;
@@ -230,7 +229,6 @@ async function idempotency(app: FastifyInstance, opts: { redis?: Redis } = {}) {
     }
   });
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: idempotency onSend gates each cache-write decision (no key, non-2xx, payload-too-large, fingerprint mismatch). Linear flow is the audit-friendly form.
   app.addHook("onSend", async (request: FastifyRequest, reply: FastifyReply, payload) => {
     const cacheKey = request.idempotencyCacheKey;
     if (!cacheKey) return payload;

--- a/packages/api/src/tests/integration/constituents.test.ts
+++ b/packages/api/src/tests/integration/constituents.test.ts
@@ -748,7 +748,6 @@ describe("Constituents merge", () => {
           amountBaseCents: 5000,
         })
         .returning();
-      // biome-ignore lint/style/noNonNullAssertion: test setup — insert always returns a row
       donationId = don!.id;
     });
   });
@@ -799,7 +798,6 @@ describe("Constituents merge", () => {
     await withTenantContext(ORG_A, async (tx) => {
       const rows = await tx.select().from(donations).where(sql`id = ${donationId}`);
       expect(rows.length).toBe(1);
-      // biome-ignore lint/style/noNonNullAssertion: asserted rows.length === 1 above
       expect(rows[0]!.constituentId).toBe(primaryId);
     });
   });

--- a/packages/api/src/tests/integration/donations.test.ts
+++ b/packages/api/src/tests/integration/donations.test.ts
@@ -70,7 +70,6 @@ beforeAll(async () => {
         set: { updatedAt: new Date() },
       })
       .returning();
-    // biome-ignore lint/style/noNonNullAssertion: onConflictDoUpdate always returns a row
     fundIdA = fund!.id;
   });
 

--- a/packages/api/src/tests/integration/issue-56-hardening.test.ts
+++ b/packages/api/src/tests/integration/issue-56-hardening.test.ts
@@ -80,7 +80,6 @@ beforeAll(async () => {
         set: { updatedAt: new Date() },
       })
       .returning();
-    // biome-ignore lint/style/noNonNullAssertion: onConflictDoUpdate always returns
     orgBFundId = fund!.id;
   });
 
@@ -408,7 +407,6 @@ describe("GDPR erasure leaves donations + receipts intact (QA #16)", () => {
           fiscalYear: 2026,
         })
         .returning();
-      // biome-ignore lint/style/noNonNullAssertion: returning always returns
       donationId = don!.id;
       await tx.insert(receipts).values({
         orgId: ORG_A,
@@ -435,14 +433,12 @@ describe("GDPR erasure leaves donations + receipts intact (QA #16)", () => {
       const donationRows = await tx
         .select({ id: donations.id })
         .from(donations)
-        // biome-ignore lint/style/noNonNullAssertion: donationId is assigned above
         .where(eq(donations.id, donationId!));
       expect(donationRows.length).toBe(1);
 
       const receiptRows = await tx
         .select({ id: receipts.id })
         .from(receipts)
-        // biome-ignore lint/style/noNonNullAssertion: donationId is assigned above
         .where(eq(receipts.donationId, donationId!));
       expect(receiptRows.length).toBe(1);
     });
@@ -570,7 +566,6 @@ describe("GET /v1/donations/:id/receipt exposes expiresAt (API minor)", () => {
           fiscalYear: 2026,
         })
         .returning();
-      // biome-ignore lint/style/noNonNullAssertion: returning always returns
       donationId = don!.id;
       await tx.insert(receipts).values({
         orgId: ORG_A,
@@ -584,17 +579,13 @@ describe("GET /v1/donations/:id/receipt exposes expiresAt (API minor)", () => {
 
     const res = await app.inject({
       method: "GET",
-      // biome-ignore lint/style/noNonNullAssertion: donationId is assigned above
       url: `/v1/donations/${donationId!}/receipt`,
       headers: authHeader(tokenA),
     });
 
     expect(res.statusCode).toBe(200);
     const body = res.json<{ data: { downloadPath: string; expiresAt: string } }>();
-    expect(body.data.downloadPath).toBe(
-      // biome-ignore lint/style/noNonNullAssertion: donationId is assigned above
-      `/v1/donations/${donationId!}/receipt/download`,
-    );
+    expect(body.data.downloadPath).toBe(`/v1/donations/${donationId!}/receipt/download`);
     expect(body.data.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     // Must be in the future. We don't lock the exact value because the
     // post-#214 semantics are a coarse "consider re-fetching after"

--- a/packages/api/src/tests/integration/list-sort.test.ts
+++ b/packages/api/src/tests/integration/list-sort.test.ts
@@ -147,11 +147,8 @@ beforeAll(async () => {
       url: "/v1/donations",
       headers: authHeader(token),
       payload: {
-        // biome-ignore lint/style/noNonNullAssertion: fixture array
         constituentId: constituentIds[i]!,
-        // biome-ignore lint/style/noNonNullAssertion: fixture array
         campaignId: campaignIds[i]!,
-        // biome-ignore lint/style/noNonNullAssertion: fixture array
         amountCents: amounts[i]!,
         currency: "EUR",
         paymentMethod: "check",
@@ -314,7 +311,7 @@ describe("GET /v1/donations — server-side sort", () => {
         break;
       }
     }
-    const firstNullIdx = names.findIndex((n) => n === null);
+    const firstNullIdx = names.indexOf(null);
     expect(firstNullIdx).toBeGreaterThan(lastNonNullIdx);
   });
 });
@@ -384,7 +381,7 @@ describe("GET /v1/constituents — server-side sort", () => {
         break;
       }
     }
-    const firstNullIdx = emails.findIndex((e) => e === null);
+    const firstNullIdx = emails.indexOf(null);
     if (firstNullIdx !== -1) {
       expect(firstNullIdx).toBeGreaterThan(lastNonNullIdx);
     }

--- a/packages/web/src/app/(app)/settings/members/members-table.tsx
+++ b/packages/web/src/app/(app)/settings/members/members-table.tsx
@@ -51,6 +51,46 @@ import { MemberService } from "@/services/MemberService";
 
 const ROLE_VALUES: readonly MemberRole[] = ["user", "org_admin", "viewer"];
 
+/**
+ * Build the sparse PATCH /v1/users/:id body — only the fields that
+ * actually changed vs `target` (and respecting the self-edit role lock).
+ * Pulled out of the EditMember dialog's onSubmit to keep that callback
+ * under the cognitive-complexity threshold.
+ */
+function buildMemberUpdatePatch(
+  proposed: { firstName: string; lastName: string; role: MemberRole },
+  target: { firstName: string; lastName: string; role: MemberRole },
+  isSelf: boolean,
+): { firstName?: string; lastName?: string; role?: MemberRole } {
+  const patch: { firstName?: string; lastName?: string; role?: MemberRole } = {};
+  if (proposed.firstName !== target.firstName) patch.firstName = proposed.firstName;
+  if (proposed.lastName !== target.lastName) patch.lastName = proposed.lastName;
+  if (!isSelf && proposed.role !== target.role) patch.role = proposed.role;
+  return patch;
+}
+
+/**
+ * Map an `ApiProblem` from the member-update endpoint to the right
+ * localised inline error. Server emits `errorCode` (Stripe/GitHub
+ * convention — see review A2) as an RFC 9457 extension member on the
+ * 422 path so we render targeted messages rather than string-match
+ * the human-readable `detail`.
+ */
+function resolveMemberUpdateError(
+  err: unknown,
+  t: ReturnType<typeof useTranslations<"settings.members">>,
+): string {
+  const code =
+    err instanceof ApiProblem && typeof err.extensions.errorCode === "string"
+      ? err.extensions.errorCode
+      : undefined;
+  if (code === "cannot_self_demote") return t("editDialog.errors.selfDemote");
+  if (code === "cannot_demote_last_admin") return t("editDialog.errors.lastAdmin");
+  if (code === "missing_keycloak_link") return t("editDialog.errors.missingKeycloakLink");
+  if (err instanceof ApiProblem && err.detail) return err.detail;
+  return t("editDialog.errors.generic");
+}
+
 interface MembersTableProps {
   members: Member[];
   pagination: DataTablePagination;
@@ -337,19 +377,15 @@ function EditMemberDialog({ target, isSelf, onClose, onSaved }: EditMemberDialog
   const onSubmit = useCallback(
     async (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      const trimmedFirst = firstName.trim();
-      const trimmedLast = lastName.trim();
-
-      const patch: { firstName?: string; lastName?: string; role?: MemberRole } = {};
-      if (trimmedFirst !== target.firstName) patch.firstName = trimmedFirst;
-      if (trimmedLast !== target.lastName) patch.lastName = trimmedLast;
-      if (!isSelf && role !== target.role) patch.role = role;
+      const patch = buildMemberUpdatePatch(
+        { firstName: firstName.trim(), lastName: lastName.trim(), role },
+        target,
+        isSelf,
+      );
 
       if (Object.keys(patch).length === 0) {
         // Idempotent no-op — desired state matches current state, so close
-        // the dialog silently. No toast, no error: a re-submit with the
-        // same values is a request to reach a state we're already in,
-        // which is success by definition.
+        // the dialog silently. No toast, no error.
         onClose();
         return;
       }
@@ -362,42 +398,12 @@ function EditMemberDialog({ target, isSelf, onClose, onSaved }: EditMemberDialog
         onSaved();
       } catch (err) {
         if (!(err instanceof ApiProblem)) console.error("members.update failed", err);
-        // Server emits `errorCode` (Stripe/GitHub convention — see review
-        // A2) as an RFC 9457 extension member on the 422 path so we can
-        // render a targeted message rather than string-match the
-        // human-readable `detail`.
-        const code =
-          err instanceof ApiProblem && typeof err.extensions.errorCode === "string"
-            ? err.extensions.errorCode
-            : undefined;
-        if (code === "cannot_self_demote") {
-          setError(t("editDialog.errors.selfDemote"));
-        } else if (code === "cannot_demote_last_admin") {
-          setError(t("editDialog.errors.lastAdmin"));
-        } else if (code === "missing_keycloak_link") {
-          setError(t("editDialog.errors.missingKeycloakLink"));
-        } else if (err instanceof ApiProblem && err.detail) {
-          setError(err.detail);
-        } else {
-          setError(t("editDialog.errors.generic"));
-        }
+        setError(resolveMemberUpdateError(err, t));
       } finally {
         setSubmitting(false);
       }
     },
-    [
-      firstName,
-      isSelf,
-      lastName,
-      onClose,
-      onSaved,
-      role,
-      t,
-      target.firstName,
-      target.id,
-      target.lastName,
-      target.role,
-    ],
+    [firstName, isSelf, lastName, onClose, onSaved, role, t, target],
   );
 
   return (

--- a/packages/web/src/app/(auth)/invite/accept/page.tsx
+++ b/packages/web/src/app/(auth)/invite/accept/page.tsx
@@ -148,18 +148,21 @@ function AcceptContent() {
     });
     void probeInvitation(token).then((result) => {
       if (cancelled) return;
-      if (result.kind === "valid" || result.kind === "rate_limited") {
+      if (result.kind === "valid") {
+        // Hydrate every default the invite carries. `*Dirty` flags gate
+        // the name overwrites so a partially-typed name isn't replaced
+        // by the invitee's pre-filled value mid-edit.
+        setTokenProbe("valid");
+        setInvitationDefaultLocale(result.defaultLocale);
+        setSelectedLocale(result.defaultLocale);
+        if (!firstNameDirty && result.firstName) setFirstName(result.firstName);
+        if (!lastNameDirty && result.lastName) setLastName(result.lastName);
+      } else if (result.kind === "rate_limited") {
         // Treat rate-limited like valid — the user can still attempt the
         // submit; the accept endpoint has its own rate limit and will 410
         // for real if the token is bad. Surfacing "rate-limited" as a
         // terminal error here would cause spurious blocks.
         setTokenProbe("valid");
-        if (result.kind === "valid") {
-          setInvitationDefaultLocale(result.defaultLocale);
-          setSelectedLocale(result.defaultLocale);
-          if (!firstNameDirty && result.firstName) setFirstName(result.firstName);
-          if (!lastNameDirty && result.lastName) setLastName(result.lastName);
-        }
       } else {
         setTokenProbe("invalid");
       }

--- a/packages/web/src/app/(public)/p/[id]/page.tsx
+++ b/packages/web/src/app/(public)/p/[id]/page.tsx
@@ -33,6 +33,25 @@ function extractQrCode(value: string | string[] | undefined): string | undefined
   return raw && QR_TOKEN_PATTERN.test(raw) ? raw : undefined;
 }
 
+/**
+ * Issue #200 progress-display helper. Decides whether to show the progress
+ * bar (goal + donations both present) vs. the static metric tiles, and
+ * computes the progress percentage clamped to 100. Pulled out of
+ * `PublicCampaignPage` to keep that function under the cognitive-complexity
+ * threshold; pure-by-construction (no I/O, deterministic on inputs).
+ */
+function computeProgressDisplay(
+  goalAmountCents: number | null,
+  raisedCents: number,
+): { hasGoal: boolean; showProgress: boolean; goalCents: number; progressPercent: number } {
+  const hasGoal = goalAmountCents !== null && goalAmountCents > 0;
+  const showProgress = hasGoal && raisedCents > 0;
+  const goalCents = goalAmountCents ?? 0;
+  const progressPercent =
+    hasGoal && goalCents > 0 ? Math.min(100, Math.round((raisedCents / goalCents) * 100)) : 0;
+  return { hasGoal, showProgress, goalCents, progressPercent };
+}
+
 export default async function PublicCampaignPage({
   params,
   searchParams,
@@ -64,17 +83,10 @@ export default async function PublicCampaignPage({
     const page = await CampaignPublicPageService.getPublishedCampaignPublicPage(client, id);
     const colorPrimary = page.colorPrimary ?? DEFAULT_THEME_COLOR;
     const onPrimary = getReadableTextColor(colorPrimary);
-    const hasGoal = page.goalAmountCents !== null && page.goalAmountCents > 0;
-    // Issue #200: render the mockup's progress bar + donor count when we have
-    // a goal AND there's been at least one donation. Falling back to the
-    // metric tiles if either signal is missing keeps fresh campaigns from
-    // showing an empty bar.
-    const showProgress = hasGoal && page.raisedCents > 0;
-    const goalCents = page.goalAmountCents ?? 0;
-    const progressPercent =
-      hasGoal && goalCents > 0
-        ? Math.min(100, Math.round((page.raisedCents / goalCents) * 100))
-        : 0;
+    const { hasGoal, showProgress, goalCents, progressPercent } = computeProgressDisplay(
+      page.goalAmountCents,
+      page.raisedCents,
+    );
 
     return (
       <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(9,100,71,0.14),_transparent_42%),linear-gradient(180deg,_var(--color-surface-container-lowest)_0%,_var(--color-surface)_100%)]">
@@ -106,28 +118,11 @@ export default async function PublicCampaignPage({
                  * even on greenfield campaigns.
                  */}
                 {page.organisationName ? (
-                  <div className="mb-6 flex">
-                    {page.organisationLogoUrl ? (
-                      <div className="relative h-14 w-14 overflow-hidden rounded-xl bg-white/10 backdrop-blur-sm">
-                        <Image
-                          src={page.organisationLogoUrl}
-                          alt={page.organisationName}
-                          fill
-                          sizes="56px"
-                          unoptimized
-                          className="object-contain"
-                          priority
-                        />
-                      </div>
-                    ) : (
-                      <InitialLetterAvatar
-                        orgName={page.organisationName}
-                        tenantId={page.organisationId}
-                        size="lg"
-                        ariaLabel={page.organisationName}
-                      />
-                    )}
-                  </div>
+                  <OrgLogoBlock
+                    organisationName={page.organisationName}
+                    organisationId={page.organisationId}
+                    organisationLogoUrl={page.organisationLogoUrl}
+                  />
                 ) : null}
                 {/*
                  * Eyebrow line shows the operator's organisation name when
@@ -213,6 +208,47 @@ function Metric({ label, value }: { label: string; value: string }) {
         {label}
       </p>
       <p className="mt-2 text-base font-semibold text-on-surface sm:text-lg">{value}</p>
+    </div>
+  );
+}
+
+/**
+ * Org logo block — shows the uploaded logo (Epic #286) or a fallback
+ * initial-letter avatar. Pulled out of `PublicCampaignPage` so the
+ * parent stays under the cognitive-complexity threshold; behaviour
+ * unchanged from the inline JSX.
+ */
+function OrgLogoBlock({
+  organisationName,
+  organisationId,
+  organisationLogoUrl,
+}: {
+  organisationName: string;
+  organisationId: string | undefined;
+  organisationLogoUrl: string | null | undefined;
+}) {
+  return (
+    <div className="mb-6 flex">
+      {organisationLogoUrl ? (
+        <div className="relative h-14 w-14 overflow-hidden rounded-xl bg-white/10 backdrop-blur-sm">
+          <Image
+            src={organisationLogoUrl}
+            alt={organisationName}
+            fill
+            sizes="56px"
+            unoptimized
+            className="object-contain"
+            priority
+          />
+        </div>
+      ) : (
+        <InitialLetterAvatar
+          orgName={organisationName}
+          tenantId={organisationId}
+          size="lg"
+          ariaLabel={organisationName}
+        />
+      )}
     </div>
   );
 }

--- a/packages/web/src/app/api/auth/callback/route.ts
+++ b/packages/web/src/app/api/auth/callback/route.ts
@@ -43,6 +43,64 @@ function sanitizeError(error: string): string {
 }
 
 /**
+ * Reads + validates the `return_to` OIDC cookie. Returns the safe path
+ * or null; logs a defence-in-depth warning if the cookie was set but
+ * didn't pass the same-origin / allowlist check the login route writes
+ * against. Pulled out of `GET` to keep the callback handler under the
+ * cognitive-complexity threshold.
+ */
+function readValidatedReturnTo(jar: Awaited<ReturnType<typeof cookies>>): string | null {
+  const rawReturnToCookie = jar.get(OIDC_RETURN_TO_COOKIE)?.value ?? null;
+  const returnTo = safeReturnToPath(rawReturnToCookie);
+  if (rawReturnToCookie && !returnTo) {
+    logAuthEvent("warn", "auth.return_to.rejected", {
+      raw: rawReturnToCookie.slice(0, 256),
+      reason: "cookie_not_same_origin_path",
+    });
+  }
+  return returnTo;
+}
+
+/**
+ * Cleans up OIDC flow cookies and returns a redirect to `/login`,
+ * optionally tagging an `error` query param. Pulled out of `GET` to
+ * collapse the half-dozen `cleanup() + new URL + searchParams.set +
+ * NextResponse.redirect` repetitions into one call site each.
+ */
+function loginRedirectAfterCleanup(
+  jar: Awaited<ReturnType<typeof cookies>>,
+  errorCode?: string,
+): NextResponse {
+  jar.delete(OIDC_STATE_COOKIE);
+  jar.delete(OIDC_VERIFIER_COOKIE);
+  jar.delete(OIDC_NONCE_COOKIE);
+  jar.delete(OIDC_RETURN_TO_COOKIE);
+  const loginUrl = new URL("/login", APP_URL);
+  if (errorCode) loginUrl.searchParams.set("error", errorCode);
+  return NextResponse.redirect(loginUrl.toString());
+}
+
+/**
+ * Picks the post-callback landing URL. Three branches:
+ *   - `returnTo` set (issue #250 step-up MFA): drop the operator back
+ *     where they were before the redirect.
+ *   - `super_admin` realm role: super-admins have no tenant membership
+ *     (ADR-022) and `/select-organization` would 302 them to
+ *     `/login?error=no_tenants` — send them to the back-office tenant
+ *     list instead.
+ *   - Otherwise: every newly-authenticated tenant user routes through
+ *     `/select-organization` (FE-2), which 302s onward to `/dashboard`
+ *     for solo-tenant users.
+ * Pulled out of `GET` to keep the callback handler under the
+ * cognitive-complexity threshold (extract-only, behavior unchanged).
+ */
+function selectPostLoginRedirect(returnTo: string | null, isSuperAdmin: boolean): string {
+  if (returnTo) return new URL(returnTo, APP_URL).toString();
+  if (isSuperAdmin) return new URL("/admin/tenants", APP_URL).toString();
+  return new URL("/select-organization", APP_URL).toString();
+}
+
+/**
  * GET /api/auth/callback
  *
  * Keycloak redirects here after the user authenticates.
@@ -61,61 +119,32 @@ export async function GET(request: NextRequest) {
 
   const jar = await cookies();
 
-  // Post-callback redirect target (issue #250 step-up). Pulled before
-  // cleanup runs; re-validated via the same allow-list as the login
-  // route writes against — a stale or tampered cookie falls back to the
-  // default landing page rather than becoming an open-redirect oracle.
-  const rawReturnToCookie = jar.get(OIDC_RETURN_TO_COOKIE)?.value ?? null;
-  const returnTo = safeReturnToPath(rawReturnToCookie);
-  if (rawReturnToCookie && !returnTo) {
-    // Defence-in-depth log: the login route already validates inbound
-    // `return_to`, but a tampered cookie or a cross-deploy session that
-    // crossed an APP_URL change would surface here. Same shape as the
-    // login-route rejection so SOC dashboards can correlate.
-    logAuthEvent("warn", "auth.return_to.rejected", {
-      raw: rawReturnToCookie.slice(0, 256),
-      reason: "cookie_not_same_origin_path",
-    });
-  }
-
-  // Clean up OIDC flow cookies regardless of outcome
-  const cleanup = () => {
-    jar.delete(OIDC_STATE_COOKIE);
-    jar.delete(OIDC_VERIFIER_COOKIE);
-    jar.delete(OIDC_NONCE_COOKIE);
-    jar.delete(OIDC_RETURN_TO_COOKIE);
-  };
+  // Post-callback redirect target (issue #250 step-up). Re-validated via
+  // the same allow-list as the login route writes against — a stale or
+  // tampered cookie falls back to the default landing page rather than
+  // becoming an open-redirect oracle.
+  const returnTo = readValidatedReturnTo(jar);
 
   // Keycloak returned an error — map to safe error code, never reflect raw text
   if (error) {
-    cleanup();
-    const loginUrl = new URL("/login", APP_URL);
-    loginUrl.searchParams.set("error", sanitizeError(error));
-    return NextResponse.redirect(loginUrl.toString());
+    return loginRedirectAfterCleanup(jar, sanitizeError(error));
   }
 
   // Validate state parameter — prevents CSRF login attacks
   const storedState = jar.get(OIDC_STATE_COOKIE)?.value;
   if (!state || !storedState || state !== storedState) {
-    cleanup();
-    const loginUrl = new URL("/login", APP_URL);
-    loginUrl.searchParams.set("error", "invalid_state");
-    return NextResponse.redirect(loginUrl.toString());
+    return loginRedirectAfterCleanup(jar, "invalid_state");
   }
 
   // No authorization code — something went wrong
   if (!code) {
-    cleanup();
-    return NextResponse.redirect(new URL("/login", APP_URL).toString());
+    return loginRedirectAfterCleanup(jar);
   }
 
   // Retrieve PKCE code_verifier for token exchange
   const codeVerifier = jar.get(OIDC_VERIFIER_COOKIE)?.value;
   if (!codeVerifier) {
-    cleanup();
-    const loginUrl = new URL("/login", APP_URL);
-    loginUrl.searchParams.set("error", "missing_verifier");
-    return NextResponse.redirect(loginUrl.toString());
+    return loginRedirectAfterCleanup(jar, "missing_verifier");
   }
 
   try {
@@ -139,10 +168,7 @@ export async function GET(request: NextRequest) {
         status: tokenRes.status,
         upstream: text.slice(0, 256),
       });
-      cleanup();
-      const loginUrl = new URL("/login", APP_URL);
-      loginUrl.searchParams.set("error", "token_exchange_failed");
-      return NextResponse.redirect(loginUrl.toString());
+      return loginRedirectAfterCleanup(jar, "token_exchange_failed");
     }
 
     const tokens = (await tokenRes.json()) as {
@@ -160,21 +186,22 @@ export async function GET(request: NextRequest) {
       logAuthEvent("error", "auth.callback.access_token_invalid", {
         message: error instanceof Error ? error.message : String(error).slice(0, 256),
       });
-      cleanup();
-      const loginUrl = new URL("/login", APP_URL);
       const errorCode =
         error instanceof Error && error.message.includes("`org_id`")
           ? "missing_org_id"
           : "callback_failed";
-      loginUrl.searchParams.set("error", errorCode);
-      return NextResponse.redirect(loginUrl.toString());
+      return loginRedirectAfterCleanup(jar, errorCode);
     }
     const isSuperAdmin = decoded.realm_access?.roles?.includes("super_admin") ?? false;
 
     const sessionMaxAge = resolveSessionMaxAge(tokens);
 
-    // Clean up OIDC flow cookies and store the verified Keycloak access token directly.
-    cleanup();
+    // Inline cleanup of OIDC flow cookies (the success path can't reuse
+    // `loginRedirectAfterCleanup` because it doesn't redirect to /login).
+    jar.delete(OIDC_STATE_COOKIE);
+    jar.delete(OIDC_VERIFIER_COOKIE);
+    jar.delete(OIDC_NONCE_COOKIE);
+    jar.delete(OIDC_RETURN_TO_COOKIE);
     jar.set(JWT_COOKIE_NAME, tokens.access_token, jwtCookieOptions(sessionMaxAge));
     jar.set(getCsrfCookieName(), crypto.randomUUID(), buildCsrfCookieOptions(sessionMaxAge));
     if (tokens.id_token) {
@@ -184,40 +211,11 @@ export async function GET(request: NextRequest) {
       jar.set(REFRESH_TOKEN_COOKIE_NAME, tokens.refresh_token, jwtCookieOptions(sessionMaxAge));
     }
 
-    // Step-up MFA flow (issue #250): if the operator was redirected here
-    // mid-task (e.g. from POST /v1/admin/impersonation 401), drop them
-    // back where they were instead of routing through the org picker.
-    // Falls through to the default landing page when no return_to is set.
-    if (returnTo) {
-      return NextResponse.redirect(new URL(returnTo, APP_URL).toString());
-    }
-
-    // Super-admin landing (PR #251 user feedback). Super-admins live in
-    // `platform_admins`, have no tenant memberships (ADR-022), and would
-    // otherwise hit `/select-organization` → `/login?error=no_tenants`
-    // because the picker treats zero memberships as "broken account".
-    // Send them straight to the back-office tenant list — that's the
-    // canonical operator landing page. The (admin) layout already gates
-    // on `super_admin` realm role, so this redirect is safe even if the
-    // role is ever stripped (the layout would 404 / bounce).
-    if (isSuperAdmin) {
-      return NextResponse.redirect(new URL("/admin/tenants", APP_URL).toString());
-    }
-
-    // FE-2: send every newly-authenticated tenant user through
-    // `/select-organization`. That page server-renders the membership
-    // fetch and will 302 to `/dashboard` immediately if the user belongs
-    // to <=1 tenant — so solo-tenant users pay one extra redirect (cheap)
-    // and multi-tenant users get the picker without the callback blocking
-    // on a sequential fetch.
-    return NextResponse.redirect(new URL("/select-organization", APP_URL).toString());
+    return NextResponse.redirect(selectPostLoginRedirect(returnTo, isSuperAdmin));
   } catch (err) {
     logAuthEvent("error", "auth.callback.unexpected_failure", {
       message: err instanceof Error ? err.message : String(err).slice(0, 256),
     });
-    cleanup();
-    const loginUrl = new URL("/login", APP_URL);
-    loginUrl.searchParams.set("error", "callback_failed");
-    return NextResponse.redirect(loginUrl.toString());
+    return loginRedirectAfterCleanup(jar, "callback_failed");
   }
 }

--- a/packages/web/src/components/admin/new-platform-admin-form.tsx
+++ b/packages/web/src/components/admin/new-platform-admin-form.tsx
@@ -25,6 +25,44 @@ interface FormValues {
   email: string;
 }
 
+type EmailErrorKey =
+  | "errors.emailTakenByTenant"
+  | "errors.emailTakenByKeycloak"
+  | "errors.emailTakenByAdmin";
+
+/**
+ * Maps a 409 `ApiProblem.detail` to the right localised email-field error.
+ * Pulled out of `onSubmit` to keep that function under the cognitive-
+ * complexity threshold; behaviour-preserving (same regex order, same
+ * fallback).
+ */
+function emailConflictErrorKey(detail: string): EmailErrorKey {
+  if (/tenant member/i.test(detail)) return "errors.emailTakenByTenant";
+  if (/Keycloak user with this email/i.test(detail)) return "errors.emailTakenByKeycloak";
+  return "errors.emailTakenByAdmin";
+}
+
+/**
+ * Surface a `PlatformAdminService.create` error on the form: 409 → field-
+ * level email error, 502 → keycloak-misconfig toast, else generic toast.
+ */
+function handleCreatePlatformAdminError(
+  err: unknown,
+  form: ReturnType<typeof useForm<FormValues>>,
+  t: ReturnType<typeof useTranslations<"admin.platformAdmins.new">>,
+): void {
+  if (err instanceof ApiProblem && err.status === 409) {
+    const key = emailConflictErrorKey(err.detail ?? "");
+    form.setError("email", { type: "server", message: t(key) });
+    return;
+  }
+  if (err instanceof ApiProblem && err.status === 502) {
+    toast.error(t("errors.keycloakMisconfig"));
+    return;
+  }
+  toast.error(t("errors.generic"));
+}
+
 /**
  * Invite-a-platform-admin form (issue #254). Behind the `(admin)/layout.tsx`
  * super_admin gate. The submit:
@@ -58,29 +96,7 @@ export function NewPlatformAdminForm() {
       router.push("/admin/platform-admins");
       router.refresh();
     } catch (err) {
-      if (err instanceof ApiProblem) {
-        const detail = err.detail ?? "";
-        if (err.status === 409) {
-          if (/tenant member/i.test(detail)) {
-            form.setError("email", { type: "server", message: t("errors.emailTakenByTenant") });
-            return;
-          }
-          if (/Keycloak user with this email/i.test(detail)) {
-            form.setError("email", {
-              type: "server",
-              message: t("errors.emailTakenByKeycloak"),
-            });
-            return;
-          }
-          form.setError("email", { type: "server", message: t("errors.emailTakenByAdmin") });
-          return;
-        }
-        if (err.status === 502) {
-          toast.error(t("errors.keycloakMisconfig"));
-          return;
-        }
-      }
-      toast.error(t("errors.generic"));
+      handleCreatePlatformAdminError(err, form, t);
     }
   }
 

--- a/packages/web/src/components/admin/platform-admin-detail-actions.tsx
+++ b/packages/web/src/components/admin/platform-admin-detail-actions.tsx
@@ -46,6 +46,35 @@ interface Props {
 }
 
 /**
+ * Maps a remove-call error to a translation key. Pulled out of
+ * `onRemoveConfirm` so the latter stays under the cognitive-complexity
+ * threshold; the test suite (`platform-admin-detail-actions.test.tsx`)
+ * locks each branch via dedicated `it()` blocks (last-admin, self-removal,
+ * 404, generic) — refactor is behavior-preserving by construction.
+ *
+ * Return type is the literal-string union (not `string`) because next-intl's
+ * `t()` signature accepts only namespace-keyed literals, not arbitrary
+ * strings.
+ */
+type RemoveErrorKey =
+  | "errors.selfRemoval"
+  | "errors.lastAdmin"
+  | "errors.notFound"
+  | "errors.generic";
+
+function removeErrorTranslationKey(err: unknown): RemoveErrorKey {
+  if (err instanceof ApiProblem) {
+    if (err.status === 400) {
+      const detail = err.detail ?? "";
+      if (/own platform-admin row/i.test(detail)) return "errors.selfRemoval";
+      if (/last active/i.test(detail)) return "errors.lastAdmin";
+    }
+    if (err.status === 404) return "errors.notFound";
+  }
+  return "errors.generic";
+}
+
+/**
  * Detail-page actions for a platform admin (issue #254): edit name,
  * re-trigger the password-reset email, soft-delete the admin.
  *
@@ -125,20 +154,7 @@ export function PlatformAdminDetailActions({ admin, operatorKeycloakId }: Props)
       router.push("/admin/platform-admins");
       router.refresh();
     } catch (err) {
-      if (err instanceof ApiProblem && err.status === 400) {
-        const detail = err.detail ?? "";
-        if (/own platform-admin row/i.test(detail)) {
-          toast.error(t("errors.selfRemoval"));
-        } else if (/last active/i.test(detail)) {
-          toast.error(t("errors.lastAdmin"));
-        } else {
-          toast.error(t("errors.generic"));
-        }
-      } else if (err instanceof ApiProblem && err.status === 404) {
-        toast.error(t("errors.notFound"));
-      } else {
-        toast.error(t("errors.generic"));
-      }
+      toast.error(t(removeErrorTranslationKey(err)));
     } finally {
       setPendingRemove(false);
     }

--- a/packages/web/src/components/admin/platform-admin-detail-actions.tsx
+++ b/packages/web/src/components/admin/platform-admin-detail-actions.tsx
@@ -166,7 +166,17 @@ export function PlatformAdminDetailActions({ admin, operatorKeycloakId }: Props)
 
       {/* Edit-name dialog */}
       <Dialog open={editOpen} onOpenChange={setEditOpen}>
-        <DialogContent>
+        <DialogContent
+          onOpenAutoFocus={(e) => {
+            // Override Radix's default-first-focusable (the close X button)
+            // and focus the first user-editable field. Equivalent to
+            // `autoFocus` on the Input below but doesn't trigger
+            // `lint/a11y/noAutofocus`, which warns against attribute-form
+            // auto-focus that the user hasn't explicitly opted into.
+            e.preventDefault();
+            editForm.setFocus("firstName");
+          }}
+        >
           <DialogHeader>
             <DialogTitle>{t("editDialog.title")}</DialogTitle>
             <DialogDescription>{t("editDialog.description")}</DialogDescription>
@@ -198,8 +208,7 @@ export function PlatformAdminDetailActions({ admin, operatorKeycloakId }: Props)
                     <FormItem>
                       <FormLabel>{tFields("firstName")}</FormLabel>
                       <FormControl>
-                        {/* biome-ignore lint/a11y/noAutofocus: dialog focus convention */}
-                        <Input {...field} autoFocus autoComplete="given-name" />
+                        <Input {...field} autoComplete="given-name" />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/packages/web/src/components/admin/start-impersonation-form.tsx
+++ b/packages/web/src/components/admin/start-impersonation-form.tsx
@@ -56,6 +56,48 @@ interface StashedPayload {
 type Mode = "delegation" | "impersonation";
 
 /**
+ * Translates the non-step-up error responses to localised copy.
+ *  - 401 + step_up_required=false → lockout (5-fail counter tipped)
+ *  - 401 (other) → step-up failed (KC didn't upgrade acr; user bailed during enrolment)
+ *  - else → API's RFC 9457 detail/title fallback
+ * The step_up_required=true branch is handled inline in `executeStart`
+ * (it triggers a redirect, not a setError). Pulled out to keep
+ * `executeStart` under the cognitive-complexity threshold.
+ */
+function resolveImpersonationErrorCopy(
+  res: Response,
+  body: StepUpRequiredResponse,
+  t: ReturnType<typeof useTranslations>,
+): string {
+  if (res.status === 401 && body.step_up_required === false) return t("errorLockout");
+  if (res.status === 401) return t("errorStepUpFailed");
+  return body.detail ?? body.title ?? `Request failed: ${res.status}`;
+}
+
+/**
+ * Stash the in-flight impersonation form payload to sessionStorage so
+ * the post-MFA mount-effect can pick it up and resubmit without making
+ * the operator re-fill (target, mode, reason). 5-min TTL matches the
+ * API's auth_time freshness window. Pulled out of `executeStart` to
+ * keep that function under the cognitive-complexity threshold; failures
+ * (privacy mode, quota exceeded) silently fall back to the legacy
+ * "operator refills the form" behaviour — annoying but not broken.
+ */
+function stashImpersonationPayload(
+  payload: Pick<StashedPayload, "target" | "mode" | "reason">,
+): void {
+  try {
+    const stash: StashedPayload = {
+      ...payload,
+      expiresAt: Date.now() + STASH_TTL_MS,
+    };
+    sessionStorage.setItem(STASH_KEY, JSON.stringify(stash));
+  } catch {
+    // sessionStorage may be unavailable. Fall through.
+  }
+}
+
+/**
  * Client form to start a support session (issue #24).
  *
  * Three pickers replace the bare UUID paste:
@@ -127,33 +169,15 @@ export function StartImpersonationForm() {
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as StepUpRequiredResponse;
 
-        // Step-up MFA required (issue #250). Send the operator through
-        // /api/auth/login with `acr_values=2` so Keycloak fires the
-        // Conditional-LoA sub-flow (OTP prompt). The login route persists
-        // `return_to` in a cookie; the callback will land them back on
-        // this page after the fresh acr=2 token is set, and the
-        // mount-effect below auto-resubmits the stashed payload.
-        // Suppressed when `step_up_required` is false (lockout case — the
-        // operator is locked out, redirecting to re-auth would just loop).
+        // Step-up MFA required (issue #250). Stash the payload + redirect
+        // through /api/auth/login with `acr_values=2`. The mount-effect
+        // below auto-hydrates from the stash on the post-MFA bounce-back.
         if (res.status === 401 && body.step_up_required) {
-          // Stash the payload so the post-MFA mount-effect can pick it up
-          // and resubmit without making the operator re-fill (target,
-          // mode, reason). 5-min TTL matches the API's auth_time
-          // freshness window — past that, a resubmit would 401 again
-          // and we'd be back in this branch anyway.
-          try {
-            const stash: StashedPayload = {
-              target: submittedTarget,
-              mode: submittedMode,
-              reason: submittedReason,
-              expiresAt: Date.now() + STASH_TTL_MS,
-            };
-            sessionStorage.setItem(STASH_KEY, JSON.stringify(stash));
-          } catch {
-            // sessionStorage may be unavailable (privacy mode, quota).
-            // Fall back to the legacy "operator refills the form"
-            // behaviour — annoying but not broken.
-          }
+          stashImpersonationPayload({
+            target: submittedTarget,
+            mode: submittedMode,
+            reason: submittedReason,
+          });
           willNavigate = true;
           setError(t("stepUpRedirecting"));
           window.location.assign(
@@ -162,27 +186,7 @@ export function StartImpersonationForm() {
           return;
         }
 
-        // Translated error copy for the step-up 401 lockout path
-        // (review I-7) — the API's RFC 9457 `detail` field is English-
-        // only since the API isn't locale-aware. The redirect branch
-        // above already handles `step_up_required: true`, so this 401
-        // branch is reached only when the 5-fail counter tipped.
-        if (res.status === 401 && body.step_up_required === false) {
-          setError(t("errorLockout"));
-          return;
-        }
-
-        // Anything else under a 401 (e.g., the auto-resubmit path lands
-        // here when KC didn't actually upgrade the acr — say the user
-        // bailed during enrolment and went Back). Use the localised
-        // step-up-failed copy so the operator gets an actionable hint
-        // instead of the API's English-only `detail`. Multi-agent
-        // review UX-2 (PR #251).
-        if (res.status === 401) {
-          setError(t("errorStepUpFailed"));
-          return;
-        }
-        setError(body.detail ?? body.title ?? `Request failed: ${res.status}`);
+        setError(resolveImpersonationErrorCopy(res, body, t));
         return;
       }
 

--- a/packages/web/src/components/branding/logo-upload-card.test.tsx
+++ b/packages/web/src/components/branding/logo-upload-card.test.tsx
@@ -5,10 +5,10 @@ import { mockToast, render, screen, userEvent, waitFor } from "@/tests/test-util
 // next/image's runtime expects the Next image-config context which JSDOM
 // can't satisfy. Forward the props onto a plain `<img>` so tests can assert
 // on `alt` / `src` for the "ready" preview path (PR #287 review, minor 13).
+// `<img>` here is correct for the test mock (no Next runtime to delegate to);
+// the `noImgElement` rule is silenced for `**/*.test.{ts,tsx}` via biome.json.
 vi.mock("next/image", () => ({
-  // biome-ignore lint/a11y/useAltText: alt is forwarded from the component under test.
   default: (props: Record<string, unknown>) => (
-    // biome-ignore lint/a11y/useAltText: alt forwarded via spread; default empty to satisfy DOM.
     <img {...(props as Record<string, string>)} alt={(props.alt as string) ?? ""} />
   ),
 }));

--- a/packages/web/src/components/branding/logo-upload-card.tsx
+++ b/packages/web/src/components/branding/logo-upload-card.tsx
@@ -227,7 +227,7 @@ export function LogoUploadCard({
       <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
         {/* Preview / fallback */}
         <div className="flex shrink-0 items-center justify-center">
-          {currentLogo && currentLogo.variants?.preview ? (
+          {currentLogo?.variants?.preview ? (
             <div className="relative h-24 w-24 overflow-hidden rounded-2xl border border-outline-variant bg-surface-container">
               <Image
                 src={currentLogo.variants.preview.url}

--- a/packages/web/src/components/branding/logo-upload-card.tsx
+++ b/packages/web/src/components/branding/logo-upload-card.tsx
@@ -112,31 +112,27 @@ export function LogoUploadCard({
     const tick = async () => {
       if (cancelled) return;
       attempts += 1;
+      // A network blip during the poll is indistinguishable from "still
+      // pending" — both fall through to the timeout/schedule branch below.
+      // Collapsing into a single decision flow keeps the catch path and the
+      // success path symmetric, which removes the duplicated timeout check.
+      let logo: OrgLogo | null = null;
       try {
-        const logo = await BrandingService.getOrgLogo();
-        if (cancelled) return;
-        if (logo && logo.status === "ready") {
-          setState({ kind: "ready", logo });
-          toast.success(t("success"));
-          return;
-        }
-        if (logo && logo.status === "failed") {
-          setState({ kind: "error", message: t("errors.uploadFailed") });
-          return;
-        }
-        if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
-          setState({ kind: "error", message: t("errors.uploadFailed") });
-          return;
-        }
-        timer = setTimeout(tick, pollDelayMs(attempts));
+        logo = await BrandingService.getOrgLogo();
       } catch {
-        if (cancelled) return;
-        if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
-          setState({ kind: "error", message: t("errors.uploadFailed") });
-          return;
-        }
-        timer = setTimeout(tick, pollDelayMs(attempts));
+        // Intentionally swallowed — handled by the unified flow below.
       }
+      if (cancelled) return;
+      if (logo?.status === "ready") {
+        setState({ kind: "ready", logo });
+        toast.success(t("success"));
+        return;
+      }
+      if (logo?.status === "failed" || Date.now() - startedAt > POLL_TIMEOUT_MS) {
+        setState({ kind: "error", message: t("errors.uploadFailed") });
+        return;
+      }
+      timer = setTimeout(tick, pollDelayMs(attempts));
     };
 
     timer = setTimeout(tick, pollDelayMs(0));
@@ -320,45 +316,7 @@ export function LogoUploadCard({
 
               <p className="text-xs text-on-surface-variant">{t("coachingCopy")}</p>
 
-              {/* Status row */}
-              {state.kind === "uploading" ? (
-                <div
-                  className="flex items-center gap-2 text-sm text-on-surface-variant"
-                  role="status"
-                >
-                  <LoaderCircle size={16} className="animate-spin" aria-hidden="true" />
-                  <span>{t("uploading")}</span>
-                </div>
-              ) : null}
-              {state.kind === "processing" ? (
-                <div
-                  className="flex items-center gap-2 text-sm text-on-surface-variant"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <LoaderCircle size={16} className="animate-spin" aria-hidden="true" />
-                  <span>{t("pendingProcessing")}</span>
-                </div>
-              ) : null}
-              {state.kind === "ready" ? (
-                <div
-                  className="inline-flex items-center gap-2 rounded-full bg-green-light px-3 py-1 text-xs text-green-text"
-                  role="status"
-                >
-                  <CheckCircle2 size={14} aria-hidden="true" />
-                  <span>{t("readyBadge")}</span>
-                </div>
-              ) : null}
-              {state.kind === "error" ? (
-                <div
-                  className="flex items-start gap-2 rounded-lg border border-error-border bg-error-container p-3 text-sm text-on-error-container"
-                  role="alert"
-                  aria-live="polite"
-                >
-                  <TriangleAlert size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
-                  <span className="flex-1">{state.message}</span>
-                </div>
-              ) : null}
+              <LogoStatusRow state={state} />
 
               {currentLogo ? (
                 <div className="flex flex-wrap gap-3 pt-2">
@@ -384,6 +342,59 @@ export function LogoUploadCard({
       </div>
     </Wrapper>
   );
+}
+
+/**
+ * Renders the inline status row beneath the dropzone. Pulled out of
+ * `LogoUploadCard` so the parent stays under the cognitive-complexity
+ * threshold; behaviour-preserving — same DOM, same aria roles.
+ */
+function LogoStatusRow({ state }: { state: CardState }) {
+  const t = useTranslations("settings.branding");
+  if (state.kind === "uploading") {
+    return (
+      <div className="flex items-center gap-2 text-sm text-on-surface-variant" role="status">
+        <LoaderCircle size={16} className="animate-spin" aria-hidden="true" />
+        <span>{t("uploading")}</span>
+      </div>
+    );
+  }
+  if (state.kind === "processing") {
+    return (
+      <div
+        className="flex items-center gap-2 text-sm text-on-surface-variant"
+        role="status"
+        aria-live="polite"
+      >
+        <LoaderCircle size={16} className="animate-spin" aria-hidden="true" />
+        <span>{t("pendingProcessing")}</span>
+      </div>
+    );
+  }
+  if (state.kind === "ready") {
+    return (
+      <div
+        className="inline-flex items-center gap-2 rounded-full bg-green-light px-3 py-1 text-xs text-green-text"
+        role="status"
+      >
+        <CheckCircle2 size={14} aria-hidden="true" />
+        <span>{t("readyBadge")}</span>
+      </div>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <div
+        className="flex items-start gap-2 rounded-lg border border-error-border bg-error-container p-3 text-sm text-on-error-container"
+        role="alert"
+        aria-live="polite"
+      >
+        <TriangleAlert size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+        <span className="flex-1">{state.message}</span>
+      </div>
+    );
+  }
+  return null;
 }
 
 interface UploadErrorMessages {

--- a/packages/web/src/components/settings/stripe-connect-panel.tsx
+++ b/packages/web/src/components/settings/stripe-connect-panel.tsx
@@ -108,7 +108,7 @@ export function StripeConnectPanel({ canManageTenant }: StripeConnectPanelProps)
             </div>
           ) : null}
 
-          {status && status.accountId && !status.chargesEnabled ? (
+          {status?.accountId && !status.chargesEnabled ? (
             <RequirementsList status={status} />
           ) : null}
 
@@ -165,7 +165,7 @@ function StatusBadge({
 function describeState(
   status: StripeConnectStatus | null,
 ): "notConnected" | "pending" | "connected" {
-  if (!status || !status.accountId) return "notConnected";
+  if (!status?.accountId) return "notConnected";
   if (status.chargesEnabled) return "connected";
   return "pending";
 }

--- a/packages/web/src/components/ui/data-table.tsx
+++ b/packages/web/src/components/ui/data-table.tsx
@@ -116,7 +116,6 @@ function HeaderCell<TData>({ header, padding }: HeaderCellProps<TData>) {
   );
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: DataTable hosts the (paginated | unpaginated) × (rows | empty) matrix inline. Splitting into branches hides the row-summary / pagination dispatch.
 export function DataTable<TData>({
   onRowClick,
   columns,

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -216,57 +216,81 @@ function applyRefreshedSession(
   });
 }
 
-export async function proxy(request: NextRequest) {
-  const { pathname } = request.nextUrl;
-  let jwt = request.cookies.get(JWT_COOKIE_NAME)?.value;
-  const refreshToken = request.cookies.get(REFRESH_TOKEN_COOKIE_NAME)?.value;
-  let refreshedSession: RefreshedSession | null = null;
-  let cookieHeader = request.headers.get("cookie") ?? undefined;
-
-  // Refresh the access token when:
-  //  (a) JWT is present and within `SESSION_REFRESH_GRACE_S` of expiry
-  //      (the original auto-refresh path), OR
-  //  (b) JWT is MISSING but a refresh_token cookie is still alive.
-  //
-  // Case (b) covers the post-impersonation-end flow: the API's
-  // `applyClearImpersonationCookie` only clears `givernance_jwt`, leaving
-  // the operator's KC `givernance_refresh_token` (which the impersonation
-  // start never touched) intact. Without (b), the next request after
-  // end-session lands on the proxy with no JWT, falls through to the
-  // protected-route guard below, and bounces the operator to `/login`.
-  // `/login` is the static form page — it does NOT auto-trigger the OIDC
-  // dance — so the operator sees the sign-in form despite their KC SSO
-  // session still being alive at the IdP. Refreshing here mints fresh
-  // operator KC tokens from the still-valid refresh_token, restoring the
-  // pre-impersonation session in one round-trip.
-  //
-  // The same path also restores any browser tab that lost only its
-  // access-token cookie (e.g. after a server-side `cookies.delete()` that
-  // didn't propagate everywhere). Explicit logout via /api/auth/logout
-  // clears the refresh_token too, so we won't auto-relog a user who chose
-  // to sign out.
+/**
+ * Refresh the access token when:
+ *  (a) JWT is present and within `SESSION_REFRESH_GRACE_S` of expiry
+ *      (the original auto-refresh path), OR
+ *  (b) JWT is MISSING but a refresh_token cookie is still alive.
+ *
+ * Case (b) covers the post-impersonation-end flow: the API's
+ * `applyClearImpersonationCookie` only clears `givernance_jwt`, leaving
+ * the operator's KC `givernance_refresh_token` intact. Without (b), the
+ * next request after end-session lands on the proxy with no JWT, falls
+ * through to the protected-route guard, and bounces the operator to
+ * `/login` — but `/login` is the static form page, NOT the OIDC dance,
+ * so the operator sees the sign-in form despite their KC SSO session
+ * still being alive at the IdP. Refreshing here mints fresh operator
+ * KC tokens from the still-valid refresh_token, restoring the
+ * pre-impersonation session in one round-trip.
+ *
+ * Pulled out of `proxy` to keep that function under the
+ * cognitive-complexity threshold; behaviour identical.
+ */
+async function applyMaybeRefreshSession(
+  request: NextRequest,
+  jwt: string | undefined,
+  refreshToken: string | undefined,
+  cookieHeader: string | undefined,
+): Promise<{
+  jwt: string | undefined;
+  cookieHeader: string | undefined;
+  refreshedSession: RefreshedSession | null;
+}> {
   const jwtExpired = !jwt;
-  if (refreshToken && (jwtExpired || shouldRefreshToken(jwt))) {
-    refreshedSession = await refreshSession(refreshToken);
-    if (refreshedSession) {
-      jwt = refreshedSession.accessToken;
-      cookieHeader = upsertCookieHeader(request, {
+  if (!refreshToken || !(jwtExpired || shouldRefreshToken(jwt))) {
+    return { jwt, cookieHeader, refreshedSession: null };
+  }
+  const refreshedSession = await refreshSession(refreshToken);
+  if (refreshedSession) {
+    return {
+      jwt: refreshedSession.accessToken,
+      cookieHeader: upsertCookieHeader(request, {
         [JWT_COOKIE_NAME]: refreshedSession.accessToken,
         ...(refreshedSession.idToken ? { [ID_TOKEN_COOKIE_NAME]: refreshedSession.idToken } : {}),
         ...(refreshedSession.refreshToken
           ? { [REFRESH_TOKEN_COOKIE_NAME]: refreshedSession.refreshToken }
           : {}),
-      });
-    } else if (jwtExpired || (decodeJwtExp(jwt ?? "") ?? 0) <= Math.floor(Date.now() / 1000)) {
-      jwt = undefined;
-      cookieHeader = upsertCookieHeader(request, {
+      }),
+      refreshedSession,
+    };
+  }
+  if (jwtExpired || (decodeJwtExp(jwt ?? "") ?? 0) <= Math.floor(Date.now() / 1000)) {
+    return {
+      jwt: undefined,
+      cookieHeader: upsertCookieHeader(request, {
         [JWT_COOKIE_NAME]: undefined,
         [ID_TOKEN_COOKIE_NAME]: undefined,
         [REFRESH_TOKEN_COOKIE_NAME]: undefined,
         [CSRF_COOKIE_NAME]: undefined,
-      });
-    }
+      }),
+      refreshedSession: null,
+    };
   }
+  return { jwt, cookieHeader, refreshedSession: null };
+}
+
+export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const initialJwt = request.cookies.get(JWT_COOKIE_NAME)?.value;
+  const refreshToken = request.cookies.get(REFRESH_TOKEN_COOKIE_NAME)?.value;
+  const initialCookieHeader = request.headers.get("cookie") ?? undefined;
+
+  const { jwt, cookieHeader, refreshedSession } = await applyMaybeRefreshSession(
+    request,
+    initialJwt,
+    refreshToken,
+    initialCookieHeader,
+  );
 
   // Allow public routes — but redirect logged-in users away from /login and /signup
   if (isPublic(pathname)) {

--- a/packages/worker/src/lib/svg-sanitiser.ts
+++ b/packages/worker/src/lib/svg-sanitiser.ts
@@ -13,8 +13,7 @@
  * MUST behave identically.
  */
 
-// biome-ignore lint/suspicious/noExplicitAny: dompurify's type exports vary across versions
-import createDOMPurify from "dompurify";
+import createDOMPurify, { type WindowLike } from "dompurify";
 import { JSDOM } from "jsdom";
 
 export class SvgSanitiserError extends Error {
@@ -65,8 +64,12 @@ export function sanitiseSvg(input: Buffer): Buffer {
   let cleaned: string;
   try {
     const window = new JSDOM("").window;
-    // biome-ignore lint/suspicious/noExplicitAny: dompurify's factory expects a Window-like
-    const purify = createDOMPurify(window as any);
+    // JSDOM's `DOMWindow` is structurally compatible with dompurify's
+    // `WindowLike` but TypeScript can't see it as such — `WindowLike` picks
+    // a narrow subset of properties from the global `Window` shape.
+    // Importing the named type from dompurify and routing through `unknown`
+    // satisfies the typechecker without resorting to `any`.
+    const purify = createDOMPurify(window as unknown as WindowLike);
     cleaned = purify.sanitize(text, {
       USE_PROFILES: { svg: true, svgFilters: false },
       RETURN_TRUSTED_TYPE: false,

--- a/packages/worker/src/processors/stripe-webhook.ts
+++ b/packages/worker/src/processors/stripe-webhook.ts
@@ -45,6 +45,97 @@ function asCharge(payload: Record<string, unknown>): Stripe.Charge {
   return payload as unknown as Stripe.Charge;
 }
 
+/**
+ * Epic #274 — re-verify the QR id under RLS before trusting it. Returns
+ * null when the metadata referenced a token that has since been deleted
+ * (rare but defensible — admin closes campaign + cascades QR rows mid-
+ * payment), or when metadata was tampered to point at a different
+ * tenant's QR row (RLS makes this query empty). The constituent fallback
+ * is the metadata value, kept for back-compat with legacy bound rows.
+ *
+ * Pulled out of `handlePaymentIntentSucceeded` to keep that function
+ * under the cognitive-complexity threshold; behaviour-preserving.
+ */
+async function resolveQrLink(
+  tx: Parameters<Parameters<typeof withWorkerContext>[1]>[0],
+  orgId: string,
+  metadata: { qrCodeId: string | null; qrCodeConstituentId: string | null },
+): Promise<{ resolvedQrCodeId: string | null; qrLinkedConstituentId: string | null }> {
+  if (!metadata.qrCodeId) {
+    return { resolvedQrCodeId: null, qrLinkedConstituentId: null };
+  }
+  const [qr] = await tx
+    .select({
+      id: campaignQrCodes.id,
+      constituentId: campaignQrCodes.constituentId,
+    })
+    .from(campaignQrCodes)
+    .where(and(eq(campaignQrCodes.id, metadata.qrCodeId), eq(campaignQrCodes.orgId, orgId)));
+  if (!qr) {
+    return { resolvedQrCodeId: null, qrLinkedConstituentId: null };
+  }
+  return {
+    resolvedQrCodeId: qr.id,
+    qrLinkedConstituentId: qr.constituentId ?? metadata.qrCodeConstituentId,
+  };
+}
+
+/**
+ * Find or create the donor constituent. Walks three resolution strategies
+ * in order: (1) QR-linked id (postal letter recipient — protects per-
+ * recipient analytics from "Jean Dupont's wife paid online" producing a
+ * brand-new row), (2) email match (drops the donor on their existing
+ * record), (3) anonymous create (no email, no QR). Pulled out of
+ * `handlePaymentIntentSucceeded` to keep that function under the
+ * cognitive-complexity threshold.
+ */
+async function findOrCreateConstituent(
+  tx: Parameters<Parameters<typeof withWorkerContext>[1]>[0],
+  orgId: string,
+  args: {
+    qrLinkedConstituentId: string | null;
+    email: string | null;
+    firstName: string;
+    lastName: string;
+    log: ReturnType<typeof jobLogger>;
+  },
+): Promise<string> {
+  const { qrLinkedConstituentId, email, firstName, lastName, log } = args;
+
+  if (qrLinkedConstituentId) {
+    const [linked] = await tx
+      .select({ id: constituents.id })
+      .from(constituents)
+      .where(and(eq(constituents.id, qrLinkedConstituentId), eq(constituents.orgId, orgId)));
+    if (linked) return linked.id;
+    // The linked constituent was deleted between print and scan — fall through.
+  }
+
+  if (email) {
+    const [existing] = await tx
+      .select({ id: constituents.id })
+      .from(constituents)
+      .where(sql`${constituents.orgId} = ${orgId} AND ${constituents.email} = ${email}`);
+    if (existing) return existing.id;
+
+    const [created] = await tx
+      .insert(constituents)
+      .values({ orgId, firstName, lastName, email, type: "donor" })
+      .returning({ id: constituents.id });
+    if (!created) throw new Error("findOrCreateConstituent: insert returned no row");
+    log.info({ constituentId: created.id }, "Created new constituent from Stripe");
+    return created.id;
+  }
+
+  // No email AND no QR — anonymous constituent.
+  const [created] = await tx
+    .insert(constituents)
+    .values({ orgId, firstName, lastName, type: "donor" })
+    .returning({ id: constituents.id });
+  if (!created) throw new Error("findOrCreateConstituent: insert returned no row");
+  return created.id;
+}
+
 /** Look up the tenant associated with a Stripe connected account ID */
 async function findTenantByStripeAccount(stripeAccountId: string) {
   const [tenant] = await db
@@ -155,91 +246,17 @@ async function handlePaymentIntentSucceeded(
       baseCurrency,
     );
 
-    // Epic #274 — re-verify the QR id under RLS before trusting it. Returns
-    // null when the metadata referenced a token that has since been deleted
-    // (rare but defensible — admin closes campaign + cascades QR rows mid-
-    // payment), or when metadata was tampered to point at a different
-    // tenant's QR row (RLS makes this query empty).
-    let resolvedQrCodeId: string | null = null;
-    let qrLinkedConstituentId: string | null = null;
-    if (qrCodeIdFromMetadata) {
-      const [qr] = await tx
-        .select({
-          id: campaignQrCodes.id,
-          constituentId: campaignQrCodes.constituentId,
-        })
-        .from(campaignQrCodes)
-        .where(and(eq(campaignQrCodes.id, qrCodeIdFromMetadata), eq(campaignQrCodes.orgId, orgId)));
-      if (qr) {
-        resolvedQrCodeId = qr.id;
-        qrLinkedConstituentId = qr.constituentId ?? qrCodeConstituentIdFromMetadata;
-      }
-    }
-
-    // Find or create constituent
-    let constituentId: string;
-
-    if (qrLinkedConstituentId) {
-      // Personalized QR scan — the donation belongs to the constituent the
-      // letter was printed for, not whoever filled in the donor form. This
-      // protects the per-recipient analytics from "Jean Dupont's wife paid
-      // online" producing a brand-new constituent row.
-      const [linked] = await tx
-        .select({ id: constituents.id })
-        .from(constituents)
-        .where(and(eq(constituents.id, qrLinkedConstituentId), eq(constituents.orgId, orgId)));
-      if (linked) {
-        constituentId = linked.id;
-      } else {
-        // The linked constituent was deleted between print and scan — fall
-        // through to the email-based resolution below.
-        constituentId = "";
-      }
-    } else {
-      constituentId = "";
-    }
-
-    if (!constituentId) {
-      if (constituentEmail) {
-        const [existing] = await tx
-          .select({ id: constituents.id })
-          .from(constituents)
-          .where(
-            sql`${constituents.orgId} = ${orgId} AND ${constituents.email} = ${constituentEmail}`,
-          );
-
-        if (existing) {
-          constituentId = existing.id;
-        } else {
-          const [created] = await tx
-            .insert(constituents)
-            .values({
-              orgId,
-              firstName: constituentFirstName,
-              lastName: constituentLastName,
-              email: constituentEmail,
-              type: "donor",
-            })
-            .returning({ id: constituents.id });
-          // biome-ignore lint/style/noNonNullAssertion: insert returning always returns
-          constituentId = created!.id;
-          log.info({ constituentId }, "Created new constituent from Stripe");
-        }
-      } else {
-        // No email provided AND not bound via QR — create anonymous constituent
-        const [created] = await tx
-          .insert(constituents)
-          .values({
-            orgId,
-            firstName: constituentFirstName,
-            lastName: constituentLastName,
-            type: "donor",
-          })
-          .returning({ id: constituents.id });
-        // biome-ignore lint/style/noNonNullAssertion: insert returning always returns
-        constituentId = created!.id;
-      }
-    }
+    const { resolvedQrCodeId, qrLinkedConstituentId } = await resolveQrLink(tx, orgId, {
+      qrCodeId: qrCodeIdFromMetadata,
+      qrCodeConstituentId: qrCodeConstituentIdFromMetadata,
+    });
+    const constituentId = await findOrCreateConstituent(tx, orgId, {
+      qrLinkedConstituentId,
+      email: constituentEmail ?? null,
+      firstName: constituentFirstName,
+      lastName: constituentLastName,
+      log,
+    });
 
     // Create the donation record — ON CONFLICT guards against BullMQ retry duplicates
     const [donation] = await tx

--- a/packages/worker/src/services/campaign-pdf.ts
+++ b/packages/worker/src/services/campaign-pdf.ts
@@ -137,6 +137,34 @@ function hasWindowEnvelopeAddress(recipient: CampaignLetterRecipient | null): bo
 }
 
 /**
+ * Render the recipient address block in the C5 envelope window zone.
+ * Pulled out of `createCampaignLetterPdfStream` to keep that function
+ * under the cognitive-complexity threshold; behaviour-preserving.
+ */
+function renderRecipientAddressBlock(
+  doc: InstanceType<typeof PDFDocument>,
+  recipient: NonNullable<CampaignLetterData["recipient"]>,
+  locale: CampaignLetterData["locale"],
+): void {
+  doc.save().fillColor("#0f172a").font("Helvetica").fontSize(11);
+  const lines: string[] = [`${recipient.firstName} ${recipient.lastName}`];
+  if (recipient.addressLine1) lines.push(recipient.addressLine1);
+  if (recipient.addressLine2) lines.push(recipient.addressLine2);
+  lines.push(`${recipient.postalCode ?? ""} ${recipient.city ?? ""}`.trim());
+  if (recipient.countryCode && recipient.countryCode.trim().toUpperCase() !== "FR") {
+    // ISO → localised country name (UPU S42 cross-border requirement).
+    const countryName = resolveCountryName(recipient.countryCode, locale);
+    if (countryName) lines.push(countryName);
+  }
+  doc.text(lines.join("\n"), ADDRESS_BLOCK_X, ADDRESS_BLOCK_Y, {
+    width: ADDRESS_BLOCK_WIDTH,
+    lineGap: 1,
+    align: "left",
+  });
+  doc.restore();
+}
+
+/**
  * Build a postal-letter PDFKit stream. Caller pipes it to S3 (or to an
  * `archiver.append`) and is responsible for awaiting the stream's `end`
  * before considering the upload complete.
@@ -200,25 +228,8 @@ export async function createCampaignLetterPdfStream(
   }
 
   // Recipient address block — middle-right of top half (C5 window zone)
-  const renderAddressBlock = hasWindowEnvelopeAddress(data.recipient);
-  if (renderAddressBlock && data.recipient) {
-    doc.save().fillColor("#0f172a").font("Helvetica").fontSize(11);
-    const lines: string[] = [`${data.recipient.firstName} ${data.recipient.lastName}`];
-    if (data.recipient.addressLine1) lines.push(data.recipient.addressLine1);
-    if (data.recipient.addressLine2) lines.push(data.recipient.addressLine2);
-    lines.push(`${data.recipient.postalCode ?? ""} ${data.recipient.city ?? ""}`.trim());
-    if (data.recipient.countryCode && data.recipient.countryCode.trim().toUpperCase() !== "FR") {
-      // ISO → localised country name (UPU S42 cross-border requirement;
-      // see api lockstep duplicate for the full rationale).
-      const countryName = resolveCountryName(data.recipient.countryCode, data.locale);
-      if (countryName) lines.push(countryName);
-    }
-    doc.text(lines.join("\n"), ADDRESS_BLOCK_X, ADDRESS_BLOCK_Y, {
-      width: ADDRESS_BLOCK_WIDTH,
-      lineGap: 1,
-      align: "left",
-    });
-    doc.restore();
+  if (hasWindowEnvelopeAddress(data.recipient) && data.recipient) {
+    renderRecipientAddressBlock(doc, data.recipient, data.locale);
   }
 
   // ── APPEAL CONTENT (flows continuously from just below the address) ──

--- a/packages/worker/src/tests/integration/postal-export.test.ts
+++ b/packages/worker/src/tests/integration/postal-export.test.ts
@@ -85,7 +85,6 @@ async function createPostalExport(mode: "personalized" | "door_drop", totalCount
       totalCount,
     })
     .returning();
-  // biome-ignore lint/style/noNonNullAssertion: returning() yields the row
   return row!.id;
 }
 
@@ -106,7 +105,6 @@ beforeAll(async () => {
       description: "Audit-fix smoke campaign",
     })
     .returning();
-  // biome-ignore lint/style/noNonNullAssertion: insert returning yields the row
   campaignId = campaign!.id;
 
   await db.insert(campaignPublicPages).values({
@@ -144,9 +142,7 @@ beforeAll(async () => {
       },
     ])
     .returning();
-  // biome-ignore lint/style/noNonNullAssertion: returning yields the rows
   constituentAId = a!.id;
-  // biome-ignore lint/style/noNonNullAssertion: returning yields the rows
   constituentBId = b!.id;
 
   await db.insert(campaignConstituents).values([
@@ -330,7 +326,6 @@ describe("processGeneratePostalExport — failure handling", () => {
         status: "active",
       })
       .returning();
-    // biome-ignore lint/style/noNonNullAssertion: returning yields the row
     const emptyCampaignId = emptyCampaign!.id;
     await db.insert(campaignPublicPages).values({
       orgId: ORG_ID,
@@ -349,7 +344,6 @@ describe("processGeneratePostalExport — failure handling", () => {
         totalCount: 0,
       })
       .returning();
-    // biome-ignore lint/style/noNonNullAssertion: returning yields the row
     const exportId = row!.id;
 
     await expect(

--- a/packages/worker/src/tests/integration/receipt-processor.test.ts
+++ b/packages/worker/src/tests/integration/receipt-processor.test.ts
@@ -42,7 +42,6 @@ beforeAll(async () => {
       type: "donor",
     })
     .returning();
-  // biome-ignore lint/style/noNonNullAssertion: insert returning always returns
   constituentId = c!.id;
 
   // Create a donation
@@ -60,7 +59,6 @@ beforeAll(async () => {
       fiscalYear: 2026,
     })
     .returning();
-  // biome-ignore lint/style/noNonNullAssertion: insert returning always returns
   donationId = d!.id;
 });
 


### PR DESCRIPTION
Drops the count from **50 → 0 warnings** across two phases.

## Phase 1 — auto-fixable + non-cognitive-complexity (15 warnings)

### Auto-fixable (4)
`biome check --write --unsafe`:
- `useOptionalChain` rewrites in `keycloak-admin.ts`, `logo-upload-card.tsx`, `stripe-connect-panel.tsx`
- `useIndexOf` rewrites in `list-sort.test.ts`

### biome.json — test-file overrides
Tests legitimately need:
- Raw `<img>` (mocking `next/image` with no Next runtime in jsdom)
- Post-`expect(length).toBe(N)` non-null assertions (idiomatic, type-only — can't become runtime errors)

So `noImgElement` and `noNonNullAssertion` are turned off for `**/*.test.{ts,tsx}` and `**/tests/**/*.{ts,tsx}`. Deleted 21 stale `// biome-ignore lint/style/noNonNullAssertion` comments in test files that became unused suppressions after the override.

### Production fixes (no behavior change)

| Where | What |
|---|---|
| `platform-admins-service.ts` | `or(...)!` → explicit truthy guard; 3× `existing.keycloakId!` simplified by tightening `getActiveAdminOrThrow`'s return type to `PlatformAdminRow & { keycloakId: string }` (the `isNotNull` predicate already encodes the runtime invariant) |
| `platform-admin-detail-actions.tsx` | `<Input autoFocus>` → `<DialogContent onOpenAutoFocus>` + `editForm.setFocus("firstName")`. Same UX (firstName focus on dialog open), Radix-idiomatic |
| `logo-upload-card.test.tsx` | Stale `// biome-ignore lint/a11y/useAltText` comments deleted (mock now passes `alt` explicitly) |
| `constituents/service.ts` | Stale `// biome-ignore lint/complexity/…` comment deleted (the suppression had drifted from its target) |
| `worker/src/lib/svg-sanitiser.ts` | `as any` → `as unknown as WindowLike` (named type imported from `dompurify`) |

## Phase 2 — cognitive complexity (35 warnings)

Per the in-thread discussion, **Option B with threshold = 20** was selected: bump the policy modestly to focus refactor effort on the functions that genuinely benefit from simplification, refactor the 16 functions scoring ≥ 21.

### biome.json policy change
```jsonc
"noExcessiveCognitiveComplexity": {
  "level": "warn",
  "options": { "maxAllowedComplexity": 20 }
}
```
Defensible at 20: many large TS codebases run at 20-25. The 16–19 band wasn't materially improved by forced extraction (e.g. a `useReducer` with 7 case branches scores 16; scattering each case into a helper hurts readability).

### Refactors (16 functions, scores 21 → all under 20)

Each commit is a single-function extraction; behaviour-preserving (no public-API change, no test additions/changes); tests + typecheck + lint all clean per commit.

| Function | Score | Approach |
|---|---|---|
| `acceptPlatformAdminInvitation` | 21 | extract `loadAcceptableInvitation(token)` |
| `PlatformAdminDetailActions` (remove handler) | 21 | extract `removeErrorTranslationKey` with literal-string union |
| `listConstituents` | 21 | extract `buildListConstituentsWhere`, pass aggregate columns directly to keep Drizzle typing happy |
| auth `/api/auth/callback` route | 21 | extract `selectPostLoginRedirect`, `loginRedirectAfterCleanup`, `readValidatedReturnTo` |
| public-campaign page `/p/[id]` | 21 | extract `<OrgLogoBlock>` component + pure `computeProgressDisplay` |
| invite-accept page | 21 | flatten nested `if (valid \|\| rate_limited)` into 3 explicit branches |
| `users` PATCH route | 47 | extract `loadAndGuardUserUpdate`, `buildUserPatch`, `writeUserUpdateAuditIfChanged`, `syncUserUpdateToKeycloak` (the borderline-architectural one) |
| `StartImpersonationForm` | 22 | extract `stashImpersonationPayload`, `resolveImpersonationErrorCopy` |
| `NewPlatformAdminForm` | 21 | extract `emailConflictErrorKey`, `handleCreatePlatformAdminError` |
| idempotency plugin | 22 | extract `rejectIdempotencyByRoleGuard`, `replayCachedResponse` |
| `members-table` (update handler) | 24 | extract `buildMemberUpdatePatch`, `resolveMemberUpdateError`; `useTranslations<"settings.members">` for proper namespacing |
| `proxy.ts` middleware | 21 | extract `applyMaybeRefreshSession` (unifies the JWT-near-expiry and JWT-missing-refresh-still-alive flows) |
| `renderRecipientAddressBlock` | 21 (×2) | extracted in lockstep across `packages/api/src/modules/campaigns/postal-pdf.ts` and `packages/worker/src/services/campaign-pdf.ts` (PDF code-boundary ADR) |
| `handlePaymentIntentSucceeded` | 21 | extract `resolveQrLink` (RLS re-verification) + `findOrCreateConstituent` (3-strategy donor resolution) |
| `LogoUploadCard` | 23 | extract `<LogoStatusRow>` sub-component for the four `state.kind === "X" ? ... : null` rows |
| polling `tick` (logo upload) | 28 | collapse the duplicated try/catch arms into a single decision flow — fetch failure now falls through to the same timeout/schedule branch as a still-pending response |

## Verification

- `pnpm typecheck` — all 6 packages pass
- `pnpm test` — 877 tests across 79 files pass (api 726 / web 113 / worker 38)
- `pnpm run lint` — **0 warnings, 0 errors** (was 50 warnings)

## Manual acceptance checklist (UI-touching refactors)

- [ ] Branding settings page: upload a logo → see "Processing…" → see ready badge + preview (exercises `LogoUploadCard` + `tick`)
- [ ] Branding settings page: upload a 6 MB raster → see error toast + inline error row
- [ ] Settings → Members: edit a member's first name → save → row updates, no error toast (exercises `members-table` patch builder)
- [ ] Settings → Members: edit yourself, attempt to demote → expect server-side rejection surfaced as error toast
- [ ] Public campaign page: open `/p/<campaign>` → org logo + progress bar render correctly
- [ ] Auth: log in from `/login?redirect=/dashboard/donations` → land on `/dashboard/donations` after Keycloak round-trip
- [ ] Platform admin: invite a new admin → accept the invitation via the email link → password set works
- [ ] Platform admin: start an impersonation session → verify it works on the impersonated tenant → end session → land back as operator without re-login
- [ ] Donation pipeline: simulate a Stripe `payment_intent.succeeded` with `qr_code_id` metadata → donation row carries the resolved QR id (worker integration test covers this; manual check on staging optional)

close #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)