### PR TITLE
feat(compliance-gate): default-deny scan for stray image:/FROM refs

### DIFF
--- a/docs/adrs/adr-026-postgres-17-cutover-and-scaleway-anchored-versioning.md
+++ b/docs/adrs/adr-026-postgres-17-cutover-and-scaleway-anchored-versioning.md
@@ -221,13 +221,17 @@ PG 18 buys nothing concrete (no PG-18-specific feature we use) and costs a guara
   remains out of scope (requires a confirmation token + reviewer
   policy and is not a robot decision).
 
-- **Compliance gate scope is the manifest's `pinned_in:` list.** A
-  future Dockerfile that adds `FROM postgres:18` outside any file
-  declared in `infra/compliance-versions.yml` would slip past the gate.
-  No `FROM postgres:` directive exists in the repo today; this is a
-  forward-looking concern. Either extend the gate to walk all
-  `Dockerfile*` files or treat the `pinned_in:` list as a default-deny
-  pattern. Follow-up.
+- **Compliance gate scope is the manifest's `pinned_in:` list.**
+  **Closed by issue #284.** The gate now runs a second pass that walks
+  every tracked file (`git ls-files`) and flags any `image: <dep>:` or
+  `FROM <dep>:` reference whose containing file is not declared in
+  `pinned_in:` for that dep — default-deny. A stray Dockerfile or
+  compose override that adds `FROM postgres:18` (or `image: postgres:18`)
+  fails CI with a `::error file=…,line=…` annotation pointing at the
+  offending line, regardless of whether anyone remembered to update the
+  manifest. Adding the file to `pinned_in:` then re-runs the existing
+  ceiling check on it — Dockerfile pins get the same major-version
+  enforcement as compose pins.
 
 ### Revisit criteria
 

--- a/scripts/check-compliance-versions.sh
+++ b/scripts/check-compliance-versions.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Validate that pinned image versions of compliance-anchored dependencies
-# don't exceed the ceiling declared in infra/compliance-versions.yml.
+# don't exceed the ceiling declared in infra/compliance-versions.yml, and
+# that no `image:` / `FROM` reference for those deps lives outside the
+# manifest's `pinned_in:` allowlist (default-deny — issue #284).
 #
 # Run as a CI step (`compliance-versions-gate` in .github/workflows/ci.yml)
 # and locally as part of `pnpm run check` if developers want a pre-push
@@ -24,18 +26,39 @@ if ! command -v yq >/dev/null 2>&1; then
   exit 2
 fi
 
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "not inside a git work tree (required for the default-deny scan)" >&2
+  exit 2
+fi
+
 violations=0
 checked=0
 
 # `yq -r` strips quotes; `keys[]` walks the dependency map keys.
 deps=$(yq -r '.dependencies | keys[]' "$MANIFEST")
 
+# Match either:
+#   `image: <dep>:<MAJOR>...` — YAML key form (compose / GH-Actions services).
+#     Leading whitespace allowed; tolerates quoted scalars (`'`/`"`) which
+#     are valid YAML and which Dependabot can emit.
+#   `FROM <dep>:<MAJOR>...` — Dockerfile directive at column 0.
+# Captures the major into group 2 (group 1 is the matched prefix variant).
+match_regex_for() {
+  local dep="$1"
+  printf '^[[:space:]]*image:[[:space:]]*['\''"]?%s:[0-9]+|^FROM[[:space:]]+%s:[0-9]+' "$dep" "$dep"
+}
+
 for dep in $deps; do
   ceiling=$(yq -r ".dependencies.\"$dep\".max_major" "$MANIFEST")
   provider=$(yq -r ".dependencies.\"$dep\".provider" "$MANIFEST")
-  files=$(yq -r ".dependencies.\"$dep\".pinned_in[]" "$MANIFEST")
+  pinned_files=$(yq -r ".dependencies.\"$dep\".pinned_in[]" "$MANIFEST")
+  regex=$(match_regex_for "$dep")
 
-  for file in $files; do
+  # ── Pass 1: ceiling check on each declared `pinned_in:` file. ─────────────
+  # Both `image:` and `FROM` forms are accepted, so a Dockerfile legitimately
+  # listed in `pinned_in:` gets the same major-version enforcement as a
+  # compose pin.
+  for file in $pinned_files; do
     if [ ! -f "$file" ]; then
       # Missing file = silently-disabled enforcement for that dep. Treat
       # as a hard error so a typo in `pinned_in:` or a renamed/moved file
