### PR TITLE
ci(staging): SHA-pin webfactory/ssh-agent across staging workflows

### DIFF
--- a/.github/workflows/check-staging-version-skew.yml
+++ b/.github/workflows/check-staging-version-skew.yml
@@ -94,8 +94,12 @@ jobs:
             exit 1
           fi
 
+      # Pinned to a commit SHA — this action receives `SSH_PRIVATE_KEY`,
+      # so a third-party action gets a SHA pin instead of a moving tag.
+      # SHA below is `webfactory/ssh-agent@v0.10.0` at 2026-05-10; bump
+      # intentionally when upgrading.
       - name: Configure SSH Auth Sock
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -177,8 +177,14 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
+      # Pinned to a commit SHA — this action receives `SSH_PRIVATE_KEY`
+      # and the surrounding job handles other secrets (`POSTGRES_PASSWORD`,
+      # `REDIS_PASSWORD`, `MINIO_ROOT_PASSWORD`), so a third-party action
+      # gets a SHA pin instead of a moving tag. SHA below is
+      # `webfactory/ssh-agent@v0.10.0` at 2026-05-10; bump intentionally
+      # when upgrading.
       - name: Configure SSH Auth Sock
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/migrate-staging-postgres.yml
+++ b/.github/workflows/migrate-staging-postgres.yml
@@ -141,8 +141,14 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
+      # Pinned to a commit SHA — this action receives `SSH_PRIVATE_KEY`
+      # and the surrounding job handles other secrets (`POSTGRES_PASSWORD`,
+      # `REDIS_PASSWORD`, `MINIO_ROOT_PASSWORD`), so a third-party action
+      # gets a SHA pin instead of a moving tag. SHA below is
+      # `webfactory/ssh-agent@v0.10.0` at 2026-05-10; bump intentionally
+      # when upgrading.
       - name: Configure SSH Auth Sock
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/staging-accessory-reboot.yml
+++ b/.github/workflows/staging-accessory-reboot.yml
@@ -72,8 +72,14 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
+      # Pinned to a commit SHA — this action receives `SSH_PRIVATE_KEY`
+      # and the surrounding job handles other secrets (`POSTGRES_PASSWORD`,
+      # `REDIS_PASSWORD`, `MINIO_ROOT_PASSWORD`, `KEYCLOAK_ADMIN_PASSWORD`),
+      # so a third-party action gets a SHA pin instead of a moving tag.
+      # SHA below is `webfactory/ssh-agent@v0.10.0` at 2026-05-10; bump
+      # intentionally when upgrading.
       - name: Configure SSH Auth Sock
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
## Summary

- SHA-pin `webfactory/ssh-agent@v0.10.0` to commit `e8387483` across all four staging workflows that load `SSH_PRIVATE_KEY`, mirroring the `dorny/paths-filter` pin pattern already in `deploy-staging.yml`.
- Each call site carries a short tag → SHA mapping comment so a future bump is intentional and grep-able.
- Issue #285 listed two files explicitly (`deploy-staging.yml`, `migrate-staging-postgres.yml`); two more (`staging-accessory-reboot.yml`, `check-staging-version-skew.yml`) call the same action with the same secret blast radius — pinning two of four would have left the same inconsistency #285 set out to fix, so all four are pinned in this PR.

## Tag → SHA mapping

| Action | Tag | SHA |
|---|---|---|
| `webfactory/ssh-agent` | `v0.10.0` | `e83874834305fe9a4a2997156cb26c5de65a8555` |

Resolved via `gh api repos/webfactory/ssh-agent/git/refs/tags/v0.10.0`; release confirmed as "v0.10.0: Upgrade to node-24".

## Files changed

- `.github/workflows/deploy-staging.yml`
- `.github/workflows/migrate-staging-postgres.yml`
- `.github/workflows/staging-accessory-reboot.yml`
- `.github/workflows/check-staging-version-skew.yml`

## Test plan

- [ ] CI green on this PR (lint/typecheck/test/compliance-gate are unaffected — pure workflow YAML).
- [ ] Next merge to `main` triggers `deploy-staging.yml` and the SHA-pinned ssh-agent step still loads the staging deploy key (Kamal reaches the VPS).
- [ ] Next `migrate-staging-postgres.yml` dispatch authenticates over SSH as before.
- [ ] `staging-accessory-reboot.yml` and `check-staging-version-skew.yml` still pass on next dispatch.

close #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)