### PR TITLE
feat(communication): bulk-email partial-send tracking + resume action (#326)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,14 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── 20-payment-strategy.md      — Payment systems: Stripe/Mollie/Mangopay comparison, ADR-010, PCI DSS, GDPR
 │   ├── 23-postal-campaigns.md      — Postal campaigns + QR reconciliation (Epic #274): user flow, domain, readiness gates, attribution
 │   ├── 24-branding-assets.md       — Organisation branding (Epic #286): logo upload, sharp variants, bucket topology, Keycloak sync, PDF embedding
+<<<<<<< HEAD
 │   ├── 25-swiss-qr-bill.md         — Swiss QR-bill (BVR) generation + camt.053 reconciliation (Epic #318): bank accounts, per-letter QRR/SCOR, ISO 20022 ingestion
 │   ├── adrs/                       — Individual ADR files (incl. ADR-023 bucket topology, ADR-024 image pipeline, ADR-025 PDF code boundary, ADR-027 Swiss QR-bill, ADR-028 camt.053 ingestion)
 │   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283; launch-prod.md for the production-environment launch — issue #344); each file is plan + live journal + post-mortem
+=======
+│   ├── adrs/                       — Individual ADR files (incl. ADR-023 bucket topology, ADR-024 image pipeline, ADR-025 PDF code boundary)
+│   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283; launch-prod.md for the production-environment launch — issue #344); each file is plan + live journal + post-mortem. Also: bulk-email-stalled-job.md — recurring SRE triage flow for issue #326's Stalled / Partial bulk-email recovery
+>>>>>>> 7498a31 (fix(communication): PR #352 multi-agent review — race, traces, tests)
 │   ├── dev/
 │   │   └── staging-secrets-setup.md — Reference for fork developers + the prod-launch runbook: every GH-Environment secret the deploy needs, how to generate it, how to rotate it (#343)
 │   ├── vision/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,14 +55,9 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── 20-payment-strategy.md      — Payment systems: Stripe/Mollie/Mangopay comparison, ADR-010, PCI DSS, GDPR
 │   ├── 23-postal-campaigns.md      — Postal campaigns + QR reconciliation (Epic #274): user flow, domain, readiness gates, attribution
 │   ├── 24-branding-assets.md       — Organisation branding (Epic #286): logo upload, sharp variants, bucket topology, Keycloak sync, PDF embedding
-<<<<<<< HEAD
 │   ├── 25-swiss-qr-bill.md         — Swiss QR-bill (BVR) generation + camt.053 reconciliation (Epic #318): bank accounts, per-letter QRR/SCOR, ISO 20022 ingestion
 │   ├── adrs/                       — Individual ADR files (incl. ADR-023 bucket topology, ADR-024 image pipeline, ADR-025 PDF code boundary, ADR-027 Swiss QR-bill, ADR-028 camt.053 ingestion)
-│   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283; launch-prod.md for the production-environment launch — issue #344); each file is plan + live journal + post-mortem
-=======
-│   ├── adrs/                       — Individual ADR files (incl. ADR-023 bucket topology, ADR-024 image pipeline, ADR-025 PDF code boundary)
-│   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283; launch-prod.md for the production-environment launch — issue #344); each file is plan + live journal + post-mortem. Also: bulk-email-stalled-job.md — recurring SRE triage flow for issue #326's Stalled / Partial bulk-email recovery
->>>>>>> 7498a31 (fix(communication): PR #352 multi-agent review — race, traces, tests)
+│   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283; launch-prod.md for the production-environment launch — issue #344); each file is plan + live journal + post-mortem. Also: bulk-email-stalled-job.md (recurring SRE triage flow for issue #326's Stalled / Partial bulk-email recovery) and feature-flag-rollback.md (emergency psql + redis-cli flip when the Back Office page is unavailable)
 │   ├── dev/
 │   │   └── staging-secrets-setup.md — Reference for fork developers + the prod-launch runbook: every GH-Environment secret the deploy needs, how to generate it, how to rotate it (#343)
 │   ├── vision/

--- a/docs/18-feature-flags.md
+++ b/docs/18-feature-flags.md
@@ -24,10 +24,21 @@ The sections that follow describe the **target** design. The **shipped** subset 
 
 Adding a new flag (Phase 1 MVP):
 1. Append the key to `FEATURE_FLAG_KEYS` in `packages/shared/src/constants/feature-flags.ts` AND to `FEATURE_FLAG_REGISTRY` with its default + description.
-2. Write a migration that `INSERT … ON CONFLICT (key) DO NOTHING` for the key with matching `default_value` + `description`.
+2. Write a migration that `INSERT … ON CONFLICT (key) DO NOTHING` for the key with matching `default_value` + `description`. The integration test in `packages/api/src/tests/integration/feature-flags.test.ts` enforces description parity between `FEATURE_FLAG_REGISTRY` and the seeded DB row — drift fails CI.
 3. Wire `requireFlag(FEATURE_FLAG_KEYS.YOUR_KEY)` on the gated routes.
 4. If the worker has a matching processor, add an `isFlagEnabled(...)` check at job pickup (defence-in-depth).
 5. If the UI surface is conditional, SSR-fetch `/v1/feature-flags` and pass `xEnabled` as a prop into the consumer component.
+
+### Audit + observability notes
+
+- **Audit trail.** Every super-admin flag toggle (`PATCH /v1/admin/feature-flags/:key`) is recorded in `audit_logs` by the existing audit plugin. `org_id` on the row reflects the JWT's `org_id` claim — which Keycloak emits even for super-admin sessions (the verifier rejects tokens without one). For platform-scoped actions like flag toggles, this is whatever tenant the super-admin's session is currently scoped to (delegation: the target tenant; non-delegation: the Keycloak platform org). Routing platform-scoped audits to the `__platform__` sentinel tenant for cleaner SIEM filtering is a separate cross-cutting follow-up — out of scope for this PR.
+- **No outbox event.** Flipping a flag does NOT emit an `outbox_events` row. The worker reads PG directly (no cache) so it observes the new value on the next job pickup; the frontend reads `/v1/feature-flags` on every SSR render. If a future flag needs realtime worker invalidation (cancel in-flight jobs the moment the flag flips), that's the case for adding `feature_flag.toggled` to the outbox.
+- **Public projection caveat.** `GET /v1/feature-flags` returns every registered flag (key + enabled only) to every authenticated caller. That's fine for the current single-flag registry; once experimental / unreleased flags land, consider adding a `public boolean` column and filtering to `public = true` in this endpoint so unreleased feature *names* don't leak via the tenant API.
+- **Cardinality.** The `requireFlag` 404 log line carries `path = routeOptions.url` (the route template, not the raw URL with query/UUIDs) so a misbehaving SPA can't blow up Loki's index. Add a Cockpit Grafana alert on `level=info AND event=flag.route_gated` count over time if you want to detect scanner enumeration.
+
+### Emergency rollback
+
+If the Back Office page is unavailable and a flag needs to come down NOW, see `docs/runbooks/feature-flag-rollback.md` — the canonical procedure is `UPDATE feature_flags SET enabled = false WHERE key = ?;` + `redis-cli DEL flags:global`.
 
 ## 1. Goals
 

--- a/docs/18-feature-flags.md
+++ b/docs/18-feature-flags.md
@@ -23,11 +23,22 @@ The sections that follow describe the **target** design. The **shipped** subset 
 | React `<FlagProvider>` + `useFlags()` hook | ❌ deferred | Each consumer page passes the prop down for now |
 
 Adding a new flag (Phase 1 MVP):
-1. Append the key to `FEATURE_FLAG_KEYS` in `packages/shared/src/constants/feature-flags.ts` AND to `FEATURE_FLAG_REGISTRY` with its default + description.
-2. Write a migration that `INSERT … ON CONFLICT (key) DO NOTHING` for the key with matching `default_value` + `description`. The integration test in `packages/api/src/tests/integration/feature-flags.test.ts` enforces description parity between `FEATURE_FLAG_REGISTRY` and the seeded DB row — drift fails CI.
+1. Append the key to `FEATURE_FLAG_KEYS` in `packages/shared/src/constants/feature-flags.ts` AND to `FEATURE_FLAG_REGISTRY` with its default + `label` + `description`.
+2. Write a migration that `INSERT … ON CONFLICT (key) DO NOTHING` for the key with matching `default_value` + `label` + `description`. The integration test in `packages/api/src/tests/integration/feature-flags.test.ts` enforces label + description parity between `FEATURE_FLAG_REGISTRY` and the seeded DB row — drift fails CI.
 3. Wire `requireFlag(FEATURE_FLAG_KEYS.YOUR_KEY)` on the gated routes.
 4. If the worker has a matching processor, add an `isFlagEnabled(...)` check at job pickup (defence-in-depth).
-5. If the UI surface is conditional, SSR-fetch `/v1/feature-flags` and pass `xEnabled` as a prop into the consumer component.
+5. If the UI surface is conditional, SSR-fetch `/v1/feature-flags` and pass `xEnabled` as a prop into the consumer component. Hide every dependent surface (buttons, columns, panels) on the consumer page — not just the action button. A dead selection column is operator-confusing UX.
+
+### Text-field convention (label / description)
+
+The `label` and `description` columns are **operator-facing**. Write them in plain language; the audience is a non-technical Back Office user, not an engineer:
+
+- **`label`** — a short friendly title (e.g. "Bulk emails to constituents"). 1-6 words. Acts as the row heading in the UI. Avoid the dotted-namespace key (`communication.bulk_email`) — the key still renders as a small monospaced subtitle so engineers reading audit logs can correlate, but operators see the label first.
+- **`description`** — one or two sentences explaining **what the feature does for the operator**. No engineering jargon (DKIM, SPF, DMARC, BullMQ, etc.), no RFC references, no incident IDs, no GitHub issue numbers.
+
+Engineering rationale (why a flag is off by default, which incident motivated it, what infra prerequisites are blocking enablement) lives in **code comments above the `FEATURE_FLAG_KEYS` entry**. That keeps the operator UI clean while leaving full context for anyone reading the code.
+
+Why DB-stored text (vs i18n-keyed): the registry is small (<10 keys foreseeable), and storing the strings in the DB lets a new flag ship without touching every locale's `messages/*.json`. Trade-off: operator-facing text is English-only for now. When the registry grows or the Back Office becomes multilingual, the migration path is straightforward — add `messages.feature_flags.<key>.label` / `.description` keys and have the API resolve them via `getTranslations` before returning the row.
 
 ### Audit + observability notes
 

--- a/docs/18-feature-flags.md
+++ b/docs/18-feature-flags.md
@@ -1,8 +1,33 @@
 # 18 — Feature Flag Strategy
 
-> **Status**: Spike / Analysis — Phase 1 implementation target
+> **Status**: Phase 1 MVP shipped (PR #352 — global flags only); spec for tenant-overrides + plan-gating remains as the Phase-2 target
 > **Owner**: Feature Flag Engineer agent (`.claude/agents/feature-flag-engineer.md`)
 > **Related**: `02-reference-architecture.md`, `03-data-model.md`, `04-business-capabilities.md`, `06-security-compliance.md`, `07-delivery-roadmap.md`
+
+## 0. What's actually shipped (Phase 1 MVP, PR #352)
+
+The sections that follow describe the **target** design. The **shipped** subset is intentionally narrow per the @magino discussion on PR #352:
+
+| Surface | Status | Notes |
+|---|---|---|
+| `feature_flags` table | ✅ shipped (migration `0047_feature_flags`) | Global flags only — `enabled` boolean per row. No `scope` / `plan_gate` columns; no `tenant_flag_overrides` table |
+| `FEATURE_FLAG_REGISTRY` const (`packages/shared/src/constants/feature-flags.ts`) | ✅ shipped | Typed `FeatureFlagKey` union; first key is `communication.bulk_email` (default: off) |
+| `flagService.isEnabled(key)` + Redis cache (TTL 60s) | ✅ shipped | `packages/api/src/lib/flags/flag-service.ts`; cache key `flags:global` holds the whole map |
+| `requireFlag(key)` preHandler | ✅ shipped | `packages/api/src/lib/flags/flag-guard.ts` — 404 on disabled, runs BEFORE other preHandlers so a scanner can't enumerate role requirements |
+| Worker-side `isFlagEnabled(key)` | ✅ shipped | `packages/worker/src/lib/flags.ts` — defence-in-depth at job pickup |
+| `GET /v1/admin/feature-flags` + `PATCH /v1/admin/feature-flags/:key` | ✅ shipped | Super-admin only (404 to others) |
+| `GET /v1/feature-flags` (public projection) | ✅ shipped | `requireAuth` only — returns `{key, enabled}` rows; drives tenant-side UI hide-on-disabled |
+| Back Office page `/admin/feature-flags` | ✅ shipped | Toggle UI; optimistic update + rollback on failure |
+| `tenant_flag_overrides` table | ❌ deferred | Section 4.2 below is the target spec |
+| Plan-gating (`plan_gate` column) | ❌ deferred | Section 5 evaluation algorithm is the target |
+| React `<FlagProvider>` + `useFlags()` hook | ❌ deferred | Each consumer page passes the prop down for now |
+
+Adding a new flag (Phase 1 MVP):
+1. Append the key to `FEATURE_FLAG_KEYS` in `packages/shared/src/constants/feature-flags.ts` AND to `FEATURE_FLAG_REGISTRY` with its default + description.
+2. Write a migration that `INSERT … ON CONFLICT (key) DO NOTHING` for the key with matching `default_value` + `description`.
+3. Wire `requireFlag(FEATURE_FLAG_KEYS.YOUR_KEY)` on the gated routes.
+4. If the worker has a matching processor, add an `isFlagEnabled(...)` check at job pickup (defence-in-depth).
+5. If the UI surface is conditional, SSR-fetch `/v1/feature-flags` and pass `xEnabled` as a prop into the consumer component.
 
 ## 1. Goals
 

--- a/docs/23-postal-campaigns.md
+++ b/docs/23-postal-campaigns.md
@@ -577,6 +577,20 @@ sequenceDiagram
 
 **Out of scope for this issue.** Exactly-once delivery (the general outbox → BullMQ contract) and persistent SMTP retry queues stay deferred — see issue #326 "Out of scope". The postal-export side keeps its existing "re-run from scratch" recovery path (the ZIP must be a complete bundle for printing, so a partial resume doesn't apply).
 
+### 6.ter Feature-flag gate (PR #352, after @magino review)
+
+The whole bulk-email surface is gated behind the global feature flag `communication.bulk_email` (registered in `packages/shared/src/constants/feature-flags.ts`, seeded `enabled = false` by migration `0047_feature_flags`). Until the platform's outbound mail domain has DKIM / SPF / DMARC configured, an operator-triggered "donor follow-up" reads to recipient MX servers as phishing — so the feature stays off in every deploy until a super-admin flips it from the Back Office page at `/admin/feature-flags`.
+
+Enforcement is three-deep:
+
+| Layer | Behaviour when flag is off |
+|---|---|
+| **API** | `requireFlag(...)` runs BEFORE auth/RBAC on every `/v1/constituents/bulk-email*` route → 404 (looks like a typo'd URL, no role-requirement leak) |
+| **Worker** | `processSendBulkEmail` calls `isFlagEnabled` at job pickup. A flipped-off flag between API enqueue and worker dispatch drops the job silently — the tracking row stays `pending`, the operator's UI keeps showing the dispatch in the "Recent emails" panel, and re-enabling + Resume picks up where they left off |
+| **Web** | The constituents page SSR-fetches `/v1/feature-flags` and hides the "Email selection" + "Recent emails" buttons when the flag is off |
+
+See [`docs/18-feature-flags.md § 0`](18-feature-flags.md) for the registry shape, the typed `FeatureFlagKey` union, and how to add a new flag.
+
 ## 7. Permissions matrix
 
 | Endpoint | Guard | Notes |
@@ -628,11 +642,8 @@ These were considered and **deliberately deferred** — they would have either t
 - Migration `0039_constituent_postal_address.sql` — Window-envelope address fields
 - Migration `0040_postal_export_idempotency.sql` — Retry-idempotent QR codes (`export_id` backlink + partial unique index) and `tenants.mission` 1000-char DB cap
 - Migration `0041_campaign_description_length_cap.sql` — `campaigns.description` 2000-char DB cap (defense-in-depth against ETL/raw-SQL bypassing the form-level validator)
-<<<<<<< HEAD
 - Migration `0045_bulk_email_jobs.sql` — `bulk_email_jobs` table for partial-send tracking + resume path (issue #326)
-=======
-- Migration `0044_bulk_email_jobs.sql` — `bulk_email_jobs` table for partial-send tracking + resume path (issue #326)
 - Migration `0046_bulk_email_jobs_review_followups.sql` — composite covering index + partial unique on active resumes (PR #352 review fixes)
+- Migration `0047_feature_flags.sql` — global feature-flag registry + bulk-email gate seeded `enabled = false` (PR #352 @magino follow-up)
 - Runbook [`docs/runbooks/bulk-email-stalled-job.md`](runbooks/bulk-email-stalled-job.md) — SRE triage flow for Stalled / Partial bulk-email recovery
->>>>>>> 7498a31 (fix(communication): PR #352 multi-agent review — race, traces, tests)
 - Mockups: `docs/design/index.html` → "Postal mailing" section

--- a/docs/23-postal-campaigns.md
+++ b/docs/23-postal-campaigns.md
@@ -509,10 +509,73 @@ Postal campaigns are paired with a **digital follow-up** mechanism so the operat
 |---|---|
 | Constituents list filter bar | New filters: `lastDonationFrom/To`, `totalAmountMinCents/Max`, `campaignId` (matches both `campaign_constituents` linkage AND donation history — union semantics) |
 | Multi-select toolbar | Bulk-email dialog accepts a free-form subject + body, hits `POST /v1/constituents/bulk-email` |
-| Worker job | Sequential send via `defaultEmailSender` (Mailpit local / Resend prod), per-recipient errors logged but never abort the batch |
+| Worker job | Sequential send via `defaultEmailSender` (Mailpit local / Resend prod), per-recipient errors logged into `bulk_email_jobs.failed_constituent_ids` but never abort the batch |
 | Reachability counter | `requested` (total ids) vs. `reachable` (constituents with a non-empty email) — surfaces the "selected 12, only 9 will get the email" warning before sending |
+| "Recent emails" panel | Lists the 20 most-recent `bulk_email_jobs` rows newest first, polls every 3s while any job is non-terminal, shows live `delivered / total` ratio + per-job Resume button |
 
 Distinct from the legacy segment-based `SendBulkEmailJob` (which targets a saved filter), this job carries the **literal id list** captured at request time so the audit trail stays unambiguous.
+
+### 6.bis Partial-send indicator + resume (issue #326)
+
+The original "fan-out happens in the worker, trust the outbox" design had a transparency gap: when the BullMQ job vanished mid-fan-out (Redis wipe, OOM kill, accessory reboot — see [ADR-026 §Redis 8 cutover](15-infra-adr.md#adr-026-postgres-17-cutover--scaleway-anchored-versioning)), the relay had already marked the outbox row `completed`, the bulk-email dispatch toast said "queued", and the operator had **no surface** showing that zero recipients were actually reached. Two problems:
+
+1. **GDPR transparency** (Art. 5(1)(b)) — the tenant operator has a right to know how many recipients actually received the email, not just how many were requested.
+2. **Operational** — there was no re-issuance path. The operator had to manually re-export the selection and re-trigger.
+
+The `bulk_email_jobs` table makes the dispatch a queryable, resumable artefact:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Op as Operator (org_admin)
+    participant Web as Next.js (web)
+    participant API as Fastify (api)
+    participant DB as Postgres
+    participant Worker as BullMQ worker
+    participant SMTP
+
+    Op->>Web: Select N constituents → Bulk email
+    Web->>API: POST /v1/constituents/bulk-email { ids, subject, body }
+    API->>DB: INSERT bulk_email_jobs (constituent_ids snapshot, total=N, status=pending)
+    API->>DB: INSERT outbox_events ('communication.bulk_email_requested', { bulkEmailJobId })
+    API-->>Web: 202 + { jobId, queued, skippedNoEmail }
+    Web->>Web: Open "Recent emails" panel pinned to jobId, poll every 3s
+
+    Note over Worker,DB: Async fan-out
+    DB->>Worker: outbox relay enqueues BullMQ job
+    Worker->>DB: UPDATE status=processing
+    loop Per recipient (skipping already-delivered / already-failed on retry)
+      Worker->>SMTP: send(to, subject, html, text)
+      alt success
+        Worker->>DB: array_append(delivered_constituent_ids), delivered_count+=1
+      else SMTP refused
+        Worker->>DB: array_append(failed_constituent_ids), failed_count+=1
+      end
+    end
+    Worker->>DB: UPDATE status=completed/partial, completed_at=NOW()
+    Web->>API: GET /v1/constituents/bulk-email-jobs/:id (poll)
+    API-->>Web: { status, deliveredCount, failedCount, totalRecipients, stalled }
+
+    Note over Op,Web: Recovery path
+    alt Worker died mid-fan-out (Redis wipe / OOM / accessory reboot)
+      Web->>Web: Row sits at `processing` with delivered=K (K<N)
+      Web->>Web: After updated_at goes > 10min stale, API derives stalled=true
+      Op->>Web: Click "Resume to remaining"
+      Web->>API: POST /v1/constituents/bulk-email-jobs/:id/resume
+      API->>DB: Compute remaining = constituent_ids \ delivered_constituent_ids
+      API->>DB: INSERT bulk_email_jobs { parent_job_id=source, constituent_ids=remaining }
+      API->>DB: INSERT outbox_events ('communication.bulk_email_requested', { bulkEmailJobId=new })
+      API-->>Web: 202 + new row
+    end
+```
+
+**Counters are denormalised next to the id arrays.** The migration carries a `CHECK` constraint that rejects any drift between `delivered_count` and `array_length(delivered_constituent_ids, 1)` (same for `failed_count` and `total_recipients`), so a buggy worker-side UPDATE that touches only one column fails loudly instead of silently misreporting "8 of 10".
+
+**Resume eligibility.** The API gates the resume action: `partial` and `failed` are always accepted; `processing` is accepted only when stalled (`updated_at` > 10 minutes ago). A still-actively-progressing job returns `400 job_still_running` so the operator can't accidentally race the original worker into double-sending. The new row's `constituent_ids` is computed as `source.constituent_ids \ source.delivered_constituent_ids` — previously SMTP-failed recipients **are** retried (operator intent: "make sure everyone who hasn't received it gets it").
+
+**PII posture.** `bulk_email_jobs` stores constituent IDs only (uuids — tenant-local foreign keys, not directly identifying). PII (email, name) is re-resolved from `constituents` at send time under the worker's RLS context, same Art. 5(1)(e) posture as before. On GDPR erasure of a constituent the worker silently drops them at send time; the stale uuid in the snapshot array is a tenant-scoped reference, not personal data.
+
+**Out of scope for this issue.** Exactly-once delivery (the general outbox → BullMQ contract) and persistent SMTP retry queues stay deferred — see issue #326 "Out of scope". The postal-export side keeps its existing "re-run from scratch" recovery path (the ZIP must be a complete bundle for printing, so a partial resume doesn't apply).
 
 ## 7. Permissions matrix
 
@@ -528,7 +591,10 @@ Distinct from the legacy segment-based `SendBulkEmailJob` (which targets a saved
 | `GET /v1/campaigns/:id/qr-stats` | `requireOrgAdmin` | Aggregate KPIs surfaced on the admin dashboard — kept on the same gate as the rest of the postal feature for a coherent permission model |
 | `GET /v1/public/qr/:code` | **Unauthenticated** | Rate-limited 60/min. The opaque token is the security boundary |
 | `POST /v1/public/campaigns/:id/donate` | **Unauthenticated** | Token in body forwarded to Stripe metadata |
-| `POST /v1/constituents/bulk-email` | `requireWrite` | Write-tier — blocked for `viewer` |
+| `POST /v1/constituents/bulk-email` | `requireOrgAdmin` | Org-admin only — same gate as the rest of the postal feature. Creates a `bulk_email_jobs` tracking row + outbox event |
+| `GET /v1/constituents/bulk-email-jobs` | `requireOrgAdmin` | Lists recent 20 jobs (newest first) — drives the "Recent emails" panel |
+| `GET /v1/constituents/bulk-email-jobs/:id` | `requireOrgAdmin` | Polling endpoint, rate-limited 60/min |
+| `POST /v1/constituents/bulk-email-jobs/:id/resume` | `requireOrgAdmin` | Creates a fresh job targeting recipients the source never reached; gated on source status (`partial` / `failed` / stalled `processing`) |
 
 ## 8. Privacy & GDPR
 
@@ -562,4 +628,5 @@ These were considered and **deliberately deferred** — they would have either t
 - Migration `0039_constituent_postal_address.sql` — Window-envelope address fields
 - Migration `0040_postal_export_idempotency.sql` — Retry-idempotent QR codes (`export_id` backlink + partial unique index) and `tenants.mission` 1000-char DB cap
 - Migration `0041_campaign_description_length_cap.sql` — `campaigns.description` 2000-char DB cap (defense-in-depth against ETL/raw-SQL bypassing the form-level validator)
+- Migration `0045_bulk_email_jobs.sql` — `bulk_email_jobs` table for partial-send tracking + resume path (issue #326)
 - Mockups: `docs/design/index.html` → "Postal mailing" section

--- a/docs/23-postal-campaigns.md
+++ b/docs/23-postal-campaigns.md
@@ -628,5 +628,11 @@ These were considered and **deliberately deferred** — they would have either t
 - Migration `0039_constituent_postal_address.sql` — Window-envelope address fields
 - Migration `0040_postal_export_idempotency.sql` — Retry-idempotent QR codes (`export_id` backlink + partial unique index) and `tenants.mission` 1000-char DB cap
 - Migration `0041_campaign_description_length_cap.sql` — `campaigns.description` 2000-char DB cap (defense-in-depth against ETL/raw-SQL bypassing the form-level validator)
+<<<<<<< HEAD
 - Migration `0045_bulk_email_jobs.sql` — `bulk_email_jobs` table for partial-send tracking + resume path (issue #326)
+=======
+- Migration `0044_bulk_email_jobs.sql` — `bulk_email_jobs` table for partial-send tracking + resume path (issue #326)
+- Migration `0046_bulk_email_jobs_review_followups.sql` — composite covering index + partial unique on active resumes (PR #352 review fixes)
+- Runbook [`docs/runbooks/bulk-email-stalled-job.md`](runbooks/bulk-email-stalled-job.md) — SRE triage flow for Stalled / Partial bulk-email recovery
+>>>>>>> 7498a31 (fix(communication): PR #352 multi-agent review — race, traces, tests)
 - Mockups: `docs/design/index.html` → "Postal mailing" section

--- a/docs/runbooks/bulk-email-stalled-job.md
+++ b/docs/runbooks/bulk-email-stalled-job.md
@@ -1,0 +1,95 @@
+# Runbook — Bulk email job stalled / partial delivery (issue #326)
+
+> **Triage flow** for `bulk_email_jobs` rows that surface to operators as
+> *Stalled* or *Partial*. Unlike the other runbooks in this directory,
+> this is **not** a one-shot ops procedure — it's the recurring SRE
+> playbook for the `bulk_email.partial` alert + operator-reported
+> "my email didn't go out".
+
+## Detection
+
+Two signals fire:
+
+1. **Operator-reported** — the "Recent emails" panel in the constituents
+   page shows a job stuck at `Sending…` with no progress (server-derived
+   `stalled: true` once `updated_at` is older than `BULK_EMAIL_STALL_MS`,
+   default 10 min).
+2. **Worker log** — a Loki query for
+   `{service="worker"} | json | event="bulk_email.partial"` returns
+   rows. Every `partial` outcome is logged at `warn`-level by
+   `finaliseJob` in [`packages/worker/src/processors/send-bulk-email.ts`].
+
+## Triage — was this a worker death or SMTP refusal?
+
+```sql
+-- One row per recipient outcome bucket.
+SELECT
+  id, status, total_recipients, delivered_count, failed_count,
+  total_recipients - delivered_count - failed_count AS missing,
+  updated_at, completed_at
+FROM bulk_email_jobs
+WHERE id = '<job-id>';
+```
+
+Decision tree:
+
+| `failed_count > 0` | `missing > 0` | What happened |
+|---|---|---|
+| Yes | No | SMTP refused for some recipients. Check `provider.email.error` log lines for the failed `constituentId`s. Likely transient (Resend 429, hard bounce). |
+| No | Yes | **Worker died mid-fan-out.** BullMQ job dropped (Redis OOM / accessory reboot / `kamal accessory reboot worker`). |
+| Yes | Yes | Mixed — both happened. Treat as worker-death (the missing slice is the priority). |
+| No | No | Job actually completed; the operator might be looking at a stale poll. Refresh. |
+
+## Recovery
+
+### Operator path (preferred)
+
+Hit **"Resume to remaining"** in the "Recent emails" panel. The server-
+side eligibility gate accepts `partial` / `failed` / stalled `processing`.
+A new `bulk_email_jobs` row is created with `parent_job_id = source.id`
+and `constituent_ids = source.constituent_ids \ delivered_constituent_ids`
+— previously SMTP-failed recipients are retried (operator intent: "make
+sure everyone who hasn't received it gets it"). The audit chain is
+queryable via `parent_job_id`.
+
+### SRE path (when the operator path is unavailable)
+
+If the API is down or the row's RLS context blocks the operator:
+
+```sql
+-- Force-stall a `processing` row so its `stalled` flag flips on the
+-- next API poll (do NOT use unless you've confirmed the worker is dead).
+UPDATE bulk_email_jobs
+SET updated_at = NOW() - INTERVAL '30 minutes'
+WHERE id = '<job-id>';
+```
+
+After this the operator's Resume button becomes available.
+
+If you must intervene at the DB layer (last resort — prefer Resume):
+
+```sql
+-- Mark the row terminal so it stops showing as "Sending…" in the UI.
+-- Counters are unchanged; the operator can decide whether to Resume.
+UPDATE bulk_email_jobs
+SET status = 'partial',
+    error = 'Marked partial by SRE — worker died mid-fan-out',
+    completed_at = NOW(),
+    updated_at = NOW()
+WHERE id = '<job-id>' AND status = 'processing';
+```
+
+## Tuning `BULK_EMAIL_STALL_MS`
+
+Default 10 min. Lives in
+[`packages/api/src/modules/constituents/bulk-email-service.ts`]. If a
+real send legitimately exceeds 10 min between recipient ticks (large
+tenant on a slow SMTP provider, retry-heavy Resend), the API will
+incorrectly surface healthy jobs as stalled. Raise the constant; ship
+in a PR (no env-var override yet — see PR #352 follow-up notes).
+
+## Related
+
+- [docs/23 § 6.bis](../23-postal-campaigns.md) — domain doc with sequence diagram + PII posture
+- [`packages/api/migrations/0044_bulk_email_jobs.sql`] — schema + CHECK constraint
+- [`packages/api/migrations/0046_bulk_email_jobs_review_followups.sql`] — composite index + partial unique on active resumes

--- a/docs/runbooks/bulk-email-stalled-job.md
+++ b/docs/runbooks/bulk-email-stalled-job.md
@@ -91,5 +91,5 @@ in a PR (no env-var override yet — see PR #352 follow-up notes).
 ## Related
 
 - [docs/23 § 6.bis](../23-postal-campaigns.md) — domain doc with sequence diagram + PII posture
-- [`packages/api/migrations/0044_bulk_email_jobs.sql`] — schema + CHECK constraint
+- [`packages/api/migrations/0045_bulk_email_jobs.sql`] — schema + CHECK constraint
 - [`packages/api/migrations/0046_bulk_email_jobs_review_followups.sql`] — composite index + partial unique on active resumes

--- a/docs/runbooks/feature-flag-rollback.md
+++ b/docs/runbooks/feature-flag-rollback.md
@@ -1,0 +1,117 @@
+# Runbook — Feature flag emergency rollback (PR #352)
+
+> SRE-facing reference for the global feature-flag registry shipped in
+> PR #352. Use when the Back Office page at `/admin/feature-flags` is
+> unavailable (API down, super-admin session compromised, frontend
+> regression) AND a flipped flag needs to come down NOW.
+
+## When to use this runbook
+
+Normal flow: a super-admin flips a flag at `/admin/feature-flags` →
+Back Office page → the PATCH writes PG, invalidates the Redis cache,
+the next API request observes the new value. End of story.
+
+This runbook is for **anything that breaks that flow**:
+
+- Back Office page is broken (frontend bug, layout 500, super-admin
+  token expired without refresh).
+- A flag was flipped accidentally and is causing observable harm to
+  donors / operators.
+- API is down but the worker is still picking up gated jobs (worker
+  reads PG directly — flag stays effective even with API down).
+- An incident response needs the flag's history reconstructed.
+
+## Emergency rollback via psql
+
+The DB is the source of truth — flip the flag there and clear the
+Redis cache. The next request rebuilds the cache from PG.
+
+```bash
+# 1. Connect to the application DB
+ssh givernance-staging   # or givernance-prod
+docker exec -it givernance-postgres-1 \
+  psql -U givernance -d givernance
+
+# 2. Flip the flag back to OFF (or to a known-good value)
+UPDATE feature_flags
+   SET enabled    = FALSE,
+       updated_at = NOW()
+ WHERE key = 'communication.bulk_email';
+
+\q
+```
+
+```bash
+# 3. Invalidate the Redis cache so the next request rebuilds from PG
+docker exec -it givernance-redis-1 \
+  redis-cli DEL flags:global
+```
+
+Verification: `curl -s -H "Authorization: Bearer $TOKEN"
+https://api.staging.givernance.org/v1/feature-flags | jq` — the row
+should report `enabled: false`.
+
+## Worker-side: confirm the drop is in effect
+
+The worker reads PG directly (no Redis cache) so a PG-level flip is
+observed on the next job pickup. To confirm the drop is hitting:
+
+```bash
+# Live tail the worker logs for the drop signal
+kamal app logs -r worker --follow -d staging | grep "Bulk email feature flag is off"
+```
+
+Each in-flight job that the worker drops will emit one warn line with
+`{ orgId, bulkEmailJobId }`. The matching `bulk_email_jobs` row stays
+`pending` — re-enabling the flag + clicking Resume from the operator
+UI picks the job back up.
+
+## Loki: audit reconciliation
+
+"Who flipped `communication.bulk_email` to ON between 14:00 and
+16:00 yesterday?" The audit-plugin row in `audit_logs` is the
+authoritative answer. The row's `org_id` is whatever tenant the
+super-admin's session was scoped to (see `docs/18 §0 — Audit notes`);
+filter on `action` to find every flag toggle regardless of the
+operator's session context.
+
+```sql
+SELECT created_at, user_id, org_id, action
+  FROM audit_logs
+ WHERE action = 'PATCH:/v1/admin/feature-flags/:key'
+   AND created_at >= '2026-05-10 14:00'
+   AND created_at <  '2026-05-10 16:00'
+ ORDER BY created_at DESC;
+```
+
+Cross-check the value transition in Loki — the route handler emits a
+structured `event=feature_flag.toggled` line with BEFORE/AFTER:
+
+```logql
+{app="givernance-api"}
+  | json
+  | event="feature_flag.toggled"
+  | flagKey="communication.bulk_email"
+```
+
+## Common confusion
+
+- **"I flipped the flag but the UI still shows the button."**
+  The constituents page SSR-fetches `/v1/feature-flags` and the
+  result is part of the rendered HTML. Hard-refresh the page (the
+  cache invalidates on every PATCH, so the API immediately reports
+  the new value; the *page* needs the new SSR render to see it).
+- **"The worker keeps sending after I disabled the flag."**
+  In-flight BullMQ jobs that the worker has already loaded but not
+  yet checked the flag for will complete. Drops fire at the start
+  of `processSendBulkEmail`, so a job mid-fan-out runs to completion.
+  Wait for the active jobs to drain (workers run at concurrency 2,
+  each send is sequential).
+
+## Related
+
+- [docs/18-feature-flags.md §0](../18-feature-flags.md) — what's
+  shipped, how to add a new flag.
+- [docs/23-postal-campaigns.md §6.ter](../23-postal-campaigns.md) —
+  bulk-email-specific gate behaviour and three-layer enforcement.
+- Migration `0047_feature_flags.sql` — schema + seed.

--- a/packages/api/migrations/0045_bulk_email_jobs.sql
+++ b/packages/api/migrations/0045_bulk_email_jobs.sql
@@ -1,0 +1,121 @@
+-- Migration: 0045_bulk_email_jobs (issue #326)
+--
+-- Bulk-email jobs — partial-send indicator + resume path for the
+-- `communication.bulk_email_requested` outbox flow.
+--
+-- Today the outbox relay (packages/relay/src/relay.ts) marks the row
+-- `completed` the moment it enqueues the BullMQ job (at-most-once
+-- enqueue, by design — see ADR-026 § "Redis 8 cutover" for why this
+-- matters around a Redis wipe). When the worker dies mid-fan-out
+-- (Redis OOM, accessory reboot, operator-initiated wipe), the
+-- operator-facing UI today reads "send succeeded" even if zero
+-- recipients were reached. Two consequences:
+--
+--   1. GDPR transparency — the tenant operator has a right to know how
+--      many recipients were actually delivered (Art. 5(1)(b)).
+--   2. Operational — there's no re-issuance path. The operator would
+--      have to manually re-export the recipient list and re-trigger.
+--
+-- This migration adds the queryable progress + resume surface:
+--
+--   - `bulk_email_jobs` row inserted in the same transaction as the
+--     outbox event (same tx the donation/receipt/postal-export flows
+--     already follow). Carries the request snapshot + per-recipient
+--     outcome arrays so the resume path can compute "remaining =
+--     constituent_ids \ delivered_constituent_ids" without scanning a
+--     separate event log.
+--
+--   - Worker increments `delivered_count` / `failed_count` and
+--     appends to the corresponding id array on each send, so the
+--     polling UI sees a live ratio. On worker process death mid-job,
+--     the row stays at its last update — the operator sees "5 of 10
+--     delivered, processing (stalled)" and can hit Resume.
+--
+--   - Resume creates a fresh `bulk_email_jobs` row with
+--     `parent_job_id = source.id` and `constituent_ids = source
+--     remaining`, then emits a new outbox event. The audit chain is
+--     queryable via `parent_job_id`.
+--
+-- RLS: standard tenant_isolation policy. Worker reads + writes go
+-- through `withWorkerContext`; API reads + writes through
+-- `withTenantContext`.
+--
+-- Idempotent — re-runs on a fresh checkout are no-ops.
+
+-- ─── Enum ───────────────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  CREATE TYPE bulk_email_job_status AS ENUM (
+    'pending',
+    'processing',
+    'completed',
+    'partial',
+    'failed'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ─── Table ──────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS bulk_email_jobs (
+  id                          UUID                  PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id                      UUID                  NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  status                      bulk_email_job_status NOT NULL DEFAULT 'pending',
+  subject                     VARCHAR(200)          NOT NULL,
+  body                        TEXT                  NOT NULL,
+  -- Snapshot of deliverable recipients at request time. Locked at
+  -- insert; worker iterates this list. uuid[] (not jsonb) so Postgres
+  -- can do `= ANY(...)` / `ARRAY(SELECT unnest(...) EXCEPT ...)`
+  -- without a cast on every read.
+  constituent_ids             UUID[]                NOT NULL,
+  -- Append-only set of recipients the worker successfully delivered to.
+  -- Default '{}' so the worker's first UPDATE can rely on the column.
+  delivered_constituent_ids   UUID[]                NOT NULL DEFAULT '{}',
+  -- Append-only set of recipients the worker tried and SMTP refused.
+  failed_constituent_ids      UUID[]                NOT NULL DEFAULT '{}',
+  -- Denormalised counts so the polling UI is O(1). Worker keeps them
+  -- in step with the array cardinality on every send.
+  total_recipients            INTEGER               NOT NULL,
+  delivered_count             INTEGER               NOT NULL DEFAULT 0,
+  failed_count                INTEGER               NOT NULL DEFAULT 0,
+  -- JWT subject → internal users.id translation. SET NULL on user
+  -- purge so GDPR erasure of a staff account doesn't FK-block the
+  -- audit row.
+  requested_by                UUID                  REFERENCES users(id) ON DELETE SET NULL,
+  -- Audit chain for resume jobs. NULL on the originating dispatch.
+  parent_job_id               UUID                  REFERENCES bulk_email_jobs(id) ON DELETE SET NULL,
+  -- Terminal failure message. NULL until status flips to `failed`.
+  error                       TEXT,
+  -- Soft-delete (ADR-021 universal).
+  deleted_at                  TIMESTAMPTZ,
+  created_at                  TIMESTAMPTZ           NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ           NOT NULL DEFAULT NOW(),
+  completed_at                TIMESTAMPTZ,
+  -- Defence-in-depth: keep the counters in step with the arrays. The
+  -- worker's UPDATE statement uses array_length to set them, but a
+  -- raw-SQL backfill or a buggy migration could drift them — the
+  -- CHECK fails loudly instead of silently misreporting "8 of 10".
+  CONSTRAINT bulk_email_jobs_counts_match_arrays_chk CHECK (
+    delivered_count = COALESCE(array_length(delivered_constituent_ids, 1), 0)
+    AND failed_count = COALESCE(array_length(failed_constituent_ids, 1), 0)
+    AND total_recipients = COALESCE(array_length(constituent_ids, 1), 0)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS bulk_email_jobs_org_idx
+  ON bulk_email_jobs (org_id);
+CREATE INDEX IF NOT EXISTS bulk_email_jobs_created_at_idx
+  ON bulk_email_jobs (created_at DESC);
+CREATE INDEX IF NOT EXISTS bulk_email_jobs_parent_idx
+  ON bulk_email_jobs (parent_job_id);
+
+ALTER TABLE bulk_email_jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bulk_email_jobs FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  CREATE POLICY tenant_isolation ON bulk_email_jobs
+    USING (org_id = app_current_organization_id());
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON bulk_email_jobs TO givernance_app;

--- a/packages/api/migrations/0046_bulk_email_jobs_review_followups.sql
+++ b/packages/api/migrations/0046_bulk_email_jobs_review_followups.sql
@@ -1,0 +1,46 @@
+-- Migration: 0046_bulk_email_jobs_review_followups (issue #326 — PR #352 multi-agent review fixes)
+--
+-- Three tightenings landed off the back of the platform + security review
+-- on PR #352. All three are idempotent and additive — they take effect on
+-- the next deploy without operator intervention.
+--
+--   1. **Composite covering index for the list query.** The Phase-1 access
+--      pattern `WHERE org_id = ? AND deleted_at IS NULL ORDER BY created_at
+--      DESC LIMIT 20` (`listBulkEmailJobs`) can't be satisfied by the two
+--      single-column indexes added in 0044 — Postgres falls back to a
+--      filter-then-sort. Fine at MVP cardinality, but the partial composite
+--      below collapses the path to one index scan and drops the standalone
+--      `created_at` index whose only consumer is this same query.
+--
+--   2. **Partial unique index on `parent_job_id` for active resumes.**
+--      Belt-and-braces companion to the `SELECT … FOR UPDATE` lock that
+--      `resumeBulkEmailJob` now takes. Two simultaneous resume calls
+--      against the same source can no longer both succeed — even if the
+--      row lock is somehow bypassed (raw SQL, future direct-DB tooling),
+--      this index makes a duplicate `INSERT` fail at the DB layer with a
+--      unique-violation rather than silently producing two child rows
+--      that both fan out to the same remaining recipients. (Security
+--      review H1 / Platform review H1.)
+--
+--      Partial-only because resume rows are short-lived in the non-
+--      terminal state — once status flips to `completed` / `partial` /
+--      `failed`, a future resume from the same parent is legitimate and
+--      mustn't be blocked by an old index entry.
+
+-- ─── 1. Composite covering index ──────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS bulk_email_jobs_org_created_at_active_idx
+  ON bulk_email_jobs (org_id, created_at DESC)
+  WHERE deleted_at IS NULL;
+
+-- The standalone `created_at` index from 0044 was only used by the listing
+-- path that the composite above now serves. Drop it to keep INSERT cost
+-- low (every INSERT writes to every index).
+DROP INDEX IF EXISTS bulk_email_jobs_created_at_idx;
+
+-- ─── 2. Partial unique on active resumes ──────────────────────────────────
+
+CREATE UNIQUE INDEX IF NOT EXISTS bulk_email_jobs_one_active_resume_per_parent
+  ON bulk_email_jobs (parent_job_id)
+  WHERE parent_job_id IS NOT NULL
+    AND status IN ('pending', 'processing');

--- a/packages/api/migrations/0047_feature_flags.sql
+++ b/packages/api/migrations/0047_feature_flags.sql
@@ -1,0 +1,60 @@
+-- Migration: 0047_feature_flags (issue #326 / PR #352 follow-up)
+--
+-- Adds the global feature-flag registry that gates the bulk-email work
+-- behind a platform-admin toggle. Scope is intentionally narrow per the
+-- @magino discussion on PR #352:
+--
+--   * **Global flags only.** Every tenant sees the same value. Per-
+--     tenant overrides + plan-gating from `docs/18-feature-flags.md`
+--     §4.2-4.3 are deferred until we actually have a use-case for them.
+--   * **Code is the source of truth for which keys exist** —
+--     `packages/shared/src/constants/feature-flags.ts` declares
+--     `FEATURE_FLAG_REGISTRY`; this migration seeds those keys with
+--     their default values. The admin UI toggles `enabled`, it does
+--     NOT create rows.
+--
+-- The bulk-email flag (`communication.bulk_email`) is seeded with
+-- `enabled = FALSE` — see the doc-18 / doc-23 cross-reference for the
+-- DKIM / SPF rationale.
+--
+-- Idempotent — `IF NOT EXISTS` on the table, `ON CONFLICT (key) DO
+-- NOTHING` on the seed so a redeploy preserves any operator-toggled
+-- value.
+
+-- ─── Table ──────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS feature_flags (
+  id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Dotted-namespace key. Lowercase + dot-separated; the application
+  -- layer enforces the convention via the typed `FeatureFlagKey`
+  -- union. UNIQUE because `requireFlag(key)` looks up by this column.
+  key          VARCHAR(100) NOT NULL UNIQUE,
+  enabled      BOOLEAN      NOT NULL DEFAULT FALSE,
+  description  TEXT         NOT NULL,
+  -- Last super-admin to flip the flag. SET NULL on user purge so a
+  -- GDPR-erased staff account doesn't FK-block the row.
+  updated_by   UUID         REFERENCES users(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS feature_flags_key_idx
+  ON feature_flags (key);
+
+-- No RLS — the registry is platform-wide, not tenant-scoped. The
+-- `requireSuperAdmin` guard on the admin routes is the access boundary.
+GRANT SELECT, INSERT, UPDATE ON feature_flags TO givernance_app;
+
+-- ─── Seed ───────────────────────────────────────────────────────────────────
+-- Keep the SQL `description` in lockstep with the
+-- `FEATURE_FLAG_REGISTRY` entry in
+-- `packages/shared/src/constants/feature-flags.ts`. The startup check
+-- (boot helper) compares the two and fails fast on drift.
+
+INSERT INTO feature_flags (key, enabled, description)
+VALUES (
+  'communication.bulk_email',
+  FALSE,
+  'Operator-triggered bulk email to selected constituents (issue #326). Disabled until the platform''s outbound mail domain has DKIM / SPF / DMARC configured — without them every send looks like phishing to recipient MX servers.'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/packages/api/migrations/0047_feature_flags.sql
+++ b/packages/api/migrations/0047_feature_flags.sql
@@ -30,6 +30,14 @@ CREATE TABLE IF NOT EXISTS feature_flags (
   -- union. UNIQUE because `requireFlag(key)` looks up by this column.
   key          VARCHAR(100) NOT NULL UNIQUE,
   enabled      BOOLEAN      NOT NULL DEFAULT FALSE,
+  -- Short, friendly heading shown in the Back Office UI (e.g. "Bulk
+  -- emails to constituents"). Plain language; the dotted `key` lives
+  -- below as a small subtitle for engineers reading audit logs.
+  label        VARCHAR(120) NOT NULL,
+  -- Operator-facing description (one or two sentences). Plain
+  -- language. Engineering rationale (RFCs, infra prerequisites,
+  -- incident IDs) stays in `FEATURE_FLAG_REGISTRY` code comments,
+  -- NOT here.
   description  TEXT         NOT NULL,
   -- Last super-admin to flip the flag. SET NULL on user purge so a
   -- GDPR-erased staff account doesn't FK-block the row.
@@ -54,15 +62,17 @@ CREATE TABLE IF NOT EXISTS feature_flags (
 GRANT SELECT, UPDATE ON feature_flags TO givernance_app;
 
 -- ─── Seed ───────────────────────────────────────────────────────────────────
--- Keep the SQL `description` in lockstep with the
+-- Keep the SQL `label` + `description` in lockstep with the
 -- `FEATURE_FLAG_REGISTRY` entry in
--- `packages/shared/src/constants/feature-flags.ts`. The startup check
--- (boot helper) compares the two and fails fast on drift.
+-- `packages/shared/src/constants/feature-flags.ts`. The integration
+-- test in `feature-flags.test.ts` asserts the parity and fails CI on
+-- drift.
 
-INSERT INTO feature_flags (key, enabled, description)
+INSERT INTO feature_flags (key, enabled, label, description)
 VALUES (
   'communication.bulk_email',
   FALSE,
-  'Operator-triggered bulk email to selected constituents (issue #326). Disabled until the platform''s outbound mail domain has DKIM / SPF / DMARC configured — without them every send looks like phishing to recipient MX servers.'
+  'Bulk emails to constituents',
+  'Lets operators send one email to several constituents at once from the Constituents page. Currently off — we''ll turn it on once the email-deliverability setup is finished so messages don''t land in donors'' spam folders.'
 )
 ON CONFLICT (key) DO NOTHING;

--- a/packages/api/migrations/0047_feature_flags.sql
+++ b/packages/api/migrations/0047_feature_flags.sql
@@ -30,14 +30,6 @@ CREATE TABLE IF NOT EXISTS feature_flags (
   -- union. UNIQUE because `requireFlag(key)` looks up by this column.
   key          VARCHAR(100) NOT NULL UNIQUE,
   enabled      BOOLEAN      NOT NULL DEFAULT FALSE,
-  -- Short, friendly heading shown in the Back Office UI (e.g. "Bulk
-  -- emails to constituents"). Plain language; the dotted `key` lives
-  -- below as a small subtitle for engineers reading audit logs.
-  label        VARCHAR(120) NOT NULL,
-  -- Operator-facing description (one or two sentences). Plain
-  -- language. Engineering rationale (RFCs, infra prerequisites,
-  -- incident IDs) stays in `FEATURE_FLAG_REGISTRY` code comments,
-  -- NOT here.
   description  TEXT         NOT NULL,
   -- Last super-admin to flip the flag. SET NULL on user purge so a
   -- GDPR-erased staff account doesn't FK-block the row.
@@ -45,6 +37,15 @@ CREATE TABLE IF NOT EXISTS feature_flags (
   created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
   updated_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
+
+-- The operator-facing `label` column is added later (migration 0049 —
+-- introduced after the magino UX review revealed the row was too
+-- technical for non-engineers). We don't backport the column into
+-- THIS migration because it may already have been applied in dev /
+-- staging — modifying an applied migration is a silent no-op
+-- under `CREATE TABLE IF NOT EXISTS`, leaving the DB in a drifted
+-- state that breaks the route. Migrations are immutable once
+-- applied anywhere.
 
 -- (No explicit `feature_flags_key_idx` — the `UNIQUE` constraint on
 -- `key` already creates a btree index that satisfies the
@@ -62,17 +63,15 @@ CREATE TABLE IF NOT EXISTS feature_flags (
 GRANT SELECT, UPDATE ON feature_flags TO givernance_app;
 
 -- ─── Seed ───────────────────────────────────────────────────────────────────
--- Keep the SQL `label` + `description` in lockstep with the
--- `FEATURE_FLAG_REGISTRY` entry in
--- `packages/shared/src/constants/feature-flags.ts`. The integration
--- test in `feature-flags.test.ts` asserts the parity and fails CI on
--- drift.
+-- Seed the bulk-email row. The `description` here is the initial-
+-- engineering-rationale version; migration 0049 rewrites it to the
+-- operator-friendly text and adds the `label` column. Kept this way
+-- to honour the "migrations are immutable once applied" rule.
 
-INSERT INTO feature_flags (key, enabled, label, description)
+INSERT INTO feature_flags (key, enabled, description)
 VALUES (
   'communication.bulk_email',
   FALSE,
-  'Bulk emails to constituents',
-  'Lets operators send one email to several constituents at once from the Constituents page. Currently off — we''ll turn it on once the email-deliverability setup is finished so messages don''t land in donors'' spam folders.'
+  'Operator-triggered bulk email to selected constituents (issue #326). Disabled until the platform''s outbound mail domain has DKIM / SPF / DMARC configured — without them every send looks like phishing to recipient MX servers.'
 )
 ON CONFLICT (key) DO NOTHING;

--- a/packages/api/migrations/0047_feature_flags.sql
+++ b/packages/api/migrations/0047_feature_flags.sql
@@ -38,12 +38,20 @@ CREATE TABLE IF NOT EXISTS feature_flags (
   updated_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS feature_flags_key_idx
-  ON feature_flags (key);
+-- (No explicit `feature_flags_key_idx` — the `UNIQUE` constraint on
+-- `key` already creates a btree index that satisfies the
+-- `WHERE key = ?` access pattern in `flagService` + `requireFlag`.
+-- PR #352 Platform review Plat-LOW-2a flagged the redundant index.)
 
 -- No RLS — the registry is platform-wide, not tenant-scoped. The
 -- `requireSuperAdmin` guard on the admin routes is the access boundary.
-GRANT SELECT, INSERT, UPDATE ON feature_flags TO givernance_app;
+--
+-- GRANTs intentionally narrow: `INSERT` is reserved for the seed
+-- migration (running as the owner role); the admin PATCH handler
+-- only UPDATEs an existing row, never INSERTs. DELETE is never
+-- granted — flag deletion is a code change + a follow-up migration,
+-- not a runtime operation. (PR #352 Platform review Plat-LOW-2b.)
+GRANT SELECT, UPDATE ON feature_flags TO givernance_app;
 
 -- ─── Seed ───────────────────────────────────────────────────────────────────
 -- Keep the SQL `description` in lockstep with the

--- a/packages/api/migrations/0048_drop_redundant_feature_flags_idx.sql
+++ b/packages/api/migrations/0048_drop_redundant_feature_flags_idx.sql
@@ -1,0 +1,13 @@
+-- 0048 — Drop the redundant `feature_flags_key_idx` index introduced
+-- in migration 0047 (PR #352 Platform review Plat-LOW-2a).
+--
+-- `feature_flags.key` already has a btree index courtesy of the
+-- `UNIQUE` constraint. The explicit secondary index is duplicate work
+-- on every INSERT and serves no read path the unique-index doesn't
+-- already cover (`WHERE key = ?` is satisfied by either).
+--
+-- Idempotent — `DROP INDEX IF EXISTS` on a missing index is a no-op
+-- (fresh checkouts that ran 0047 after this PR landed will already
+-- not have the index, courtesy of the migration edit).
+
+DROP INDEX IF EXISTS feature_flags_key_idx;

--- a/packages/api/migrations/0049_feature_flags_friendly_text.sql
+++ b/packages/api/migrations/0049_feature_flags_friendly_text.sql
@@ -1,0 +1,59 @@
+-- Migration: 0049_feature_flags_friendly_text (PR #352 magino UX review)
+--
+-- Adds the operator-facing `label` column to `feature_flags` and
+-- rewrites the bulk-email row's text in plain language. The Back
+-- Office UI was previously rendering engineering jargon
+-- ("communication.bulk_email", "DKIM / SPF / DMARC", "issue #326")
+-- to non-technical super-admins, which read more like a deploy ticket
+-- than an operator control.
+--
+-- Why this is a separate migration (not folded into 0047): an earlier
+-- iteration of this PR modified 0047 in place to add the column. That
+-- broke any environment where 0047 had already been applied — the
+-- idempotent `CREATE TABLE IF NOT EXISTS` silently skipped the
+-- re-run, leaving the DB without the `label` column and the
+-- `/v1/admin/feature-flags` route 500-ing on a missing column. Lesson:
+-- once a migration is applied anywhere (even local dev), treat it as
+-- immutable. Additive schema + data fixes belong in a NEW migration.
+--
+-- Three-step shape:
+--   1. Add `label` as NULLABLE (existing rows need a back-fill window).
+--   2. UPDATE the seeded row(s) with both `label` and the rewritten
+--      friendly `description`. Idempotent — re-running won't change
+--      operator-toggled `enabled`.
+--   3. Promote `label` to NOT NULL. Safe by step 2: every seeded row
+--      now has the column populated.
+--
+-- Idempotent — every step uses `IF NOT EXISTS` / unconditional UPDATE,
+-- so re-runs on a fresh checkout are no-ops.
+
+-- ─── 1. Add the column as NULLABLE ──────────────────────────────────────────
+
+ALTER TABLE feature_flags
+  ADD COLUMN IF NOT EXISTS label VARCHAR(120);
+
+-- ─── 2. Back-fill + rewrite the bulk-email row ──────────────────────────────
+-- Keep the SQL `label` + `description` in lockstep with the
+-- `FEATURE_FLAG_REGISTRY` entry in
+-- `packages/shared/src/constants/feature-flags.ts`. The integration
+-- test in `feature-flags.test.ts` asserts the parity and fails CI on
+-- drift.
+
+UPDATE feature_flags
+SET
+  label = 'Bulk emails to constituents',
+  description = 'Lets operators send one email to several constituents at once from the Constituents page. Currently off — we''ll turn it on once the email-deliverability setup is finished so messages don''t land in donors'' spam folders.',
+  updated_at = NOW()
+WHERE key = 'communication.bulk_email';
+
+-- ─── 3. Promote `label` to NOT NULL ─────────────────────────────────────────
+-- Wrapped in a DO block so re-applying against a DB where the column
+-- is already NOT NULL is a no-op rather than an error.
+
+DO $$
+BEGIN
+  ALTER TABLE feature_flags
+    ALTER COLUMN label SET NOT NULL;
+EXCEPTION
+  WHEN invalid_table_definition THEN NULL;
+END $$;

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1777980000000,
       "tag": "0044_swiss_qr_bill_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1777990000000,
+      "tag": "0045_bulk_email_jobs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1777990000000,
       "tag": "0045_bulk_email_jobs",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1778000000000,
+      "tag": "0046_bulk_email_jobs_review_followups",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1778000000000,
       "tag": "0046_bulk_email_jobs_review_followups",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1778010000000,
+      "tag": "0047_feature_flags",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1778020000000,
       "tag": "0048_drop_redundant_feature_flags_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1778030000000,
+      "tag": "0049_feature_flags_friendly_text",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1778010000000,
       "tag": "0047_feature_flags",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1778020000000,
+      "tag": "0048_drop_redundant_feature_flags_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/lib/flags/flag-guard.ts
+++ b/packages/api/src/lib/flags/flag-guard.ts
@@ -1,0 +1,46 @@
+/**
+ * `requireFlag(key)` — Fastify preHandler that gates a route on a
+ * feature flag. Disabled = 404, NOT 403:
+ *
+ *   - 404 doesn't disclose feature existence to an unauthorised
+ *     scanner. The gated route should look indistinguishable from
+ *     a typo'd URL.
+ *   - The web layer's `notFound()` server-component pattern aligns:
+ *     a flag-off route returns 404 in both layers.
+ *
+ * The guard reads from the shared `flagService` (which itself reads
+ * Redis → PG on miss). Evaluation is async but cached, so the worst
+ * case is one PG query per minute per replica.
+ *
+ * Doc 18 §6.1 specifies this pattern; bulk-email (issue #326 / PR #352)
+ * is the first consumer.
+ */
+
+import type { FeatureFlagKey } from "@givernance/shared/constants";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { problemDetail } from "../schemas.js";
+import { flagService as defaultFlagService, type FlagService } from "./flag-service.js";
+
+/**
+ * Build a `preHandler` that 404s the route when `flagKey` is off.
+ *
+ * The injected `service` is the per-request `request.flagService` when
+ * the flag plugin is registered (see `flag-plugin.ts`), or the module
+ * singleton otherwise. Tests can pass a stub directly.
+ */
+export function requireFlag(flagKey: FeatureFlagKey, service: FlagService = defaultFlagService) {
+  return async function flagPreHandler(request: FastifyRequest, reply: FastifyReply) {
+    const effective: FlagService = request.flagService ?? service;
+    const enabled = await effective.isEnabled(flagKey);
+    if (!enabled) {
+      // Structured log so SRE can see how often a gated route is hit
+      // while disabled — useful signal that a feature is in demand
+      // OR that an unauthorised scanner is poking around.
+      request.log.info(
+        { event: "flag.route_gated", flagKey, path: request.url, method: request.method },
+        "Route gated off — feature flag disabled",
+      );
+      return reply.status(404).send(problemDetail(404, "Not Found", "Route not found"));
+    }
+  };
+}

--- a/packages/api/src/lib/flags/flag-guard.ts
+++ b/packages/api/src/lib/flags/flag-guard.ts
@@ -36,8 +36,18 @@ export function requireFlag(flagKey: FeatureFlagKey, service: FlagService = defa
       // Structured log so SRE can see how often a gated route is hit
       // while disabled — useful signal that a feature is in demand
       // OR that an unauthorised scanner is poking around.
+      //
+      // `path` is the route TEMPLATE (e.g. `/v1/constituents/bulk-email-jobs/:id`),
+      // not the raw URL. Templates keep Loki cardinality bounded so a
+      // misbehaving SPA polling `/.../<uuid>/` 100×/sec doesn't blow
+      // up the index. (PR #352 Log review M2.)
       request.log.info(
-        { event: "flag.route_gated", flagKey, path: request.url, method: request.method },
+        {
+          event: "flag.route_gated",
+          flagKey,
+          path: request.routeOptions.url ?? request.url,
+          method: request.method,
+        },
         "Route gated off — feature flag disabled",
       );
       return reply.status(404).send(problemDetail(404, "Not Found", "Route not found"));

--- a/packages/api/src/lib/flags/flag-plugin.ts
+++ b/packages/api/src/lib/flags/flag-plugin.ts
@@ -1,0 +1,34 @@
+/**
+ * Fastify plugin — decorates every request with a `flagService` so
+ * route handlers + sub-services don't have to import the module
+ * singleton directly. Aligns with how the rest of the codebase
+ * threads cross-cutting deps (audit, idempotency, redis).
+ *
+ * Tests can override the decorator before the route fires:
+ *
+ *   app.addHook("onRequest", (req, _reply, done) => {
+ *     req.flagService = stubFlagService;
+ *     done();
+ *   });
+ */
+
+import fp from "fastify-plugin";
+import { type FlagService, flagService } from "./flag-service.js";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    /**
+     * Per-request feature-flag evaluator. Backed by the shared
+     * `flagService` (Redis-cached + PG-sourced). Decorated by
+     * `flagPlugin`; never undefined in registered routes.
+     */
+    flagService: FlagService;
+  }
+}
+
+export const flagPlugin = fp(async (app) => {
+  app.decorateRequest("flagService", null as unknown as FlagService);
+  app.addHook("onRequest", async (request) => {
+    request.flagService = flagService;
+  });
+});

--- a/packages/api/src/lib/flags/flag-service.ts
+++ b/packages/api/src/lib/flags/flag-service.ts
@@ -37,6 +37,7 @@ const CACHE_TTL_SECONDS = 60;
 export interface FeatureFlagRow {
   key: string;
   enabled: boolean;
+  label: string;
   description: string;
   updatedBy: string | null;
   createdAt: string;
@@ -145,6 +146,7 @@ export function createFlagService(deps: FlagServiceDeps = {}): FlagService {
         .select({
           key: featureFlags.key,
           enabled: featureFlags.enabled,
+          label: featureFlags.label,
           description: featureFlags.description,
           updatedBy: featureFlags.updatedBy,
           createdAt: featureFlags.createdAt,
@@ -155,6 +157,7 @@ export function createFlagService(deps: FlagServiceDeps = {}): FlagService {
       return rows.map((row) => ({
         key: row.key,
         enabled: row.enabled,
+        label: row.label,
         description: row.description,
         updatedBy: row.updatedBy,
         createdAt:

--- a/packages/api/src/lib/flags/flag-service.ts
+++ b/packages/api/src/lib/flags/flag-service.ts
@@ -1,0 +1,188 @@
+/**
+ * Feature flag evaluation service — Phase-1 MVP (global flags only).
+ *
+ * The whole registry lives in one Redis key, `flags:global`, stored as
+ * a single JSON-serialised `Record<flagKey, boolean>`. Reads are
+ * O(1); writes invalidate by overwriting the same key in one round-
+ * trip. There are <10 flags expected in the foreseeable future, so a
+ * full-map invalidate is cheaper to reason about than per-key keys.
+ *
+ * Why a single map + 60s TTL:
+ *   - Misses fall through to PG → one query rebuilds the whole map,
+ *     so a cold cache costs one round-trip not N.
+ *   - 60s upper bound on staleness is acceptable for an operator-
+ *     toggled flag — the admin UI also explicit-invalidates on write
+ *     so a flip is visible immediately on the next request.
+ *   - Unknown keys (typo / removed flag still referenced in old code)
+ *     evaluate to `false`, matching doc 18 §5.
+ *
+ * Per-tenant overrides + plan-gating from doc 18 are intentionally
+ * out of scope here — the function signature takes a `key` only, so
+ * future tenant-overload won't break existing callers.
+ */
+
+import { featureFlags } from "@givernance/shared/schema";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type Redis from "ioredis";
+import pino from "pino";
+import { db } from "../db.js";
+import { redis as defaultRedis } from "../redis.js";
+
+const logger = pino({ name: "flag-service" });
+
+const CACHE_KEY = "flags:global";
+const CACHE_TTL_SECONDS = 60;
+
+/** Strict registry shape — only the columns the evaluator + admin UI need. */
+export interface FeatureFlagRow {
+  key: string;
+  enabled: boolean;
+  description: string;
+  updatedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Test-seam: the production code uses the module-level `db` / `redis`
+ * singletons. Tests inject their own to assert the cache-miss → PG
+ * fallback behaviour without mocking the imports.
+ */
+export interface FlagServiceDeps {
+  // biome-ignore lint/suspicious/noExplicitAny: NodePgDatabase is generic over the schema; we don't need to narrow inside the service
+  db?: NodePgDatabase<any>;
+  redis?: Redis;
+}
+
+function getDb(deps: FlagServiceDeps): NodePgDatabase<Record<string, never>> {
+  return (deps.db ?? db) as NodePgDatabase<Record<string, never>>;
+}
+
+function getRedis(deps: FlagServiceDeps): Redis {
+  return deps.redis ?? defaultRedis;
+}
+
+/**
+ * Read every flag row from PG and return them as a `key → enabled`
+ * map. Used internally on cache miss; also exposed for the admin
+ * list endpoint (read-through behaviour is the same).
+ */
+async function loadFromDb(
+  conn: NodePgDatabase<Record<string, never>>,
+): Promise<Record<string, boolean>> {
+  const rows = await conn
+    .select({ key: featureFlags.key, enabled: featureFlags.enabled })
+    .from(featureFlags);
+  const map: Record<string, boolean> = {};
+  for (const row of rows) {
+    map[row.key] = row.enabled;
+  }
+  return map;
+}
+
+async function getMap(deps: FlagServiceDeps = {}): Promise<Record<string, boolean>> {
+  const cache = getRedis(deps);
+  try {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) {
+      return JSON.parse(cached) as Record<string, boolean>;
+    }
+  } catch (err) {
+    // Cache failure must NOT crash flag evaluation — fall through to
+    // PG. A Redis outage already manifests as elevated p99 (cache
+    // misses); we don't want to also flip every gated route to 404.
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "flags: cache read failed, falling back to PG",
+    );
+  }
+
+  const map = await loadFromDb(getDb(deps));
+
+  try {
+    await cache.set(CACHE_KEY, JSON.stringify(map), "EX", CACHE_TTL_SECONDS);
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "flags: cache write failed, evaluator will keep falling through to PG until Redis recovers",
+    );
+  }
+
+  return map;
+}
+
+export interface FlagService {
+  /**
+   * Evaluate a single flag. Unknown keys (typo / DB drift) evaluate
+   * to `false` per doc 18 §5 — never throws, never returns null. Any
+   * unexpected DB error bubbles up; the route layer's existing 500
+   * handler catches it.
+   */
+  isEnabled(key: string): Promise<boolean>;
+  /** Bulk fetch — used by the admin list endpoint + the web SSR layer. */
+  list(): Promise<FeatureFlagRow[]>;
+  /**
+   * Invalidate the Redis cache. Called by the admin PATCH route AFTER
+   * the DB write succeeds so the next read sees the new value.
+   * Idempotent — a stale del on a key that's already gone is a no-op.
+   */
+  invalidate(): Promise<void>;
+}
+
+/**
+ * Build a `FlagService` bound to the supplied (or default) db + redis
+ * handles. Each Fastify request decorates a fresh instance via the
+ * plugin below so per-request mocking stays cheap.
+ */
+export function createFlagService(deps: FlagServiceDeps = {}): FlagService {
+  return {
+    async isEnabled(key) {
+      const map = await getMap(deps);
+      return map[key] === true;
+    },
+    async list() {
+      const rows = await getDb(deps)
+        .select({
+          key: featureFlags.key,
+          enabled: featureFlags.enabled,
+          description: featureFlags.description,
+          updatedBy: featureFlags.updatedBy,
+          createdAt: featureFlags.createdAt,
+          updatedAt: featureFlags.updatedAt,
+        })
+        .from(featureFlags)
+        .orderBy(featureFlags.key);
+      return rows.map((row) => ({
+        key: row.key,
+        enabled: row.enabled,
+        description: row.description,
+        updatedBy: row.updatedBy,
+        createdAt:
+          row.createdAt instanceof Date ? row.createdAt.toISOString() : String(row.createdAt),
+        updatedAt:
+          row.updatedAt instanceof Date ? row.updatedAt.toISOString() : String(row.updatedAt),
+      }));
+    },
+    async invalidate() {
+      try {
+        await getRedis(deps).del(CACHE_KEY);
+      } catch (err) {
+        // Same posture as the read path — log + continue. The 60-second
+        // TTL is the worst-case lag between admin flip and observable
+        // effect; if Redis is down the admin sees their change on the
+        // next request anyway (PG read-through).
+        logger.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "flags: cache invalidate failed, value will refresh within TTL",
+        );
+      }
+    },
+  };
+}
+
+/**
+ * Default singleton for non-request code (workers, scripts). Inside
+ * Fastify routes prefer `request.flagService` so per-test injection
+ * stays cheap.
+ */
+export const flagService: FlagService = createFlagService();

--- a/packages/api/src/modules/admin/feature-flags-routes.ts
+++ b/packages/api/src/modules/admin/feature-flags-routes.ts
@@ -45,6 +45,7 @@ const FlagKeyParams = Type.Object({
 const FlagRowSchema = Type.Object({
   key: Type.String(),
   enabled: Type.Boolean(),
+  label: Type.String(),
   description: Type.String(),
   updatedBy: Type.Union([Type.Null(), Type.String()]),
   createdAt: Type.String(),

--- a/packages/api/src/modules/admin/feature-flags-routes.ts
+++ b/packages/api/src/modules/admin/feature-flags-routes.ts
@@ -1,0 +1,185 @@
+/**
+ * Platform-admin routes for the global feature-flag registry
+ * (issue #326 / PR #352 follow-up — Magino-on-comment).
+ *
+ * Scope is intentionally minimal:
+ *   - `GET    /v1/admin/feature-flags` — list every flag for the
+ *     Back Office page.
+ *   - `PATCH  /v1/admin/feature-flags/:key` — flip `enabled`. No
+ *     other field is mutable from the UI: description + key are
+ *     code-owned (see `FEATURE_FLAG_REGISTRY`); the only operator
+ *     decision is on/off.
+ *
+ * No POST / DELETE — flag rows are created by the seed migration
+ * (`0047_feature_flags.sql`) and live for the life of the code
+ * reference. Removing a flag means deleting the code AND the row in
+ * a follow-up migration; the UI can't sneak this in.
+ *
+ * Guard: `requireSuperAdmin` → 404 to non-super-admins (same anti-
+ * disclosure posture as the rest of `/v1/admin/*`).
+ *
+ * Audit: the existing `audit-plugin` already records every mutating
+ * request to `audit_logs`. A PATCH against this route therefore lands
+ * with `action = 'PATCH:/v1/admin/feature-flags/:key'` and
+ * `resourceType = 'admin'` — no extra wiring needed. The structured
+ * service log below adds the BEFORE/AFTER values so SIEM can answer
+ * "who flipped what" without joining tables.
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
+import { flagService } from "../../lib/flags/flag-service.js";
+import { requireAuth, requireSuperAdmin } from "../../lib/guards.js";
+import {
+  DataArrayResponseNoPagination,
+  DataResponse,
+  ErrorResponses,
+  problemDetail,
+} from "../../lib/schemas.js";
+import { setFeatureFlag } from "./feature-flags-service.js";
+
+const FlagKeyParams = Type.Object({
+  key: Type.String({ minLength: 1, maxLength: 100 }),
+});
+
+const FlagRowSchema = Type.Object({
+  key: Type.String(),
+  enabled: Type.Boolean(),
+  description: Type.String(),
+  updatedBy: Type.Union([Type.Null(), Type.String()]),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+});
+
+const ToggleBody = Type.Object({
+  enabled: Type.Boolean(),
+});
+
+/**
+ * Tenant-readable projection — just `{ key, enabled }` so a non-admin
+ * UI can hide gated surfaces without seeing super-admin metadata
+ * (description, updated_by, timestamps). Same shape every authenticated
+ * caller gets; not tenant-scoped because the registry is global in
+ * the MVP.
+ */
+const PublicFlagRowSchema = Type.Object({
+  key: Type.String(),
+  enabled: Type.Boolean(),
+});
+
+export async function featureFlagsRoutes(app: FastifyInstance) {
+  /**
+   * Tenant-readable flag list. Drives the SSR-side check on tenant
+   * pages that need to hide a button when a flag is off (e.g. the
+   * bulk-email button on the constituents page — PR #352 / issue
+   * #326). Only `requireAuth` because flag *visibility* (the fact
+   * that "feature X exists and is off") is not sensitive — what's
+   * gated by super-admin is *control* + *description*, both of which
+   * stay on `/v1/admin/feature-flags`.
+   */
+  app.get(
+    "/feature-flags",
+    {
+      preHandler: requireAuth,
+      // Same polling-cadence cap as the per-id GET on bulk-email-jobs
+      // — the constituents page fetches once per render, but a buggy
+      // client could re-fetch in a loop.
+      config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
+      schema: {
+        tags: ["Feature flags"],
+        response: {
+          200: DataArrayResponseNoPagination(PublicFlagRowSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async () => {
+      const rows = await flagService.list();
+      return { data: rows.map((row) => ({ key: row.key, enabled: row.enabled })) };
+    },
+  );
+
+  /**
+   * List every flag in the registry. The Back Office page reads this
+   * once on mount; no polling needed — flag flips are operator-driven
+   * and infrequent.
+   */
+  app.get(
+    "/admin/feature-flags",
+    {
+      preHandler: requireSuperAdmin,
+      schema: {
+        tags: ["Admin"],
+        response: {
+          200: DataArrayResponseNoPagination(FlagRowSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async () => {
+      const rows = await flagService.list();
+      return { data: rows };
+    },
+  );
+
+  /**
+   * Flip a flag's `enabled` value. Returns the updated row.
+   *
+   * `key` is path-bound + validated against the existing registry
+   * (404 on unknown key). The flag's `description` + `key` are
+   * code-owned and not mutable from this endpoint — keep this in
+   * lockstep with `FEATURE_FLAG_REGISTRY`.
+   */
+  app.patch(
+    "/admin/feature-flags/:key",
+    {
+      preHandler: requireSuperAdmin,
+      // Rate limit a chatty admin UI / scripted toggle storm.
+      config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
+      schema: {
+        tags: ["Admin"],
+        params: FlagKeyParams,
+        body: ToggleBody,
+        response: {
+          200: DataResponse(FlagRowSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const userId = request.auth?.userId;
+      if (!userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { key } = request.params as { key: string };
+      const { enabled } = request.body as { enabled: boolean };
+
+      // `updated_by` references `users(id)` and SET NULLs on purge.
+      // Super-admins live in `platform_admins` (no `users` row), so
+      // we leave this NULL and rely on `audit_logs` for the "who"
+      // — actorId there carries the JWT subject.
+      const result = await setFeatureFlag(key, enabled, null);
+      if (!result) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Feature flag not found"));
+      }
+
+      // Invalidate the Redis cache so the new value is observed on
+      // the next gated-route hit (rather than waiting for the 60-s
+      // TTL to expire).
+      await flagService.invalidate();
+
+      request.log.info(
+        {
+          event: "feature_flag.toggled",
+          flagKey: key,
+          enabled,
+          previousEnabled: result.previousEnabled,
+          actorUserId: userId,
+        },
+        "Feature flag toggled",
+      );
+
+      return { data: result.row };
+    },
+  );
+}

--- a/packages/api/src/modules/admin/feature-flags-service.ts
+++ b/packages/api/src/modules/admin/feature-flags-service.ts
@@ -19,6 +19,7 @@ export interface FlagToggleResult {
   row: {
     key: string;
     enabled: boolean;
+    label: string;
     description: string;
     updatedBy: string | null;
     createdAt: string;
@@ -62,6 +63,7 @@ export async function setFeatureFlag(
       .returning({
         key: featureFlags.key,
         enabled: featureFlags.enabled,
+        label: featureFlags.label,
         description: featureFlags.description,
         updatedBy: featureFlags.updatedBy,
         createdAt: featureFlags.createdAt,
@@ -74,6 +76,7 @@ export async function setFeatureFlag(
       row: {
         key: updated.key,
         enabled: updated.enabled,
+        label: updated.label,
         description: updated.description,
         updatedBy: updated.updatedBy,
         createdAt:

--- a/packages/api/src/modules/admin/feature-flags-service.ts
+++ b/packages/api/src/modules/admin/feature-flags-service.ts
@@ -1,0 +1,91 @@
+/**
+ * Admin-side feature-flag service (issue #326 / PR #352 follow-up).
+ *
+ * Owns the WRITE path — flips `feature_flags.enabled` and returns
+ * the resulting row + the previous value so the route's structured
+ * log line can record a BEFORE/AFTER discriminator without an extra
+ * round-trip.
+ *
+ * Reads live in `lib/flags/flag-service.ts`. The split matches the
+ * rest of the admin module shape: read-cache concerns ≠ write/audit
+ * concerns.
+ */
+
+import { featureFlags } from "@givernance/shared/schema";
+import { eq } from "drizzle-orm";
+import { db } from "../../lib/db.js";
+
+export interface FlagToggleResult {
+  row: {
+    key: string;
+    enabled: boolean;
+    description: string;
+    updatedBy: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  /** Value before this PATCH. Useful for BEFORE/AFTER audit log lines. */
+  previousEnabled: boolean;
+}
+
+/**
+ * Flip a flag's `enabled` to the supplied value. Returns `null` when
+ * the key isn't in the registry — the route renders that as a 404
+ * (anti-disclosure: same response shape as a typo'd URL).
+ *
+ * `updatedBy` is the internal users.id when available (always null for
+ * platform-admin super-admins; tenant-admin flags would carry their
+ * users.id if the flag-edit surface ever opens up tenant-side).
+ *
+ * No-ops (current value already matches the requested value) still
+ * bump `updated_at` so the audit_logs row is queryable as "the
+ * admin clicked Save at 14:32" even when nothing changed.
+ */
+export async function setFeatureFlag(
+  key: string,
+  enabled: boolean,
+  updatedBy: string | null,
+): Promise<FlagToggleResult | null> {
+  return db.transaction(async (tx) => {
+    const [current] = await tx
+      .select({ enabled: featureFlags.enabled })
+      .from(featureFlags)
+      .where(eq(featureFlags.key, key))
+      .limit(1);
+
+    if (!current) return null;
+
+    const [updated] = await tx
+      .update(featureFlags)
+      .set({ enabled, updatedBy, updatedAt: new Date() })
+      .where(eq(featureFlags.key, key))
+      .returning({
+        key: featureFlags.key,
+        enabled: featureFlags.enabled,
+        description: featureFlags.description,
+        updatedBy: featureFlags.updatedBy,
+        createdAt: featureFlags.createdAt,
+        updatedAt: featureFlags.updatedAt,
+      });
+
+    if (!updated) return null;
+
+    return {
+      row: {
+        key: updated.key,
+        enabled: updated.enabled,
+        description: updated.description,
+        updatedBy: updated.updatedBy,
+        createdAt:
+          updated.createdAt instanceof Date
+            ? updated.createdAt.toISOString()
+            : String(updated.createdAt),
+        updatedAt:
+          updated.updatedAt instanceof Date
+            ? updated.updatedAt.toISOString()
+            : String(updated.updatedAt),
+      },
+      previousEnabled: current.enabled,
+    };
+  });
+}

--- a/packages/api/src/modules/constituents/bulk-email-service.ts
+++ b/packages/api/src/modules/constituents/bulk-email-service.ts
@@ -1,18 +1,28 @@
 /**
- * Bulk-email service (Epic #274).
+ * Bulk-email service (Epic #274; partial-send + resume per issue #326).
  *
  * The HTTP path:
  *   1. Validates that every targeted constituent belongs to this org and has
  *      an email on file (skipped without one are reported back, not blocked).
- *   2. Inserts a `communication.bulk_email_requested` outbox event with the
- *      payload (subject + body + recipient list snapshot).
- *   3. Returns the dispatch counts so the UI can render
- *      "12 emails queued, 3 skipped — no address on file".
+ *   2. Inserts a `bulk_email_jobs` row carrying the request snapshot
+ *      (subject + body + deliverable id list + 0/total counters) AND a
+ *      `communication.bulk_email_requested` outbox event referencing it.
+ *      Both writes share one transaction, same pattern as the
+ *      postal-export flow (Epic #274) so the outbox event and the
+ *      tracking row stay in lockstep.
+ *   3. Returns the new job id + dispatch counts so the UI can both
+ *      render "12 emails queued, 3 skipped — no address on file" AND
+ *      start polling the job for live `delivered / total` progress.
  *
  * The outbox relay forwards the event to the BullMQ `emails` queue, where
- * the `send-bulk-email` processor renders the template and dispatches each
- * email through the configured `EmailSender` (Mailpit in dev, Resend in
- * prod).
+ * the `send-bulk-email` processor reads the `bulk_email_jobs` row,
+ * re-resolves email + name from the database under the worker's RLS
+ * context (PII never lives in the outbox payload nor Redis), and
+ * increments `delivered_count` / `failed_count` per recipient. On
+ * mid-flight worker death (Redis OOM, accessory reboot, operator wipe)
+ * the row stays at its last update — the operator sees the partial
+ * ratio and can hit Resume to re-target the remaining recipients
+ * (`constituent_ids \ delivered_constituent_ids`).
  *
  * Scope (MVP):
  *   - No template language. The admin types subject + plain-text body in
@@ -22,9 +32,15 @@
  *   - No per-recipient personalization beyond the standard salutation.
  */
 
-import { constituents, outboxEvents } from "@givernance/shared/schema";
+import {
+  type BulkEmailJobStatus,
+  bulkEmailJobs,
+  constituents,
+  outboxEvents,
+} from "@givernance/shared/schema";
 import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { withTenantContext } from "../../lib/db.js";
+import { resolveInternalUserId } from "../../lib/resolve-user.js";
 
 export class BulkEmailValidationError extends Error {
   constructor(message: string) {
@@ -46,12 +62,24 @@ export interface BulkEmailInput {
 }
 
 export interface BulkEmailResult {
+  /**
+   * The `bulk_email_jobs.id` the API just inserted. The UI uses this to
+   * start polling `GET /v1/constituents/bulk-email-jobs/:id` for live
+   * delivered / total progress.
+   */
+  jobId: string;
   /** Constituents enqueued for delivery (had an email on file). */
   queued: number;
   /** Constituents dropped because they had no email address. */
   skippedNoEmail: number;
 }
 
+/**
+ * Dispatch a new bulk email. Inserts both the tracking row and the
+ * outbox event in the same transaction so they're either both visible
+ * to the relay or neither — no half-states the worker can pick up
+ * without the bulk_email_jobs row to update.
+ */
 export async function dispatchBulkEmail(
   orgId: string,
   userId: string,
@@ -65,11 +93,11 @@ export async function dispatchBulkEmail(
   return withTenantContext(orgId, async (tx) => {
     // Verify the requested ids belong to this org and are deliverable
     // (have an email). Read only the boolean we need — explicitly avoid
-    // pulling email/firstName/lastName into the outbox payload so PII
-    // is **not** persisted in `outbox_events.payload` (JSONB) nor pushed
-    // through Redis as the BullMQ job payload (GDPR Art. 5(1)(e) storage
-    // minimisation). The worker re-fetches contact details at send time
-    // under its own RLS context.
+    // pulling email/firstName/lastName into the snapshot so PII is **not**
+    // persisted in `bulk_email_jobs.constituent_ids` (a uuid array) nor
+    // pushed through Redis as the BullMQ job payload (GDPR Art. 5(1)(e)
+    // storage minimisation). The worker re-fetches contact details at
+    // send time under its own RLS context.
     const rows = await tx
       .select({
         id: constituents.id,
@@ -93,27 +121,67 @@ export async function dispatchBulkEmail(
     const deliverableIds = rows.filter((r) => r.hasEmail).map((r) => r.id);
     const skippedNoEmail = rows.length - deliverableIds.length;
 
-    if (deliverableIds.length === 0) {
-      return { queued: 0, skippedNoEmail };
+    // Same translation-on-insert pattern as `startPostalExport`:
+    // `requested_by` FKs `users.id` (internal UUID), but `userId` is the
+    // JWT subject (= `users.keycloak_id`). resolveInternalUserId returns
+    // `null` when the subject doesn't match an active tenant member
+    // (pure-impersonation by a platform admin against a tenant they
+    // don't belong to) — the audit chain still captures the real actor
+    // via the impersonation session id forwarded through the outbox.
+    const requestedByInternal = await resolveInternalUserId(tx, orgId, userId);
+
+    const totalRecipients = deliverableIds.length;
+    const [job] = await tx
+      .insert(bulkEmailJobs)
+      .values({
+        orgId,
+        status: "pending",
+        subject: input.subject,
+        body: input.body,
+        constituentIds: deliverableIds,
+        totalRecipients,
+        requestedBy: requestedByInternal,
+      })
+      .returning({ id: bulkEmailJobs.id });
+
+    if (!job) {
+      throw new Error("Failed to insert bulk_email_jobs row");
+    }
+
+    // Outbox payload is intentionally minimal: only the bulk_email_jobs
+    // row id is required to drive the worker. The constituent_ids list
+    // lives in the DB row — re-reading it from there (rather than
+    // forwarding it through Redis) keeps the BullMQ job payload small
+    // AND means a resume's worker reads the freshest "delivered" set,
+    // not a stale snapshot.
+    //
+    // Skip emitting the outbox event entirely when there's nothing to
+    // do — a zero-deliverable dispatch (all recipients skipped) would
+    // otherwise queue a no-op job. The row is still inserted with
+    // `total_recipients = 0` and an immediate `completed` status so the
+    // UI shows the dispatch in the recent jobs list.
+    if (totalRecipients === 0) {
+      await tx
+        .update(bulkEmailJobs)
+        .set({
+          status: "completed",
+          completedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(bulkEmailJobs.id, job.id));
+      return { jobId: job.id, queued: 0, skippedNoEmail };
     }
 
     await tx.insert(outboxEvents).values({
       tenantId: orgId,
       type: "communication.bulk_email_requested",
       payload: {
+        bulkEmailJobId: job.id,
         requestedBy: userId,
-        subject: input.subject,
-        body: input.body,
-        // Ship only the id list — the worker re-resolves email + name at
-        // send time. Keeps PII out of the outbox table and out of Redis.
-        constituentIds: deliverableIds,
       },
     });
 
-    return {
-      queued: deliverableIds.length,
-      skippedNoEmail,
-    };
+    return { jobId: job.id, queued: totalRecipients, skippedNoEmail };
   });
 }
 
@@ -142,5 +210,295 @@ export async function countDeliverableRecipients(
         ),
       );
     return rows.length;
+  });
+}
+
+/**
+ * Serialised shape of a `bulk_email_jobs` row exposed to the API +
+ * polling UI. ISO-string dates for transport, plain string union for
+ * status (no Drizzle types leak through to clients).
+ */
+export interface BulkEmailJobView {
+  id: string;
+  status: BulkEmailJobStatus;
+  subject: string;
+  /**
+   * `processing` jobs whose `updated_at` has gone cold (default 10 min)
+   * are surfaced to the UI as `stalled`. The schema enum stays a small
+   * fixed set; this derived flag lives next to it instead of bloating
+   * the enum. The resume endpoint accepts stalled jobs in addition to
+   * the natural terminal partial/failed states.
+   */
+  stalled: boolean;
+  totalRecipients: number;
+  deliveredCount: number;
+  failedCount: number;
+  requestedBy: string | null;
+  parentJobId: string | null;
+  error: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+/**
+ * Threshold past which a `processing` job is considered stalled. Chosen
+ * to comfortably exceed the longest reasonable per-recipient SMTP send
+ * (Mailpit < 1s, Resend < 5s, worst-case retry chain < a few seconds)
+ * AND give the operator a clear "this is stuck, not still going" UX.
+ * Worker progress updates touch `updated_at` on every send, so a
+ * healthy run never goes 10 minutes between ticks.
+ */
+export const BULK_EMAIL_STALL_MS = 10 * 60 * 1000;
+
+function toIso(value: Date | string | null): string | null {
+  if (value === null) return null;
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+function isStalled(status: BulkEmailJobStatus, updatedAt: Date | string): boolean {
+  if (status !== "processing") return false;
+  const updatedMs = updatedAt instanceof Date ? updatedAt.getTime() : Date.parse(String(updatedAt));
+  if (!Number.isFinite(updatedMs)) return false;
+  return Date.now() - updatedMs > BULK_EMAIL_STALL_MS;
+}
+
+function mapJob(row: {
+  id: string;
+  status: BulkEmailJobStatus;
+  subject: string;
+  totalRecipients: number;
+  deliveredCount: number;
+  failedCount: number;
+  requestedBy: string | null;
+  parentJobId: string | null;
+  error: string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+  completedAt: Date | string | null;
+}): BulkEmailJobView {
+  return {
+    id: row.id,
+    status: row.status,
+    subject: row.subject,
+    stalled: isStalled(row.status, row.updatedAt),
+    totalRecipients: row.totalRecipients,
+    deliveredCount: row.deliveredCount,
+    failedCount: row.failedCount,
+    requestedBy: row.requestedBy,
+    parentJobId: row.parentJobId,
+    error: row.error,
+    // biome-ignore lint/style/noNonNullAssertion: Drizzle returns Date for these timestamp columns
+    createdAt: toIso(row.createdAt)!,
+    // biome-ignore lint/style/noNonNullAssertion: same
+    updatedAt: toIso(row.updatedAt)!,
+    completedAt: toIso(row.completedAt),
+  };
+}
+
+/** List the 20 most-recent bulk email jobs for the tenant, newest first. */
+export async function listBulkEmailJobs(orgId: string): Promise<BulkEmailJobView[]> {
+  return withTenantContext(orgId, async (tx) => {
+    const rows = await tx
+      .select({
+        id: bulkEmailJobs.id,
+        status: bulkEmailJobs.status,
+        subject: bulkEmailJobs.subject,
+        totalRecipients: bulkEmailJobs.totalRecipients,
+        deliveredCount: bulkEmailJobs.deliveredCount,
+        failedCount: bulkEmailJobs.failedCount,
+        requestedBy: bulkEmailJobs.requestedBy,
+        parentJobId: bulkEmailJobs.parentJobId,
+        error: bulkEmailJobs.error,
+        createdAt: bulkEmailJobs.createdAt,
+        updatedAt: bulkEmailJobs.updatedAt,
+        completedAt: bulkEmailJobs.completedAt,
+      })
+      .from(bulkEmailJobs)
+      .where(and(eq(bulkEmailJobs.orgId, orgId), isNull(bulkEmailJobs.deletedAt)))
+      .orderBy(sql`${bulkEmailJobs.createdAt} DESC`)
+      .limit(20);
+    return rows.map(mapJob);
+  });
+}
+
+/** Get a single bulk email job by id — used by the polling endpoint. */
+export async function getBulkEmailJob(
+  orgId: string,
+  jobId: string,
+): Promise<BulkEmailJobView | null> {
+  return withTenantContext(orgId, async (tx) => {
+    const [row] = await tx
+      .select({
+        id: bulkEmailJobs.id,
+        status: bulkEmailJobs.status,
+        subject: bulkEmailJobs.subject,
+        totalRecipients: bulkEmailJobs.totalRecipients,
+        deliveredCount: bulkEmailJobs.deliveredCount,
+        failedCount: bulkEmailJobs.failedCount,
+        requestedBy: bulkEmailJobs.requestedBy,
+        parentJobId: bulkEmailJobs.parentJobId,
+        error: bulkEmailJobs.error,
+        createdAt: bulkEmailJobs.createdAt,
+        updatedAt: bulkEmailJobs.updatedAt,
+        completedAt: bulkEmailJobs.completedAt,
+      })
+      .from(bulkEmailJobs)
+      .where(
+        and(
+          eq(bulkEmailJobs.id, jobId),
+          eq(bulkEmailJobs.orgId, orgId),
+          isNull(bulkEmailJobs.deletedAt),
+        ),
+      );
+    return row ? mapJob(row) : null;
+  });
+}
+
+/**
+ * Structured error code for `resumeBulkEmailJob` — same pattern as
+ * `PostalExportError.code` so the route can map each cause to a stable
+ * problem-detail title and the UI can branch on it.
+ */
+export type BulkEmailResumeErrorCode = "job_not_found" | "job_still_running" | "nothing_to_resume";
+
+export class BulkEmailResumeError extends Error {
+  constructor(
+    message: string,
+    public readonly code: BulkEmailResumeErrorCode,
+  ) {
+    super(message);
+    this.name = "BulkEmailResumeError";
+  }
+}
+
+/**
+ * Create a new bulk email job targeting the recipients the source job
+ * never reached.
+ *
+ * Eligibility:
+ *   - Source must NOT be `pending` (never picked up) or actively
+ *     `processing` with a fresh `updated_at` — otherwise a resume
+ *     could race the original worker into double-sending.
+ *   - `processing` jobs whose `updated_at` is older than
+ *     {@link BULK_EMAIL_STALL_MS} are considered stalled and accepted —
+ *     this covers the Redis-wipe / OOM-kill scenario the issue calls
+ *     out: the original worker is gone but the row never reached a
+ *     terminal state.
+ *   - Source must have at least one remaining recipient
+ *     (`delivered_count < total_recipients`).
+ *
+ * The new row carries `parent_job_id = source.id`. Its `constituent_ids`
+ * is computed at insert time as `source.constituent_ids \
+ * source.delivered_constituent_ids` — this includes both never-attempted
+ * and previously-SMTP-failed recipients. The operator's intent is "make
+ * sure everyone who hasn't received it gets it", so retrying SMTP
+ * failures is the right default.
+ */
+export async function resumeBulkEmailJob(
+  orgId: string,
+  userId: string,
+  sourceJobId: string,
+): Promise<BulkEmailJobView> {
+  return withTenantContext(orgId, async (tx) => {
+    const [source] = await tx
+      .select({
+        id: bulkEmailJobs.id,
+        status: bulkEmailJobs.status,
+        subject: bulkEmailJobs.subject,
+        body: bulkEmailJobs.body,
+        constituentIds: bulkEmailJobs.constituentIds,
+        deliveredConstituentIds: bulkEmailJobs.deliveredConstituentIds,
+        totalRecipients: bulkEmailJobs.totalRecipients,
+        deliveredCount: bulkEmailJobs.deliveredCount,
+        updatedAt: bulkEmailJobs.updatedAt,
+      })
+      .from(bulkEmailJobs)
+      .where(
+        and(
+          eq(bulkEmailJobs.id, sourceJobId),
+          eq(bulkEmailJobs.orgId, orgId),
+          isNull(bulkEmailJobs.deletedAt),
+        ),
+      );
+
+    if (!source) {
+      throw new BulkEmailResumeError("Bulk email job not found", "job_not_found");
+    }
+
+    // Eligibility gate. `pending` covers "outbox row hasn't been
+    // enqueued yet" — resuming would beat the original worker to the
+    // recipients. `processing` covers "worker is actively sending" —
+    // resume would race it. The only `processing` we accept is a
+    // stalled one (no `updated_at` movement in 10+ minutes).
+    if (source.status === "pending") {
+      throw new BulkEmailResumeError(
+        "Source job hasn't been picked up by a worker yet. Wait for it to start.",
+        "job_still_running",
+      );
+    }
+    if (source.status === "processing" && !isStalled(source.status, source.updatedAt)) {
+      throw new BulkEmailResumeError(
+        "Source job is actively delivering. Wait for it to finish or stall.",
+        "job_still_running",
+      );
+    }
+
+    if (source.deliveredCount >= source.totalRecipients) {
+      throw new BulkEmailResumeError(
+        "Source job already delivered to every recipient — nothing to resume.",
+        "nothing_to_resume",
+      );
+    }
+
+    // Remaining = original set minus already-delivered. The two id
+    // arrays are tenant-local; the set-difference is small (≤ 500
+    // items per job per route validator) so an in-process compute is
+    // fine — keeps the migration single-table and avoids a CTE per
+    // resume.
+    const deliveredSet = new Set(source.deliveredConstituentIds ?? []);
+    const remainingIds = (source.constituentIds ?? []).filter((id) => !deliveredSet.has(id));
+
+    if (remainingIds.length === 0) {
+      // Belt-and-braces: counts can drift transiently if a buggy
+      // worker mutates only one column, but the DB CHECK constraint
+      // prevents that. Still keep the safety net so a future schema
+      // change doesn't silently produce a zero-recipient resume.
+      throw new BulkEmailResumeError(
+        "Source job already delivered to every recipient — nothing to resume.",
+        "nothing_to_resume",
+      );
+    }
+
+    const requestedByInternal = await resolveInternalUserId(tx, orgId, userId);
+
+    const [resumed] = await tx
+      .insert(bulkEmailJobs)
+      .values({
+        orgId,
+        status: "pending",
+        subject: source.subject,
+        body: source.body,
+        constituentIds: remainingIds,
+        totalRecipients: remainingIds.length,
+        requestedBy: requestedByInternal,
+        parentJobId: source.id,
+      })
+      .returning();
+
+    if (!resumed) {
+      throw new Error("Failed to insert resume bulk_email_jobs row");
+    }
+
+    await tx.insert(outboxEvents).values({
+      tenantId: orgId,
+      type: "communication.bulk_email_requested",
+      payload: {
+        bulkEmailJobId: resumed.id,
+        requestedBy: userId,
+      },
+    });
+
+    return mapJob(resumed);
   });
 }

--- a/packages/api/src/modules/constituents/bulk-email-service.ts
+++ b/packages/api/src/modules/constituents/bulk-email-service.ts
@@ -36,11 +36,14 @@ import {
   type BulkEmailJobStatus,
   bulkEmailJobs,
   constituents,
+  type OutboxMetadata,
   outboxEvents,
 } from "@givernance/shared/schema";
 import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
+import type { FastifyRequest } from "fastify";
 import { withTenantContext } from "../../lib/db.js";
 import { resolveInternalUserId } from "../../lib/resolve-user.js";
+import { buildOutboxMetadata } from "../../lib/trace-context.js";
 
 export class BulkEmailValidationError extends Error {
   constructor(message: string) {
@@ -84,11 +87,20 @@ export async function dispatchBulkEmail(
   orgId: string,
   userId: string,
   input: BulkEmailInput,
+  request?: FastifyRequest,
 ): Promise<BulkEmailResult> {
   const ids = Array.from(new Set(input.constituentIds.filter(Boolean)));
   if (ids.length === 0) {
     throw new BulkEmailValidationError("Provide at least one recipient");
   }
+
+  // W3C trace-context propagation (PR #352 review — Log-1). Threaded
+  // through into the outbox `metadata` column so the relay → BullMQ →
+  // worker pipeline can stitch Loki logs back to the originating
+  // request. `null` when called outside an HTTP request (tests, internal
+  // tooling) — the worker falls back to the outbox row id as the
+  // correlator (worker.ts: `extractTraceId(traceparent) ?? id`).
+  const metadata: OutboxMetadata | null = request ? buildOutboxMetadata(request) : null;
 
   return withTenantContext(orgId, async (tx) => {
     // Verify the requested ids belong to this org and are deliverable
@@ -175,6 +187,7 @@ export async function dispatchBulkEmail(
     await tx.insert(outboxEvents).values({
       tenantId: orgId,
       type: "communication.bulk_email_requested",
+      metadata,
       payload: {
         bulkEmailJobId: job.id,
         requestedBy: userId,
@@ -399,8 +412,19 @@ export async function resumeBulkEmailJob(
   orgId: string,
   userId: string,
   sourceJobId: string,
+  request?: FastifyRequest,
 ): Promise<BulkEmailJobView> {
+  const metadata: OutboxMetadata | null = request ? buildOutboxMetadata(request) : null;
   return withTenantContext(orgId, async (tx) => {
+    // `FOR UPDATE` on the source row keeps the eligibility check + the
+    // child-row INSERT atomic against a concurrent resume call (PR #352
+    // multi-agent review — H1). Two operators double-clicking Resume,
+    // or a retried 502, would otherwise both pass the gate, both INSERT
+    // a child row, and both fan out to the same remaining recipients
+    // (every "remaining" donor gets the email twice).
+    //
+    // The lock is released at tx end. Concurrent readers (the polling
+    // GET endpoint) are unaffected — PG's row lock only blocks writers.
     const [source] = await tx
       .select({
         id: bulkEmailJobs.id,
@@ -420,7 +444,8 @@ export async function resumeBulkEmailJob(
           eq(bulkEmailJobs.orgId, orgId),
           isNull(bulkEmailJobs.deletedAt),
         ),
-      );
+      )
+      .for("update");
 
     if (!source) {
       throw new BulkEmailResumeError("Bulk email job not found", "job_not_found");
@@ -493,6 +518,7 @@ export async function resumeBulkEmailJob(
     await tx.insert(outboxEvents).values({
       tenantId: orgId,
       type: "communication.bulk_email_requested",
+      metadata,
       payload: {
         bulkEmailJobId: resumed.id,
         requestedBy: userId,

--- a/packages/api/src/modules/constituents/routes.ts
+++ b/packages/api/src/modules/constituents/routes.ts
@@ -15,7 +15,14 @@ import {
   SortOrderSchema,
   UuidSchema,
 } from "../../lib/schemas.js";
-import { BulkEmailValidationError, dispatchBulkEmail } from "./bulk-email-service.js";
+import {
+  BulkEmailResumeError,
+  BulkEmailValidationError,
+  dispatchBulkEmail,
+  getBulkEmailJob,
+  listBulkEmailJobs,
+  resumeBulkEmailJob,
+} from "./bulk-email-service.js";
 import {
   CONSTITUENT_SORT_FIELDS,
   createConstituent,
@@ -208,6 +215,30 @@ const MergeResult = Type.Object({ merged: Type.Boolean(), etag: Type.String() })
 
 const MergeHeaders = Type.Object({
   "if-match": Type.Optional(Type.String({ minLength: 1, maxLength: 255 })),
+});
+
+const BulkEmailJobStatusSchema = Type.Union([
+  Type.Literal("pending"),
+  Type.Literal("processing"),
+  Type.Literal("completed"),
+  Type.Literal("partial"),
+  Type.Literal("failed"),
+]);
+
+const BulkEmailJobRowSchema = Type.Object({
+  id: UuidSchema,
+  status: BulkEmailJobStatusSchema,
+  subject: Type.String(),
+  stalled: Type.Boolean(),
+  totalRecipients: Type.Integer(),
+  deliveredCount: Type.Integer(),
+  failedCount: Type.Integer(),
+  requestedBy: Type.Union([Type.Null(), UuidSchema]),
+  parentJobId: Type.Union([Type.Null(), UuidSchema]),
+  error: Type.Union([Type.Null(), Type.String()]),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+  completedAt: Type.Union([Type.Null(), Type.String()]),
 });
 
 export async function constituentRoutes(app: FastifyInstance) {
@@ -540,12 +571,16 @@ export async function constituentRoutes(app: FastifyInstance) {
   );
 
   /**
-   * Bulk-send a transactional email to the supplied constituents (Epic #274).
+   * Bulk-send a transactional email to the supplied constituents (Epic #274;
+   * partial-send tracking per issue #326).
    *
-   * The HTTP path inserts an outbox event and returns immediately — the
-   * actual delivery happens asynchronously in the `emails` queue worker.
-   * Skipped recipients (no email on file) are reported back so the UI can
-   * surface "12 queued, 3 skipped" without re-querying.
+   * The HTTP path inserts a `bulk_email_jobs` tracking row + outbox event
+   * and returns immediately — the actual delivery happens asynchronously
+   * in the `emails` queue worker. Response carries `jobId` so the UI can
+   * start polling `GET /constituents/bulk-email-jobs/:id` for live
+   * delivered/total progress. Skipped recipients (no email on file) are
+   * reported back so the UI can surface "12 queued, 3 skipped" without
+   * re-querying.
    *
    * Rate-limited: a single org-admin spamming the bulk-email button is the
    * primary unintentional abuse path.
@@ -565,6 +600,7 @@ export async function constituentRoutes(app: FastifyInstance) {
         response: {
           202: DataResponse(
             Type.Object({
+              jobId: UuidSchema,
               queued: Type.Integer(),
               skippedNoEmail: Type.Integer(),
             }),
@@ -591,10 +627,124 @@ export async function constituentRoutes(app: FastifyInstance) {
           subject: body.subject,
           body: body.body,
         });
+        reply.header("Location", `/v1/constituents/bulk-email-jobs/${result.jobId}`);
         return reply.status(202).send({ data: result });
       } catch (err) {
         if (err instanceof BulkEmailValidationError) {
           return reply.status(400).send(problemDetail(400, "Bad Request", err.message));
+        }
+        throw err;
+      }
+    },
+  );
+
+  // ─── Bulk-email job tracking + resume (issue #326) ─────────────────────
+
+  /**
+   * List recent bulk-email jobs for the tenant (newest 20). Drives the
+   * "Recent emails" panel in the constituents table.
+   */
+  app.get(
+    "/constituents/bulk-email-jobs",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Constituents"],
+        response: {
+          200: DataArrayResponseNoPagination(BulkEmailJobRowSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const rows = await listBulkEmailJobs(orgId);
+      return { data: rows };
+    },
+  );
+
+  /**
+   * Get a single bulk-email job. Used for short-interval polling — the
+   * frontend hits this every 2s while a job is in-flight. Rate-limited at
+   * 60/min/admin so a buggy client (multiple tabs, runaway useEffect)
+   * can't hammer the endpoint past the intended polling cadence — same
+   * cadence as the postal-export poll route.
+   */
+  app.get(
+    "/constituents/bulk-email-jobs/:id",
+    {
+      preHandler: requireOrgAdmin,
+      config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
+      schema: {
+        tags: ["Constituents"],
+        params: IdParams,
+        response: {
+          200: DataResponse(BulkEmailJobRowSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { id } = request.params as { id: string };
+      const row = await getBulkEmailJob(orgId, id);
+      if (!row) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Bulk email job not found"));
+      }
+      return { data: row };
+    },
+  );
+
+  /**
+   * Resume a bulk-email job — creates a fresh job targeting the recipients
+   * the source never reached (`constituent_ids \ delivered_constituent_ids`).
+   *
+   * Accepts source jobs in:
+   *   - `partial` / `failed` — natural terminal states.
+   *   - `processing` if stalled (no `updated_at` movement for ≥ 10 min) —
+   *     the Redis-wipe / OOM-kill / accessory-reboot case the issue calls
+   *     out. The error code is the same as the running case so the UI
+   *     surfaces a consistent "try again later" message; the API
+   *     decides eligibility, the UI doesn't.
+   */
+  app.post(
+    "/constituents/bulk-email-jobs/:id/resume",
+    {
+      preHandler: requireOrgAdmin,
+      config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
+      schema: {
+        tags: ["Constituents"],
+        params: IdParams,
+        response: {
+          202: DataResponse(BulkEmailJobRowSchema),
+          400: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { id } = request.params as { id: string };
+      try {
+        const result = await resumeBulkEmailJob(orgId, userId, id);
+        reply.header("Location", `/v1/constituents/bulk-email-jobs/${result.id}`);
+        return reply.status(202).send({ data: result });
+      } catch (err) {
+        if (err instanceof BulkEmailResumeError) {
+          if (err.code === "job_not_found") {
+            return reply.status(404).send(problemDetail(404, err.code, err.message));
+          }
+          return reply.status(400).send(problemDetail(400, err.code, err.message));
         }
         throw err;
       }

--- a/packages/api/src/modules/constituents/routes.ts
+++ b/packages/api/src/modules/constituents/routes.ts
@@ -1,7 +1,9 @@
 /** Constituent routes — full CRUD with search, filtering, and soft-delete */
 
+import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
+import { requireFlag } from "../../lib/flags/flag-guard.js";
 import { requireAuth, requireOrgAdmin, requireWrite } from "../../lib/guards.js";
 import {
   DataArrayResponse,
@@ -588,7 +590,11 @@ export async function constituentRoutes(app: FastifyInstance) {
   app.post(
     "/constituents/bulk-email",
     {
-      preHandler: requireOrgAdmin,
+      // Flag-gate FIRST so a disabled feature looks identical to a
+      // typo'd URL (404) — `requireFlag` returns before `requireOrgAdmin`
+      // even runs so an unauthorised scanner can't enumerate which
+      // gated routes need which roles.
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_BULK_EMAIL), requireOrgAdmin],
       config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
       schema: {
         tags: ["Constituents"],
@@ -652,7 +658,7 @@ export async function constituentRoutes(app: FastifyInstance) {
   app.get(
     "/constituents/bulk-email-jobs",
     {
-      preHandler: requireOrgAdmin,
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_BULK_EMAIL), requireOrgAdmin],
       // PR #352 review M1: cap polling cadence even on the list path —
       // matches the per-id GET below so a buggy client (multiple tabs,
       // runaway useEffect) can't bypass the cadence limit by hitting
@@ -686,7 +692,7 @@ export async function constituentRoutes(app: FastifyInstance) {
   app.get(
     "/constituents/bulk-email-jobs/:id",
     {
-      preHandler: requireOrgAdmin,
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_BULK_EMAIL), requireOrgAdmin],
       config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
       schema: {
         tags: ["Constituents"],
@@ -726,7 +732,7 @@ export async function constituentRoutes(app: FastifyInstance) {
   app.post(
     "/constituents/bulk-email-jobs/:id/resume",
     {
-      preHandler: requireOrgAdmin,
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_BULK_EMAIL), requireOrgAdmin],
       config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
       schema: {
         tags: ["Constituents"],

--- a/packages/api/src/modules/constituents/routes.ts
+++ b/packages/api/src/modules/constituents/routes.ts
@@ -622,11 +622,16 @@ export async function constituentRoutes(app: FastifyInstance) {
         body: string;
       };
       try {
-        const result = await dispatchBulkEmail(orgId, userId, {
-          constituentIds: body.constituentIds,
-          subject: body.subject,
-          body: body.body,
-        });
+        const result = await dispatchBulkEmail(
+          orgId,
+          userId,
+          {
+            constituentIds: body.constituentIds,
+            subject: body.subject,
+            body: body.body,
+          },
+          request,
+        );
         reply.header("Location", `/v1/constituents/bulk-email-jobs/${result.jobId}`);
         return reply.status(202).send({ data: result });
       } catch (err) {
@@ -648,6 +653,11 @@ export async function constituentRoutes(app: FastifyInstance) {
     "/constituents/bulk-email-jobs",
     {
       preHandler: requireOrgAdmin,
+      // PR #352 review M1: cap polling cadence even on the list path —
+      // matches the per-id GET below so a buggy client (multiple tabs,
+      // runaway useEffect) can't bypass the cadence limit by hitting
+      // the list endpoint instead.
+      config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
       schema: {
         tags: ["Constituents"],
         response: {
@@ -736,11 +746,17 @@ export async function constituentRoutes(app: FastifyInstance) {
       }
       const { id } = request.params as { id: string };
       try {
-        const result = await resumeBulkEmailJob(orgId, userId, id);
+        const result = await resumeBulkEmailJob(orgId, userId, id, request);
         reply.header("Location", `/v1/constituents/bulk-email-jobs/${result.id}`);
         return reply.status(202).send({ data: result });
       } catch (err) {
         if (err instanceof BulkEmailResumeError) {
+          // PR #352 review — Log-3: emit a structured warn so the
+          // rejection reason lands in Loki, not only the HTTP body.
+          request.log.warn(
+            { code: err.code, sourceJobId: id, orgId },
+            "bulk email resume rejected",
+          );
           if (err.code === "job_not_found") {
             return reply.status(404).send(problemDetail(404, err.code, err.message));
           }

--- a/packages/api/src/plugins/audit.ts
+++ b/packages/api/src/plugins/audit.ts
@@ -35,88 +35,122 @@ function extractResourceId(actualUrl: string): string | undefined {
   return UUID_RE.test(id) ? id : undefined;
 }
 
+/**
+ * Insert the audit row + handle the GDPR-flagged failure branch. Lives
+ * outside the hook body so the hook's cognitive complexity stays under
+ * Biome's ceiling. (PR #352 review — fix for the complexity bump
+ * introduced by `resolveAuditOrgId`.)
+ */
+async function persistAuditRow(
+  request: FastifyRequest,
+  auditOrgId: string,
+  routeUrl: string,
+  ipHash: string,
+): Promise<void> {
+  try {
+    await withTenantContext(auditOrgId, async (tx) => {
+      await tx.insert(auditLogs).values({
+        orgId: auditOrgId,
+        userId: request.auth?.userId ?? "",
+        // RFC 8693 `act` claim: when an admin impersonates a user (issue
+        // #24, ADR-016) the JWT carries `{ sub: <user>, act: { sub: <admin> } }`.
+        // We record the actor ONLY when it differs from the subject, i.e.
+        // only for impersonated requests. Under normal auth `actor_id` is
+        // NULL, which is honest — there is no separate actor. Audit readers
+        // who want the effective actor compute `COALESCE(actor_id, user_id)`.
+        // (PR #142 review M2.)
+        actorId: request.auth?.act?.sub ?? null,
+        // Issue #24 — when the request was authenticated through an
+        // impersonation token, persist the session id and mode so SIEM
+        // filters can isolate the full session trail without having to
+        // reconstruct it heuristically from `actor_id`.
+        impersonationSessionId: request.auth?.impersonation?.sessionId ?? null,
+        impersonationMode: request.auth?.impersonation?.mode ?? null,
+        action: `${request.method}:${routeUrl}`,
+        resourceType: extractResourceType(routeUrl),
+        resourceId: extractResourceId(request.url),
+        ipHash,
+        userAgent: request.headers["user-agent"] ?? undefined,
+      });
+    });
+  } catch (err) {
+    // Log error prominently — GDPR Art. 5(2) requires accountability (M3 fix).
+    // We still don't fail the request, but we emit a structured error at 'error' level
+    // so alerting can catch audit failures. Carry forward the auth/rbac
+    // discriminators so SOC can correlate a failed audit insert with the
+    // original denial reason without joining on `reqId` (review L8).
+    request.log.error(
+      {
+        err,
+        method: request.method,
+        url: request.url,
+        audit: "INSERT_FAILED",
+        ...(request.authDenial ? { authDenial: request.authDenial } : {}),
+        ...(request.rbacDenial ? { rbacDenial: request.rbacDenial } : {}),
+      },
+      "CRITICAL: audit log insert failed — GDPR accountability gap",
+    );
+  }
+}
+
+/**
+ * Emit the structured `audit` info-level log line alongside the DB
+ * row. Issue #182 + PR #185 review pinned the discriminator shape;
+ * extracted here so the hook body stays linear.
+ */
+function emitAuditInfoLine(request: FastifyRequest, reply: FastifyReply): void {
+  request.log.info(
+    {
+      method: request.method,
+      url: request.url,
+      statusCode: reply.statusCode,
+      userId: request.auth?.userId,
+      actorId: request.auth?.act?.sub ?? null,
+      orgId: request.auth?.orgId,
+      // Issue #24 — log the impersonation discriminators alongside auth
+      // metadata so LogQL `audit{impersonationMode="..."}` lights up the
+      // full session trail without joining audit_logs.
+      ...(request.auth?.impersonation
+        ? {
+            impersonationMode: request.auth.impersonation.mode,
+            impersonationSessionId: request.auth.impersonation.sessionId,
+          }
+        : {}),
+      // Issue #182 + PR #185 review PJD-5 / L2: split discriminators.
+      // `authDenial` for the 401 branch (missing/invalid token) so SOC
+      // dashboards filtering for RBAC probing can EXCLUDE these as
+      // benign auth noise; `rbacDenial` for the 403/404 role-rejection
+      // branch with structured `requiredRoles` array.
+      ...(request.authDenial ? { authDenial: request.authDenial } : {}),
+      ...(request.rbacDenial ? { rbacDenial: request.rbacDenial } : {}),
+    },
+    "audit",
+  );
+}
+
 async function audit(app: FastifyInstance) {
   app.addHook("onResponse", async (request: FastifyRequest, reply: FastifyReply) => {
     // Only audit mutating methods
     if (!["POST", "PUT", "PATCH", "DELETE"].includes(request.method)) return;
-    // Only audit authenticated requests
+    // Only audit authenticated requests with a tenant scope.
+    //
+    // `org_id` is a required Keycloak JWT claim (`verifyKeycloakJwt`
+    // rejects tokens without it), so this branch fires for the few
+    // remaining auth modes that don't carry one (e.g. system-issued
+    // service tokens). Super-admin actions still land in audit_logs
+    // under whatever `org_id` their token carries — for delegation
+    // mode that's the target tenant, for platform-scoped actions
+    // (`/v1/admin/*`) that's the Keycloak platform org. Routing
+    // platform-scoped audits to the `__platform__` sentinel tenant
+    // for cleaner SIEM filtering is tracked separately (PR #352
+    // review Log-H1 noted this; cross-cutting follow-up).
     if (!request.auth?.orgId) return;
 
     const routeUrl = request.routeOptions.url ?? request.url;
     const ipHash = createHash("sha256").update(request.ip).digest("hex").slice(0, 16);
 
-    try {
-      await withTenantContext(request.auth.orgId, async (tx) => {
-        await tx.insert(auditLogs).values({
-          orgId: request.auth?.orgId ?? "",
-          userId: request.auth?.userId ?? "",
-          // RFC 8693 `act` claim: when an admin impersonates a user (issue
-          // #24, ADR-016) the JWT carries `{ sub: <user>, act: { sub: <admin> } }`.
-          // We record the actor ONLY when it differs from the subject, i.e.
-          // only for impersonated requests. Under normal auth `actor_id` is
-          // NULL, which is honest — there is no separate actor. Audit readers
-          // who want the effective actor compute `COALESCE(actor_id, user_id)`.
-          // (PR #142 review M2.)
-          actorId: request.auth?.act?.sub ?? null,
-          // Issue #24 — when the request was authenticated through an
-          // impersonation token, persist the session id and mode so SIEM
-          // filters can isolate the full session trail without having to
-          // reconstruct it heuristically from `actor_id`.
-          impersonationSessionId: request.auth?.impersonation?.sessionId ?? null,
-          impersonationMode: request.auth?.impersonation?.mode ?? null,
-          action: `${request.method}:${routeUrl}`,
-          resourceType: extractResourceType(routeUrl),
-          resourceId: extractResourceId(request.url),
-          ipHash,
-          userAgent: request.headers["user-agent"] ?? undefined,
-        });
-      });
-    } catch (err) {
-      // Log error prominently — GDPR Art. 5(2) requires accountability (M3 fix).
-      // We still don't fail the request, but we emit a structured error at 'error' level
-      // so alerting can catch audit failures. Carry forward the auth/rbac
-      // discriminators so SOC can correlate a failed audit insert with the
-      // original denial reason without joining on `reqId` (review L8).
-      request.log.error(
-        {
-          err,
-          method: request.method,
-          url: request.url,
-          audit: "INSERT_FAILED",
-          ...(request.authDenial ? { authDenial: request.authDenial } : {}),
-          ...(request.rbacDenial ? { rbacDenial: request.rbacDenial } : {}),
-        },
-        "CRITICAL: audit log insert failed — GDPR accountability gap",
-      );
-    }
-
-    request.log.info(
-      {
-        method: request.method,
-        url: request.url,
-        statusCode: reply.statusCode,
-        userId: request.auth.userId,
-        actorId: request.auth.act?.sub ?? null,
-        orgId: request.auth.orgId,
-        // Issue #24 — log the impersonation discriminators alongside auth
-        // metadata so LogQL `audit{impersonationMode="..."}` lights up the
-        // full session trail without joining audit_logs.
-        ...(request.auth.impersonation
-          ? {
-              impersonationMode: request.auth.impersonation.mode,
-              impersonationSessionId: request.auth.impersonation.sessionId,
-            }
-          : {}),
-        // Issue #182 + PR #185 review PJD-5 / L2: split discriminators.
-        // `authDenial` for the 401 branch (missing/invalid token) so SOC
-        // dashboards filtering for RBAC probing can EXCLUDE these as
-        // benign auth noise; `rbacDenial` for the 403/404 role-rejection
-        // branch with structured `requiredRoles` array.
-        ...(request.authDenial ? { authDenial: request.authDenial } : {}),
-        ...(request.rbacDenial ? { rbacDenial: request.rbacDenial } : {}),
-      },
-      "audit",
-    );
+    await persistAuditRow(request, request.auth.orgId, routeUrl, ipHash);
+    emitAuditInfoLine(request, reply);
   });
 }
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -10,8 +10,10 @@ import { PINO_REDACT_PATHS } from "@givernance/shared/constants";
 import Fastify, { type FastifyBaseLogger, type FastifyError, type FastifyInstance } from "fastify";
 import pino from "pino";
 import { env } from "./env.js";
+import { flagPlugin } from "./lib/flags/flag-plugin.js";
 import { redis } from "./lib/redis.js";
 import { PROBLEM_JSON, problemDetail } from "./lib/schemas.js";
+import { featureFlagsRoutes } from "./modules/admin/feature-flags-routes.js";
 import { impersonationRoutes } from "./modules/admin/impersonation-routes.js";
 import { platformAdminsRoutes } from "./modules/admin/platform-admins-routes.js";
 import { auditRoutes } from "./modules/audit/routes.js";
@@ -178,6 +180,7 @@ export async function createServer(opts: CreateServerOpts = {}): Promise<Fastify
   await app.register(impersonationPlugin);
   await app.register(idempotencyPlugin);
   await app.register(auditPlugin);
+  await app.register(flagPlugin);
 
   // --- Routes ---
   await app.register(healthRoutes);
@@ -200,6 +203,7 @@ export async function createServer(opts: CreateServerOpts = {}): Promise<Fastify
   await app.register(reportsRoutes, { prefix: "/v1" });
   await app.register(impersonationRoutes, { prefix: "/v1" });
   await app.register(platformAdminsRoutes, { prefix: "/v1" });
+  await app.register(featureFlagsRoutes, { prefix: "/v1" });
   await app.register(tenantAdminRoutes, { prefix: "/v1" });
   await app.register(sessionRoutes, { prefix: "/v1" });
   await app.register(disputeRoutes, { prefix: "/v1" });

--- a/packages/api/src/tests/integration/feature-flags.test.ts
+++ b/packages/api/src/tests/integration/feature-flags.test.ts
@@ -359,27 +359,39 @@ describe("requireFlag gate on /v1/constituents/bulk-email", () => {
 
 describe("Feature flag CHECK against DB drift between schema + seed", () => {
   it("the seed migration inserted the canonical bulk-email row", async () => {
-    const rows = await db.execute<{ key: string; enabled: boolean; description: string }>(sql`
-      SELECT key, enabled, description
+    const rows = await db.execute<{
+      key: string;
+      enabled: boolean;
+      label: string;
+      description: string;
+    }>(sql`
+      SELECT key, enabled, label, description
       FROM feature_flags
       WHERE key = 'communication.bulk_email'
     `);
     expect(rows.rows.length).toBe(1);
-    expect(rows.rows[0]?.description).toContain("DKIM");
+    const seeded = rows.rows[0]!;
+    // Operator-facing text is plain language — no engineering jargon.
+    // Pin the friendly label as a regression net against someone
+    // pasting RFC references / issue IDs back into the seed.
+    expect(seeded.label).toBe("Bulk emails to constituents");
+    expect(seeded.description.toLowerCase()).not.toContain("dkim");
+    expect(seeded.description.toLowerCase()).not.toContain("issue #");
   });
 
-  // PR #352 review Plat-M3: the code-side `FEATURE_FLAG_REGISTRY` and
-  // the DB-side seed are two halves of the same source-of-truth.
-  // Editing one and forgetting the other leaves the operator UI with
-  // a description that doesn't match a fresh-DB seed. This test
-  // catches the drift in CI.
-  it("FEATURE_FLAG_REGISTRY matches the seeded DB rows (description + key parity)", async () => {
+  // PR #352 review Plat-M3 (extended after the magino UX review):
+  // the code-side `FEATURE_FLAG_REGISTRY` and the DB-side seed are
+  // two halves of the same source-of-truth. Editing one and forgetting
+  // the other leaves the Back Office UI with a label/description that
+  // doesn't match a fresh-DB seed. This test catches the drift in CI.
+  it("FEATURE_FLAG_REGISTRY matches the seeded DB rows (label + description + key parity)", async () => {
     for (const entry of FEATURE_FLAG_REGISTRY) {
       const [dbRow] = await db
-        .select({ description: featureFlags.description })
+        .select({ label: featureFlags.label, description: featureFlags.description })
         .from(featureFlags)
         .where(eq(featureFlags.key, entry.key));
       expect(dbRow, `Missing seed row for ${entry.key}`).toBeDefined();
+      expect(dbRow?.label, `Label drift for ${entry.key}`).toBe(entry.label);
       expect(dbRow?.description, `Description drift for ${entry.key}`).toBe(entry.description);
     }
   });

--- a/packages/api/src/tests/integration/feature-flags.test.ts
+++ b/packages/api/src/tests/integration/feature-flags.test.ts
@@ -15,8 +15,9 @@
  * `afterAll` so they don't pollute the cross-suite test DB.
  */
 
-import { featureFlags } from "@givernance/shared/schema";
-import { eq, sql } from "drizzle-orm";
+import { FEATURE_FLAG_REGISTRY } from "@givernance/shared/constants";
+import { auditLogs, featureFlags } from "@givernance/shared/schema";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { db } from "../../lib/db.js";
@@ -141,6 +142,71 @@ describe("Admin feature-flag registry — PATCH /v1/admin/feature-flags/:key", (
     });
     expect(res.statusCode).toBe(404);
   });
+
+  // PR #352 review QA-H1: 401 on unauthenticated PATCH — mirrors the
+  // existing 401 case on the admin GET so the auth boundary is locked
+  // in both directions of the verb space.
+  it("unauthenticated PATCH is 401", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/admin/feature-flags/communication.bulk_email",
+      payload: { enabled: true },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  // PR #352 review Log-H1: every super-admin flag flip MUST land in
+  // `audit_logs`. The Log Analyst's first read suggested super-admins
+  // had no `org_id` claim → silently skipped — that's false:
+  // `verifyKeycloakJwt` rejects tokens without an `org_id`, so the
+  // audit plugin always sees one. The row IS written; this test
+  // pins that. Cleaner platform-scoped routing (audit rows under the
+  // `__platform__` sentinel) is a separate follow-up — see doc 18 §0.
+  it("super-admin flip is recorded in audit_logs", async () => {
+    const before = new Date();
+    const token = signToken(app, { realm_access: { roles: ["super_admin"] } });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/admin/feature-flags/communication.bulk_email",
+      headers: authHeader(token),
+      payload: { enabled: true },
+    });
+    expect(res.statusCode).toBe(200);
+
+    // Poll for the audit row — the plugin's `onResponse` hook fires
+    // after `inject` resolves, so a direct SELECT can race the insert.
+    // Same pattern as `issue-56-hardening.test.ts:awaitAuditRow`.
+    const deadline = Date.now() + 2000;
+    let auditRow: { action: string; orgId: string; userId: string | null } | undefined;
+    while (Date.now() < deadline) {
+      const [r] = await db
+        .select({
+          action: auditLogs.action,
+          orgId: auditLogs.orgId,
+          userId: auditLogs.userId,
+        })
+        .from(auditLogs)
+        .where(
+          and(
+            eq(auditLogs.action, "PATCH:/v1/admin/feature-flags/:key"),
+            gte(auditLogs.createdAt, before),
+          ),
+        )
+        .orderBy(desc(auditLogs.createdAt))
+        .limit(1);
+      if (r) {
+        auditRow = r;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    expect(auditRow).toBeDefined();
+    expect(auditRow?.action).toBe("PATCH:/v1/admin/feature-flags/:key");
+    expect(auditRow?.userId).toBeTruthy();
+    expect(auditRow?.orgId).toBeTruthy();
+  });
 });
 
 describe("Tenant-readable feature-flag projection — GET /v1/feature-flags", () => {
@@ -175,22 +241,73 @@ describe("Tenant-readable feature-flag projection — GET /v1/feature-flags", ()
 });
 
 describe("requireFlag gate on /v1/constituents/bulk-email", () => {
-  it("returns 404 when the flag is off (looks like a typo'd route)", async () => {
-    // Flag is OFF by default in `beforeEach`.
-    const token = signToken(app);
-    const res = await app.inject({
+  // PR #352 review QA-H2: parametrise the 404 over all four gated
+  // routes so a refactor that drops `requireFlag` from any one of
+  // them is caught here, not in production.
+  //
+  // Payloads on the POSTs must satisfy the body validator
+  // (`preValidation` runs BEFORE `preHandler` — an invalid body
+  // 400s before the flag gate fires, hiding the regression we
+  // want to catch).
+  type GatedRoute = {
+    method: "GET" | "POST";
+    url: string;
+    payload?: Record<string, unknown>;
+  };
+  const gatedRoutes: GatedRoute[] = [
+    {
       method: "POST",
       url: "/v1/constituents/bulk-email",
-      headers: authHeader(token),
       payload: {
         constituentIds: ["00000000-0000-0000-0000-000000000aaa"],
-        subject: "Hello",
-        body: "Should not get through the gate.",
+        subject: "x",
+        body: "x",
       },
+    },
+    {
+      method: "GET",
+      url: "/v1/constituents/bulk-email-jobs",
+    },
+    {
+      method: "GET",
+      url: "/v1/constituents/bulk-email-jobs/00000000-0000-0000-0000-000000000aaa",
+    },
+    {
+      method: "POST",
+      url: "/v1/constituents/bulk-email-jobs/00000000-0000-0000-0000-000000000aaa/resume",
+      payload: {},
+    },
+  ];
+
+  for (const route of gatedRoutes) {
+    it(`returns 404 on ${route.method} ${route.url} when the flag is off`, async () => {
+      const token = signToken(app);
+      const res = await app.inject({
+        method: route.method,
+        url: route.url,
+        headers: authHeader(token),
+        payload: route.payload,
+      });
+      expect(res.statusCode).toBe(404);
     });
-    expect(res.statusCode).toBe(404);
-    expect(res.json<{ title: string }>().title).toBe("Not Found");
-  });
+
+    // PR #352 review Sec-M2: an unauthenticated scanner enumerating
+    // gated routes must NOT get 401 (which would disclose route
+    // existence) — must look identical to a typo'd URL.
+    it(`unauthenticated ${route.method} ${route.url} also returns 404 (anti-disclosure)`, async () => {
+      const res = await app.inject({
+        method: route.method,
+        url: route.url,
+        payload: route.payload,
+      });
+      // Auth plugin returns 401 only when the route runs requireAuth
+      // BEFORE the flag check. requireFlag runs first, so the
+      // unauthenticated caller hits the gate 404. Accept either 404
+      // (gate fires first) or 401 (auth fires first) — confirm
+      // ANY 4xx response is `not 200, not 5xx`.
+      expect(res.statusCode).toBe(404);
+    });
+  }
 
   it("returns 404 from the flag gate BEFORE the RBAC gate runs", async () => {
     // Send a viewer token — the route's RBAC gate would have produced
@@ -249,6 +366,22 @@ describe("Feature flag CHECK against DB drift between schema + seed", () => {
     `);
     expect(rows.rows.length).toBe(1);
     expect(rows.rows[0]?.description).toContain("DKIM");
+  });
+
+  // PR #352 review Plat-M3: the code-side `FEATURE_FLAG_REGISTRY` and
+  // the DB-side seed are two halves of the same source-of-truth.
+  // Editing one and forgetting the other leaves the operator UI with
+  // a description that doesn't match a fresh-DB seed. This test
+  // catches the drift in CI.
+  it("FEATURE_FLAG_REGISTRY matches the seeded DB rows (description + key parity)", async () => {
+    for (const entry of FEATURE_FLAG_REGISTRY) {
+      const [dbRow] = await db
+        .select({ description: featureFlags.description })
+        .from(featureFlags)
+        .where(eq(featureFlags.key, entry.key));
+      expect(dbRow, `Missing seed row for ${entry.key}`).toBeDefined();
+      expect(dbRow?.description, `Description drift for ${entry.key}`).toBe(entry.description);
+    }
   });
 
   it("Tenant A token can read the public projection — RLS isn't applied (flags are global)", async () => {

--- a/packages/api/src/tests/integration/feature-flags.test.ts
+++ b/packages/api/src/tests/integration/feature-flags.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Feature-flag registry integration tests (issue #326 / PR #352 follow-up).
+ *
+ * Three surfaces covered:
+ *   1. Admin API (`/v1/admin/feature-flags`) — super-admin GET + PATCH.
+ *   2. Tenant-readable API (`/v1/feature-flags`) — any authenticated
+ *      caller gets `{key, enabled}` rows.
+ *   3. The `requireFlag` gate — POST /v1/constituents/bulk-email is
+ *      404 when the flag is off, 401/202/etc. when it's on (the
+ *      route's other preHandlers still run).
+ *
+ * The bulk-email flag is seeded `enabled = false` by migration
+ * 0047_feature_flags. Tests that need it on flip via the admin PATCH
+ * (verifying the cache invalidation works end-to-end) AND reset it in
+ * `afterAll` so they don't pollute the cross-suite test DB.
+ */
+
+import { featureFlags } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { flagService } from "../../lib/flags/flag-service.js";
+import { redis } from "../../lib/redis.js";
+import { createServer } from "../../server.js";
+import { authHeader, ensureTestTenants, ORG_A, signToken } from "../helpers/auth.js";
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+});
+
+afterAll(async () => {
+  // Belt-and-braces: leave the bulk-email flag in its seed state so
+  // subsequent suites that share the test DB see a deterministic
+  // starting point.
+  await db
+    .update(featureFlags)
+    .set({ enabled: false })
+    .where(eq(featureFlags.key, "communication.bulk_email"));
+  await flagService.invalidate();
+  await app.close();
+});
+
+beforeEach(async () => {
+  // Reset rate-limit + flag cache between tests so a flip in one test
+  // doesn't bleed into the next.
+  const keys = await redis.keys("*rate-limit*");
+  if (keys.length > 0) await redis.del(...keys);
+  await flagService.invalidate();
+});
+
+afterEach(async () => {
+  await db
+    .update(featureFlags)
+    .set({ enabled: false })
+    .where(eq(featureFlags.key, "communication.bulk_email"));
+  await flagService.invalidate();
+});
+
+describe("Admin feature-flag registry — GET /v1/admin/feature-flags", () => {
+  it("super-admin lists every registered flag (description included)", async () => {
+    const token = signToken(app, { realm_access: { roles: ["super_admin"] } });
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/feature-flags",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: Array<{ key: string; enabled: boolean; description: string }>;
+    }>();
+    const bulkEmail = body.data.find((row) => row.key === "communication.bulk_email");
+    expect(bulkEmail).toBeDefined();
+    expect(bulkEmail?.enabled).toBe(false);
+    expect(bulkEmail?.description.length).toBeGreaterThan(0);
+  });
+
+  it("non-super-admin gets 404 (anti-disclosure, not 403)", async () => {
+    const token = signToken(app); // default = org_admin, no super_admin
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/feature-flags",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("unauthenticated GET is 401", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/feature-flags",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("Admin feature-flag registry — PATCH /v1/admin/feature-flags/:key", () => {
+  it("super-admin can flip the value AND the cache picks it up immediately", async () => {
+    const token = signToken(app, { realm_access: { roles: ["super_admin"] } });
+
+    // Pre-flight: confirm the flag starts disabled.
+    expect(await flagService.isEnabled("communication.bulk_email")).toBe(false);
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/admin/feature-flags/communication.bulk_email",
+      headers: authHeader(token),
+      payload: { enabled: true },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { enabled: boolean } }>().data.enabled).toBe(true);
+
+    // Cache was invalidated by the route → next read should hit PG
+    // and return the new value. (The PATCH handler explicitly calls
+    // flagService.invalidate() after the DB write.)
+    expect(await flagService.isEnabled("communication.bulk_email")).toBe(true);
+  });
+
+  it("unknown flag key returns 404", async () => {
+    const token = signToken(app, { realm_access: { roles: ["super_admin"] } });
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/admin/feature-flags/does.not.exist",
+      headers: authHeader(token),
+      payload: { enabled: true },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("non-super-admin gets 404 (no information leak about the route)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/admin/feature-flags/communication.bulk_email",
+      headers: authHeader(token),
+      payload: { enabled: true },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("Tenant-readable feature-flag projection — GET /v1/feature-flags", () => {
+  it("authenticated org_admin gets `{ key, enabled }` only (no description / metadata)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/feature-flags",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: Array<Record<string, unknown>> }>();
+    const bulkEmail = body.data.find((row) => row.key === "communication.bulk_email");
+    expect(bulkEmail).toBeDefined();
+    expect(bulkEmail).toEqual({
+      key: "communication.bulk_email",
+      enabled: false,
+    });
+    // The public projection must NOT include the admin-only metadata.
+    expect(bulkEmail).not.toHaveProperty("description");
+    expect(bulkEmail).not.toHaveProperty("updatedBy");
+    expect(bulkEmail).not.toHaveProperty("updatedAt");
+  });
+
+  it("unauthenticated request is 401", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/feature-flags",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("requireFlag gate on /v1/constituents/bulk-email", () => {
+  it("returns 404 when the flag is off (looks like a typo'd route)", async () => {
+    // Flag is OFF by default in `beforeEach`.
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/constituents/bulk-email",
+      headers: authHeader(token),
+      payload: {
+        constituentIds: ["00000000-0000-0000-0000-000000000aaa"],
+        subject: "Hello",
+        body: "Should not get through the gate.",
+      },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ title: string }>().title).toBe("Not Found");
+  });
+
+  it("returns 404 from the flag gate BEFORE the RBAC gate runs", async () => {
+    // Send a viewer token — the route's RBAC gate would have produced
+    // 403, but the flag gate fires first and 404s. This is the
+    // anti-disclosure posture: a scanner can't enumerate which gated
+    // routes need which roles.
+    const viewerToken = signToken(app, {
+      role: "viewer",
+      realm_access: { roles: ["app-viewer"] },
+    });
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/constituents/bulk-email",
+      headers: authHeader(viewerToken),
+      payload: {
+        constituentIds: ["00000000-0000-0000-0000-000000000aaa"],
+        subject: "Hello",
+        body: "Should not get through.",
+      },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("hands off to the existing route handler when the flag is ON", async () => {
+    // Flip the flag on directly + invalidate cache.
+    await db
+      .update(featureFlags)
+      .set({ enabled: true })
+      .where(eq(featureFlags.key, "communication.bulk_email"));
+    await flagService.invalidate();
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/constituents/bulk-email",
+      headers: authHeader(token),
+      payload: {
+        constituentIds: ["00000000-0000-0000-0000-000000000bad"],
+        subject: "Hello",
+        body: "Cross-tenant id — should reach the service and 400.",
+      },
+    });
+    // Flag is on, RBAC passes (token is org_admin), so the request
+    // reaches the service which rejects the bogus id with 400 — NOT
+    // 404 (flag-gate) and NOT 403 (RBAC).
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("Feature flag CHECK against DB drift between schema + seed", () => {
+  it("the seed migration inserted the canonical bulk-email row", async () => {
+    const rows = await db.execute<{ key: string; enabled: boolean; description: string }>(sql`
+      SELECT key, enabled, description
+      FROM feature_flags
+      WHERE key = 'communication.bulk_email'
+    `);
+    expect(rows.rows.length).toBe(1);
+    expect(rows.rows[0]?.description).toContain("DKIM");
+  });
+
+  it("Tenant A token can read the public projection — RLS isn't applied (flags are global)", async () => {
+    // The registry table has no RLS by design — confirm that a tenant
+    // user reading it doesn't get filtered to 0 rows. (Regression
+    // guard: if someone later adds RLS, this test will catch it.)
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/feature-flags",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: unknown[] }>();
+    expect(body.data.length).toBeGreaterThan(0);
+    void ORG_A; // Imported for symmetry with other suites; no per-tenant assertion needed.
+  });
+});

--- a/packages/api/src/tests/integration/postal-campaigns.test.ts
+++ b/packages/api/src/tests/integration/postal-campaigns.test.ts
@@ -10,10 +10,18 @@
 
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { db } from "../../lib/db.js";
+import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
-import { authHeader, ensureTestTenants, ORG_A, signToken } from "../helpers/auth.js";
+import {
+  authHeader,
+  ensureTestTenants,
+  ORG_A,
+  ORG_B,
+  seedTenantUser,
+  signToken,
+} from "../helpers/auth.js";
 
 let app: FastifyInstance;
 let campaignId: string;
@@ -438,6 +446,17 @@ describe("QR tracking metrics", () => {
 });
 
 describe("Bulk email dispatch", () => {
+  // The bulk-email POST + resume POST routes are rate-limited at 10/min
+  // each. This file now contains a dozen+ tests that hit them in a
+  // single test-file run; clear the rate-limit keys between tests so a
+  // suite that wouldn't trip the limit in real usage doesn't bleed
+  // 429s across unrelated assertions. Same pattern as
+  // `signup.test.ts` and `team-invitations.test.ts`.
+  beforeEach(async () => {
+    const keys = await redis.keys("*rate-limit*");
+    if (keys.length > 0) await redis.del(...keys);
+  });
+
   it("POST /v1/constituents/bulk-email creates a tracking row + outbox event with only the job id (issue #326)", async () => {
     const token = signToken(app);
     const res = await app.inject({
@@ -559,10 +578,14 @@ describe("Bulk email dispatch", () => {
 });
 
 describe("Bulk email job tracking + resume (issue #326)", () => {
+  beforeEach(async () => {
+    const keys = await redis.keys("*rate-limit*");
+    if (keys.length > 0) await redis.del(...keys);
+  });
+
   it("GET /v1/constituents/bulk-email-jobs lists the newest jobs first", async () => {
     const token = signToken(app);
 
-    // Reset polling rate limits leftover from the previous suite.
     const res = await app.inject({
       method: "GET",
       url: "/v1/constituents/bulk-email-jobs",
@@ -577,12 +600,25 @@ describe("Bulk email job tracking + resume (issue #326)", () => {
         totalRecipients: number;
         deliveredCount: number;
         stalled: boolean;
+        createdAt: string;
       }>;
     }>();
     expect(body.data.length).toBeGreaterThanOrEqual(1);
-    // Stalled flag is a server-derived boolean; on fresh `pending` rows
-    // it's always false.
-    expect(body.data.every((row) => row.stalled === false)).toBe(true);
+    // Every `pending` row in the list must report `stalled === false`
+    // (the flag only flips for `processing` rows whose updated_at has
+    // gone stale). The list mixes pending + processing in this suite —
+    // we check the property surface, not the value of every row.
+    for (const row of body.data) {
+      if (row.status === "pending") {
+        expect(row.stalled).toBe(false);
+      }
+      // Boolean shape regardless of status.
+      expect(typeof row.stalled).toBe("boolean");
+    }
+    // Newest-first ordering.
+    const timestamps = body.data.map((row) => new Date(row.createdAt).getTime());
+    const sorted = [...timestamps].sort((a, b) => b - a);
+    expect(timestamps).toEqual(sorted);
   });
 
   it("GET /v1/constituents/bulk-email-jobs/:id polls a single job", async () => {
@@ -838,6 +874,243 @@ describe("Bulk email job tracking + resume (issue #326)", () => {
           ARRAY[${constituentAId}::uuid],
           ARRAY[]::uuid[],
           1, 5, 0
+        )
+      `),
+    ).rejects.toThrow();
+  });
+
+  // PR #352 review M2: lock the RFC 9457 body shape on at least one error
+  // path. Catches regressions to a plain `{ error: "..." }` body or a
+  // type-stripped problem-detail (per project memory
+  // `feedback_lock_rfc9457_body_in_tests.md`).
+  it("rejection responses follow the full RFC 9457 problem-detail shape", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/constituents/bulk-email-jobs/00000000-0000-0000-0000-000000000bad/resume",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{
+      type: string;
+      title: string;
+      status: number;
+      detail: string;
+    }>();
+    expect(body.type).toMatch(/^https?:\/\//);
+    expect(body.title).toBe("job_not_found");
+    expect(body.status).toBe(404);
+    expect(typeof body.detail).toBe("string");
+    expect(body.detail.length).toBeGreaterThan(0);
+  });
+
+  // PR #352 review H4: every new admin-gated endpoint must reject `viewer`
+  // tokens with 403 — per project memory `feedback_role_test_coverage_both_directions.md`
+  // we cover BOTH directions of the boundary (admin-200 above + viewer-403 here).
+  it("rejects viewer tokens with 403 on every new bulk-email-jobs endpoint", async () => {
+    const viewerToken = signToken(app, {
+      role: "viewer",
+      realm_access: { roles: ["app-viewer"] },
+    });
+    // Seed an active `viewer` user row so the auth plugin's active-row
+    // check resolves before the role gate fires.
+    await seedTenantUser(ORG_A, { role: "viewer" });
+
+    const list = await app.inject({
+      method: "GET",
+      url: "/v1/constituents/bulk-email-jobs",
+      headers: authHeader(viewerToken),
+    });
+    expect(list.statusCode).toBe(403);
+
+    const get = await app.inject({
+      method: "GET",
+      url: "/v1/constituents/bulk-email-jobs/00000000-0000-0000-0000-000000000aaa",
+      headers: authHeader(viewerToken),
+    });
+    expect(get.statusCode).toBe(403);
+
+    const resume = await app.inject({
+      method: "POST",
+      url: "/v1/constituents/bulk-email-jobs/00000000-0000-0000-0000-000000000aaa/resume",
+      headers: authHeader(viewerToken),
+    });
+    expect(resume.statusCode).toBe(403);
+
+    // Re-seed the admin row so subsequent tests in this file regain the
+    // org_admin token's active membership.
+    await seedTenantUser(ORG_A);
+  });
+
+  // PR #352 review H3: a tenant A admin must NOT be able to GET or
+  // resume a `bulk_email_jobs` row that belongs to tenant B. RLS makes
+  // this safe in the service path; the test is the regression net for
+  // anything that ever bypasses `withTenantContext`.
+  it("isolates bulk_email_jobs rows across tenants — 404, not 200", async () => {
+    // Seed a tenant B row directly. We use raw SQL because seeding via
+    // the API would also need a tenant B token, which only complicates
+    // the test without exercising the surface we care about.
+    const tenantBRow = await db.execute<{ id: string }>(sql`
+      INSERT INTO bulk_email_jobs (
+        org_id, status, subject, body,
+        constituent_ids, total_recipients
+      ) VALUES (
+        ${ORG_B}::uuid,
+        'completed',
+        'Tenant B private dispatch',
+        'Tenant A must never see this.',
+        ARRAY[]::uuid[],
+        0
+      )
+      RETURNING id
+    `);
+    const tenantBJobId = tenantBRow.rows[0]?.id;
+    if (!tenantBJobId) throw new Error("Failed to seed tenant B row");
+
+    const tenantAToken = signToken(app);
+
+    // GET — RLS hides the row, so the API returns 404 (not 403, which
+    // would leak existence) — same shape as a missing id.
+    const getRes = await app.inject({
+      method: "GET",
+      url: `/v1/constituents/bulk-email-jobs/${tenantBJobId}`,
+      headers: authHeader(tenantAToken),
+    });
+    expect(getRes.statusCode).toBe(404);
+
+    // Resume — same posture: 404 with code `job_not_found`. A 400
+    // `job_still_running` would prove the resume path could see the
+    // tenant B row even though it can't write to it.
+    const resumeRes = await app.inject({
+      method: "POST",
+      url: `/v1/constituents/bulk-email-jobs/${tenantBJobId}/resume`,
+      headers: authHeader(tenantAToken),
+    });
+    expect(resumeRes.statusCode).toBe(404);
+    expect(resumeRes.json<{ title: string }>().title).toBe("job_not_found");
+  });
+
+  // PR #352 review L1 (QA): a deliberately-zero-deliverable dispatch
+  // (every selected constituent has no email) must close the row
+  // `completed` in the same transaction WITHOUT emitting an outbox
+  // event. Exercises the early-return path in `dispatchBulkEmail`.
+  it("zero-deliverable dispatch marks the row completed without an outbox event", async () => {
+    const token = signToken(app);
+
+    // Count outbox rows of this type before — we'll assert no new rows
+    // are added by this dispatch.
+    const before = await db.execute<{ c: number }>(sql`
+      SELECT count(*)::int AS c FROM outbox_events
+      WHERE tenant_id = ${ORG_A}::uuid
+        AND type = 'communication.bulk_email_requested'
+    `);
+    const outboxCountBefore = before.rows[0]?.c ?? 0;
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/constituents/bulk-email",
+      headers: authHeader(token),
+      payload: {
+        constituentIds: [constituentNoEmailId],
+        subject: "Nobody to email",
+        body: "But please track the request anyway.",
+      },
+    });
+    expect(res.statusCode).toBe(202);
+    const { jobId, queued, skippedNoEmail } = res.json<{
+      data: { jobId: string; queued: number; skippedNoEmail: number };
+    }>().data;
+    expect(queued).toBe(0);
+    expect(skippedNoEmail).toBe(1);
+
+    // Row exists and is already `completed` with completed_at set —
+    // the operator sees the dispatch in the panel and can move on.
+    const trackingRows = await db.execute(sql`
+      SELECT status, total_recipients, completed_at
+      FROM bulk_email_jobs
+      WHERE id = ${jobId}::uuid
+    `);
+    const tracking = trackingRows.rows[0] as {
+      status: string;
+      total_recipients: number;
+      completed_at: string | null;
+    };
+    expect(tracking.status).toBe("completed");
+    expect(tracking.total_recipients).toBe(0);
+    expect(tracking.completed_at).not.toBeNull();
+
+    const after = await db.execute<{ c: number }>(sql`
+      SELECT count(*)::int AS c FROM outbox_events
+      WHERE tenant_id = ${ORG_A}::uuid
+        AND type = 'communication.bulk_email_requested'
+    `);
+    expect(after.rows[0]?.c ?? 0).toBe(outboxCountBefore);
+  });
+
+  // PR #352 review H1: the resume path takes `SELECT ... FOR UPDATE`
+  // on the source row, AND migration 0046 enforces a partial unique
+  // index on `(parent_job_id) WHERE status IN ('pending', 'processing')`.
+  // Even if the row lock is somehow bypassed (raw SQL, future direct-
+  // DB tooling), a duplicate INSERT fails at the index layer.
+  it("rejects a second active resume from the same parent (partial unique index)", async () => {
+    // Seed a partial source.
+    const sourceRows = await db.execute<{ id: string }>(sql`
+      INSERT INTO bulk_email_jobs (
+        org_id, status, subject, body,
+        constituent_ids,
+        delivered_constituent_ids,
+        failed_constituent_ids,
+        total_recipients, delivered_count, failed_count
+      ) VALUES (
+        ${ORG_A}::uuid,
+        'partial',
+        'Partial source — double resume',
+        'First resume should win; second should be blocked.',
+        ARRAY[${constituentAId}::uuid, ${constituentBId}::uuid],
+        ARRAY[${constituentAId}::uuid],
+        ARRAY[]::uuid[],
+        2, 1, 0
+      )
+      RETURNING id
+    `);
+    const sourceId = sourceRows.rows[0]?.id;
+    if (!sourceId) throw new Error("Failed to seed source row");
+
+    // First resume row — should succeed and stay in `pending`.
+    const firstResume = await db.execute<{ id: string }>(sql`
+      INSERT INTO bulk_email_jobs (
+        org_id, status, subject, body,
+        constituent_ids, total_recipients,
+        parent_job_id
+      ) VALUES (
+        ${ORG_A}::uuid,
+        'pending',
+        'First resume',
+        'Body.',
+        ARRAY[${constituentBId}::uuid],
+        1,
+        ${sourceId}::uuid
+      )
+      RETURNING id
+    `);
+    expect(firstResume.rows.length).toBe(1);
+
+    // Second resume row pointing at the same parent while the first is
+    // still non-terminal must fail at the index layer.
+    await expect(
+      db.execute(sql`
+        INSERT INTO bulk_email_jobs (
+          org_id, status, subject, body,
+          constituent_ids, total_recipients,
+          parent_job_id
+        ) VALUES (
+          ${ORG_A}::uuid,
+          'pending',
+          'Second resume',
+          'Body.',
+          ARRAY[${constituentBId}::uuid],
+          1,
+          ${sourceId}::uuid
         )
       `),
     ).rejects.toThrow();

--- a/packages/api/src/tests/integration/postal-campaigns.test.ts
+++ b/packages/api/src/tests/integration/postal-campaigns.test.ts
@@ -438,7 +438,7 @@ describe("QR tracking metrics", () => {
 });
 
 describe("Bulk email dispatch", () => {
-  it("POST /v1/constituents/bulk-email queues an outbox event and reports skipped recipients", async () => {
+  it("POST /v1/constituents/bulk-email creates a tracking row + outbox event with only the job id (issue #326)", async () => {
     const token = signToken(app);
     const res = await app.inject({
       method: "POST",
@@ -451,13 +451,57 @@ describe("Bulk email dispatch", () => {
       },
     });
     expect(res.statusCode).toBe(202);
-    expect(res.json<{ data: { queued: number; skippedNoEmail: number } }>().data).toEqual({
-      queued: 1,
-      skippedNoEmail: 1,
-    });
+    const body = res.json<{
+      data: { jobId: string; queued: number; skippedNoEmail: number };
+    }>().data;
+    expect(body.queued).toBe(1);
+    expect(body.skippedNoEmail).toBe(1);
+    expect(body.jobId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(res.headers.location).toBe(`/v1/constituents/bulk-email-jobs/${body.jobId}`);
 
+    // Tracking row holds the deliverable id snapshot + zero counters.
+    // PII (email, name) stays out of bulk_email_jobs — only uuids.
+    const trackingRows = await db.execute(sql`
+      SELECT
+        status,
+        total_recipients,
+        delivered_count,
+        failed_count,
+        constituent_ids,
+        delivered_constituent_ids,
+        failed_constituent_ids,
+        parent_job_id,
+        subject
+      FROM bulk_email_jobs
+      WHERE id = ${body.jobId}::uuid
+    `);
+    expect(trackingRows.rows.length).toBe(1);
+    const tracking = trackingRows.rows[0] as {
+      status: string;
+      total_recipients: number;
+      delivered_count: number;
+      failed_count: number;
+      constituent_ids: string[];
+      delivered_constituent_ids: string[];
+      failed_constituent_ids: string[];
+      parent_job_id: string | null;
+      subject: string;
+    };
+    expect(tracking.status).toBe("pending");
+    expect(tracking.total_recipients).toBe(1);
+    expect(tracking.delivered_count).toBe(0);
+    expect(tracking.failed_count).toBe(0);
+    expect(tracking.constituent_ids).toEqual([constituentAId]);
+    expect(tracking.delivered_constituent_ids).toEqual([]);
+    expect(tracking.failed_constituent_ids).toEqual([]);
+    expect(tracking.parent_job_id).toBeNull();
+    expect(tracking.subject).toBe("Test bulk email");
+
+    // Outbox payload now carries only the tracking row id — the worker
+    // re-reads subject/body/recipient_ids from the DB. No PII, no
+    // recipient list snapshot in the BullMQ payload.
     const outboxRows = await db.execute(sql`
-      SELECT type, payload FROM outbox_events
+      SELECT payload FROM outbox_events
       WHERE tenant_id = ${ORG_A}::uuid
         AND type = 'communication.bulk_email_requested'
       ORDER BY created_at DESC
@@ -465,15 +509,21 @@ describe("Bulk email dispatch", () => {
     `);
     expect(outboxRows.rows.length).toBe(1);
     const payload = (
-      outboxRows.rows[0] as { payload: { constituentIds?: unknown[]; recipients?: unknown } }
+      outboxRows.rows[0] as {
+        payload: {
+          bulkEmailJobId?: string;
+          constituentIds?: unknown[];
+          recipients?: unknown;
+          subject?: unknown;
+          body?: unknown;
+        };
+      }
     ).payload;
-    // The payload carries only the deliverable constituent id list — PII
-    // (email/name) is re-resolved by the worker at send time, never
-    // persisted to outbox or Redis (GDPR Art. 5(1)(e)).
-    expect(payload.constituentIds).toBeDefined();
-    expect(Array.isArray(payload.constituentIds)).toBe(true);
-    expect((payload.constituentIds as string[]).length).toBe(1);
+    expect(payload.bulkEmailJobId).toBe(body.jobId);
+    expect(payload.constituentIds).toBeUndefined();
     expect(payload.recipients).toBeUndefined();
+    expect(payload.subject).toBeUndefined();
+    expect(payload.body).toBeUndefined();
   });
 
   it("rejects empty bulk-email selection with 400", async () => {
@@ -505,6 +555,292 @@ describe("Bulk email dispatch", () => {
       },
     });
     expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("Bulk email job tracking + resume (issue #326)", () => {
+  it("GET /v1/constituents/bulk-email-jobs lists the newest jobs first", async () => {
+    const token = signToken(app);
+
+    // Reset polling rate limits leftover from the previous suite.
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents/bulk-email-jobs",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: Array<{
+        id: string;
+        status: string;
+        subject: string;
+        totalRecipients: number;
+        deliveredCount: number;
+        stalled: boolean;
+      }>;
+    }>();
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+    // Stalled flag is a server-derived boolean; on fresh `pending` rows
+    // it's always false.
+    expect(body.data.every((row) => row.stalled === false)).toBe(true);
+  });
+
+  it("GET /v1/constituents/bulk-email-jobs/:id polls a single job", async () => {
+    // Create a fresh job to query.
+    const token = signToken(app);
+    const dispatch = await app.inject({
+      method: "POST",
+      url: "/v1/constituents/bulk-email",
+      headers: authHeader(token),
+      payload: {
+        constituentIds: [constituentAId],
+        subject: "Poll me",
+        body: "Polling test.",
+      },
+    });
+    expect(dispatch.statusCode).toBe(202);
+    const { jobId } = dispatch.json<{ data: { jobId: string } }>().data;
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/constituents/bulk-email-jobs/${jobId}`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const view = res.json<{ data: { id: string; status: string; totalRecipients: number } }>().data;
+    expect(view.id).toBe(jobId);
+    expect(view.status).toBe("pending");
+    expect(view.totalRecipients).toBe(1);
+  });
+
+  it("GET /v1/constituents/bulk-email-jobs/:id 404s for unknown ids", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/constituents/bulk-email-jobs/00000000-0000-0000-0000-000000000bad",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("POST /v1/constituents/bulk-email-jobs/:id/resume rejects a pending source as still-running (400)", async () => {
+    const token = signToken(app);
+    const dispatch = await app.inject({
+      method: "POST",
+      url: "/v1/constituents/bulk-email",
+      headers: authHeader(token),
+      payload: {
+        constituentIds: [constituentAId],
+        subject: "Pending source",
+        body: "Still running.",
+      },
+    });
+    expect(dispatch.statusCode).toBe(202);
+    const { jobId } = dispatch.json<{ data: { jobId: string } }>().data;
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/constituents/bulk-email-jobs/${jobId}/resume`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(400);
+    const problem = res.json<{ title: string; status: number }>();
+    expect(problem.title).toBe("job_still_running");
+    expect(problem.status).toBe(400);
+  });
+
+  it("POST /v1/constituents/bulk-email-jobs/:id/resume creates a new job for the remaining recipients of a partial source", async () => {
+    const token = signToken(app);
+
+    // Stage a partial source row directly: 2 requested, 1 delivered, 0
+    // failed. Simulates the Redis-wipe scenario described in issue #326
+    // — the worker delivered to one recipient and never touched the
+    // other before the BullMQ job vanished.
+    const sourceJob = await db.execute<{ id: string }>(sql`
+      INSERT INTO bulk_email_jobs (
+        org_id, status, subject, body,
+        constituent_ids,
+        delivered_constituent_ids,
+        failed_constituent_ids,
+        total_recipients, delivered_count, failed_count
+      ) VALUES (
+        ${ORG_A}::uuid,
+        'partial',
+        'Partial source',
+        'Body of the partial source job.',
+        ARRAY[${constituentAId}::uuid, ${constituentBId}::uuid],
+        ARRAY[${constituentAId}::uuid],
+        ARRAY[]::uuid[],
+        2, 1, 0
+      )
+      RETURNING id
+    `);
+    const sourceId = sourceJob.rows[0]?.id;
+    expect(sourceId).toBeDefined();
+    if (!sourceId) throw new Error("Failed to seed source row");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/constituents/bulk-email-jobs/${sourceId}/resume`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(202);
+    const resumed = res.json<{
+      data: {
+        id: string;
+        status: string;
+        subject: string;
+        totalRecipients: number;
+        deliveredCount: number;
+        parentJobId: string | null;
+      };
+    }>().data;
+    expect(resumed.status).toBe("pending");
+    expect(resumed.subject).toBe("Partial source");
+    expect(resumed.totalRecipients).toBe(1);
+    expect(resumed.deliveredCount).toBe(0);
+    expect(resumed.parentJobId).toBe(sourceId);
+    expect(res.headers.location).toBe(`/v1/constituents/bulk-email-jobs/${resumed.id}`);
+
+    // The new row's constituent_ids must be exactly the recipient that
+    // wasn't delivered in the source.
+    const resumedRows = await db.execute(sql`
+      SELECT constituent_ids
+      FROM bulk_email_jobs
+      WHERE id = ${resumed.id}::uuid
+    `);
+    expect((resumedRows.rows[0] as { constituent_ids: string[] }).constituent_ids).toEqual([
+      constituentBId,
+    ]);
+
+    // A fresh outbox event is queued for the resume — same shape as a
+    // first-time dispatch (only carries the bulkEmailJobId).
+    const outboxRows = await db.execute(sql`
+      SELECT payload FROM outbox_events
+      WHERE tenant_id = ${ORG_A}::uuid
+        AND type = 'communication.bulk_email_requested'
+      ORDER BY created_at DESC
+      LIMIT 1
+    `);
+    const payload = (outboxRows.rows[0] as { payload: { bulkEmailJobId?: string } }).payload;
+    expect(payload.bulkEmailJobId).toBe(resumed.id);
+  });
+
+  it("POST /v1/constituents/bulk-email-jobs/:id/resume 400s when nothing is left to resume", async () => {
+    const token = signToken(app);
+
+    // A `completed` source: delivered_count == total_recipients.
+    const completed = await db.execute<{ id: string }>(sql`
+      INSERT INTO bulk_email_jobs (
+        org_id, status, subject, body,
+        constituent_ids,
+        delivered_constituent_ids,
+        failed_constituent_ids,
+        total_recipients, delivered_count, failed_count
+      ) VALUES (
+        ${ORG_A}::uuid,
+        'completed',
+        'Fully delivered',
+        'Body.',
+        ARRAY[${constituentAId}::uuid],
+        ARRAY[${constituentAId}::uuid],
+        ARRAY[]::uuid[],
+        1, 1, 0
+      )
+      RETURNING id
+    `);
+    const completedId = completed.rows[0]?.id;
+    if (!completedId) throw new Error("Failed to seed completed row");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/constituents/bulk-email-jobs/${completedId}/resume`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(400);
+    const problem = res.json<{ title: string }>();
+    expect(problem.title).toBe("nothing_to_resume");
+  });
+
+  it("POST /v1/constituents/bulk-email-jobs/:id/resume 404s for unknown ids (separate code path from validation 400)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/constituents/bulk-email-jobs/00000000-0000-0000-0000-000000000bad/resume",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+    const problem = res.json<{ title: string }>();
+    expect(problem.title).toBe("job_not_found");
+  });
+
+  it("POST /v1/constituents/bulk-email-jobs/:id/resume accepts a stalled processing source (Redis-wipe scenario, issue #326)", async () => {
+    const token = signToken(app);
+
+    // A `processing` row whose `updated_at` is 30 minutes in the past —
+    // server treats this as stalled (the BULK_EMAIL_STALL_MS threshold
+    // is 10 minutes) and lets the resume go through.
+    const stalled = await db.execute<{ id: string }>(sql`
+      INSERT INTO bulk_email_jobs (
+        org_id, status, subject, body,
+        constituent_ids,
+        delivered_constituent_ids,
+        failed_constituent_ids,
+        total_recipients, delivered_count, failed_count,
+        updated_at
+      ) VALUES (
+        ${ORG_A}::uuid,
+        'processing',
+        'Stalled source',
+        'Worker died mid-fan-out.',
+        ARRAY[${constituentAId}::uuid, ${constituentBId}::uuid],
+        ARRAY[]::uuid[],
+        ARRAY[]::uuid[],
+        2, 0, 0,
+        NOW() - INTERVAL '30 minutes'
+      )
+      RETURNING id
+    `);
+    const stalledId = stalled.rows[0]?.id;
+    if (!stalledId) throw new Error("Failed to seed stalled row");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/constituents/bulk-email-jobs/${stalledId}/resume`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(202);
+    const resumed = res.json<{
+      data: { totalRecipients: number; parentJobId: string | null };
+    }>().data;
+    // 0 delivered ⇒ resume re-targets the full set.
+    expect(resumed.totalRecipients).toBe(2);
+    expect(resumed.parentJobId).toBe(stalledId);
+  });
+
+  it("counts/array CHECK constraint rejects drifted counter writes (defence-in-depth)", async () => {
+    // Direct SQL: deliver_count says 5 but the array has 1 entry. The
+    // CHECK constraint from migration 0045 must reject the INSERT.
+    await expect(
+      db.execute(sql`
+        INSERT INTO bulk_email_jobs (
+          org_id, status, subject, body,
+          constituent_ids,
+          delivered_constituent_ids,
+          failed_constituent_ids,
+          total_recipients, delivered_count, failed_count
+        ) VALUES (
+          ${ORG_A}::uuid,
+          'partial',
+          'Drifted counters',
+          'Should be rejected by CHECK.',
+          ARRAY[${constituentAId}::uuid],
+          ARRAY[${constituentAId}::uuid],
+          ARRAY[]::uuid[],
+          1, 5, 0
+        )
+      `),
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/api/src/tests/integration/postal-campaigns.test.ts
+++ b/packages/api/src/tests/integration/postal-campaigns.test.ts
@@ -8,10 +8,12 @@
  * inserts a `pending` row and emits the outbox event.
  */
 
-import { sql } from "drizzle-orm";
+import { featureFlags } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { db } from "../../lib/db.js";
+import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
 import {
@@ -446,6 +448,26 @@ describe("QR tracking metrics", () => {
 });
 
 describe("Bulk email dispatch", () => {
+  // The bulk-email feature is shipped behind the
+  // `communication.bulk_email` feature flag (PR #352 / @magino review).
+  // Seeded `enabled = false` by migration 0047. Force it ON for the
+  // duration of these tests so we exercise the original behaviour;
+  // the dedicated `feature-flags.test.ts` covers the off-path.
+  beforeAll(async () => {
+    await db
+      .update(featureFlags)
+      .set({ enabled: true })
+      .where(eq(featureFlags.key, "communication.bulk_email"));
+    await flagService.invalidate();
+  });
+  afterAll(async () => {
+    await db
+      .update(featureFlags)
+      .set({ enabled: false })
+      .where(eq(featureFlags.key, "communication.bulk_email"));
+    await flagService.invalidate();
+  });
+
   // The bulk-email POST + resume POST routes are rate-limited at 10/min
   // each. This file now contains a dozen+ tests that hit them in a
   // single test-file run; clear the rate-limit keys between tests so a
@@ -578,6 +600,21 @@ describe("Bulk email dispatch", () => {
 });
 
 describe("Bulk email job tracking + resume (issue #326)", () => {
+  beforeAll(async () => {
+    await db
+      .update(featureFlags)
+      .set({ enabled: true })
+      .where(eq(featureFlags.key, "communication.bulk_email"));
+    await flagService.invalidate();
+  });
+  afterAll(async () => {
+    await db
+      .update(featureFlags)
+      .set({ enabled: false })
+      .where(eq(featureFlags.key, "communication.bulk_email"));
+    await flagService.invalidate();
+  });
+
   beforeEach(async () => {
     const keys = await redis.keys("*rate-limit*");
     if (keys.length > 0) await redis.del(...keys);

--- a/packages/api/src/tests/integration/schema-parity.test.ts
+++ b/packages/api/src/tests/integration/schema-parity.test.ts
@@ -219,6 +219,25 @@ describe("Drizzle ↔ SQL schema parity (issue #261)", () => {
           "users_one_first_admin_per_org",
           { predicate: "first_admin = true", reason: "ADR-021 ownership invariant" },
         ],
+        [
+          // Issue #326 / migration 0046: at most one non-terminal
+          // resume per parent — prevents two concurrent Resume clicks
+          // from each inserting a child row that fans out to the same
+          // remaining recipients (PR #352 review H1). Soft-deleted
+          // resume rows are still a "used" slot semantically: a
+          // tenant must explicitly mark the row terminal (or wait for
+          // the worker to do so) before they can spawn another active
+          // resume, otherwise the soft-delete becomes a backdoor that
+          // lets two concurrent in-flight resumes coexist. Predicate
+          // is therefore status-based, not deleted_at-based.
+          "bulk_email_jobs_one_active_resume_per_parent",
+          {
+            predicate:
+              "(parent_job_id IS NOT NULL) AND (status = ANY (ARRAY['pending'::bulk_email_job_status, 'processing'::bulk_email_job_status]))",
+            reason:
+              "ADR-021 + issue #326 — non-terminal status, not deleted_at, is the right gate for resume uniqueness",
+          },
+        ],
       ]);
 
       const offenders: string[] = [];

--- a/packages/shared/src/constants/feature-flags.ts
+++ b/packages/shared/src/constants/feature-flags.ts
@@ -49,17 +49,28 @@ export type FeatureFlagKey = (typeof FEATURE_FLAG_KEYS)[keyof typeof FEATURE_FLA
  * Registry entries the seed migration uses to provision the
  * `feature_flags` table. The migration is INSERT … ON CONFLICT DO
  * NOTHING so existing values are preserved across redeploys — the
- * default below is the *first-deploy* value, not a runtime override.
+ * defaults below are the *first-deploy* values, not runtime overrides.
+ *
+ * Text-field convention (PR #352 magino review):
+ *   - `label` and `description` are **operator-facing**. Plain
+ *     language, no engineering jargon, no issue numbers, no RFC
+ *     references. These render in the Back Office UI.
+ *   - The engineering rationale (DKIM/SPF/DMARC, incident IDs,
+ *     follow-up issues) lives in the JSDoc above each `FEATURE_FLAG_KEYS`
+ *     entry — invisible to operators, visible to anyone reading the
+ *     code.
  */
 export const FEATURE_FLAG_REGISTRY: ReadonlyArray<{
   key: FeatureFlagKey;
   defaultEnabled: boolean;
+  label: string;
   description: string;
 }> = [
   {
     key: FEATURE_FLAG_KEYS.COMMUNICATION_BULK_EMAIL,
     defaultEnabled: false,
+    label: "Bulk emails to constituents",
     description:
-      "Operator-triggered bulk email to selected constituents (issue #326). Disabled until the platform's outbound mail domain has DKIM / SPF / DMARC configured — without them every send looks like phishing to recipient MX servers.",
+      "Lets operators send one email to several constituents at once from the Constituents page. Currently off — we'll turn it on once the email-deliverability setup is finished so messages don't land in donors' spam folders.",
   },
 ];

--- a/packages/shared/src/constants/feature-flags.ts
+++ b/packages/shared/src/constants/feature-flags.ts
@@ -1,0 +1,65 @@
+/**
+ * Canonical feature-flag registry — the single source of truth for what
+ * keys the codebase consumes. Every `requireFlag(...)`, `useFlag(...)`,
+ * or worker-side `flagService.isEnabled(...)` call MUST reference a key
+ * declared here.
+ *
+ * Why a code-side const rather than "trust the DB":
+ *   - Typo-safety. `isEnabled("comm.bulk_email")` (wrong) silently
+ *     evaluates to `false` (unknown → off, per doc 18 §5). The typed
+ *     `FeatureFlagKey` union breaks the build instead.
+ *   - Lifecycle visibility. Removing a key from this file is the
+ *     reviewable signal that a flag is being retired — the matching
+ *     DB row is then dropped in a follow-up migration.
+ *   - Doc/code parity. `docs/18-feature-flags.md` references this file
+ *     so the doc never drifts away from what actually ships.
+ *
+ * Seed contract: every key here MUST have a matching row in the
+ * `feature_flags` table (provisioned by migration `0047_feature_flags`).
+ * The startup boot path SHOULD assert this — drift is a deploy bug.
+ */
+
+export const FEATURE_FLAG_KEYS = {
+  /**
+   * Gates the bulk-email feature added in PR #352 (issue #326).
+   *
+   * Disabled by default until DKIM / SPF / DMARC are configured for
+   * the platform's outbound mail domain. Without them every operator-
+   * triggered "donor follow-up" looks like phishing to recipient
+   * MX servers — discussed with @magino on PR #352. Once the DNS
+   * posture is in place this flips to `enabled = true` from the
+   * Back Office UI; no deploy required.
+   *
+   * Surfaces gated by this key:
+   *   - API: POST /v1/constituents/bulk-email
+   *   - API: GET / POST /v1/constituents/bulk-email-jobs[/:id[/resume]]
+   *   - Worker: `communication.bulk_email_requested` outbox events
+   *     drop silently when the flag is off (defence in depth — if a
+   *     request slipped through the API gate, the worker is the
+   *     second wall).
+   *   - Web: "Email selection" + "Recent emails" buttons on the
+   *     constituents page hide when the flag is off.
+   */
+  COMMUNICATION_BULK_EMAIL: "communication.bulk_email",
+} as const;
+
+export type FeatureFlagKey = (typeof FEATURE_FLAG_KEYS)[keyof typeof FEATURE_FLAG_KEYS];
+
+/**
+ * Registry entries the seed migration uses to provision the
+ * `feature_flags` table. The migration is INSERT … ON CONFLICT DO
+ * NOTHING so existing values are preserved across redeploys — the
+ * default below is the *first-deploy* value, not a runtime override.
+ */
+export const FEATURE_FLAG_REGISTRY: ReadonlyArray<{
+  key: FeatureFlagKey;
+  defaultEnabled: boolean;
+  description: string;
+}> = [
+  {
+    key: FEATURE_FLAG_KEYS.COMMUNICATION_BULK_EMAIL,
+    defaultEnabled: false,
+    description:
+      "Operator-triggered bulk email to selected constituents (issue #326). Disabled until the platform's outbound mail domain has DKIM / SPF / DMARC configured — without them every send looks like phishing to recipient MX servers.",
+  },
+];

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -6,6 +6,11 @@
 
 export { resolveCountryName } from "./country-names";
 export {
+  FEATURE_FLAG_KEYS,
+  FEATURE_FLAG_REGISTRY,
+  type FeatureFlagKey,
+} from "./feature-flags";
+export {
   IMPERSONATION_END_REASON_VALUES,
   IMPERSONATION_MODE_VALUES,
   type ImpersonationEndReason,

--- a/packages/shared/src/jobs/index.ts
+++ b/packages/shared/src/jobs/index.ts
@@ -11,13 +11,26 @@ export interface GenerateReceiptJob {
   };
 }
 
-/** Send bulk email to a segment of constituents */
+/**
+ * Send bulk email to a tracked job's recipient snapshot (issue #326).
+ *
+ * `bulkEmailJobId` is the FK into `bulk_email_jobs`. The worker reads
+ * subject, body, and constituent_ids from that row at job start —
+ * minimises what flows through Redis (no PII, no large payload) and
+ * lets a resume job consume the freshest `delivered_constituent_ids`
+ * snapshot when it computes "remaining".
+ *
+ * `templateId` and `segmentFilter` are retained as optional fields for
+ * the future template-engine / saved-segment paths (out of scope for
+ * #326; the current MVP path passes only `bulkEmailJobId`).
+ */
 export interface SendBulkEmailJob {
   name: "send-bulk-email";
   data: {
     orgId: string;
-    templateId: string;
-    segmentFilter: Record<string, unknown>;
+    bulkEmailJobId: string;
+    templateId?: string;
+    segmentFilter?: Record<string, unknown>;
     scheduledAt?: string;
   };
 }

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -1318,6 +1318,59 @@ export const bulkEmailJobs = pgTable(
   ],
 );
 
+// ─── Feature Flags (doc 18 — global-only MVP) ──────────────────────────────
+
+/**
+ * Platform-wide feature flag registry. **Phase-1 MVP scope: global flags
+ * only** — every tenant sees the same value. Per-tenant overrides
+ * (`tenant_flag_overrides`) and plan-gating are deferred to the
+ * next-iteration spec in `docs/18-feature-flags.md`.
+ *
+ * Why global-only first:
+ *   - The first real consumer (bulk-email, gated until DKIM/SPF lands —
+ *     see PR #352 discussion with @magino) is a platform-wide pause,
+ *     not a per-tenant trial.
+ *   - Schema is forward-compatible: a future `tenant_flag_overrides`
+ *     table joins on `key` without backfilling.
+ *
+ * Reads are cached in Redis with a 60s TTL keyed `flags:global` (single
+ * map covering every flag in the registry). Cache is invalidated on
+ * every write by the admin API. The seed migration inserts the
+ * canonical set; the admin UI only toggles `enabled`, it does NOT
+ * create or delete flags — drift between code and DB is the failure
+ * mode the registry exists to prevent.
+ */
+export const featureFlags = pgTable(
+  "feature_flags",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    /**
+     * Dotted-namespace key, e.g. `communication.bulk_email`. Lowercase,
+     * dot-separated, no whitespace. The `requireFlag(key)` middleware
+     * looks rows up by this column; the seed migration is the source of
+     * truth for what keys exist.
+     */
+    key: varchar("key", { length: 100 }).notNull().unique(),
+    /** Current value. Single boolean per row — no per-tenant variance in the MVP. */
+    enabled: boolean("enabled").notNull().default(false),
+    /**
+     * Operator-facing description shown next to the toggle in the
+     * Back Office UI. Explain *what* the flag gates and *why* it's
+     * gated; the changelog goes in `audit_logs`.
+     */
+    description: text("description").notNull(),
+    /**
+     * Last super-admin to flip the flag. `SET NULL` on user purge so a
+     * GDPR-erased staff account doesn't FK-block the row. Audit history
+     * lives in `audit_logs` keyed on `feature_flag.toggled`.
+     */
+    updatedBy: uuid("updated_by").references(() => users.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("feature_flags_key_idx").on(table.key)],
+);
+
 // ─── Public Page Status Enum ───────────────────────────────────────────────
 
 export const publicPageStatusEnum = pgEnum("public_page_status", ["draft", "published"]);

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -1354,9 +1354,18 @@ export const featureFlags = pgTable(
     /** Current value. Single boolean per row — no per-tenant variance in the MVP. */
     enabled: boolean("enabled").notNull().default(false),
     /**
-     * Operator-facing description shown next to the toggle in the
-     * Back Office UI. Explain *what* the flag gates and *why* it's
-     * gated; the changelog goes in `audit_logs`.
+     * Short, friendly title shown as the row heading in the Back Office
+     * UI (e.g. "Bulk emails to constituents"). Plain language, no
+     * dotted-namespace prefix, no engineering jargon — operators are
+     * the audience.
+     */
+    label: varchar("label", { length: 120 }).notNull(),
+    /**
+     * Operator-facing description shown under the label in the
+     * Back Office UI. One or two sentences in plain language, focused
+     * on **what the feature does for the operator**. The engineering
+     * rationale (RFCs, incident IDs, infra prerequisites) belongs in
+     * `FEATURE_FLAG_REGISTRY` code comments, NOT in this column.
      */
     description: text("description").notNull(),
     /**

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -3,6 +3,7 @@
  * All tables include org_id for row-level security and audit columns.
  */
 
+import { sql } from "drizzle-orm";
 import {
   type AnyPgColumn,
   bigint,
@@ -1197,6 +1198,123 @@ export const campaignPostalExports = pgTable(
     index("campaign_postal_exports_org_idx").on(table.orgId),
     index("campaign_postal_exports_campaign_idx").on(table.campaignId),
     index("campaign_postal_exports_created_at_idx").on(table.createdAt),
+  ],
+);
+
+// ─── Bulk Email Jobs (issue #326) ──────────────────────────────────────────
+
+/**
+ * Bulk-email job lifecycle. `pending` → `processing` → terminal.
+ *
+ * Terminal states split delivery outcome:
+ *   - `completed` — every requested recipient was delivered.
+ *   - `partial`   — some delivered, some did not (SMTP refused OR worker
+ *                   never reached them because the BullMQ job was dropped
+ *                   by a Redis wipe / OOM / accessory reboot). Surfaces a
+ *                   "Resume / re-send to remaining recipients" action.
+ *   - `failed`    — terminal failure before per-recipient sends could
+ *                   start (DB error, malformed row). Resume still works
+ *                   because `delivered_count = 0` ⇒ remaining = total.
+ */
+export const BULK_EMAIL_JOB_STATUS_VALUES = [
+  "pending",
+  "processing",
+  "completed",
+  "partial",
+  "failed",
+] as const;
+export type BulkEmailJobStatus = (typeof BULK_EMAIL_JOB_STATUS_VALUES)[number];
+
+export const bulkEmailJobStatusEnum = pgEnum("bulk_email_job_status", [
+  ...BULK_EMAIL_JOB_STATUS_VALUES,
+]);
+
+/**
+ * Bulk email job — per-dispatch record carrying the recipient snapshot
+ * and the per-recipient delivery outcome. Replaces "fire-and-forget +
+ * trust the outbox" with a queryable progress + resume surface so a
+ * Redis wipe / OOM / accessory reboot mid-fan-out doesn't silently lose
+ * recipients (issue #326).
+ *
+ * Storage trade-off vs. GDPR Art. 5(1)(e):
+ *   - `constituent_ids` (uuid[]) is the *snapshot* of deliverable ids at
+ *     request time. Stored in the DB so the resume path can compute the
+ *     remaining set without depending on the outbox row (which is
+ *     short-lived: the relay marks it `completed` the moment it enqueues).
+ *   - PII (email, name) is NOT persisted here — the worker re-resolves
+ *     it from `constituents` under RLS at send time, same as before. A
+ *     uuid is a tenant-scoped foreign key, not personal data.
+ *   - On GDPR erasure of a constituent, the worker silently drops them
+ *     at send time (already covered by `processSendBulkEmail`'s
+ *     soft-delete filter); the uuid lingering in the array is a tenant-
+ *     local reference, not directly identifying.
+ */
+export const bulkEmailJobs = pgTable(
+  "bulk_email_jobs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    status: bulkEmailJobStatusEnum("status").notNull().default("pending"),
+    /** Admin-supplied subject. Capped at 200 by the route validator and the DB column width. */
+    subject: varchar("subject", { length: 200 }).notNull(),
+    /**
+     * Admin-supplied plain-text body. Capped at 50 000 by the route
+     * validator; `text` here avoids a tighter DB cap that would surprise
+     * the resume path (a resume carries the original body forward).
+     */
+    body: text("body").notNull(),
+    /**
+     * Requested deliverable recipients — the constituent ids the API
+     * filtered down to "has email on file" at request time. Locked at
+     * insert; the worker iterates this list and writes outcomes into
+     * `delivered_constituent_ids` / `failed_constituent_ids`. Resume
+     * computes `constituent_ids \ delivered_constituent_ids`.
+     */
+    constituentIds: uuid("constituent_ids").array().notNull(),
+    /** Append-only set of recipients the worker successfully sent to. */
+    deliveredConstituentIds: uuid("delivered_constituent_ids")
+      .array()
+      .notNull()
+      .default(sql`'{}'::uuid[]`),
+    /** Append-only set of recipients the worker tried and SMTP refused. */
+    failedConstituentIds: uuid("failed_constituent_ids")
+      .array()
+      .notNull()
+      .default(sql`'{}'::uuid[]`),
+    /** = `constituent_ids` length. Denormalised so the polling UI reads O(1). */
+    totalRecipients: integer("total_recipients").notNull(),
+    /** = `delivered_constituent_ids` length. Worker keeps it in step on every send. */
+    deliveredCount: integer("delivered_count").notNull().default(0),
+    /** = `failed_constituent_ids` length. Worker keeps it in step on every send. */
+    failedCount: integer("failed_count").notNull().default(0),
+    /**
+     * JWT subject → internal users.id translation. Same convention as
+     * `campaign_postal_exports.requested_by`: SET NULL on user purge so
+     * GDPR erasure of a staff account doesn't FK-block the audit row.
+     */
+    requestedBy: uuid("requested_by").references(() => users.id, { onDelete: "set null" }),
+    /**
+     * Audit chain for resume jobs. Each resume creates a fresh row whose
+     * `parent_job_id` points at the row that left recipients on the
+     * table. NULL on the originating dispatch.
+     */
+    parentJobId: uuid("parent_job_id").references((): AnyPgColumn => bulkEmailJobs.id, {
+      onDelete: "set null",
+    }),
+    /** Terminal failure message. NULL until status flips to `failed`. */
+    error: text("error"),
+    /** Soft-delete (ADR-021 universal). Listing filters `deleted_at IS NULL`. */
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("bulk_email_jobs_org_idx").on(table.orgId),
+    index("bulk_email_jobs_created_at_idx").on(table.createdAt),
+    index("bulk_email_jobs_parent_idx").on(table.parentJobId),
   ],
 );
 

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -1368,7 +1368,9 @@ export const featureFlags = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [index("feature_flags_key_idx").on(table.key)],
+  // No explicit key-index — the `UNIQUE` constraint on `key` already
+  // creates one and that's what `flagService` + `requireFlag` look up
+  // by. (PR #352 Platform review Plat-LOW-2a.)
 );
 
 // ─── Public Page Status Enum ───────────────────────────────────────────────

--- a/packages/web/src/app/(admin)/admin/feature-flags/page.tsx
+++ b/packages/web/src/app/(admin)/admin/feature-flags/page.tsx
@@ -1,0 +1,55 @@
+import { AlertTriangle } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+
+import { FeatureFlagsTable } from "@/components/admin/feature-flags-table";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { type FeatureFlagRow, FeatureFlagsService } from "@/services/FeatureFlagsService";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Super-admin-only Back Office page: global feature-flag registry
+ * (PR #352 follow-up; the bulk-email feature gated by
+ * `communication.bulk_email` is the first consumer, disabled by
+ * default until DKIM/SPF land — see `docs/23 § 6.bis` for the
+ * rationale).
+ *
+ * SSR pattern matches `admin/platform-admins/page.tsx`: fetch the
+ * full registry once on the server, render through a client
+ * component that owns the toggle interaction + optimistic updates.
+ */
+export default async function FeatureFlagsPage() {
+  const t = await getTranslations("admin.featureFlags");
+  const api = await createServerApiClient();
+
+  let rows: FeatureFlagRow[] = [];
+  let fetchFailed = false;
+  try {
+    rows = await FeatureFlagsService.list(api);
+  } catch {
+    // Same posture as platform-admins/page.tsx — render a banner, not
+    // a misleading "no flags yet" empty state.
+    fetchFailed = true;
+  }
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="font-heading text-2xl text-on-surface">{t("title")}</h1>
+        <p className="mt-1 text-sm text-on-surface-variant">{t("subtitle")}</p>
+      </header>
+
+      {fetchFailed ? (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-2xl border border-error bg-error-container p-4 text-on-error-container"
+        >
+          <AlertTriangle aria-hidden="true" className="mt-0.5 shrink-0" size={20} />
+          <p className="text-sm">{t("fetchFailed")}</p>
+        </div>
+      ) : (
+        <FeatureFlagsTable rows={rows} />
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/app/(app)/constituents/constituents-table.tsx
+++ b/packages/web/src/app/(app)/constituents/constituents-table.tsx
@@ -272,7 +272,14 @@ export function ConstituentsTable({
 
   const columns = useMemo<ColumnDef<ConstituentListRow>[]>(
     () => [
-      ...(canManageAdminActions
+      // The select-row checkboxes only earn their place when there's
+      // actually a multi-select action available. Today that's solely
+      // the bulk-email feature (issue #326) — when the
+      // `communication.bulk_email` flag is off, the column is dead
+      // surface area and confuses operators ("what is this for?").
+      // Gate on `bulkEmailEnabled` alongside the role check so the
+      // column disappears in lockstep with the action buttons above.
+      ...(canManageAdminActions && bulkEmailEnabled
         ? [
             {
               id: "select",
@@ -412,7 +419,16 @@ export function ConstituentsTable({
           ]
         : []),
     ],
-    [canManageAdminActions, canWrite, locale, selectedIds, t, togglePageSelection, tType],
+    [
+      bulkEmailEnabled,
+      canManageAdminActions,
+      canWrite,
+      locale,
+      selectedIds,
+      t,
+      togglePageSelection,
+      tType,
+    ],
   );
 
   return (

--- a/packages/web/src/app/(app)/constituents/constituents-table.tsx
+++ b/packages/web/src/app/(app)/constituents/constituents-table.tsx
@@ -103,6 +103,13 @@ interface ConstituentsTableProps {
    * the row dropdown entirely when no action is available.
    */
   canWrite: boolean;
+  /**
+   * `false` when `communication.bulk_email` feature flag is off (PR #352
+   * follow-up; issue #326). Hides the "Email selection" + "Recent emails"
+   * buttons. The API also 404s the bulk-email routes when the flag is
+   * off — this prop is the UI half of the same gate.
+   */
+  bulkEmailEnabled: boolean;
   /** Server-resolved sort/order — see donations-table.tsx for rationale. */
   sort: ConstituentSortField;
   order: ConstituentSortOrder;
@@ -113,6 +120,7 @@ export function ConstituentsTable({
   pagination,
   canManageAdminActions,
   canWrite,
+  bulkEmailEnabled,
   sort,
   order,
 }: ConstituentsTableProps) {
@@ -446,7 +454,7 @@ export function ConstituentsTable({
           {tFilters("advancedLabel")}
           {hasActiveAdvancedFilters ? <Badge variant="info">•</Badge> : null}
         </Button>
-        {canManageAdminActions ? (
+        {canManageAdminActions && bulkEmailEnabled ? (
           <>
             <Button
               type="button"

--- a/packages/web/src/app/(app)/constituents/constituents-table.tsx
+++ b/packages/web/src/app/(app)/constituents/constituents-table.tsx
@@ -2,9 +2,11 @@
 
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import {
+  History,
   Mail,
   MoreHorizontal,
   Pencil,
+  RefreshCw,
   Search,
   SlidersHorizontal,
   Trash2,
@@ -62,7 +64,7 @@ import {
   fullName,
   initials,
 } from "@/models/constituent";
-import { ConstituentService } from "@/services/ConstituentService";
+import { type BulkEmailJobView, ConstituentService } from "@/services/ConstituentService";
 
 type BadgeVariant = "success" | "warning" | "error" | "info" | "neutral";
 
@@ -130,6 +132,12 @@ export function ConstituentsTable({
   // sort/page, a selection is per-tab and not deep-linkable.
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkEmailOpen, setBulkEmailOpen] = useState(false);
+  const [bulkEmailJobsOpen, setBulkEmailJobsOpen] = useState(false);
+  // After a successful dispatch we keep tracking the new job so the
+  // operator can watch the ratio move from 0/N to N/N — addresses the
+  // issue #326 transparency concern: the original "toast and forget"
+  // UX could not tell a "0 of N delivered, worker died" story.
+  const [trackedJobId, setTrackedJobId] = useState<string | null>(null);
   const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false);
 
   const initialLastDonationFrom = searchParams.get("lastDonationFrom") ?? "";
@@ -439,16 +447,28 @@ export function ConstituentsTable({
           {hasActiveAdvancedFilters ? <Badge variant="info">•</Badge> : null}
         </Button>
         {canManageAdminActions ? (
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            onClick={() => setBulkEmailOpen(true)}
-            disabled={selectedIds.size === 0}
-          >
-            <Mail size={16} aria-hidden="true" />
-            {t("bulkEmail.action", { count: selectedIds.size })}
-          </Button>
+          <>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => setBulkEmailJobsOpen(true)}
+              aria-label={t("bulkEmail.jobs.openLabel")}
+            >
+              <History size={16} aria-hidden="true" />
+              {t("bulkEmail.jobs.title")}
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={() => setBulkEmailOpen(true)}
+              disabled={selectedIds.size === 0}
+            >
+              <Mail size={16} aria-hidden="true" />
+              {t("bulkEmail.action", { count: selectedIds.size })}
+            </Button>
+          </>
         ) : null}
       </div>
 
@@ -470,7 +490,24 @@ export function ConstituentsTable({
         open={bulkEmailOpen}
         onOpenChange={setBulkEmailOpen}
         selectedIds={Array.from(selectedIds)}
-        onSent={() => setSelectedIds(new Set())}
+        onSent={(jobId) => {
+          setSelectedIds(new Set());
+          // Auto-open the jobs panel pinned to the new job so the
+          // operator's eye lands on the live progress ratio, not a
+          // disappearing toast.
+          setTrackedJobId(jobId);
+          setBulkEmailJobsOpen(true);
+        }}
+      />
+
+      <BulkEmailJobsDialog
+        open={bulkEmailJobsOpen}
+        onOpenChange={(open) => {
+          setBulkEmailJobsOpen(open);
+          if (!open) setTrackedJobId(null);
+        }}
+        highlightJobId={trackedJobId}
+        onResumed={(newJobId) => setTrackedJobId(newJobId)}
       />
 
       <AdvancedFiltersDialog
@@ -546,7 +583,11 @@ interface BulkEmailDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   selectedIds: string[];
-  onSent: () => void;
+  /**
+   * Receives the freshly-created `bulk_email_jobs.id` so the caller can
+   * pin the jobs panel to it and watch live progress (issue #326).
+   */
+  onSent: (jobId: string) => void;
 }
 
 function BulkEmailDialog({ open, onOpenChange, selectedIds, onSent }: BulkEmailDialogProps) {
@@ -576,7 +617,7 @@ function BulkEmailDialog({ open, onOpenChange, selectedIds, onSent }: BulkEmailD
       setSubject("");
       setBody("");
       onOpenChange(false);
-      onSent();
+      onSent(result.jobId);
     } catch (err) {
       const message =
         err instanceof ApiProblem
@@ -632,6 +673,232 @@ function BulkEmailDialog({ open, onOpenChange, selectedIds, onSent }: BulkEmailD
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/**
+ * Recent bulk-email jobs panel + resume action (issue #326).
+ *
+ * Lists the 20 most-recent `bulk_email_jobs` rows newest first. While any
+ * job is non-terminal (pending / processing), the panel polls every 3s so
+ * the ratio moves in real time — same UX as the postal-export progress
+ * bar. The `Resume` button is gated on the server-side eligibility
+ * (`partial` / `failed` / stalled `processing`); the API decides, the UI
+ * doesn't second-guess.
+ *
+ * `highlightJobId` is a soft visual anchor for the row the parent wants
+ * the operator's eye to land on (most commonly the job we just dispatched
+ * or just resumed) — the row is rendered first if present.
+ */
+interface BulkEmailJobsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  highlightJobId: string | null;
+  onResumed: (newJobId: string) => void;
+}
+
+const BULK_EMAIL_POLL_MS = 3000;
+
+function BulkEmailJobsDialog({
+  open,
+  onOpenChange,
+  highlightJobId,
+  onResumed,
+}: BulkEmailJobsDialogProps) {
+  const t = useTranslations("constituents.bulkEmail.jobs");
+  const [jobs, setJobs] = useState<BulkEmailJobView[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [resumingId, setResumingId] = useState<string | null>(null);
+
+  const fetchJobs = useCallback(async () => {
+    try {
+      const rows = await ConstituentService.listBulkEmailJobs(createClientApiClient());
+      setJobs(rows);
+    } catch (err) {
+      // Console-only: a transient list error shouldn't cover the screen
+      // with a toast that re-fires every 3s. The panel falls back to the
+      // last-known list — same shape as the postal-export polling UI.
+      console.error("bulkEmail.jobs.list failed", err);
+    }
+  }, []);
+
+  // Initial fetch on open, plus poll while any job is in-flight.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    void fetchJobs().finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, fetchJobs]);
+
+  const anyInFlight = useMemo(
+    () => jobs.some((job) => job.status === "pending" || job.status === "processing"),
+    [jobs],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    if (!anyInFlight) return;
+    const id = setInterval(() => {
+      void fetchJobs();
+    }, BULK_EMAIL_POLL_MS);
+    return () => clearInterval(id);
+  }, [open, anyInFlight, fetchJobs]);
+
+  const orderedJobs = useMemo(() => {
+    if (!highlightJobId) return jobs;
+    const anchor = jobs.find((job) => job.id === highlightJobId);
+    if (!anchor) return jobs;
+    return [anchor, ...jobs.filter((job) => job.id !== highlightJobId)];
+  }, [jobs, highlightJobId]);
+
+  const handleResume = useCallback(
+    async (jobId: string) => {
+      setResumingId(jobId);
+      try {
+        const next = await ConstituentService.resumeBulkEmailJob(createClientApiClient(), jobId);
+        toast.success(t("resumeSuccess"));
+        onResumed(next.id);
+        // Optimistically prepend so the operator sees the new row before
+        // the next poll tick lands.
+        setJobs((prev) => [next, ...prev.filter((row) => row.id !== next.id)]);
+      } catch (err) {
+        // Branch on the structured code the API sets in `title`. Falls
+        // back to a generic toast for transport-level errors.
+        const code = err instanceof ApiProblem ? err.title : "";
+        if (code === "job_still_running") {
+          toast.error(t("resumeErrors.still_running"));
+        } else if (code === "nothing_to_resume") {
+          toast.error(t("resumeErrors.nothing_to_resume"));
+        } else {
+          const message =
+            err instanceof ApiProblem
+              ? (err.detail ?? err.title ?? t("resumeErrors.generic"))
+              : t("resumeErrors.generic");
+          toast.error(message);
+        }
+      } finally {
+        setResumingId(null);
+      }
+    },
+    [onResumed, t],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t("title")}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => void fetchJobs()}
+              disabled={loading}
+              aria-label={t("refresh")}
+            >
+              <RefreshCw size={14} aria-hidden="true" />
+              {t("refresh")}
+            </Button>
+          </div>
+          {orderedJobs.length === 0 ? (
+            <p className="text-sm text-on-surface-variant">{t("empty")}</p>
+          ) : (
+            <ul className="space-y-2">
+              {orderedJobs.map((job) => (
+                <BulkEmailJobCard
+                  key={job.id}
+                  job={job}
+                  isHighlighted={job.id === highlightJobId}
+                  onResume={() => void handleResume(job.id)}
+                  resuming={resumingId === job.id}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {t("close")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface BulkEmailJobCardProps {
+  job: BulkEmailJobView;
+  isHighlighted: boolean;
+  onResume: () => void;
+  resuming: boolean;
+}
+
+function BulkEmailJobCard({ job, isHighlighted, onResume, resuming }: BulkEmailJobCardProps) {
+  const t = useTranslations("constituents.bulkEmail.jobs");
+
+  // Derived status for the badge. Stalled is a server-set boolean on top
+  // of `processing`; we surface it as its own status label so the
+  // operator immediately understands "this looks stuck".
+  const effectiveStatus = job.stalled ? "stalled" : job.status;
+  const variant: BadgeVariant =
+    effectiveStatus === "completed"
+      ? "success"
+      : effectiveStatus === "partial" || effectiveStatus === "stalled"
+        ? "warning"
+        : effectiveStatus === "failed"
+          ? "error"
+          : "info";
+
+  // Server already gates resume eligibility (issue #326 service); we
+  // mirror the rule for an immediate UI affordance so the button isn't a
+  // mystery 400 click. Pending / actively-processing rows hide the
+  // button; partial / failed / stalled-processing rows expose it.
+  const canResume =
+    job.deliveredCount < job.totalRecipients &&
+    (job.status === "partial" ||
+      job.status === "failed" ||
+      (job.status === "processing" && job.stalled));
+
+  return (
+    <li
+      className={`rounded-md border border-outline-variant p-3 ${
+        isHighlighted ? "ring-2 ring-primary/40" : ""
+      }`}
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <div className="font-medium text-on-surface">{job.subject || t("subjectFallback")}</div>
+        <Badge variant={variant} shape="square">
+          {t(`status.${effectiveStatus}`)}
+        </Badge>
+      </div>
+      <div className="mt-1 text-sm text-on-surface-variant">
+        {t("ratio", { delivered: job.deliveredCount, total: job.totalRecipients })}
+        {job.failedCount > 0 ? (
+          <span className="ml-2">· {t("failedSuffix", { count: job.failedCount })}</span>
+        ) : null}
+      </div>
+      {canResume ? (
+        <div className="mt-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onResume}
+            disabled={resuming}
+          >
+            {resuming ? t("resuming") : t("resume")}
+          </Button>
+        </div>
+      ) : null}
+    </li>
   );
 }
 

--- a/packages/web/src/app/(app)/constituents/page.tsx
+++ b/packages/web/src/app/(app)/constituents/page.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { Plus, Users } from "lucide-react";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
@@ -15,6 +16,7 @@ import type {
   ConstituentType,
 } from "@/models/constituent";
 import { ConstituentService } from "@/services/ConstituentService";
+import { FeatureFlagsService, isFlagEnabled } from "@/services/FeatureFlagsService";
 
 import { ConstituentsTable } from "./constituents-table";
 
@@ -84,6 +86,20 @@ export default async function ConstituentsPage({ searchParams }: ConstituentsPag
 
   const client = await createServerApiClient();
 
+  // SSR fetch of the global feature flags — used here to hide the
+  // bulk-email surfaces (Email selection button + Recent emails
+  // panel) when the `communication.bulk_email` flag is off. PR #352
+  // / issue #326. A network failure here defaults the flag to OFF
+  // (safest posture — if we can't confirm the feature is on, don't
+  // render it).
+  let bulkEmailEnabled = false;
+  try {
+    const flags = await FeatureFlagsService.listPublic(client);
+    bulkEmailEnabled = isFlagEnabled(flags, FEATURE_FLAG_KEYS.COMMUNICATION_BULK_EMAIL);
+  } catch {
+    bulkEmailEnabled = false;
+  }
+
   let result: ConstituentListResponse;
   try {
     result = await ConstituentService.listConstituents(client, {
@@ -133,6 +149,7 @@ export default async function ConstituentsPage({ searchParams }: ConstituentsPag
           pagination={result.pagination}
           canManageAdminActions={canManageAdminActions}
           canWrite={canWrite}
+          bulkEmailEnabled={bulkEmailEnabled}
           sort={sort}
           order={order}
         />

--- a/packages/web/src/components/admin/feature-flags-table.test.tsx
+++ b/packages/web/src/components/admin/feature-flags-table.test.tsx
@@ -1,0 +1,102 @@
+import { ApiProblem } from "@/lib/api";
+import { FeatureFlagsService } from "@/services/FeatureFlagsService";
+import { mockToast, render, screen, userEvent, waitFor } from "@/tests/test-utils";
+
+import { FeatureFlagsTable } from "./feature-flags-table";
+
+/**
+ * Render + optimistic toggle test for the super-admin Back Office
+ * surface (PR #352 / @magino follow-up). The component owns
+ * optimistic UI: clicking the toggle flips the local state IMMEDIATELY,
+ * fires `FeatureFlagsService.setEnabled`, and rolls back on error.
+ * The QA review (M3) called the optimistic+rollback path "non-trivial
+ * logic with zero tests" — pin both branches here.
+ */
+vi.mock("@/services/FeatureFlagsService", () => ({
+  FeatureFlagsService: {
+    setEnabled: vi.fn(),
+  },
+  isFlagEnabled: vi.fn(),
+}));
+
+vi.mock("@/lib/api/client-browser", () => ({
+  createClientApiClient: () => ({}),
+}));
+
+const baseRow = {
+  key: "communication.bulk_email",
+  enabled: false,
+  description: "Operator-triggered bulk email — disabled until DKIM/SPF is configured.",
+  updatedBy: null,
+  createdAt: "2026-05-10T10:00:00.000Z",
+  updatedAt: "2026-05-10T10:00:00.000Z",
+};
+
+describe("FeatureFlagsTable", () => {
+  beforeEach(() => {
+    vi.mocked(FeatureFlagsService.setEnabled).mockReset();
+    mockToast.success.mockClear();
+    mockToast.error.mockClear();
+  });
+
+  it("renders one row per flag with the key + description + status badge", () => {
+    render(<FeatureFlagsTable rows={[baseRow]} />);
+
+    expect(screen.getByText("communication.bulk_email")).toBeInTheDocument();
+    expect(screen.getByText(/DKIM\/SPF/)).toBeInTheDocument();
+    // Default-disabled badge + Enable button (mirror of the toggle state).
+    // Use an exact match — the description literally contains the word
+    // "disabled" too, which would make a loose /Disabled/i match
+    // multi-element.
+    expect(screen.getByText("Disabled", { exact: true })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument();
+  });
+
+  it("optimistically flips the button label on click + toasts success", async () => {
+    const user = userEvent.setup();
+    vi.mocked(FeatureFlagsService.setEnabled).mockResolvedValue({ ...baseRow, enabled: true });
+
+    render(<FeatureFlagsTable rows={[baseRow]} />);
+
+    await user.click(screen.getByRole("button", { name: /Enable/i }));
+
+    // After the click, the optimistic flip means the button has
+    // already become "Disable" before the API resolves.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Disable/i })).toBeInTheDocument();
+    });
+    expect(FeatureFlagsService.setEnabled).toHaveBeenCalledWith(
+      expect.anything(),
+      "communication.bulk_email",
+      true,
+    );
+    expect(mockToast.success).toHaveBeenCalled();
+  });
+
+  it("rolls back the optimistic flip when the API call fails", async () => {
+    const user = userEvent.setup();
+    vi.mocked(FeatureFlagsService.setEnabled).mockRejectedValue(
+      new ApiProblem({
+        type: "https://httpproblems.com/http-status/500",
+        title: "Internal Server Error",
+        status: 500,
+        detail: "boom",
+      }),
+    );
+
+    render(<FeatureFlagsTable rows={[baseRow]} />);
+    await user.click(screen.getByRole("button", { name: /Enable/i }));
+
+    // After the rejection, the button label MUST have rolled back to
+    // "Enable" — no stale optimistic state stranded.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument();
+    });
+    expect(mockToast.error).toHaveBeenCalled();
+  });
+
+  it("renders the empty-state message when the registry is empty", () => {
+    render(<FeatureFlagsTable rows={[]} />);
+    expect(screen.getByText(/No feature flags registered\./)).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/admin/feature-flags-table.test.tsx
+++ b/packages/web/src/components/admin/feature-flags-table.test.tsx
@@ -26,7 +26,9 @@ vi.mock("@/lib/api/client-browser", () => ({
 const baseRow = {
   key: "communication.bulk_email",
   enabled: false,
-  description: "Operator-triggered bulk email — disabled until DKIM/SPF is configured.",
+  label: "Bulk emails to constituents",
+  description:
+    "Lets operators send one email to several constituents at once from the Constituents page.",
   updatedBy: null,
   createdAt: "2026-05-10T10:00:00.000Z",
   updatedAt: "2026-05-10T10:00:00.000Z",
@@ -39,15 +41,18 @@ describe("FeatureFlagsTable", () => {
     mockToast.error.mockClear();
   });
 
-  it("renders one row per flag with the key + description + status badge", () => {
+  it("renders the friendly label as the heading, with the dotted key + description as supporting text", () => {
     render(<FeatureFlagsTable rows={[baseRow]} />);
 
+    // The user-visible heading is the friendly `label`, NOT the
+    // dotted `key`. The key still renders as a small subtitle so
+    // engineers can correlate `audit_logs.action = PATCH:/…/:key`.
+    expect(
+      screen.getByRole("heading", { name: /Bulk emails to constituents/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText("communication.bulk_email")).toBeInTheDocument();
-    expect(screen.getByText(/DKIM\/SPF/)).toBeInTheDocument();
+    expect(screen.getByText(/send one email to several constituents/i)).toBeInTheDocument();
     // Default-disabled badge + Enable button (mirror of the toggle state).
-    // Use an exact match — the description literally contains the word
-    // "disabled" too, which would make a loose /Disabled/i match
-    // multi-element.
     expect(screen.getByText("Disabled", { exact: true })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument();
   });

--- a/packages/web/src/components/admin/feature-flags-table.tsx
+++ b/packages/web/src/components/admin/feature-flags-table.tsx
@@ -86,16 +86,23 @@ export function FeatureFlagsTable({ rows: initialRows }: FeatureFlagsTableProps)
         >
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div className="space-y-1">
-              <div className="flex items-center gap-2">
-                <code className="rounded bg-surface-container-highest px-2 py-0.5 text-sm font-mono text-on-surface">
-                  {row.key}
-                </code>
+              {/*
+                Heading is the friendly `label` (e.g. "Bulk emails to
+                constituents"), not the dotted `key`. The key still
+                renders below as a small monospaced subtitle so an
+                engineer reading audit_logs can match
+                `PATCH:/v1/admin/feature-flags/:key` back to a row.
+              */}
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="font-medium text-on-surface">{row.label}</h2>
                 <Badge variant={row.enabled ? "success" : "neutral"} shape="square">
                   {row.enabled ? t("status.enabled") : t("status.disabled")}
                 </Badge>
               </div>
               <p className="text-sm text-on-surface-variant">{row.description}</p>
               <p className="text-xs text-on-surface-variant">
+                <code className="font-mono">{row.key}</code>
+                <span className="mx-1">·</span>
                 {t("lastUpdated", { date: formatDate(row.updatedAt, locale) })}
               </p>
             </div>

--- a/packages/web/src/components/admin/feature-flags-table.tsx
+++ b/packages/web/src/components/admin/feature-flags-table.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { formatDate } from "@/lib/format";
+import { type FeatureFlagRow, FeatureFlagsService } from "@/services/FeatureFlagsService";
+
+/**
+ * Feature-flag toggle table — super-admin Back Office (PR #352
+ * follow-up). One row per registered flag. Tile-style cards instead of
+ * a `<table>` because the only "data" is a key + description + a
+ * single toggle; a flat list reads cleaner than a 4-column table on
+ * mobile and we never expect more than ~10 rows.
+ *
+ * The Enable / Disable button is the entire toggle — no <Switch>
+ * component because the project doesn't ship one yet, and a labelled
+ * Button ("Disable communication.bulk_email") is more accessible than
+ * a hand-rolled checkbox-styled-as-switch for an action that has
+ * platform-wide consequences.
+ *
+ * Optimistic update + rollback on failure: clicking the button flips
+ * the local state immediately so the operator sees instant feedback;
+ * if the API call fails we revert + toast the error. Same pattern as
+ * the donations status toggle.
+ */
+interface FeatureFlagsTableProps {
+  rows: FeatureFlagRow[];
+}
+
+export function FeatureFlagsTable({ rows: initialRows }: FeatureFlagsTableProps) {
+  const t = useTranslations("admin.featureFlags");
+  const locale = useLocale();
+  const [rows, setRows] = useState<FeatureFlagRow[]>(initialRows);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  if (rows.length === 0) {
+    return <p className="text-sm text-on-surface-variant">{t("empty")}</p>;
+  }
+
+  const handleToggle = async (row: FeatureFlagRow) => {
+    setBusyKey(row.key);
+    const previousEnabled = row.enabled;
+    // Optimistic flip — instant UI feedback.
+    setRows((prev) =>
+      prev.map((r) => (r.key === row.key ? { ...r, enabled: !previousEnabled } : r)),
+    );
+    try {
+      const updated = await FeatureFlagsService.setEnabled(
+        createClientApiClient(),
+        row.key,
+        !previousEnabled,
+      );
+      setRows((prev) => prev.map((r) => (r.key === row.key ? updated : r)));
+      toast.success(
+        updated.enabled
+          ? t("toast.enabled", { key: row.key })
+          : t("toast.disabled", { key: row.key }),
+      );
+    } catch (err) {
+      // Roll back to the pre-click value.
+      setRows((prev) =>
+        prev.map((r) => (r.key === row.key ? { ...r, enabled: previousEnabled } : r)),
+      );
+      const message =
+        err instanceof ApiProblem
+          ? (err.detail ?? err.title ?? t("toast.error"))
+          : t("toast.error");
+      toast.error(message);
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  return (
+    <ul className="space-y-3">
+      {rows.map((row) => (
+        <li
+          key={row.key}
+          className="rounded-2xl border border-outline-variant bg-surface p-4 shadow-sm"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <code className="rounded bg-surface-container-highest px-2 py-0.5 text-sm font-mono text-on-surface">
+                  {row.key}
+                </code>
+                <Badge variant={row.enabled ? "success" : "neutral"} shape="square">
+                  {row.enabled ? t("status.enabled") : t("status.disabled")}
+                </Badge>
+              </div>
+              <p className="text-sm text-on-surface-variant">{row.description}</p>
+              <p className="text-xs text-on-surface-variant">
+                {t("lastUpdated", { date: formatDate(row.updatedAt, locale) })}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant={row.enabled ? "secondary" : "primary"}
+              size="sm"
+              disabled={busyKey === row.key}
+              onClick={() => void handleToggle(row)}
+            >
+              {busyKey === row.key
+                ? t("actions.saving")
+                : row.enabled
+                  ? t("actions.disable")
+                  : t("actions.enable")}
+            </Button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -3,6 +3,7 @@
 import {
   Building2,
   ChevronsUpDown,
+  Flag,
   Gift,
   LayoutDashboard,
   LogOut,
@@ -45,7 +46,7 @@ interface NavItem {
 
 interface AdminNavItem {
   href: string;
-  labelKey: "tenants" | "disputes" | "impersonation" | "platformAdmins";
+  labelKey: "tenants" | "disputes" | "impersonation" | "platformAdmins" | "featureFlags";
   icon: ComponentType<SVGProps<SVGSVGElement> & { size?: number | string }>;
 }
 
@@ -71,6 +72,7 @@ const ADMIN_NAV_ITEMS: AdminNavItem[] = [
   { href: "/admin/disputes", labelKey: "disputes", icon: ShieldAlert },
   { href: "/admin/impersonation", labelKey: "impersonation", icon: UserCog },
   { href: "/admin/platform-admins", labelKey: "platformAdmins", icon: ShieldCheck },
+  { href: "/admin/feature-flags", labelKey: "featureFlags", icon: Flag },
 ];
 
 interface SidebarProps {

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -314,7 +314,8 @@
         "tenants": "Tenants",
         "disputes": "Disputes",
         "impersonation": "Support sessions",
-        "platformAdmins": "Platform admins"
+        "platformAdmins": "Platform admins",
+        "featureFlags": "Feature flags"
       }
     },
     "topbar": {
@@ -438,6 +439,27 @@
         "resumeAction": "Resume session",
         "resumeCancel": "Cancel"
       }
+    },
+    "featureFlags": {
+      "title": "Feature flags",
+      "subtitle": "Global on/off switches for platform-wide features. Disabled flags hide the matching surfaces from operators and short-circuit the matching worker jobs.",
+      "fetchFailed": "Could not load the feature flags. Please refresh the page.",
+      "empty": "No feature flags registered.",
+      "status": {
+        "enabled": "Enabled",
+        "disabled": "Disabled"
+      },
+      "actions": {
+        "enable": "Enable",
+        "disable": "Disable",
+        "saving": "Saving…"
+      },
+      "toast": {
+        "enabled": "Enabled {key}",
+        "disabled": "Disabled {key}",
+        "error": "Could not update this flag. Please try again."
+      },
+      "lastUpdated": "Last updated {date}"
     },
     "disputes": {
       "list": {

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1648,6 +1648,32 @@
       "errors": {
         "empty": "Please fill in both subject and message before sending.",
         "send": "Could not queue the bulk email. Please try again."
+      },
+      "jobs": {
+        "title": "Recent emails",
+        "openLabel": "Recent emails",
+        "empty": "No bulk emails sent yet.",
+        "ratio": "{delivered} of {total} delivered",
+        "subjectFallback": "(no subject)",
+        "status": {
+          "pending": "Queued",
+          "processing": "Sending…",
+          "completed": "Delivered",
+          "partial": "Partial",
+          "failed": "Failed",
+          "stalled": "Stalled"
+        },
+        "failedSuffix": "{count, plural, one {# failed} other {# failed}}",
+        "resume": "Resume to remaining",
+        "resuming": "Resuming…",
+        "close": "Close",
+        "refresh": "Refresh",
+        "resumeSuccess": "Resume queued. Tracking new job…",
+        "resumeErrors": {
+          "still_running": "The original job is still delivering. Wait until it finishes or stalls.",
+          "nothing_to_resume": "Everyone has already received this email.",
+          "generic": "Could not resume this email. Please try again."
+        }
       }
     },
     "deleteDialog": {

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1648,6 +1648,32 @@
       "errors": {
         "empty": "Renseignez un objet et un message avant l'envoi.",
         "send": "Impossible d'envoyer. Veuillez réessayer."
+      },
+      "jobs": {
+        "title": "Emails récents",
+        "openLabel": "Emails récents",
+        "empty": "Aucun email groupé envoyé pour l'instant.",
+        "ratio": "{delivered} sur {total} livrés",
+        "subjectFallback": "(sans objet)",
+        "status": {
+          "pending": "En file",
+          "processing": "Envoi en cours…",
+          "completed": "Livrés",
+          "partial": "Partiel",
+          "failed": "Échec",
+          "stalled": "Bloqué"
+        },
+        "failedSuffix": "{count, plural, one {# échec} other {# échecs}}",
+        "resume": "Renvoyer aux destinataires restants",
+        "resuming": "Reprise en cours…",
+        "close": "Fermer",
+        "refresh": "Actualiser",
+        "resumeSuccess": "Reprise en file. Suivi du nouvel envoi…",
+        "resumeErrors": {
+          "still_running": "Le job d'origine est toujours en cours. Attendez qu'il termine ou se bloque.",
+          "nothing_to_resume": "Tous les destinataires ont déjà reçu cet email.",
+          "generic": "Impossible de reprendre cet envoi. Veuillez réessayer."
+        }
       }
     },
     "deleteDialog": {

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -314,7 +314,8 @@
         "tenants": "Tenants",
         "disputes": "Litiges",
         "impersonation": "Sessions de support",
-        "platformAdmins": "Admins plateforme"
+        "platformAdmins": "Admins plateforme",
+        "featureFlags": "Feature flags"
       }
     },
     "topbar": {
@@ -438,6 +439,27 @@
         "resumeAction": "Reprendre la session",
         "resumeCancel": "Annuler"
       }
+    },
+    "featureFlags": {
+      "title": "Feature flags",
+      "subtitle": "Interrupteurs globaux on/off pour les fonctionnalités plateforme. Désactivés, ils masquent les surfaces correspondantes côté opérateurs et coupent court aux jobs du worker.",
+      "fetchFailed": "Impossible de charger les feature flags. Veuillez rafraîchir la page.",
+      "empty": "Aucun feature flag enregistré.",
+      "status": {
+        "enabled": "Activé",
+        "disabled": "Désactivé"
+      },
+      "actions": {
+        "enable": "Activer",
+        "disable": "Désactiver",
+        "saving": "Enregistrement…"
+      },
+      "toast": {
+        "enabled": "{key} activé",
+        "disabled": "{key} désactivé",
+        "error": "Impossible de mettre à jour ce flag. Veuillez réessayer."
+      },
+      "lastUpdated": "Mis à jour {date}"
     },
     "disputes": {
       "list": {

--- a/packages/web/src/services/ConstituentService.ts
+++ b/packages/web/src/services/ConstituentService.ts
@@ -8,6 +8,28 @@ import type {
 } from "@/models/constituent";
 
 /**
+ * Snapshot of a bulk-email job — mirrors the API's `BulkEmailJobRowSchema`.
+ * Issue #326: drives the "Recent emails" panel and the per-job polling
+ * progress indicator on the constituents page.
+ */
+export interface BulkEmailJobView {
+  id: string;
+  status: "pending" | "processing" | "completed" | "partial" | "failed";
+  subject: string;
+  /** True when API has detected the job stalled (worker died mid-fan-out). */
+  stalled: boolean;
+  totalRecipients: number;
+  deliveredCount: number;
+  failedCount: number;
+  requestedBy: string | null;
+  parentJobId: string | null;
+  error: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+/**
  * ConstituentService — ADR-011 Layer 2 (services).
  *
  * Thin adapter over the typed ApiClient that maps HTTP responses to the
@@ -69,8 +91,12 @@ export const ConstituentService = {
 
   /**
    * Bulk-send a transactional email to a selection of constituents (Epic
-   * #274). Returns the queued + skipped counts; the API's 202 response
-   * means the dispatch is now in the outbox, not that mail has been sent.
+   * #274; partial-send tracking per issue #326).
+   *
+   * The API's 202 response means the dispatch is now in the outbox + a
+   * `bulk_email_jobs` row has been created — NOT that mail has been
+   * sent. `jobId` is the tracking id the UI uses to poll for live
+   * delivered/total progress.
    */
   async sendBulkEmail(
     client: ApiClient,
@@ -79,10 +105,41 @@ export const ConstituentService = {
       subject: string;
       body: string;
     },
-  ): Promise<{ queued: number; skippedNoEmail: number }> {
+  ): Promise<{ jobId: string; queued: number; skippedNoEmail: number }> {
     const response = await client.post<{
-      data: { queued: number; skippedNoEmail: number };
+      data: { jobId: string; queued: number; skippedNoEmail: number };
     }>("/v1/constituents/bulk-email", input);
+    return response.data;
+  },
+
+  /** List recent bulk-email jobs (newest 20) — issue #326. */
+  async listBulkEmailJobs(client: ApiClient): Promise<BulkEmailJobView[]> {
+    const response = await client.get<{ data: BulkEmailJobView[] }>(
+      "/v1/constituents/bulk-email-jobs",
+    );
+    return response.data;
+  },
+
+  /** Poll a single bulk-email job for live progress — issue #326. */
+  async getBulkEmailJob(client: ApiClient, id: string): Promise<BulkEmailJobView> {
+    const response = await client.get<{ data: BulkEmailJobView }>(
+      `/v1/constituents/bulk-email-jobs/${encodeURIComponent(id)}`,
+    );
+    return response.data;
+  },
+
+  /**
+   * Resume a bulk-email job — re-targets the recipients the source job
+   * never reached. The API decides eligibility (`partial` / `failed` /
+   * stalled `processing`) and returns the new job; 400 / 404 surface
+   * structured codes the caller can branch on (`job_still_running`,
+   * `nothing_to_resume`, `job_not_found`). Issue #326.
+   */
+  async resumeBulkEmailJob(client: ApiClient, id: string): Promise<BulkEmailJobView> {
+    const response = await client.post<{ data: BulkEmailJobView }>(
+      `/v1/constituents/bulk-email-jobs/${encodeURIComponent(id)}/resume`,
+      {},
+    );
     return response.data;
   },
 

--- a/packages/web/src/services/FeatureFlagsService.ts
+++ b/packages/web/src/services/FeatureFlagsService.ts
@@ -1,0 +1,76 @@
+import type { ApiClient } from "@/lib/api";
+
+/**
+ * Back-office service for the platform-wide feature-flag registry
+ * (PR #352 follow-up; see `docs/18-feature-flags.md`).
+ *
+ * Read endpoint is super-admin-gated (404 to anyone else). The page
+ * fetches once server-side via `createServerApiClient` and renders
+ * a toggle UI; per-row PATCH calls flow through the browser client.
+ */
+
+export interface FeatureFlagRow {
+  key: string;
+  enabled: boolean;
+  description: string;
+  updatedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ListResponse {
+  data: FeatureFlagRow[];
+}
+
+interface PatchResponse {
+  data: FeatureFlagRow;
+}
+
+/**
+ * Tenant-facing projection — just `{ key, enabled }`. Returned by the
+ * non-super-admin `/v1/feature-flags` GET so tenant pages can decide
+ * whether to render a gated UI surface without seeing the admin
+ * metadata (description, updatedBy).
+ */
+export interface PublicFeatureFlag {
+  key: string;
+  enabled: boolean;
+}
+
+interface PublicListResponse {
+  data: PublicFeatureFlag[];
+}
+
+export const FeatureFlagsService = {
+  /** Super-admin list — drives the Back Office page. */
+  async list(client: ApiClient): Promise<FeatureFlagRow[]> {
+    const response = await client.get<ListResponse>("/v1/admin/feature-flags");
+    return response.data;
+  },
+
+  /**
+   * Tenant-readable list. Returns just `{ key, enabled }` for every
+   * flag. Used by tenant pages to hide gated UI surfaces SSR-side.
+   * Safe to call from any authenticated caller.
+   */
+  async listPublic(client: ApiClient): Promise<PublicFeatureFlag[]> {
+    const response = await client.get<PublicListResponse>("/v1/feature-flags");
+    return response.data;
+  },
+
+  async setEnabled(client: ApiClient, key: string, enabled: boolean): Promise<FeatureFlagRow> {
+    const response = await client.patch<PatchResponse>(
+      `/v1/admin/feature-flags/${encodeURIComponent(key)}`,
+      { enabled },
+    );
+    return response.data;
+  },
+};
+
+/**
+ * Helper: O(1) lookup of a flag value from a list. Returns `false` on
+ * unknown key (matches the API + worker posture in doc 18 §5).
+ */
+export function isFlagEnabled(flags: PublicFeatureFlag[], key: string): boolean {
+  return flags.find((flag) => flag.key === key)?.enabled === true;
+}

--- a/packages/web/src/services/FeatureFlagsService.ts
+++ b/packages/web/src/services/FeatureFlagsService.ts
@@ -12,6 +12,9 @@ import type { ApiClient } from "@/lib/api";
 export interface FeatureFlagRow {
   key: string;
   enabled: boolean;
+  /** Short, friendly heading (e.g. "Bulk emails to constituents"). */
+  label: string;
+  /** One or two sentences in plain language explaining what the feature does. */
   description: string;
   updatedBy: string | null;
   createdAt: string;

--- a/packages/worker/src/lib/flags.ts
+++ b/packages/worker/src/lib/flags.ts
@@ -17,11 +17,17 @@
  *     failure — that's how a flagged-off feature accidentally fires).
  */
 
+import type { FeatureFlagKey } from "@givernance/shared/constants";
 import { featureFlags } from "@givernance/shared/schema";
 import { eq } from "drizzle-orm";
 import { db } from "./db.js";
 
-export async function isFlagEnabled(key: string): Promise<boolean> {
+/**
+ * `key` is the typed `FeatureFlagKey` union so a worker processor
+ * cannot accidentally pass a string that doesn't exist in the
+ * registry. (PR #352 Platform review Plat-LOW-8.)
+ */
+export async function isFlagEnabled(key: FeatureFlagKey): Promise<boolean> {
   const [row] = await db
     .select({ enabled: featureFlags.enabled })
     .from(featureFlags)

--- a/packages/worker/src/lib/flags.ts
+++ b/packages/worker/src/lib/flags.ts
@@ -1,0 +1,31 @@
+/**
+ * Worker-side feature flag evaluator. Mirrors the API's
+ * `flag-service.ts` but reads PG directly via the worker's owner-role
+ * pool — no Redis cache. Workers are stateless and check a flag at
+ * most once per job; the round-trip to PG is in the noise next to the
+ * SMTP send / S3 upload that follows.
+ *
+ * Why a worker-side copy (rather than an HTTP call into the API): the
+ * worker process must not depend on the API process being up. Flag
+ * evaluation is a critical-path defence-in-depth check for any gated
+ * processor — if the API was down at deploy time, the worker must
+ * still correctly drop disabled-feature jobs.
+ *
+ * Same posture as the API:
+ *   - Unknown keys evaluate to `false` (doc 18 §5).
+ *   - Errors are surfaced (don't silently say "enabled" on a DB
+ *     failure — that's how a flagged-off feature accidentally fires).
+ */
+
+import { featureFlags } from "@givernance/shared/schema";
+import { eq } from "drizzle-orm";
+import { db } from "./db.js";
+
+export async function isFlagEnabled(key: string): Promise<boolean> {
+  const [row] = await db
+    .select({ enabled: featureFlags.enabled })
+    .from(featureFlags)
+    .where(eq(featureFlags.key, key))
+    .limit(1);
+  return row?.enabled === true;
+}

--- a/packages/worker/src/processors/send-bulk-email.ts
+++ b/packages/worker/src/processors/send-bulk-email.ts
@@ -27,12 +27,14 @@
  * selection.
  */
 
+import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import type { SendBulkEmailJob } from "@givernance/shared/jobs";
 import { bulkEmailJobs, constituents } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
 import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { withWorkerContext } from "../lib/db.js";
 import { defaultEmailSender, type EmailSender } from "../lib/email.js";
+import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
 
 function escapeHtml(value: string): string {
@@ -84,6 +86,13 @@ function renderText(body: string, recipientName: string): string {
  */
 export interface ProcessSendBulkEmailDeps {
   emailSender?: EmailSender;
+  /**
+   * Test-seam: production wires `isFlagEnabled` (PG read). Worker
+   * integration tests override this to assert the flag-off short-
+   * circuit without seeding the registry. Returns `true` when omitted
+   * for test setups that don't care about the gate.
+   */
+  isFlagEnabled?: (key: string) => Promise<boolean>;
 }
 
 export async function processSendBulkEmail(
@@ -93,6 +102,24 @@ export async function processSendBulkEmail(
   const data = job.data;
   const log = jobLogger({ tenantId: data.orgId, jobId: job.id });
   const sender = deps.emailSender ?? defaultEmailSender;
+  const evaluateFlag = deps.isFlagEnabled ?? isFlagEnabled;
+
+  // Defence-in-depth flag gate. The API route already checks the flag
+  // (`requireFlag` 404s a disabled feature), but a flipped-off flag
+  // can race a relay tick that already enqueued the job — the worker
+  // is the second wall. Dropping silently here is the correct
+  // posture: the operator's UI already shows the dispatch toast, and
+  // the DB row stays at `pending` until the admin either flips the
+  // flag back on (a retry will then resume), explicitly cancels, or
+  // the row falls out of the 20-row recent list.
+  const featureEnabled = await evaluateFlag(FEATURE_FLAG_KEYS.COMMUNICATION_BULK_EMAIL);
+  if (!featureEnabled) {
+    log.warn(
+      { orgId: data.orgId, bulkEmailJobId: data.bulkEmailJobId },
+      "Bulk email feature flag is off — dropping job without sending",
+    );
+    return { sent: 0, failed: 0, skipped: 0 };
+  }
 
   const bulkEmailJobId = data.bulkEmailJobId;
   if (!bulkEmailJobId) {

--- a/packages/worker/src/processors/send-bulk-email.ts
+++ b/packages/worker/src/processors/send-bulk-email.ts
@@ -1,38 +1,39 @@
 /**
- * Bulk-email processor (Epic #274).
+ * Bulk-email processor (Epic #274; partial-send tracking per issue #326).
  *
- * Inputs: a `segmentFilter` carrying the rendered subject + body and the
- * **constituent id list** captured by the API at request time. The
- * processor re-resolves email + name from the database under the worker's
- * RLS context — PII never touches the outbox JSONB nor Redis (GDPR
- * Art. 5(1)(e) storage minimisation; see `bulk-email-service.ts` for the
- * full rationale).
+ * Input: `bulkEmailJobId` referencing a `bulk_email_jobs` row. The
+ * processor reads subject, body, and the deliverable constituent_ids
+ * snapshot from the row, re-resolves email + name from `constituents`
+ * under the worker's RLS context (PII never touches Redis), and walks
+ * the recipient list sequentially. Each successful send appends the
+ * recipient id to `delivered_constituent_ids` and bumps `delivered_count`
+ * in the same UPDATE; each SMTP failure does the same to the `failed_*`
+ * column pair.
  *
- * If a constituent has been soft-deleted between request and send, they
- * are silently dropped (right-to-erasure honoured at send time, not at
- * request time). If their email has been removed they are reported as
- * `failed` in the job summary.
+ * Why incremental per-send updates (vs. a single end-of-job UPDATE):
+ *   - The polling UI sees the ratio move in real time — same UX as the
+ *     postal-export progress bar.
+ *   - On worker process death (Redis wipe, accessory reboot, OOM kill),
+ *     the row stays at its last successful update. The operator sees the
+ *     partial ratio and can hit "Resume" to re-target the remaining
+ *     recipients (issue #326). Without per-send updates, a dropped job
+ *     would leave the row at 0/N — indistinguishable from "never started".
  *
- * Each recipient is sent in series via the configured `EmailSender`
- * (Mailpit in dev, Resend in prod). Per-recipient failures are logged
- * but do not fail the whole job — partial delivery beats no delivery for
- * an admin-triggered campaign.
+ * Soft-deleted constituents (deletedAt IS NOT NULL) are silently dropped
+ * at send time so a right-to-erasure between request and send is
+ * honoured. They count as neither delivered nor failed: the gap surfaces
+ * as `total - delivered - failed > 0` which the operator can resolve by
+ * (a) accepting the lower headcount or (b) re-running with a fresh
+ * selection.
  */
 
 import type { SendBulkEmailJob } from "@givernance/shared/jobs";
-import { constituents } from "@givernance/shared/schema";
+import { bulkEmailJobs, constituents } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
-import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { withWorkerContext } from "../lib/db.js";
-import { defaultEmailSender } from "../lib/email.js";
+import { defaultEmailSender, type EmailSender } from "../lib/email.js";
 import { jobLogger } from "../lib/logger.js";
-
-interface BulkEmailSegmentFilter {
-  subject?: string;
-  body?: string;
-  constituentIds?: string[];
-  requestedBy?: string;
-}
 
 function escapeHtml(value: string): string {
   return value
@@ -76,18 +77,100 @@ function renderText(body: string, recipientName: string): string {
   return `${greeting}\n\n${body}\n\n— Sent via Givernance.`;
 }
 
-export async function processSendBulkEmail(job: Job<SendBulkEmailJob["data"]>) {
+/**
+ * Test-seam: the production code wires `defaultEmailSender` here. Worker
+ * integration tests inject a recording sender so they can assert per-
+ * recipient send semantics without booting a real SMTP transport.
+ */
+export interface ProcessSendBulkEmailDeps {
+  emailSender?: EmailSender;
+}
+
+export async function processSendBulkEmail(
+  job: Job<SendBulkEmailJob["data"]>,
+  deps: ProcessSendBulkEmailDeps = {},
+): Promise<{ sent: number; failed: number; skipped: number }> {
   const data = job.data;
-  const segment = (data.segmentFilter ?? {}) as BulkEmailSegmentFilter;
   const log = jobLogger({ tenantId: data.orgId, jobId: job.id });
+  const sender = deps.emailSender ?? defaultEmailSender;
 
-  const subject = segment.subject ?? "Message from your nonprofit";
-  const body = segment.body ?? "";
-  const constituentIds = segment.constituentIds ?? [];
+  const bulkEmailJobId = data.bulkEmailJobId;
+  if (!bulkEmailJobId) {
+    log.warn(
+      { orgId: data.orgId },
+      "Bulk email job dispatched without bulkEmailJobId — nothing to do",
+    );
+    return { sent: 0, failed: 0, skipped: 0 };
+  }
 
-  if (constituentIds.length === 0) {
-    log.warn({ orgId: data.orgId }, "Bulk email job had no constituent ids, no-op");
-    return { sent: 0, failed: 0 };
+  // Load the tracking row + flip to `processing` in one round-trip. If the
+  // row was already terminal (a duplicate-delivery retry of the BullMQ
+  // job, e.g. job-id re-add during a Redis hand-off), short-circuit so
+  // we don't accidentally fan out to recipients twice. The transition is
+  // idempotent: status moves from `pending` to `processing` once.
+  const tracking = await withWorkerContext(data.orgId, async (tx) => {
+    const [row] = await tx
+      .select({
+        id: bulkEmailJobs.id,
+        status: bulkEmailJobs.status,
+        subject: bulkEmailJobs.subject,
+        body: bulkEmailJobs.body,
+        constituentIds: bulkEmailJobs.constituentIds,
+        deliveredConstituentIds: bulkEmailJobs.deliveredConstituentIds,
+        failedConstituentIds: bulkEmailJobs.failedConstituentIds,
+        totalRecipients: bulkEmailJobs.totalRecipients,
+      })
+      .from(bulkEmailJobs)
+      .where(
+        and(
+          eq(bulkEmailJobs.id, bulkEmailJobId),
+          eq(bulkEmailJobs.orgId, data.orgId),
+          isNull(bulkEmailJobs.deletedAt),
+        ),
+      );
+    if (!row) return null;
+
+    // Already terminal — duplicate retry. Don't re-run.
+    if (row.status === "completed" || row.status === "partial" || row.status === "failed") {
+      return { ...row, alreadyTerminal: true };
+    }
+
+    await tx
+      .update(bulkEmailJobs)
+      .set({ status: "processing", updatedAt: new Date() })
+      .where(eq(bulkEmailJobs.id, bulkEmailJobId));
+    return { ...row, alreadyTerminal: false };
+  });
+
+  if (!tracking) {
+    log.warn({ bulkEmailJobId }, "Bulk email job row not found — outbox/DB drift");
+    return { sent: 0, failed: 0, skipped: 0 };
+  }
+  if (tracking.alreadyTerminal) {
+    log.info(
+      { bulkEmailJobId, status: tracking.status },
+      "Bulk email job already terminal — skipping duplicate retry",
+    );
+    return { sent: 0, failed: 0, skipped: 0 };
+  }
+
+  // Compute the work list: recipients in the snapshot who have NOT yet
+  // been delivered AND have NOT yet been recorded as failed. On a fresh
+  // job both sets are empty so this is just `constituent_ids`. On a
+  // retry-after-partial (e.g. a BullMQ retry that the queue itself
+  // recovered, rather than a Resume) this skips the recipients the
+  // previous attempt already handled — same idempotency posture as the
+  // postal-export retry path.
+  const delivered = new Set(tracking.deliveredConstituentIds ?? []);
+  const previouslyFailed = new Set(tracking.failedConstituentIds ?? []);
+  const targetIds = (tracking.constituentIds ?? []).filter(
+    (id) => !delivered.has(id) && !previouslyFailed.has(id),
+  );
+
+  if (targetIds.length === 0) {
+    // Nothing left to do; finalise immediately.
+    await finaliseJob(data.orgId, bulkEmailJobId, null, log);
+    return { sent: 0, failed: 0, skipped: 0 };
   }
 
   // Re-fetch contact details under the worker's RLS context. Soft-deleted
@@ -104,7 +187,7 @@ export async function processSendBulkEmail(job: Job<SendBulkEmailJob["data"]>) {
       .from(constituents)
       .where(
         and(
-          inArray(constituents.id, constituentIds),
+          inArray(constituents.id, targetIds),
           eq(constituents.orgId, data.orgId),
           isNull(constituents.deletedAt),
           isNotNull(constituents.email),
@@ -112,42 +195,141 @@ export async function processSendBulkEmail(job: Job<SendBulkEmailJob["data"]>) {
       );
   });
 
-  if (recipients.length === 0) {
-    log.warn(
-      { orgId: data.orgId, requestedCount: constituentIds.length },
-      "Bulk email job had no deliverable recipients after re-fetch (all soft-deleted or email cleared)",
-    );
-    return { sent: 0, failed: 0 };
-  }
-
   let sent = 0;
   let failed = 0;
+  // `targetIds.length - recipients.length` = silently-dropped constituents
+  // (soft-deleted between request and send, or had their email cleared).
+  // Don't write them into the failed set: a GDPR-erased constituent
+  // SHOULDN'T appear in the operator's failed list. Just log + count.
+  const skipped = targetIds.length - recipients.length;
 
   for (const recipient of recipients) {
     if (!recipient.email) {
-      failed += 1;
+      // Defensive — `isNotNull(email)` should have filtered these.
       continue;
     }
     try {
-      await defaultEmailSender.send({
+      await sender.send({
         to: recipient.email,
-        subject,
-        html: renderHtml(subject, body, recipient.firstName),
-        text: renderText(body, recipient.firstName),
+        subject: tracking.subject,
+        html: renderHtml(tracking.subject, tracking.body, recipient.firstName),
+        text: renderText(tracking.body, recipient.firstName),
       });
       sent += 1;
+      await recordOutcome(data.orgId, bulkEmailJobId, recipient.id, "delivered");
     } catch (err) {
       failed += 1;
       log.error(
         {
           err: err instanceof Error ? err.message : String(err),
           constituentId: recipient.id,
+          bulkEmailJobId,
         },
         "Bulk email send failed for recipient",
       );
+      await recordOutcome(data.orgId, bulkEmailJobId, recipient.id, "failed");
     }
   }
 
-  log.info({ sent, failed, total: recipients.length }, "Bulk email job complete");
-  return { sent, failed };
+  await finaliseJob(data.orgId, bulkEmailJobId, null, log);
+
+  log.info(
+    { sent, failed, skipped, total: targetIds.length, bulkEmailJobId },
+    "Bulk email job complete",
+  );
+  return { sent, failed, skipped };
+}
+
+/**
+ * Atomically append a recipient id to one of the outcome arrays AND keep
+ * the count column in step. The CHECK constraint in migration 0045 rejects
+ * any UPDATE that lets the count drift from the array length, so we have
+ * to update both columns in the same statement.
+ *
+ * Per-recipient round-trip is intentional — it makes the polling UI live
+ * AND means the next worker process can pick up exactly where this one
+ * left off if it dies mid-send.
+ */
+async function recordOutcome(
+  orgId: string,
+  bulkEmailJobId: string,
+  constituentId: string,
+  outcome: "delivered" | "failed",
+): Promise<void> {
+  if (outcome === "delivered") {
+    await withWorkerContext(orgId, async (tx) => {
+      await tx
+        .update(bulkEmailJobs)
+        .set({
+          deliveredConstituentIds: sql`array_append(${bulkEmailJobs.deliveredConstituentIds}, ${constituentId}::uuid)`,
+          deliveredCount: sql`${bulkEmailJobs.deliveredCount} + 1`,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(bulkEmailJobs.id, bulkEmailJobId), eq(bulkEmailJobs.orgId, orgId)));
+    });
+    return;
+  }
+  await withWorkerContext(orgId, async (tx) => {
+    await tx
+      .update(bulkEmailJobs)
+      .set({
+        failedConstituentIds: sql`array_append(${bulkEmailJobs.failedConstituentIds}, ${constituentId}::uuid)`,
+        failedCount: sql`${bulkEmailJobs.failedCount} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(bulkEmailJobs.id, bulkEmailJobId), eq(bulkEmailJobs.orgId, orgId)));
+  });
+}
+
+/**
+ * Flip the row to its terminal state. Computed from the current counter
+ * values rather than what THIS run did — handles the BullMQ retry case
+ * (previous run delivered to 5/10, dies; retry delivers to 0 because the
+ * skip-already-handled filter saw them all done) cleanly.
+ *
+ * Status mapping:
+ *   - delivered_count == total_recipients ⇒ `completed`.
+ *   - delivered_count < total_recipients   ⇒ `partial`. The operator UI
+ *     surfaces a Resume action. Includes the "some failed" case AND the
+ *     "some soft-deleted" case (counts won't match the array union when
+ *     constituents were dropped silently at send time).
+ *
+ * `error` is the worker-level fatal message (NOT per-recipient). We pass
+ * `null` on normal completion; the per-recipient SMTP error is already
+ * logged + recorded into `failed_constituent_ids`.
+ */
+async function finaliseJob(
+  orgId: string,
+  bulkEmailJobId: string,
+  error: string | null,
+  log: ReturnType<typeof jobLogger>,
+): Promise<void> {
+  await withWorkerContext(orgId, async (tx) => {
+    const [row] = await tx
+      .select({
+        deliveredCount: bulkEmailJobs.deliveredCount,
+        totalRecipients: bulkEmailJobs.totalRecipients,
+      })
+      .from(bulkEmailJobs)
+      .where(and(eq(bulkEmailJobs.id, bulkEmailJobId), eq(bulkEmailJobs.orgId, orgId)));
+
+    if (!row) return;
+
+    const status = row.deliveredCount >= row.totalRecipients ? "completed" : "partial";
+
+    await tx
+      .update(bulkEmailJobs)
+      .set({
+        status,
+        error,
+        completedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(and(eq(bulkEmailJobs.id, bulkEmailJobId), eq(bulkEmailJobs.orgId, orgId)));
+
+    log.info(
+      { bulkEmailJobId, status, delivered: row.deliveredCount, total: row.totalRecipients },
+      "Bulk email job finalised",
+    );
+  });
 }

--- a/packages/worker/src/processors/send-bulk-email.ts
+++ b/packages/worker/src/processors/send-bulk-email.ts
@@ -327,9 +327,23 @@ async function finaliseJob(
       })
       .where(and(eq(bulkEmailJobs.id, bulkEmailJobId), eq(bulkEmailJobs.orgId, orgId)));
 
-    log.info(
-      { bulkEmailJobId, status, delivered: row.deliveredCount, total: row.totalRecipients },
-      "Bulk email job finalised",
-    );
+    // PR #352 review M4: promote the partial outcome to a `warn` so SREs
+    // can build a Loki alert on `level=warn AND event=bulk_email.partial`
+    // without scraping the structured `status` field out of every info
+    // line. Successful completions stay at `info` — no signal value.
+    const baseFields = {
+      bulkEmailJobId,
+      status,
+      delivered: row.deliveredCount,
+      total: row.totalRecipients,
+    };
+    if (status === "partial") {
+      log.warn(
+        { ...baseFields, event: "bulk_email.partial" },
+        "Bulk email job finalised with partial delivery — operator can Resume",
+      );
+    } else {
+      log.info({ ...baseFields, event: "bulk_email.completed" }, "Bulk email job finalised");
+    }
   });
 }

--- a/packages/worker/src/tests/integration/send-bulk-email.test.ts
+++ b/packages/worker/src/tests/integration/send-bulk-email.test.ts
@@ -16,7 +16,20 @@ import { eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "../../lib/db.js";
 import type { EmailSender, SendEmailInput } from "../../lib/email.js";
-import { processSendBulkEmail } from "../../processors/send-bulk-email.js";
+import {
+  type ProcessSendBulkEmailDeps,
+  processSendBulkEmail,
+} from "../../processors/send-bulk-email.js";
+
+/**
+ * Most tests in this file want to exercise the recipient fan-out
+ * logic, not the feature-flag gate (the gate gets its own dedicated
+ * test). Force the flag to `true` so each test can focus on its
+ * scenario without seeding the registry first.
+ */
+const flagOn: Pick<ProcessSendBulkEmailDeps, "isFlagEnabled"> = {
+  isFlagEnabled: async () => true,
+};
 
 // Dedicated tenant id so this file's fixtures never collide with the
 // other worker integration tests (file-level parallelism is off, but
@@ -135,7 +148,7 @@ describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
 
     const result = await processSendBulkEmail(
       makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
-      { emailSender: sender },
+      { emailSender: sender, ...flagOn },
     );
 
     expect(result).toEqual({ sent: 2, failed: 0, skipped: 0 });
@@ -173,7 +186,7 @@ describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
 
     const result = await processSendBulkEmail(
       makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
-      { emailSender: sender },
+      { emailSender: sender, ...flagOn },
     );
 
     expect(result).toEqual({ sent: 2, failed: 1, skipped: 0 });
@@ -210,7 +223,7 @@ describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
 
     const result = await processSendBulkEmail(
       makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
-      { emailSender: sender },
+      { emailSender: sender, ...flagOn },
     );
 
     expect(result).toEqual({ sent: 1, failed: 0, skipped: 0 });
@@ -248,7 +261,7 @@ describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
 
     const result = await processSendBulkEmail(
       makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
-      { emailSender: sender },
+      { emailSender: sender, ...flagOn },
     );
 
     expect(result).toEqual({ sent: 0, failed: 0, skipped: 0 });
@@ -273,7 +286,7 @@ describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
         orgId: ORG_ID,
         bulkEmailJobId: "00000000-0000-0000-0000-000000000bad",
       }),
-      { emailSender: sender },
+      { emailSender: sender, ...flagOn },
     );
     expect(result).toEqual({ sent: 0, failed: 0, skipped: 0 });
     expect(sends).toEqual([]);
@@ -295,7 +308,7 @@ describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
     const { sender, sends } = recordingSender();
     const result = await processSendBulkEmail(
       makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
-      { emailSender: sender },
+      { emailSender: sender, ...flagOn },
     );
     expect(result).toEqual({ sent: 1, failed: 0, skipped: 1 });
     expect(sends.map((s) => s.to)).toEqual(["alice.bulk@example.org"]);
@@ -325,6 +338,39 @@ describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
       .where(eq(constituents.id, constituentBId));
   });
 
+  // PR #352 / @magino follow-up: feature-flag gate. If the
+  // `communication.bulk_email` flag is OFF by the time the worker
+  // picks up the job (toggled off in the admin UI between API enqueue
+  // and worker dispatch), the processor must short-circuit without
+  // sending or mutating the tracking row. Defence-in-depth on top of
+  // the route-level `requireFlag` gate.
+  it("drops silently when the bulk-email feature flag is off (defence-in-depth)", async () => {
+    const jobId = await seedJob({ constituentIds: [constituentAId, constituentBId] });
+    const { sender, sends } = recordingSender();
+
+    const result = await processSendBulkEmail(
+      makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
+      { emailSender: sender, isFlagEnabled: async () => false },
+    );
+
+    expect(result).toEqual({ sent: 0, failed: 0, skipped: 0 });
+    expect(sends).toEqual([]);
+
+    // The tracking row stays at its pre-job state — no `processing`
+    // transition, no counters incremented. The operator's UI shows
+    // the dispatch in the recent jobs panel; if they later flip the
+    // flag on, a Resume on the (still `pending`) job picks it up.
+    const [row] = await db
+      .select({
+        status: bulkEmailJobs.status,
+        deliveredCount: bulkEmailJobs.deliveredCount,
+      })
+      .from(bulkEmailJobs)
+      .where(eq(bulkEmailJobs.id, jobId));
+    expect(row?.status).toBe("pending");
+    expect(row?.deliveredCount).toBe(0);
+  });
+
   // PR #352 review M3 (QA-6): when SMTP refuses every recipient the
   // terminal status is `partial` (delivered_count == 0), NOT `failed`
   // (which we reserve for worker-fatal pre-recipient errors). The
@@ -337,7 +383,7 @@ describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
 
     const result = await processSendBulkEmail(
       makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
-      { emailSender: sender },
+      { emailSender: sender, ...flagOn },
     );
 
     expect(result).toEqual({ sent: 0, failed: 2, skipped: 0 });

--- a/packages/worker/src/tests/integration/send-bulk-email.test.ts
+++ b/packages/worker/src/tests/integration/send-bulk-email.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Worker integration tests for the bulk-email processor (issue #326).
+ *
+ * Focus: per-recipient outcome tracking + terminal status flip. The
+ * `bulk_email_jobs` row must end the run with delivered/failed counters
+ * that match the array contents AND a status that reflects the actual
+ * delivery outcome (completed vs. partial).
+ *
+ * SMTP is stubbed at the EmailSender boundary — no real Mailpit, no real
+ * Resend HTTP traffic. That keeps the test deterministic AND lets us
+ * inject per-recipient failures to exercise the partial-send path.
+ */
+
+import { bulkEmailJobs, constituents, tenants } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "../../lib/db.js";
+import type { EmailSender, SendEmailInput } from "../../lib/email.js";
+import { processSendBulkEmail } from "../../processors/send-bulk-email.js";
+
+// Dedicated tenant id so this file's fixtures never collide with the
+// other worker integration tests (file-level parallelism is off, but
+// defensive — same posture as postal-export.test.ts).
+const ORG_ID = "00000000-0000-0000-0000-00000000007b";
+
+let constituentAId: string;
+let constituentBId: string;
+let constituentCId: string;
+
+function makeMockJob(data: Record<string, unknown>) {
+  return {
+    data,
+    id: `test-bulk-email-job-${Math.random().toString(16).slice(2)}`,
+    attemptsMade: 0,
+    log: vi.fn(),
+  } as never;
+}
+
+/** Insert a `bulk_email_jobs` row in `pending` state and return its id. */
+async function seedJob(args: {
+  status?: "pending" | "processing" | "partial" | "failed";
+  constituentIds: string[];
+  delivered?: string[];
+  failed?: string[];
+}): Promise<string> {
+  const delivered = args.delivered ?? [];
+  const failed = args.failed ?? [];
+  const [row] = await db
+    .insert(bulkEmailJobs)
+    .values({
+      orgId: ORG_ID,
+      status: args.status ?? "pending",
+      subject: "Worker test",
+      body: "Hi {firstName},\n\nThanks for your support.",
+      constituentIds: args.constituentIds,
+      deliveredConstituentIds: delivered,
+      failedConstituentIds: failed,
+      totalRecipients: args.constituentIds.length,
+      deliveredCount: delivered.length,
+      failedCount: failed.length,
+    })
+    .returning({ id: bulkEmailJobs.id });
+  if (!row) throw new Error("Failed to seed bulk_email_jobs row");
+  return row.id;
+}
+
+beforeAll(async () => {
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug) VALUES (${ORG_ID}, 'Bulk Worker Org', 'bulk-worker') ON CONFLICT (id) DO NOTHING`,
+  );
+
+  const [a, b, c] = await db
+    .insert(constituents)
+    .values([
+      {
+        orgId: ORG_ID,
+        firstName: "Alice",
+        lastName: "Bulk",
+        email: "alice.bulk@example.org",
+        type: "donor",
+      },
+      {
+        orgId: ORG_ID,
+        firstName: "Bob",
+        lastName: "Bulk",
+        email: "bob.bulk@example.org",
+        type: "donor",
+      },
+      {
+        orgId: ORG_ID,
+        firstName: "Carol",
+        lastName: "Bulk",
+        email: "carol.bulk@example.org",
+        type: "donor",
+      },
+    ])
+    .returning();
+  constituentAId = a!.id;
+  constituentBId = b!.id;
+  constituentCId = c!.id;
+});
+
+afterAll(async () => {
+  // Clean up so re-runs are deterministic. Tenant cascade handles
+  // constituents + bulk_email_jobs.
+  await db.delete(tenants).where(eq(tenants.id, ORG_ID));
+});
+
+beforeEach(async () => {
+  // Wipe any rows leftover from a previous test in this file so the
+  // assertions below operate on freshly-seeded data.
+  await db.execute(sql`DELETE FROM bulk_email_jobs WHERE org_id = ${ORG_ID}::uuid`);
+});
+
+function recordingSender(failingEmails: Set<string> = new Set()): {
+  sender: EmailSender;
+  sends: SendEmailInput[];
+} {
+  const sends: SendEmailInput[] = [];
+  const sender: EmailSender = {
+    async send(input) {
+      sends.push(input);
+      if (failingEmails.has(input.to)) {
+        throw new Error(`SMTP refused ${input.to}`);
+      }
+    },
+  };
+  return { sender, sends };
+}
+
+describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
+  it("marks the job `completed` and updates delivered_count when every recipient succeeds", async () => {
+    const jobId = await seedJob({ constituentIds: [constituentAId, constituentBId] });
+    const { sender, sends } = recordingSender();
+
+    const result = await processSendBulkEmail(
+      makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
+      { emailSender: sender },
+    );
+
+    expect(result).toEqual({ sent: 2, failed: 0, skipped: 0 });
+    expect(sends.map((s) => s.to).sort()).toEqual([
+      "alice.bulk@example.org",
+      "bob.bulk@example.org",
+    ]);
+
+    const [row] = await db
+      .select({
+        status: bulkEmailJobs.status,
+        deliveredCount: bulkEmailJobs.deliveredCount,
+        failedCount: bulkEmailJobs.failedCount,
+        deliveredConstituentIds: bulkEmailJobs.deliveredConstituentIds,
+        failedConstituentIds: bulkEmailJobs.failedConstituentIds,
+        completedAt: bulkEmailJobs.completedAt,
+      })
+      .from(bulkEmailJobs)
+      .where(eq(bulkEmailJobs.id, jobId));
+    expect(row?.status).toBe("completed");
+    expect(row?.deliveredCount).toBe(2);
+    expect(row?.failedCount).toBe(0);
+    expect(row?.deliveredConstituentIds?.sort()).toEqual([constituentAId, constituentBId].sort());
+    expect(row?.failedConstituentIds).toEqual([]);
+    expect(row?.completedAt).not.toBeNull();
+  });
+
+  it("marks the job `partial` when some recipients fail at the SMTP layer", async () => {
+    const jobId = await seedJob({
+      constituentIds: [constituentAId, constituentBId, constituentCId],
+    });
+    // Bob's send blows up — the loop records him in failed_constituent_ids
+    // and proceeds with the others.
+    const { sender, sends } = recordingSender(new Set(["bob.bulk@example.org"]));
+
+    const result = await processSendBulkEmail(
+      makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
+      { emailSender: sender },
+    );
+
+    expect(result).toEqual({ sent: 2, failed: 1, skipped: 0 });
+    expect(sends.length).toBe(3);
+
+    const [row] = await db
+      .select({
+        status: bulkEmailJobs.status,
+        deliveredCount: bulkEmailJobs.deliveredCount,
+        failedCount: bulkEmailJobs.failedCount,
+        deliveredConstituentIds: bulkEmailJobs.deliveredConstituentIds,
+        failedConstituentIds: bulkEmailJobs.failedConstituentIds,
+      })
+      .from(bulkEmailJobs)
+      .where(eq(bulkEmailJobs.id, jobId));
+    expect(row?.status).toBe("partial");
+    expect(row?.deliveredCount).toBe(2);
+    expect(row?.failedCount).toBe(1);
+    expect(row?.failedConstituentIds).toEqual([constituentBId]);
+    expect(row?.deliveredConstituentIds?.sort()).toEqual([constituentAId, constituentCId].sort());
+  });
+
+  it("skips recipients already in delivered_constituent_ids on retry (BullMQ retry idempotency)", async () => {
+    // Simulates a BullMQ retry: the previous attempt delivered to Alice
+    // and the worker process died before finalising. On retry, the
+    // processor's filter `targetIds = constituent_ids \ delivered \
+    // failed` must skip Alice and only attempt Bob.
+    const jobId = await seedJob({
+      status: "processing",
+      constituentIds: [constituentAId, constituentBId],
+      delivered: [constituentAId],
+    });
+    const { sender, sends } = recordingSender();
+
+    const result = await processSendBulkEmail(
+      makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
+      { emailSender: sender },
+    );
+
+    expect(result).toEqual({ sent: 1, failed: 0, skipped: 0 });
+    expect(sends.map((s) => s.to)).toEqual(["bob.bulk@example.org"]);
+
+    const [row] = await db
+      .select({
+        status: bulkEmailJobs.status,
+        deliveredCount: bulkEmailJobs.deliveredCount,
+        deliveredConstituentIds: bulkEmailJobs.deliveredConstituentIds,
+      })
+      .from(bulkEmailJobs)
+      .where(eq(bulkEmailJobs.id, jobId));
+    expect(row?.status).toBe("completed");
+    expect(row?.deliveredCount).toBe(2);
+    expect(row?.deliveredConstituentIds?.sort()).toEqual([constituentAId, constituentBId].sort());
+  });
+
+  it("does NOT re-fan-out when the row is already in a terminal state (duplicate-retry guard)", async () => {
+    // A `completed` row should be left alone — re-running the worker
+    // against the same job (Redis hand-off, BullMQ job-id collision) must
+    // not send a second time.
+    const jobId = await seedJob({
+      status: "partial",
+      constituentIds: [constituentAId, constituentBId],
+      delivered: [constituentAId],
+    });
+    // Manually flip to a terminal state.
+    await db
+      .update(bulkEmailJobs)
+      .set({ status: "completed", completedAt: new Date() })
+      .where(eq(bulkEmailJobs.id, jobId));
+
+    const { sender, sends } = recordingSender();
+
+    const result = await processSendBulkEmail(
+      makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
+      { emailSender: sender },
+    );
+
+    expect(result).toEqual({ sent: 0, failed: 0, skipped: 0 });
+    expect(sends).toEqual([]);
+
+    const [row] = await db
+      .select({ status: bulkEmailJobs.status, deliveredCount: bulkEmailJobs.deliveredCount })
+      .from(bulkEmailJobs)
+      .where(eq(bulkEmailJobs.id, jobId));
+    expect(row?.status).toBe("completed");
+    expect(row?.deliveredCount).toBe(1);
+  });
+
+  it("handles a missing bulk_email_jobs row gracefully (outbox/DB drift)", async () => {
+    // The worker is best-effort: if the DB row vanished (manual cleanup,
+    // GDPR cascade) the processor logs a warning and short-circuits
+    // rather than throwing — which would trigger BullMQ retries against
+    // a row that's never coming back.
+    const { sender, sends } = recordingSender();
+    const result = await processSendBulkEmail(
+      makeMockJob({
+        orgId: ORG_ID,
+        bulkEmailJobId: "00000000-0000-0000-0000-000000000bad",
+      }),
+      { emailSender: sender },
+    );
+    expect(result).toEqual({ sent: 0, failed: 0, skipped: 0 });
+    expect(sends).toEqual([]);
+  });
+});

--- a/packages/worker/src/tests/integration/send-bulk-email.test.ts
+++ b/packages/worker/src/tests/integration/send-bulk-email.test.ts
@@ -278,4 +278,81 @@ describe("processSendBulkEmail — issue #326 per-recipient tracking", () => {
     expect(result).toEqual({ sent: 0, failed: 0, skipped: 0 });
     expect(sends).toEqual([]);
   });
+
+  // PR #352 review M3 (QA-5): a constituent soft-deleted between the
+  // request and the worker's send (right-to-erasure honoured at the
+  // very last moment) must be silently dropped — neither delivered nor
+  // failed in the counters — and the final status flips to `partial`
+  // because `delivered_count < total_recipients`.
+  it("silently drops soft-deleted recipients and finalises as partial", async () => {
+    const jobId = await seedJob({ constituentIds: [constituentAId, constituentBId] });
+    // Soft-delete Bob between request and send.
+    await db
+      .update(constituents)
+      .set({ deletedAt: new Date() })
+      .where(eq(constituents.id, constituentBId));
+
+    const { sender, sends } = recordingSender();
+    const result = await processSendBulkEmail(
+      makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
+      { emailSender: sender },
+    );
+    expect(result).toEqual({ sent: 1, failed: 0, skipped: 1 });
+    expect(sends.map((s) => s.to)).toEqual(["alice.bulk@example.org"]);
+
+    const [row] = await db
+      .select({
+        status: bulkEmailJobs.status,
+        deliveredCount: bulkEmailJobs.deliveredCount,
+        failedCount: bulkEmailJobs.failedCount,
+        deliveredConstituentIds: bulkEmailJobs.deliveredConstituentIds,
+        failedConstituentIds: bulkEmailJobs.failedConstituentIds,
+      })
+      .from(bulkEmailJobs)
+      .where(eq(bulkEmailJobs.id, jobId));
+    expect(row?.status).toBe("partial");
+    expect(row?.deliveredCount).toBe(1);
+    expect(row?.failedCount).toBe(0);
+    expect(row?.deliveredConstituentIds).toEqual([constituentAId]);
+    // Soft-deleted Bob is NOT in failed_constituent_ids — that's
+    // reserved for SMTP refusals, not GDPR drops.
+    expect(row?.failedConstituentIds).toEqual([]);
+
+    // Restore Bob so subsequent tests in this file are deterministic.
+    await db
+      .update(constituents)
+      .set({ deletedAt: null })
+      .where(eq(constituents.id, constituentBId));
+  });
+
+  // PR #352 review M3 (QA-6): when SMTP refuses every recipient the
+  // terminal status is `partial` (delivered_count == 0), NOT `failed`
+  // (which we reserve for worker-fatal pre-recipient errors). The
+  // operator can still Resume to retry every recipient.
+  it("ends as `partial` (not `failed`) when SMTP refuses every recipient", async () => {
+    const jobId = await seedJob({ constituentIds: [constituentAId, constituentBId] });
+    const { sender, sends } = recordingSender(
+      new Set(["alice.bulk@example.org", "bob.bulk@example.org"]),
+    );
+
+    const result = await processSendBulkEmail(
+      makeMockJob({ orgId: ORG_ID, bulkEmailJobId: jobId }),
+      { emailSender: sender },
+    );
+
+    expect(result).toEqual({ sent: 0, failed: 2, skipped: 0 });
+    expect(sends.length).toBe(2);
+
+    const [row] = await db
+      .select({
+        status: bulkEmailJobs.status,
+        deliveredCount: bulkEmailJobs.deliveredCount,
+        failedCount: bulkEmailJobs.failedCount,
+      })
+      .from(bulkEmailJobs)
+      .where(eq(bulkEmailJobs.id, jobId));
+    expect(row?.status).toBe("partial");
+    expect(row?.deliveredCount).toBe(0);
+    expect(row?.failedCount).toBe(2);
+  });
 });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -217,21 +217,19 @@ async function processDomainEvent(job: Job): Promise<void> {
   }
 
   if (type === "communication.bulk_email_requested") {
+    // Issue #326 — the outbox payload only carries the bulk_email_jobs
+    // row id. The processor reads subject/body/constituent_ids from that
+    // row at job start so:
+    //   - PII (email, name) never lives in Redis — same GDPR Art. 5(1)(e)
+    //     posture as before, just via a smaller payload.
+    //   - A resume job picks up the freshest `delivered_constituent_ids`
+    //     snapshot when computing "remaining", not a stale outbox copy.
+    const bulkEmailJobId = payload.bulkEmailJobId as string;
     await emailsQueue.add(
       "send-bulk-email",
       {
         orgId: tenantId,
-        templateId: "ad-hoc-bulk-email",
-        segmentFilter: {
-          subject: payload.subject,
-          body: payload.body,
-          // Forward only the constituent id list — PII (email, name) is
-          // re-resolved by the processor at send time so it never lives
-          // in Redis. See `bulk-email-service.ts` for the GDPR Art. 5(1)(e)
-          // rationale.
-          constituentIds: payload.constituentIds,
-          requestedBy: payload.requestedBy,
-        },
+        bulkEmailJobId,
         traceparent,
       },
       // Per-payload job id so a transactional retry of the outbox row
@@ -239,7 +237,7 @@ async function processDomainEvent(job: Job): Promise<void> {
       { jobId: `bulk-email-${id}` },
     );
 
-    log.info({ outboxId: id }, "Enqueued bulk email dispatch");
+    log.info({ outboxId: id, bulkEmailJobId }, "Enqueued bulk email dispatch");
     return;
   }
 
@@ -315,7 +313,10 @@ function startWorkers() {
     ...defaultJobOpts,
   });
 
-  const emailsWorker = new Worker(QUEUE_NAMES.EMAILS, processSendBulkEmail, {
+  // Wrap the processor in an arrow so BullMQ's second-arg `token: string`
+  // doesn't collide with the processor's optional `deps` parameter used
+  // by the worker test suite (issue #326).
+  const emailsWorker = new Worker(QUEUE_NAMES.EMAILS, (job) => processSendBulkEmail(job), {
     connection: createRedisConnection(),
     concurrency: 2,
     ...defaultJobOpts,


### PR DESCRIPTION
close #326

## Summary

When a Redis accessory reboot, OOM kill, or operator-initiated wipe drops in-flight BullMQ jobs, a fanning-out bulk email today shows "send succeeded → 0 recipients reached" in the operator UI — the relay marked the outbox row `completed` the moment it enqueued, and there is no surface that says "K of N were actually delivered". GDPR Art. 5(1)(b) transparency gap + zero re-issuance path.

This PR adds a queryable `bulk_email_jobs` row + a Resume action:

- The HTTP path inserts a tracking row alongside the outbox event, returns `{ jobId, queued, skippedNoEmail }`.
- The worker bumps `delivered_count` (or `failed_count`) per send, appending to the matching id array — the polling UI sees the ratio move in real time, and a worker death leaves the row at its last update.
- The new `POST /v1/constituents/bulk-email-jobs/:id/resume` creates a fresh job for `constituent_ids \ delivered_constituent_ids`. Eligibility is gated server-side on `partial` / `failed` / stalled `processing` (no `updated_at` movement for ≥ 10 min) so a Resume can't race the original worker into double-sending.
- Constituents table gets a "Recent emails" panel that polls every 3s while any job is non-terminal and exposes the per-row Resume button.

PII posture is unchanged from the original Epic #274 flow: emails/names are re-resolved at send time under the worker's RLS context. The new table stores uuids only — tenant-local foreign keys, not personal data.

## Files of note

- `packages/api/migrations/0044_bulk_email_jobs.sql` — table + enum + RLS + `CHECK` constraint that rejects counter/array drift (defence-in-depth)
- `packages/api/src/modules/constituents/bulk-email-service.ts` — `dispatchBulkEmail`, `listBulkEmailJobs`, `getBulkEmailJob`, `resumeBulkEmailJob`
- `packages/api/src/modules/constituents/routes.ts` — three new routes (list / get / resume)
- `packages/worker/src/processors/send-bulk-email.ts` — per-recipient `array_append` + counter bump
- `packages/web/src/app/(app)/constituents/constituents-table.tsx` — `BulkEmailJobsDialog` with polling + Resume
- `docs/23-postal-campaigns.md` § 6.bis — flow diagram, resume eligibility rules, PII posture

## Validation

Full pipeline green:

- `pnpm install` / `pnpm build` / `pnpm run format` / `pnpm run lint` (biome check `.`) / `pnpm typecheck` / `pnpm check:translations`
- `pnpm test` against real Postgres 17 + Redis 8 — **900 tests passing**:
  - API: 735 (+9 new — POST shape, GET list/poll, resume happy/error/stalled, drift CHECK)
  - Relay: 6 (unchanged)
  - Web: 113 (unchanged)
  - Worker: 46 (+8 new — completed/partial/retry-skip/duplicate-terminal/missing-row paths against a recording EmailSender)

## Manual acceptance checklist (for reviewer)

Database / migration:
- [ ] Migration 0044 applies cleanly on a fresh checkout (`pnpm db:migrate`)
- [ ] `bulk_email_jobs` row has all columns from the migration, RLS enabled, `givernance_app` granted SELECT/INSERT/UPDATE/DELETE
- [ ] CHECK constraint rejects a deliberately-drifted INSERT (covered by test `counts/array CHECK constraint rejects drifted counter writes`)

API:
- [ ] `POST /v1/constituents/bulk-email` returns 202 with `{ jobId, queued, skippedNoEmail }` and a `Location` header pointing at the new tracking row
- [ ] Outbox payload no longer carries `subject` / `body` / `constituentIds` (only `bulkEmailJobId`)
- [ ] `GET /v1/constituents/bulk-email-jobs/:id` polls and returns the live ratio
- [ ] `POST /v1/constituents/bulk-email-jobs/:id/resume`:
  - 400 `job_still_running` on a fresh `pending` source
  - 400 `nothing_to_resume` on a `completed` source
  - 404 `job_not_found` on an unknown id
  - 202 on a `partial` source with `constituent_ids = source\delivered`
  - 202 on a stalled `processing` source (updated_at older than `BULK_EMAIL_STALL_MS`)

Worker:
- [ ] Per-recipient send updates `delivered_count` + `delivered_constituent_ids` (array_append) in lockstep
- [ ] SMTP failure for one recipient does not abort the batch — the rest deliver, failed id lands in `failed_constituent_ids`
- [ ] Final status is `completed` if `delivered_count == total_recipients`, otherwise `partial`
- [ ] BullMQ retry of the same job skips recipients already in `delivered_constituent_ids` / `failed_constituent_ids`
- [ ] A duplicate retry against an already-terminal row short-circuits without re-sending

Web UI:
- [ ] After dispatch, the "Recent emails" panel auto-opens pinned to the new job
- [ ] Panel polls every 3s while any job is `pending` / `processing`
- [ ] Status badge shows `Sending…` / `Partial` / `Delivered` / `Failed` / `Stalled` correctly
- [ ] Resume button only appears on `partial` / `failed` / stalled-`processing` rows
- [ ] Resume on a still-running source surfaces the structured error message via toast

## Out of scope

- Exactly-once delivery / general outbox→BullMQ contract rework
- Persistent SMTP retry queues
- Postal-export parity (the ZIP must be a complete bundle for printing; the operator re-runs from scratch, the recovery semantics don't map)

🤖 Generated with [Claude Code](https://claude.com/claude-code)