@@ -45,32 +68,56 @@ for dep in $deps; do
       continue
     fi
 
-    # Match `image: <dep>:<MAJOR>...` only when `image:` is the YAML key
-    # (leading whitespace allowed, no `#` before — that would be a comment).
-    # Tolerates quoted forms (`image: "postgres:17"`, `image: 'postgres:17'`)
-    # which are valid YAML scalars and which Dependabot can emit.
-    # Captures the first numeric component as the major.
     while IFS= read -r match; do
       [ -z "$match" ] && continue
       lineno=$(echo "$match" | cut -d: -f1)
-      version=$(echo "$match" | sed -E "s|^[[:space:]]*[0-9]+:[[:space:]]*image:[[:space:]]*['\"]?${dep}:([0-9]+).*|\1|")
+      # Strip the `<lineno>:` prefix grep adds, then peel off whichever
+      # form matched (image: '"'"'…'"'"' OR FROM …) to leave the major.
+      version=$(echo "$match" | sed -E "s|^[0-9]+:[[:space:]]*image:[[:space:]]*['\"]?${dep}:([0-9]+).*|\1|; s|^[0-9]+:FROM[[:space:]]+${dep}:([0-9]+).*|\1|")
 
       if [ "$version" -gt "$ceiling" ]; then
         echo "::error file=$file,line=$lineno::$dep:$version exceeds compliance ceiling $ceiling (provider: $provider). Bump infra/compliance-versions.yml first, after the provider publishes support. See ADR-026."
         violations=$((violations + 1))
       fi
       checked=$((checked + 1))
-    done < <(grep -nE "^[[:space:]]*image:[[:space:]]*['\"]?${dep}:[0-9]+" "$file" || true)
+    done < <(grep -nE "$regex" "$file" || true)
   done
+
+  # ── Pass 2: default-deny scan across the whole tracked tree. ──────────────
+  # Any `image: <dep>:` or `FROM <dep>:` match in a file NOT declared in
+  # `pinned_in:` is a violation. Closes the gap that a stray Dockerfile or
+  # an accidentally-added compose override could otherwise drive through
+  # (issue #284). `git ls-files` naturally excludes `.git`, gitignored
+  # paths (node_modules, dist, .next, .turbo, …), and untracked scratch
+  # files — so adding a file to the index makes the gate notice it.
+  while IFS= read -r match; do
+    [ -z "$match" ] && continue
+    file=$(echo "$match" | cut -d: -f1)
+    lineno=$(echo "$match" | cut -d: -f2)
+
+    # Skip files already declared in `pinned_in:` for this dep — Pass 1
+    # already enforced the ceiling on them.
+    declared=0
+    for pinned_file in $pinned_files; do
+      if [ "$file" = "$pinned_file" ]; then
+        declared=1
+        break
+      fi
+    done
+    [ "$declared" -eq 1 ] && continue
+
+    echo "::error file=$file,line=$lineno::$dep image reference in undeclared file. Either add '$file' to dependencies.$dep.pinned_in in $MANIFEST (after confirming the version is at or below the $ceiling ceiling), or remove the reference. See ADR-026."
+    violations=$((violations + 1))
+  done < <(git ls-files -z | xargs -0 grep -nHE "$regex" 2>/dev/null || true)
 done
 
 if [ "$violations" -gt 0 ]; then
   echo "" >&2
-  echo "$violations compliance-ceiling violation(s) found across $checked pin(s)." >&2
+  echo "$violations compliance violation(s) found across $checked declared pin(s)." >&2
   echo "Resolution:" >&2
-  echo "  1) Wait for the provider to add support, bump infra/compliance-versions.yml, then merge; OR" >&2
-  echo "  2) Revert the offending pin(s) to the current ceiling." >&2
+  echo "  1) Ceiling exceeded: wait for the provider, bump infra/compliance-versions.yml, then merge; OR revert the offending pin." >&2
+  echo "  2) Undeclared reference: add the file to the dep's pinned_in list (or remove the reference)." >&2
   exit 1
 fi
 
-echo "Compliance ceilings OK: $checked pin(s) checked across $(echo "$deps" | wc -w | tr -d ' ') dependencies."
+echo "Compliance ceilings OK: $checked pin(s) checked across $(echo "$deps" | wc -w | tr -d ' ') dependencies; default-deny scan clean."

--- a/scripts/check-compliance-versions.sh
+++ b/scripts/check-compliance-versions.sh
@@ -34,31 +34,59 @@ fi
 violations=0
 checked=0
 
-# `yq -r` strips quotes; `keys[]` walks the dependency map keys.
-deps=$(yq -r '.dependencies | keys[]' "$MANIFEST")
-
 # Match either:
 #   `image: <dep>:<MAJOR>...` — YAML key form (compose / GH-Actions services).
 #     Leading whitespace allowed; tolerates quoted scalars (`'`/`"`) which
 #     are valid YAML and which Dependabot can emit.
-#   `FROM <dep>:<MAJOR>...` — Dockerfile directive at column 0.
-# Captures the major into group 2 (group 1 is the matched prefix variant).
+#   `FROM <dep>:<MAJOR>...` — Dockerfile directive.
+#     Case-insensitive (`from` is valid Dockerfile syntax — directives are
+#     not case-sensitive per the Dockerfile reference). Leading whitespace
+#     tolerated (Docker is lenient about indentation). Optional repeated
+#     `--flag=value` between `FROM` and the image name (e.g.
+#     `FROM --platform=linux/amd64 postgres:17`).
+# Captures: group 1 = optional last `--flag=value` on FROM (unused);
+# group 2 = major.
 match_regex_for() {
   local dep="$1"
-  printf '^[[:space:]]*image:[[:space:]]*['\''"]?%s:[0-9]+|^FROM[[:space:]]+%s:[0-9]+' "$dep" "$dep"
+  printf '^[[:space:]]*image:[[:space:]]*['\''"]?%s:[0-9]+|^[[:space:]]*[Ff][Rr][Oo][Mm][[:space:]]+(--[A-Za-z][A-Za-z0-9-]*=[^[:space:]]+[[:space:]]+)*%s:[0-9]+' "$dep" "$dep"
 }
 
-for dep in $deps; do
+# `yq -r` strips quotes; `keys[]` walks the dependency map keys.
+# Read into a bash array via `while read` so a hostile manifest entry
+# containing whitespace or shell glob characters can't word-split or
+# expand against the CWD when iterated. (Avoids `mapfile`, which is
+# bash 4+ only — macOS ships 3.2.)
+deps=()
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  deps+=("$line")
+done < <(yq -r '.dependencies | keys[]' "$MANIFEST")
+
+for dep in "${deps[@]}"; do
+  # Reject dep names that aren't simple identifiers — they would be
+  # interpolated into a regex below, where metacharacters (`|`, `.`, `*`)
+  # would silently change semantics. Today's deps (`postgres`, `redis`)
+  # pass; expand the pattern when a future dep needs it.
+  if ! printf '%s' "$dep" | grep -qE '^[a-z][a-z0-9-]*$'; then
+    echo "::error ::compliance manifest contains a dep name with disallowed characters: $dep (allowed: ^[a-z][a-z0-9-]*\$)"
+    violations=$((violations + 1))
+    continue
+  fi
+
   ceiling=$(yq -r ".dependencies.\"$dep\".max_major" "$MANIFEST")
   provider=$(yq -r ".dependencies.\"$dep\".provider" "$MANIFEST")
-  pinned_files=$(yq -r ".dependencies.\"$dep\".pinned_in[]" "$MANIFEST")
+  pinned_files=()
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    pinned_files+=("$line")
+  done < <(yq -r ".dependencies.\"$dep\".pinned_in[]" "$MANIFEST")
   regex=$(match_regex_for "$dep")
 
   # ── Pass 1: ceiling check on each declared `pinned_in:` file. ─────────────
   # Both `image:` and `FROM` forms are accepted, so a Dockerfile legitimately
   # listed in `pinned_in:` gets the same major-version enforcement as a
   # compose pin.
-  for file in $pinned_files; do
+  for file in "${pinned_files[@]}"; do
     if [ ! -f "$file" ]; then
       # Missing file = silently-disabled enforcement for that dep. Treat
       # as a hard error so a typo in `pinned_in:` or a renamed/moved file
@@ -70,10 +98,15 @@ for dep in $deps; do
 
     while IFS= read -r match; do
       [ -z "$match" ] && continue
-      lineno=$(echo "$match" | cut -d: -f1)
-      # Strip the `<lineno>:` prefix grep adds, then peel off whichever
-      # form matched (image: '"'"'…'"'"' OR FROM …) to leave the major.
-      version=$(echo "$match" | sed -E "s|^[0-9]+:[[:space:]]*image:[[:space:]]*['\"]?${dep}:([0-9]+).*|\1|; s|^[0-9]+:FROM[[:space:]]+${dep}:([0-9]+).*|\1|")
+      lineno=$(printf '%s' "$match" | sed -E 's|^([0-9]+):.*|\1|')
+      # Peel off whichever form matched to leave the major. Two sed
+      # branches because the alternation has different shapes (image:
+      # has no flag-prefix; FROM may have repeated `--flag=value` flags
+      # between the directive and the image).
+      version=$(printf '%s' "$match" | sed -E "
+        s|^[0-9]+:[[:space:]]*image:[[:space:]]*['\"]?${dep}:([0-9]+).*|\1|
+        s|^[0-9]+:[[:space:]]*[Ff][Rr][Oo][Mm][[:space:]]+(--[A-Za-z][A-Za-z0-9-]*=[^[:space:]]+[[:space:]]+)*${dep}:([0-9]+).*|\2|
+      ")
 
       if [ "$version" -gt "$ceiling" ]; then
         echo "::error file=$file,line=$lineno::$dep:$version exceeds compliance ceiling $ceiling (provider: $provider). Bump infra/compliance-versions.yml first, after the provider publishes support. See ADR-026."
@@ -87,18 +120,21 @@ for dep in $deps; do
   # Any `image: <dep>:` or `FROM <dep>:` match in a file NOT declared in
   # `pinned_in:` is a violation. Closes the gap that a stray Dockerfile or
   # an accidentally-added compose override could otherwise drive through
-  # (issue #284). `git ls-files` naturally excludes `.git`, gitignored
-  # paths (node_modules, dist, .next, .turbo, …), and untracked scratch
-  # files — so adding a file to the index makes the gate notice it.
-  while IFS= read -r match; do
-    [ -z "$match" ] && continue
-    file=$(echo "$match" | cut -d: -f1)
-    lineno=$(echo "$match" | cut -d: -f2)
+  # (issue #284). The file list comes from `git ls-files -z` (NUL-separated,
+  # so any legal POSIX filename — including `:` — round-trips intact); the
+  # per-file `grep -nIE` then yields `<lineno>:<content>` where the first
+  # `:` reliably separates lineno from content. `-I` skips binaries so we
+  # don't risk a regex hit against random bytes. Untracked / gitignored
+  # paths (node_modules, dist, .next, .turbo, scratch fixtures) are
+  # excluded — a developer can experiment locally without failing CI;
+  # staging the file makes the gate notice it.
+  while IFS= read -r -d '' file; do
+    [ -f "$file" ] || continue
 
     # Skip files already declared in `pinned_in:` for this dep — Pass 1
     # already enforced the ceiling on them.
     declared=0
-    for pinned_file in $pinned_files; do
+    for pinned_file in "${pinned_files[@]}"; do
       if [ "$file" = "$pinned_file" ]; then
         declared=1
         break
@@ -106,9 +142,13 @@ for dep in $deps; do
     done
     [ "$declared" -eq 1 ] && continue
 
-    echo "::error file=$file,line=$lineno::$dep image reference in undeclared file. Either add '$file' to dependencies.$dep.pinned_in in $MANIFEST (after confirming the version is at or below the $ceiling ceiling), or remove the reference. See ADR-026."
-    violations=$((violations + 1))
-  done < <(git ls-files -z | xargs -0 grep -nHE "$regex" 2>/dev/null || true)
+    while IFS= read -r match; do
+      [ -z "$match" ] && continue
+      lineno=${match%%:*}
+      echo "::error file=$file,line=$lineno::$dep image reference in undeclared file. Either add '$file' to dependencies.$dep.pinned_in in $MANIFEST (after confirming the version is at or below the $ceiling ceiling), or remove the reference. See ADR-026."
+      violations=$((violations + 1))
+    done < <(grep -nIE "$regex" "$file" 2>/dev/null || true)
+  done < <(git ls-files -z)
 done
 
 if [ "$violations" -gt 0 ]; then
@@ -120,4 +160,4 @@ if [ "$violations" -gt 0 ]; then
   exit 1
 fi
 
-echo "Compliance ceilings OK: $checked pin(s) checked across $(echo "$deps" | wc -w | tr -d ' ') dependencies; default-deny scan clean."
+echo "Compliance ceilings OK: $checked pin(s) checked across ${#deps[@]} dependencies; default-deny scan clean."


### PR DESCRIPTION
close #284

## Why

Today the compliance gate (`scripts/check-compliance-versions.sh`) only walks files listed in each manifest entry's `pinned_in:`. A future Dockerfile that adds `FROM postgres:18` outside that list — or a stray `docker-compose.<override>.yml` with `image: postgres:18` — slips past the gate. ADR-026 § Known caveats and follow-ups documents the gap.

## What

Picked **Option B** from the issue (default-deny pinned_in) over Option A (per-dep `scan_dockerfiles:` flag) because:

- **Single mechanism, no flag to forget** — Option A still needed `scan_dockerfiles: true` per dep; default-deny needs nothing per dep.
- **Catches stray Dockerfile AND stray compose-override** with the same code path.
- **First-roll-out is silent** — audited the tree before the change: only six matches exist (`docker-compose.yml`, `config/deploy-staging.yml`, `.github/workflows/ci.yml`, each twice for postgres + redis), all already declared. No accidental tracked fixtures.
- **Aligns with ADR-026's intent** — the manifest is already framed as the single source of truth for compliance-anchored pins. Default-deny makes that posture authoritative.

The gate now runs two passes per dep:

1. **Ceiling check on each declared `pinned_in:` file** (existing). Extended to also match `^FROM <dep>:<n>` so a Dockerfile pin gets the same major-version enforcement as a compose pin.
2. **Default-deny scan** across `git ls-files`. Any `image: <dep>:` or `FROM <dep>:` whose containing file is not in `pinned_in:` for that dep fails CI with `::error file=…,line=…`.

`git ls-files` is the source of truth — naturally excludes `.git`, `node_modules`, `dist`, `.next`, `.turbo`, and any gitignored scratch path. Untracked experimental files don't fail CI; staging them does.

## Files

- [scripts/check-compliance-versions.sh](scripts/check-compliance-versions.sh) — Pass 1 extended to match `FROM`; new Pass 2 default-deny scan; resolution message updated to cover both failure modes.
- [docs/adrs/adr-026-postgres-17-cutover-and-scaleway-anchored-versioning.md](docs/adrs/adr-026-postgres-17-cutover-and-scaleway-anchored-versioning.md) — caveat marked closed with a description of the new behavior.

## Manual acceptance

**Acceptance criterion from the issue**
- [x] `mkdir -p infra/test && echo 'FROM postgres:18' > infra/test/Dockerfile && git add infra/test/Dockerfile` → gate exits non-zero with `::error file=infra/test/Dockerfile,line=1::postgres image reference in undeclared file…` ✅ verified locally
- [x] Same path declared in `pinned_in:` → Pass 1 catches the ceiling violation instead (`postgres:18 exceeds compliance ceiling 17…`) ✅ verified locally
- [x] Stray `docker-compose.rogue.yml` with `image: postgres:18-alpine` → gate fails with the same default-deny error ✅ verified locally
- [x] Untracked `infra/test/Dockerfile` (post `git rm --cached`) → gate is clean ✅ verified locally

**Regression baselines (existing behavior preserved)**
- [x] Clean tree → `Compliance ceilings OK: 6 pin(s) checked across 2 dependencies; default-deny scan clean.` ✅
- [x] Pass 1 still emits the original ceiling message + same `::error` annotation when a declared pin overshoots ✅

**CI**
- [ ] CI's `compliance-versions-gate` job is green on this PR

## Out of scope

- The pre-existing prose-snippet caveat (`docs/02` mentions image tags in a code-fenced YAML skeleton) is not addressed — Pass 2 uses the same `^image:` / `^FROM` anchors as Pass 1, so prose snippets at column 0 inside fenced blocks don't trigger. Catching those requires markdown-aware parsing, which is a different concern from #284's "stray Dockerfile" scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)