### PR TITLE
feat(swiss-qr-bill): Bank Accounts CRUD (Epic #318 PR #2/N)

### DIFF
--- a/docs/design/settings/bank-accounts-form.html
+++ b/docs/design/settings/bank-accounts-form.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Givernance — Settings — Bank account (new / edit)</title>
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:wght@400;500&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <link rel="stylesheet" href="../shared/base.css">
+  <style>
+    /* ── Settings → Bank accounts form (Epic #318) ── */
+    .page { padding: var(--space-8) var(--space-6); max-width: 920px; margin: 0 auto; }
+    .breadcrumb { font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-2); }
+    .breadcrumb a { color: var(--color-primary); text-decoration: none; }
+    h1 { font-family: var(--font-heading); font-size: var(--text-3xl); color: var(--color-text); margin: var(--space-1) 0; }
+    .subtitle { color: var(--color-text-secondary); font-size: var(--text-sm); max-width: 65ch; margin-bottom: var(--space-6); }
+
+    .form-card { background: var(--color-white); border-radius: var(--radius-lg); box-shadow: var(--shadow-card); padding: var(--space-6); }
+    .form-section { margin-bottom: var(--space-6); padding-bottom: var(--space-5); border-bottom: 1px solid var(--color-border); }
+    .form-section:last-of-type { border-bottom: 0; padding-bottom: 0; }
+    .form-section h2 { font-size: var(--text-base); font-weight: var(--weight-semi); color: var(--color-text); margin-bottom: var(--space-1); }
+    .form-section .section-help { font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-4); max-width: 60ch; }
+
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
+    .full { grid-column: 1 / -1; }
+    .form-row label { display: block; font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--color-text); margin-bottom: 4px; }
+    .form-row .required { color: var(--color-danger); margin-left: 4px; }
+    .form-row input, .form-row select { width: 100%; height: var(--input-height); border: 1px solid var(--color-border); border-radius: var(--radius-input); padding: 0 var(--space-3); font-size: var(--text-base); background: var(--color-white); }
+    .form-row input:focus, .form-row select:focus { outline: none; border-color: var(--color-primary); }
+    .form-row .help { font-size: var(--text-xs); color: var(--color-text-muted); margin-top: 4px; }
+    .form-row .help.ok { color: var(--color-primary); }
+    .form-row .help.warn { color: var(--color-danger); }
+
+    .actions { display: flex; justify-content: flex-end; gap: var(--space-3); margin-top: var(--space-6); }
+    .actions .btn-cancel { background: transparent; border: none; height: 36px; padding: 0 var(--space-4); font-weight: var(--weight-medium); color: var(--color-text-secondary); cursor: pointer; }
+    .actions .btn-primary { background: var(--color-primary); color: var(--color-on-primary); border: none; height: 36px; padding: 0 var(--space-5); border-radius: var(--radius-button); font-weight: var(--weight-medium); cursor: pointer; }
+    .actions .btn-primary:disabled { background: var(--color-border); cursor: not-allowed; }
+
+    .iban-preview { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3); background: var(--color-surface-container); border-radius: var(--radius-md); margin-top: var(--space-3); font-size: var(--text-xs); }
+    .iban-preview .label { color: var(--color-text-muted); text-transform: uppercase; letter-spacing: var(--tracking-wide); font-weight: var(--weight-semi); }
+    .iban-preview .value { font-family: var(--font-mono); color: var(--color-text); }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <div class="breadcrumb"><a href="#">Dashboard</a> / <a href="#">Settings</a> / <a href="bank-accounts-list.html">Bank accounts</a> / New</div>
+    <h1>New bank account</h1>
+    <p class="subtitle">IBAN holder data prints on every QR-bill. The IG QR-bill v2.4 <em>structured address (S)</em> shape is used — combined-address forms are no longer supported (mandatory from 2026-09-30).</p>
+
+    <form class="form-card" novalidate>
+      <section class="form-section">
+        <h2>Account details</h2>
+        <p class="section-help">IBAN, bank name and currency. The IBAN kind (QR-IBAN vs regular IBAN) is derived automatically from the IID range.</p>
+
+        <div class="grid-2">
+          <div class="form-row">
+            <label for="iban">IBAN<span class="required">*</span></label>
+            <input id="iban" type="text" placeholder="CH93 0076 2011 6238 5295 7" value="CH44 3199 9123 0008 8901 2" maxlength="42">
+            <p class="help ok">Detected: <strong>QR-IBAN</strong> — Swiss QR-bills will use a 27-digit QRR reference (mod-10).</p>
+          </div>
+          <div class="form-row">
+            <label for="bank">Bank name<span class="required">*</span></label>
+            <input id="bank" type="text" placeholder="PostFinance, UBS Switzerland AG…" value="PostFinance" maxlength="100">
+          </div>
+          <div class="form-row">
+            <label for="bic">BIC / SWIFT (optional)</label>
+            <input id="bic" type="text" placeholder="POFICHBE" value="POFICHBEXXX" maxlength="13">
+            <p class="help">8 or 11 characters per ISO 9362. Optional — most Swiss e-banking flows don't require it for QR-bill payments.</p>
+          </div>
+          <div class="form-row">
+            <label for="currency">Currency<span class="required">*</span></label>
+            <select id="currency">
+              <option value="CHF" selected>CHF</option>
+              <option value="EUR">EUR</option>
+            </select>
+            <p class="help">CHF or EUR. EUR + QR-IBAN is illegal under IG QR-bill v2.4 — use a regular IBAN with SCOR for EUR donations.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="form-section">
+        <h2>Holder address</h2>
+        <p class="section-help">Printed on the QR-bill in the IG structured-address shape: street + building number + postal code + town + country. Restricted to CH or LI per IG QR-bill v2.4.</p>
+
+        <div class="grid-2">
+          <div class="form-row full">
+            <label for="holderName">Holder name<span class="required">*</span></label>
+            <input id="holderName" type="text" value="Association Givernance Demo" maxlength="70">
+            <p class="help">Printed at the top of the QR-bill. Up to 70 characters.</p>
+          </div>
+          <div class="form-row">
+            <label for="street">Street<span class="required">*</span></label>
+            <input id="street" type="text" value="Rue de la Paix" maxlength="70">
+          </div>
+          <div class="form-row">
+            <label for="building">Building number</label>
+            <input id="building" type="text" value="12" maxlength="16">
+            <p class="help">Optional. Up to 16 characters (e.g. "12" or "12b").</p>
+          </div>
+          <div class="form-row">
+            <label for="zip">Postal code<span class="required">*</span></label>
+            <input id="zip" type="text" value="1003" maxlength="16">
+          </div>
+          <div class="form-row">
+            <label for="town">Town / City<span class="required">*</span></label>
+            <input id="town" type="text" value="Lausanne" maxlength="35">
+          </div>
+          <div class="form-row">
+            <label for="country">Country<span class="required">*</span></label>
+            <select id="country">
+              <option value="CH" selected>CH</option>
+              <option value="LI">LI</option>
+            </select>
+            <p class="help">CH or LI only — IG QR-bill applies to those two jurisdictions.</p>
+          </div>
+        </div>
+
+        <div class="iban-preview" role="note">
+          <div>
+            <div class="label">QR-bill preview reference</div>
+            <div class="value">21 00000 00003 13947 14300 09017</div>
+          </div>
+          <div style="margin-left:auto;">
+            <div class="label">Currency / Amount</div>
+            <div class="value">CHF · donor-fills</div>
+          </div>
+        </div>
+      </section>
+
+      <div class="actions">
+        <button type="button" class="btn-cancel">Cancel</button>
+        <button type="submit" class="btn-primary">Create bank account</button>
+      </div>
+    </form>
+  </main>
+</body>
+</html>

--- a/docs/design/settings/bank-accounts-list.html
+++ b/docs/design/settings/bank-accounts-list.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Givernance — Settings — Bank accounts (list)</title>
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:wght@400;500&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <link rel="stylesheet" href="../shared/base.css">
+  <style>
+    /* ── Settings → Bank accounts list (Epic #318) ── */
+    .page { padding: var(--space-8) var(--space-6); max-width: 1100px; margin: 0 auto; }
+    .page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-4); margin-bottom: var(--space-6); }
+    .breadcrumb { font-size: var(--text-xs); color: var(--color-text-muted); margin-bottom: var(--space-2); }
+    .breadcrumb a { color: var(--color-primary); text-decoration: none; }
+    h1 { font-family: var(--font-heading); font-size: var(--text-3xl); color: var(--color-text); margin: var(--space-1) 0; }
+    .subtitle { color: var(--color-text-secondary); font-size: var(--text-sm); max-width: 60ch; }
+
+    .btn-primary { background: var(--color-primary); color: var(--color-on-primary); border: none; height: 36px; padding: 0 var(--space-4); border-radius: var(--radius-button); font-weight: var(--weight-medium); cursor: pointer; }
+
+    .tabs { display: inline-flex; gap: var(--space-2); background: var(--color-surface-container); padding: var(--space-2); border-radius: var(--radius-lg); margin-bottom: var(--space-5); }
+    .tab { padding: var(--space-2) var(--space-4); border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--color-text-secondary); cursor: pointer; }
+    .tab.active { background: var(--color-white); color: var(--color-text); box-shadow: var(--shadow-card); }
+
+    .card { background: var(--color-white); border-radius: var(--radius-lg); box-shadow: var(--shadow-card); overflow: hidden; }
+
+    table.bank-accounts { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
+    table.bank-accounts thead th { text-align: left; background: var(--color-surface-container); color: var(--color-text-secondary); font-weight: var(--weight-medium); padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--color-border); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: var(--tracking-wide); }
+    table.bank-accounts tbody td { padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--color-border); vertical-align: middle; }
+    table.bank-accounts tbody tr:last-child td { border-bottom: 0; }
+    table.bank-accounts tbody tr:hover { background: var(--color-surface-container); }
+    .iban { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-text-secondary); }
+    .bank-name { font-weight: var(--weight-semi); color: var(--color-text); }
+    .badge { display: inline-block; padding: 2px var(--space-2); border-radius: var(--radius-pill); font-size: 11px; font-weight: var(--weight-semi); }
+    .badge-qr { background: #DCFCE7; color: #166534; }
+    .badge-iban { background: #DBEAFE; color: #1E40AF; }
+
+    .row-actions { display: inline-flex; gap: var(--space-2); }
+    .row-actions button { background: transparent; border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: 4px 10px; font-size: var(--text-xs); cursor: pointer; color: var(--color-text-secondary); }
+    .row-actions button.danger { color: var(--color-danger); border-color: var(--color-danger-50, #FCA5A5); }
+
+    .empty { padding: var(--space-12) var(--space-6); text-align: center; }
+    .empty .icon { font-size: 36px; margin-bottom: var(--space-3); }
+    .empty h2 { font-size: var(--text-lg); color: var(--color-text); margin-bottom: var(--space-2); }
+    .empty p { color: var(--color-text-secondary); max-width: 50ch; margin: 0 auto var(--space-4); font-size: var(--text-sm); line-height: var(--leading-relaxed); }
+
+    .info-note { margin-top: var(--space-5); padding: var(--space-4); background: var(--color-primary-50, #ECFDF5); border-left: 3px solid var(--color-primary); border-radius: var(--radius-md); font-size: var(--text-sm); color: var(--color-text-secondary); }
+    .info-note strong { color: var(--color-text); }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <div class="page-header">
+      <div>
+        <div class="breadcrumb"><a href="#">Dashboard</a> &nbsp;/&nbsp; <a href="#">Settings</a> &nbsp;/&nbsp; Bank accounts</div>
+        <h1>Bank accounts</h1>
+        <p class="subtitle">Swiss operating accounts that back QR-bill issuance. Holder data prints on every BVR; the IBAN type (QR-IBAN vs regular) determines whether Givernance mints a QRR or a SCOR reference.</p>
+      </div>
+      <button class="btn-primary">+ Add bank account</button>
+    </div>
+
+    <nav class="tabs" aria-label="Settings sections">
+      <div class="tab">Organisation</div>
+      <div class="tab">Members</div>
+      <div class="tab">Funds</div>
+      <div class="tab active">Bank accounts</div>
+    </nav>
+
+    <div class="card">
+      <table class="bank-accounts">
+        <thead>
+          <tr>
+            <th>Bank</th>
+            <th>IBAN</th>
+            <th>Type</th>
+            <th>Currency</th>
+            <th>Holder</th>
+            <th aria-label="Row actions"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="bank-name">PostFinance</td>
+            <td class="iban">CH44 3199 9123 0008 8901 2</td>
+            <td><span class="badge badge-qr">QR-IBAN</span></td>
+            <td>CHF</td>
+            <td>Association Demo</td>
+            <td>
+              <div class="row-actions">
+                <button>Edit</button>
+                <button class="danger">Archive</button>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td class="bank-name">UBS Switzerland AG</td>
+            <td class="iban">CH93 0076 2011 6238 5295 7</td>
+            <td><span class="badge badge-iban">Regular IBAN</span></td>
+            <td>CHF</td>
+            <td>Association Demo</td>
+            <td>
+              <div class="row-actions">
+                <button>Edit</button>
+                <button class="danger">Archive</button>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td class="bank-name">LLB</td>
+            <td class="iban">LI21 0881 0000 2324 013A A</td>
+            <td><span class="badge badge-iban">Regular IBAN</span></td>
+            <td>EUR</td>
+            <td>Association Demo — endowment account</td>
+            <td>
+              <div class="row-actions">
+                <button>Edit</button>
+                <button class="danger">Archive</button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="info-note">
+      <strong>Heads-up:</strong> EUR + QR-IBAN is illegal under IG QR-bill v2.4 (euroSIC discontinuation). Use a regular IBAN with EUR + SCOR for cross-border donors. Givernance enforces this server-side and surfaces an inline warning on the form.
+    </div>
+
+    <section class="card" style="margin-top: var(--space-6); padding: var(--space-6);">
+      <h2 style="font-size: var(--text-sm); text-transform: uppercase; letter-spacing: var(--tracking-wide); color: var(--color-text-muted); margin-bottom: var(--space-3);">Empty state (no bank accounts yet)</h2>
+      <div class="empty">
+        <div class="icon">🏦</div>
+        <h2>No bank accounts yet</h2>
+        <p>Add your first Swiss operating account to mint Swiss QR-bills on postal mailings. CHF or EUR, regular IBAN or QR-IBAN — Givernance derives the reference type automatically.</p>
+        <button class="btn-primary">+ Add bank account</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/packages/api/src/modules/bank-accounts/routes.ts
+++ b/packages/api/src/modules/bank-accounts/routes.ts
@@ -1,0 +1,318 @@
+/**
+ * Bank Accounts routes — tenant-scoped CRUD under `requireOrgAdmin`
+ * (Epic #318, PR #2).
+ *
+ * Audit log is captured by the `audit` plugin automatically on every
+ * mutating request. The `resource_type=bank-accounts` + `resource_id`
+ * pair lands in `audit_logs` per the URL parser in `plugins/audit.ts`.
+ */
+
+import {
+  BANK_ACCOUNT_CURRENCY_VALUES,
+  BANK_ACCOUNT_IBAN_KIND_VALUES,
+} from "@givernance/shared/schema";
+import { Type } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
+import { requireAuth, requireOrgAdmin } from "../../lib/guards.js";
+import {
+  DataArrayResponse,
+  DataResponse,
+  ErrorResponses,
+  IdParams,
+  PaginationQuery,
+  ProblemDetailSchema,
+  problemDetail,
+  SortOrderSchema,
+  UuidSchema,
+} from "../../lib/schemas.js";
+import {
+  BANK_ACCOUNT_SORT_FIELDS,
+  BankAccountConflictError,
+  BankAccountValidationError,
+  createBankAccount,
+  deleteBankAccount,
+  getBankAccount,
+  getBankAccountUsage,
+  listBankAccounts,
+  updateBankAccount,
+} from "./service.js";
+
+// ─── Schemas ────────────────────────────────────────────────────────────────
+
+const BankAccountCurrencySchema = Type.Union(
+  BANK_ACCOUNT_CURRENCY_VALUES.map((v) => Type.Literal(v)),
+);
+
+const BankAccountIbanKindSchema = Type.Union(
+  BANK_ACCOUNT_IBAN_KIND_VALUES.map((v) => Type.Literal(v)),
+);
+
+const BankAccountResponse = Type.Object({
+  id: UuidSchema,
+  orgId: UuidSchema,
+  holderName: Type.String(),
+  /** IG QR-bill v2.4 S-shape: street name (`StrtNm`). */
+  holderStreet: Type.String(),
+  /** IG QR-bill v2.4 S-shape: building number (`BldgNb`), nullable. */
+  holderBuildingNumber: Type.Union([Type.String(), Type.Null()]),
+  holderPostalCode: Type.String(),
+  /** IG QR-bill v2.4 S-shape: town / city (`TwnNm`). */
+  holderTown: Type.String(),
+  holderCountryCode: Type.String(),
+  iban: Type.String(),
+  ibanKind: BankAccountIbanKindSchema,
+  bic: Type.Union([Type.String(), Type.Null()]),
+  bankName: Type.String(),
+  currency: BankAccountCurrencySchema,
+  deletedAt: Type.Union([Type.String(), Type.Null()]),
+  createdAt: Type.String(),
+  updatedAt: Type.String(),
+});
+
+// IG QR-bill v2.4 column-width caps mirrored at the API surface so the
+// readiness gate doesn't fire on a row the API accepted. See
+// `bank_accounts` migration column widths.
+const BankAccountCreateBody = Type.Object({
+  holderName: Type.String({ minLength: 1, maxLength: 70 }),
+  holderStreet: Type.String({ minLength: 1, maxLength: 70 }),
+  holderBuildingNumber: Type.Optional(Type.Union([Type.String({ maxLength: 16 }), Type.Null()])),
+  holderPostalCode: Type.String({ minLength: 1, maxLength: 16 }),
+  holderTown: Type.String({ minLength: 1, maxLength: 35 }),
+  holderCountryCode: Type.Optional(Type.String({ minLength: 2, maxLength: 2 })),
+  /** Free-form input — service canonicalises (strips whitespace, uppercases). */
+  iban: Type.String({ minLength: 5, maxLength: 42 }),
+  bic: Type.Optional(Type.Union([Type.String({ maxLength: 13 }), Type.Null()])),
+  bankName: Type.String({ minLength: 1, maxLength: 100 }),
+  currency: Type.Optional(BankAccountCurrencySchema),
+});
+
+const BankAccountUpdateBody = Type.Object(
+  {
+    holderName: Type.Optional(Type.String({ minLength: 1, maxLength: 70 })),
+    holderStreet: Type.Optional(Type.String({ minLength: 1, maxLength: 70 })),
+    holderBuildingNumber: Type.Optional(Type.Union([Type.String({ maxLength: 16 }), Type.Null()])),
+    holderPostalCode: Type.Optional(Type.String({ minLength: 1, maxLength: 16 })),
+    holderTown: Type.Optional(Type.String({ minLength: 1, maxLength: 35 })),
+    holderCountryCode: Type.Optional(Type.String({ minLength: 2, maxLength: 2 })),
+    bic: Type.Optional(Type.Union([Type.String({ maxLength: 13 }), Type.Null()])),
+    bankName: Type.Optional(Type.String({ minLength: 1, maxLength: 100 })),
+    currency: Type.Optional(BankAccountCurrencySchema),
+  },
+  { minProperties: 1 },
+);
+
+const BankAccountSortFieldSchema = Type.Union(BANK_ACCOUNT_SORT_FIELDS.map((f) => Type.Literal(f)));
+
+const BankAccountListQuery = Type.Intersect([
+  PaginationQuery,
+  Type.Object({
+    sort: Type.Optional(BankAccountSortFieldSchema),
+    order: Type.Optional(SortOrderSchema),
+    includeDeleted: Type.Optional(Type.Boolean()),
+  }),
+]);
+
+const BankAccountUsageResponse = Type.Object({
+  swissQrReferenceCount: Type.Integer({ minimum: 0 }),
+  linkedCampaignCount: Type.Integer({ minimum: 0 }),
+});
+
+// ─── Routes ────────────────────────────────────────────────────────────────
+
+export async function bankAccountRoutes(app: FastifyInstance) {
+  app.get(
+    "/bank-accounts",
+    {
+      preHandler: requireAuth,
+      schema: {
+        tags: ["Bank Accounts"],
+        querystring: BankAccountListQuery,
+        response: { 200: DataArrayResponse(BankAccountResponse), ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+
+      const query = request.query as {
+        page?: number;
+        perPage?: number;
+        sort?: (typeof BANK_ACCOUNT_SORT_FIELDS)[number];
+        order?: "asc" | "desc";
+        includeDeleted?: boolean;
+      };
+
+      const result = await listBankAccounts(orgId, {
+        page: query.page ?? 1,
+        perPage: query.perPage ?? 20,
+        sort: query.sort,
+        order: query.order,
+        includeDeleted: query.includeDeleted ?? false,
+      });
+
+      return { data: result.data, pagination: result.pagination };
+    },
+  );
+
+  app.post(
+    "/bank-accounts",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Bank Accounts"],
+        body: BankAccountCreateBody,
+        response: {
+          201: DataResponse(BankAccountResponse),
+          400: ProblemDetailSchema,
+          409: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+
+      try {
+        const account = await createBankAccount(
+          orgId,
+          request.body as Parameters<typeof createBankAccount>[1],
+        );
+        return reply.status(201).send({ data: account });
+      } catch (err) {
+        if (err instanceof BankAccountValidationError) {
+          return reply
+            .status(400)
+            .send(problemDetail(400, "Validation Error", err.message, { field: err.field }));
+        }
+        if (err instanceof BankAccountConflictError) {
+          return reply.status(409).send(problemDetail(409, "Conflict", err.message));
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.get(
+    "/bank-accounts/:id",
+    {
+      preHandler: requireAuth,
+      schema: {
+        tags: ["Bank Accounts"],
+        params: IdParams,
+        response: { 200: DataResponse(BankAccountResponse), ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { id } = request.params as { id: string };
+      const account = await getBankAccount(orgId, id);
+      if (!account) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Bank account not found"));
+      }
+      return { data: account };
+    },
+  );
+
+  app.get(
+    "/bank-accounts/:id/usage",
+    {
+      preHandler: requireAuth,
+      schema: {
+        tags: ["Bank Accounts"],
+        params: IdParams,
+        response: { 200: DataResponse(BankAccountUsageResponse), ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { id } = request.params as { id: string };
+      const account = await getBankAccount(orgId, id, { includeDeleted: true });
+      if (!account) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Bank account not found"));
+      }
+      const usage = await getBankAccountUsage(orgId, id);
+      return { data: usage };
+    },
+  );
+
+  app.patch(
+    "/bank-accounts/:id",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Bank Accounts"],
+        params: IdParams,
+        body: BankAccountUpdateBody,
+        response: {
+          200: DataResponse(BankAccountResponse),
+          400: ProblemDetailSchema,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { id } = request.params as { id: string };
+
+      try {
+        const updated = await updateBankAccount(
+          orgId,
+          id,
+          request.body as Parameters<typeof updateBankAccount>[2],
+        );
+        if (!updated) {
+          return reply.status(404).send(problemDetail(404, "Not Found", "Bank account not found"));
+        }
+        return { data: updated };
+      } catch (err) {
+        if (err instanceof BankAccountValidationError) {
+          return reply
+            .status(400)
+            .send(problemDetail(400, "Validation Error", err.message, { field: err.field }));
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.delete(
+    "/bank-accounts/:id",
+    {
+      preHandler: requireOrgAdmin,
+      schema: {
+        tags: ["Bank Accounts"],
+        params: IdParams,
+        response: {
+          200: DataResponse(BankAccountResponse),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { id } = request.params as { id: string };
+      const deleted = await deleteBankAccount(orgId, id);
+      if (!deleted) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Bank account not found"));
+      }
+      return { data: deleted };
+    },
+  );
+}

--- a/packages/api/src/modules/bank-accounts/service.ts
+++ b/packages/api/src/modules/bank-accounts/service.ts
@@ -1,0 +1,438 @@
+/**
+ * Bank Accounts service — tenant-scoped CRUD for Swiss QR-bill operating
+ * accounts (Epic #318, PR #2).
+ *
+ * Audit log is captured automatically by the `audit` plugin on every
+ * mutating request — this service writes no `audit_logs` rows itself.
+ *
+ * Soft-delete contract: a bank account that has ever issued a
+ * `swiss_qr_references` row cannot be hard-deleted (FK with ON DELETE
+ * RESTRICT). `deleteBankAccount` is therefore a soft-delete: it sets
+ * `deleted_at = NOW()` and `campaigns.bank_account_id` cascades to NULL
+ * via the campaigns-side FK (ON DELETE SET NULL). The partial unique
+ * index on `(org_id, iban) WHERE deleted_at IS NULL` lets the same IBAN
+ * be re-added after soft-delete (the old row stays for audit).
+ */
+
+import {
+  type BankAccount,
+  bankAccounts,
+  campaigns,
+  swissQrReferences,
+} from "@givernance/shared/schema";
+import type { Pagination } from "@givernance/shared/types";
+import { classifyIban } from "@givernance/shared/validators";
+import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
+import { withTenantContext } from "../../lib/db.js";
+
+/** Tuple drives both the route's TypeBox literal union + this fallback. */
+export const BANK_ACCOUNT_SORT_FIELDS = ["bankName", "currency", "createdAt"] as const;
+export type BankAccountSortField = (typeof BANK_ACCOUNT_SORT_FIELDS)[number];
+export type BankAccountSortOrder = "asc" | "desc";
+
+export interface ListBankAccountsQuery {
+  page: number;
+  perPage: number;
+  sort?: string;
+  order?: string;
+  /** Show soft-deleted accounts too (admin audit surface; default false). */
+  includeDeleted?: boolean;
+}
+
+/** Defense-in-depth — see donations/service.ts for the rationale. */
+function normalizeSort(value: string | undefined): BankAccountSortField {
+  if (value && BANK_ACCOUNT_SORT_FIELDS.includes(value as BankAccountSortField)) {
+    return value as BankAccountSortField;
+  }
+  return "createdAt";
+}
+
+function normalizeOrder(value: string | undefined): BankAccountSortOrder {
+  return value === "asc" ? "asc" : "desc";
+}
+
+function buildOrderBy(sort: BankAccountSortField, order: BankAccountSortOrder) {
+  const dir = order === "asc" ? asc : desc;
+  if (sort === "bankName") return [dir(sql`lower(${bankAccounts.bankName})`), asc(bankAccounts.id)];
+  if (sort === "currency") return [dir(bankAccounts.currency), asc(bankAccounts.id)];
+  return [dir(bankAccounts.createdAt), asc(bankAccounts.id)];
+}
+
+/**
+ * Canonicalise an IBAN at the service boundary: strip whitespace,
+ * uppercase. The DB has a CHECK constraint enforcing `^[A-Z0-9]+$`, so
+ * persisting anything else would fail the migration's last-line-of-defence.
+ */
+function canonicaliseIban(input: string): string {
+  return input.replace(/\s+/g, "").toUpperCase();
+}
+
+/** Canonicalise BIC the same way. */
+function canonicaliseBic(input: string | null | undefined): string | null {
+  if (input == null) return null;
+  const trimmed = input.replace(/\s+/g, "").toUpperCase();
+  return trimmed === "" ? null : trimmed;
+}
+
+export interface CreateBankAccountInput {
+  holderName: string;
+  holderStreet: string;
+  holderBuildingNumber?: string | null;
+  holderPostalCode: string;
+  holderTown: string;
+  holderCountryCode?: string;
+  iban: string;
+  bic?: string | null;
+  bankName: string;
+  currency?: "CHF" | "EUR";
+}
+
+export interface UpdateBankAccountInput {
+  holderName?: string;
+  holderStreet?: string;
+  holderBuildingNumber?: string | null;
+  holderPostalCode?: string;
+  holderTown?: string;
+  holderCountryCode?: string;
+  bic?: string | null;
+  bankName?: string;
+  currency?: "CHF" | "EUR";
+}
+
+export class BankAccountConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BankAccountConflictError";
+  }
+}
+
+export class BankAccountValidationError extends Error {
+  public readonly field: string;
+  constructor(field: string, message: string) {
+    super(message);
+    this.field = field;
+    this.name = "BankAccountValidationError";
+  }
+}
+
+/**
+ * Resolve the `iban_kind` discriminator from the IBAN itself — operators
+ * never type "qr_iban" vs "iban" by hand, the API derives it from the
+ * IID range (30000–31999 for QR-IBAN).
+ */
+function deriveIbanKind(iban: string): "iban" | "qr_iban" {
+  return classifyIban(iban) === "qr_iban" ? "qr_iban" : "iban";
+}
+
+function validateCurrencyVsKind(currency: "CHF" | "EUR", ibanKind: "iban" | "qr_iban"): void {
+  // EUR + QRR is illegal under IG QR-bill v2.4 (euroSIC discontinuation).
+  // A QR-IBAN forces QRR for the reference type, so EUR + QR-IBAN is the
+  // exact pathological combination we block here at create-time, with the
+  // same error code surfaced by the campaign readiness gate.
+  if (currency === "EUR" && ibanKind === "qr_iban") {
+    throw new BankAccountValidationError(
+      "currency",
+      "EUR is illegal with a QR-IBAN (which forces QRR — banned under IG QR-bill v2.4 since euroSIC was discontinued). Use a regular IBAN with EUR + SCOR, or switch the currency to CHF.",
+    );
+  }
+}
+
+/** List bank accounts for an org with pagination. */
+export async function listBankAccounts(orgId: string, query: ListBankAccountsQuery) {
+  const { page, perPage, includeDeleted = false } = query;
+  const offset = (page - 1) * perPage;
+  const sort = normalizeSort(query.sort);
+  const order = normalizeOrder(query.order);
+
+  return withTenantContext(orgId, async (tx) => {
+    const where = includeDeleted
+      ? eq(bankAccounts.orgId, orgId)
+      : and(eq(bankAccounts.orgId, orgId), isNull(bankAccounts.deletedAt));
+
+    const [data, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(bankAccounts)
+        .where(where)
+        .orderBy(...buildOrderBy(sort, order))
+        .limit(perPage)
+        .offset(offset),
+      tx.select({ count: sql<number>`count(*)` }).from(bankAccounts).where(where),
+    ]);
+
+    const total = Number(countResult[0]?.count ?? 0);
+    const pagination: Pagination = {
+      page,
+      perPage,
+      total,
+      totalPages: Math.ceil(total / perPage),
+    };
+
+    return { data, pagination };
+  });
+}
+
+/** Get a single bank account by ID. Returns null if not found OR soft-deleted (callers wanting the soft-deleted row use `includeDeleted=true`). */
+export async function getBankAccount(
+  orgId: string,
+  id: string,
+  options: { includeDeleted?: boolean } = {},
+): Promise<BankAccount | null> {
+  return withTenantContext(orgId, async (tx) => {
+    const conditions = options.includeDeleted
+      ? and(eq(bankAccounts.id, id), eq(bankAccounts.orgId, orgId))
+      : and(eq(bankAccounts.id, id), eq(bankAccounts.orgId, orgId), isNull(bankAccounts.deletedAt));
+
+    const [row] = await tx.select().from(bankAccounts).where(conditions);
+    return row ?? null;
+  });
+}
+
+/** Create a bank account. Throws `BankAccountValidationError` on illegal payloads, `BankAccountConflictError` on duplicate IBAN. */
+export async function createBankAccount(
+  orgId: string,
+  input: CreateBankAccountInput,
+): Promise<BankAccount> {
+  const iban = canonicaliseIban(input.iban);
+  if (classifyIban(iban) === "invalid") {
+    throw new BankAccountValidationError("iban", "IBAN failed mod-97 / format validation.");
+  }
+  const country = iban.slice(0, 2);
+  if (country !== "CH" && country !== "LI") {
+    throw new BankAccountValidationError(
+      "iban",
+      `Swiss QR-bill scope: only CH and LI IBANs are supported (got ${country}).`,
+    );
+  }
+
+  const ibanKind = deriveIbanKind(iban);
+  const currency = input.currency ?? "CHF";
+  validateCurrencyVsKind(currency, ibanKind);
+
+  const holderCountryCode = (input.holderCountryCode ?? "CH").toUpperCase();
+  if (!["CH", "LI"].includes(holderCountryCode)) {
+    throw new BankAccountValidationError(
+      "holderCountryCode",
+      "Holder country must be CH or LI (IG QR-bill scope).",
+    );
+  }
+
+  const bic = canonicaliseBic(input.bic);
+  if (bic && ![8, 11].includes(bic.length)) {
+    throw new BankAccountValidationError(
+      "bic",
+      `BIC must be exactly 8 or 11 characters when present (ISO 9362). Got ${bic.length}.`,
+    );
+  }
+
+  return withTenantContext(orgId, async (tx) => {
+    // Surface duplicate-IBAN as a typed conflict rather than letting the
+    // DB unique-violation bubble up as a 500.
+    const [existingByIban] = await tx
+      .select({ id: bankAccounts.id })
+      .from(bankAccounts)
+      .where(
+        and(
+          eq(bankAccounts.orgId, orgId),
+          eq(bankAccounts.iban, iban),
+          isNull(bankAccounts.deletedAt),
+        ),
+      )
+      .limit(1);
+
+    if (existingByIban) {
+      throw new BankAccountConflictError(
+        "A bank account with this IBAN already exists for this organisation.",
+      );
+    }
+
+    const [row] = await tx
+      .insert(bankAccounts)
+      .values({
+        orgId,
+        holderName: input.holderName,
+        holderStreet: input.holderStreet,
+        holderBuildingNumber:
+          input.holderBuildingNumber == null || input.holderBuildingNumber === ""
+            ? null
+            : input.holderBuildingNumber,
+        holderPostalCode: input.holderPostalCode,
+        holderTown: input.holderTown,
+        holderCountryCode,
+        iban,
+        ibanKind,
+        bic,
+        bankName: input.bankName,
+        currency,
+      })
+      .returning();
+
+    if (!row) {
+      throw new Error("Failed to insert bank account");
+    }
+    return row;
+  });
+}
+
+/**
+ * Update a bank account. The IBAN itself is **immutable** post-create —
+ * the operator must soft-delete and re-create if they need to change it
+ * (financial-record integrity: a changed IBAN on the same row would
+ * silently re-attribute every prior `swiss_qr_references` and
+ * `camt_statements` import).
+ */
+/**
+ * Pre-flight validation for `updateBankAccount`. Extracted so the main
+ * service body stays under the cognitive-complexity ceiling (biome rule).
+ */
+function validateUpdateBankAccountInput(input: UpdateBankAccountInput): void {
+  if (input.bic !== undefined) {
+    const bic = canonicaliseBic(input.bic);
+    if (bic && ![8, 11].includes(bic.length)) {
+      throw new BankAccountValidationError(
+        "bic",
+        `BIC must be exactly 8 or 11 characters when present (ISO 9362). Got ${bic.length}.`,
+      );
+    }
+  }
+  if (input.holderCountryCode !== undefined) {
+    const cc = input.holderCountryCode.toUpperCase();
+    if (!["CH", "LI"].includes(cc)) {
+      throw new BankAccountValidationError(
+        "holderCountryCode",
+        "Holder country must be CH or LI (IG QR-bill scope).",
+      );
+    }
+  }
+}
+
+/**
+ * Build the partial-update patch from the input. Pure function — no IO.
+ * Extracted to keep `updateBankAccount` under the cognitive-complexity
+ * ceiling. The `updatedAt` is always set on the patch so the
+ * `audit_logs.created_at` correlation works even when only one field
+ * changes.
+ */
+function buildUpdatePatch(input: UpdateBankAccountInput) {
+  const patch: Partial<typeof bankAccounts.$inferInsert> = { updatedAt: new Date() };
+  if (input.holderName !== undefined) patch.holderName = input.holderName;
+  if (input.holderStreet !== undefined) patch.holderStreet = input.holderStreet;
+  if (input.holderBuildingNumber !== undefined) {
+    patch.holderBuildingNumber =
+      input.holderBuildingNumber === null || input.holderBuildingNumber === ""
+        ? null
+        : input.holderBuildingNumber;
+  }
+  if (input.holderPostalCode !== undefined) patch.holderPostalCode = input.holderPostalCode;
+  if (input.holderTown !== undefined) patch.holderTown = input.holderTown;
+  if (input.holderCountryCode !== undefined) {
+    patch.holderCountryCode = input.holderCountryCode.toUpperCase();
+  }
+  if (input.bic !== undefined) patch.bic = canonicaliseBic(input.bic);
+  if (input.bankName !== undefined) patch.bankName = input.bankName;
+  if (input.currency !== undefined) patch.currency = input.currency;
+  return patch;
+}
+
+export async function updateBankAccount(
+  orgId: string,
+  id: string,
+  input: UpdateBankAccountInput,
+): Promise<BankAccount | null> {
+  validateUpdateBankAccountInput(input);
+
+  return withTenantContext(orgId, async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(bankAccounts)
+      .where(
+        and(eq(bankAccounts.id, id), eq(bankAccounts.orgId, orgId), isNull(bankAccounts.deletedAt)),
+      );
+
+    if (!existing) {
+      return null;
+    }
+
+    // Currency change is constrained by the IBAN's kind (immutable),
+    // so the same EUR+QR-IBAN combo we block at create-time fires here.
+    if (input.currency && input.currency !== existing.currency) {
+      validateCurrencyVsKind(input.currency, existing.ibanKind);
+    }
+
+    const patch = buildUpdatePatch(input);
+
+    const [updated] = await tx
+      .update(bankAccounts)
+      .set(patch)
+      .where(and(eq(bankAccounts.id, id), eq(bankAccounts.orgId, orgId)))
+      .returning();
+
+    return updated ?? null;
+  });
+}
+
+/**
+ * Soft-delete a bank account. Sets `deleted_at = NOW()`; the FK on
+ * `swiss_qr_references.bank_account_id` is ON DELETE RESTRICT so a hard
+ * delete is intentionally impossible once a single QR-bill has been
+ * issued (financial record retention). Linked campaigns degrade
+ * gracefully via the `campaigns.bank_account_id` ON DELETE SET NULL FK.
+ *
+ * Returns the soft-deleted row, or null if already deleted / not found.
+ */
+export async function deleteBankAccount(orgId: string, id: string): Promise<BankAccount | null> {
+  return withTenantContext(orgId, async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(bankAccounts)
+      .where(
+        and(eq(bankAccounts.id, id), eq(bankAccounts.orgId, orgId), isNull(bankAccounts.deletedAt)),
+      );
+
+    if (!existing) {
+      return null;
+    }
+
+    // Unlink campaigns (cascade is automatic via the campaigns FK,
+    // but doing it explicitly inside the same transaction keeps the
+    // audit story atomic — the campaign UPDATE lands in the same TX
+    // as the bank-account UPDATE, so the audit-log relay can correlate
+    // them via `created_at`).
+    await tx
+      .update(campaigns)
+      .set({ bankAccountId: null, updatedAt: new Date() })
+      .where(and(eq(campaigns.orgId, orgId), eq(campaigns.bankAccountId, id)));
+
+    const [deleted] = await tx
+      .update(bankAccounts)
+      .set({ deletedAt: new Date(), updatedAt: new Date() })
+      .where(and(eq(bankAccounts.id, id), eq(bankAccounts.orgId, orgId)))
+      .returning();
+
+    return deleted ?? null;
+  });
+}
+
+/**
+ * Return basic usage stats for a bank account — used by the UI to
+ * surface "this account has issued N QR-bills" before the operator
+ * confirms a soft-delete.
+ */
+export async function getBankAccountUsage(orgId: string, id: string) {
+  return withTenantContext(orgId, async (tx) => {
+    const [refCount] = await tx
+      .select({ count: sql<number>`count(*)` })
+      .from(swissQrReferences)
+      .where(and(eq(swissQrReferences.orgId, orgId), eq(swissQrReferences.bankAccountId, id)));
+
+    const [campaignCount] = await tx
+      .select({ count: sql<number>`count(*)` })
+      .from(campaigns)
+      .where(and(eq(campaigns.orgId, orgId), eq(campaigns.bankAccountId, id)));
+
+    return {
+      swissQrReferenceCount: Number(refCount?.count ?? 0),
+      linkedCampaignCount: Number(campaignCount?.count ?? 0),
+    };
+  });
+}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -15,6 +15,7 @@ import { PROBLEM_JSON, problemDetail } from "./lib/schemas.js";
 import { impersonationRoutes } from "./modules/admin/impersonation-routes.js";
 import { platformAdminsRoutes } from "./modules/admin/platform-admins-routes.js";
 import { auditRoutes } from "./modules/audit/routes.js";
+import { bankAccountRoutes } from "./modules/bank-accounts/routes.js";
 import { brandingRoutes } from "./modules/branding/routes.js";
 import { postalCampaignRoutes } from "./modules/campaigns/postal-routes.js";
 import { campaignRoutes } from "./modules/campaigns/routes.js";
@@ -188,6 +189,7 @@ export async function createServer(opts: CreateServerOpts = {}): Promise<Fastify
   await app.register(brandingRoutes, { prefix: "/v1" });
   await app.register(donationRoutes, { prefix: "/v1" });
   await app.register(fundRoutes, { prefix: "/v1" });
+  await app.register(bankAccountRoutes, { prefix: "/v1" });
   await app.register(pledgeRoutes, { prefix: "/v1" });
   await app.register(campaignRoutes, { prefix: "/v1" });
   await app.register(postalCampaignRoutes, { prefix: "/v1" });

--- a/packages/api/src/tests/integration/bank-accounts.test.ts
+++ b/packages/api/src/tests/integration/bank-accounts.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Bank Accounts CRUD integration tests (Epic #318, PR #2).
+ *
+ * Covers tenant isolation (RLS), IBAN normalisation + classification,
+ * soft-delete cascade to campaigns, EUR + QR-IBAN rejection, BIC length
+ * validation, and the audit-plugin coverage (resource_type + resource_id
+ * extracted from the /v1/bank-accounts/:id URL).
+ */
+
+import { bankAccounts, campaigns } from "@givernance/shared/schema";
+import { and, eq, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { createServer } from "../../server.js";
+import {
+  authHeader,
+  ensureTestTenants,
+  ORG_A,
+  ORG_B,
+  signToken,
+  signTokenB,
+} from "../helpers/auth.js";
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+  // Fresh slate — partial unique on (org_id, iban) WHERE deleted_at IS
+  // NULL would collide on every re-run otherwise. Hard-delete here is
+  // safe because no swiss_qr_references rows exist yet (PR #3 lands
+  // the worker integration that issues them).
+  await db.execute(sql`DELETE FROM bank_accounts WHERE org_id IN (${ORG_A}, ${ORG_B})`);
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+// ─── Canonical test IBANs ──────────────────────────────────────────────────
+// `CH9300762011623852957` — canonical PostFinance test IBAN (regular).
+// `CH4431999123000889012` — SIX-reserved test QR-IBAN (IID 31999).
+// `LI21088100002324013AA` — canonical valid LI IBAN.
+// `FR1420041010050500013M02606` — real valid French IBAN (non-CH/LI).
+const VALID_CH_IBAN = "CH9300762011623852957";
+const VALID_QR_IBAN = "CH4431999123000889012";
+const VALID_LI_IBAN = "LI21088100002324013AA";
+const VALID_FR_IBAN = "FR1420041010050500013M02606";
+
+const BASE_HOLDER = {
+  holderName: "Association Givernance Test",
+  holderStreet: "Rue de la Paix",
+  holderBuildingNumber: "12",
+  holderPostalCode: "1003",
+  holderTown: "Lausanne",
+  holderCountryCode: "CH",
+};
+
+describe("Bank Accounts CRUD", () => {
+  let regularAccountId: string;
+  let qrIbanAccountId: string;
+
+  it("POST /v1/bank-accounts creates a regular-IBAN account", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+      payload: {
+        ...BASE_HOLDER,
+        // Mixed-case + whitespace ingress to verify canonicalisation.
+        iban: "ch93 0076 2011 6238 5295 7",
+        bankName: "PostFinance",
+        currency: "CHF",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      data: { id: string; iban: string; ibanKind: string; currency: string };
+    }>();
+    expect(body.data.iban).toBe(VALID_CH_IBAN); // canonicalised
+    expect(body.data.ibanKind).toBe("iban");
+    expect(body.data.currency).toBe("CHF");
+    regularAccountId = body.data.id;
+  });
+
+  it("POST /v1/bank-accounts derives `qr_iban` from the IID range (30000-31999)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+      payload: {
+        ...BASE_HOLDER,
+        iban: VALID_QR_IBAN,
+        bankName: "UBS Switzerland AG",
+        currency: "CHF",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ data: { id: string; ibanKind: string } }>();
+    expect(body.data.ibanKind).toBe("qr_iban");
+    qrIbanAccountId = body.data.id;
+  });
+
+  it("POST /v1/bank-accounts rejects a non-CH/LI IBAN", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+      payload: {
+        ...BASE_HOLDER,
+        iban: VALID_FR_IBAN,
+        bankName: "BNP Paribas",
+        currency: "EUR",
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ detail: string }>();
+    expect(body.detail).toMatch(/CH and LI/);
+  });
+
+  it("POST /v1/bank-accounts accepts a Liechtenstein IBAN", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+      payload: {
+        ...BASE_HOLDER,
+        holderCountryCode: "LI",
+        iban: VALID_LI_IBAN,
+        bankName: "LLB",
+        currency: "CHF",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("PATCH /v1/bank-accounts/:id rejects a BIC of invalid length (ISO 9362 = 8 or 11)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/bank-accounts/${regularAccountId}`,
+      headers: authHeader(token),
+      payload: { bic: "ABCDEFG" }, // 7 chars — invalid
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ detail: string }>();
+    expect(body.detail).toMatch(/BIC/);
+  });
+
+  it("POST /v1/bank-accounts rejects a malformed (mod-97-fail) IBAN", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+      payload: {
+        ...BASE_HOLDER,
+        iban: "CH9300762011623852958", // last digit flipped — checksum fails
+        bankName: "PostFinance",
+        currency: "CHF",
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("GET /v1/bank-accounts lists tenant accounts excluding soft-deleted", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: Array<{ id: string; deletedAt: string | null }>;
+      pagination: { total: number };
+    }>();
+    expect(body.pagination.total).toBeGreaterThanOrEqual(2);
+    expect(body.data.every((a) => a.deletedAt === null)).toBe(true);
+  });
+
+  it("GET /v1/bank-accounts/:id returns one account", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/bank-accounts/${regularAccountId}`,
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { id: string; iban: string } }>();
+    expect(body.data.id).toBe(regularAccountId);
+    expect(body.data.iban).toBe(VALID_CH_IBAN);
+  });
+
+  it("PATCH /v1/bank-accounts/:id updates mutable fields", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/bank-accounts/${regularAccountId}`,
+      headers: authHeader(token),
+      payload: {
+        holderName: "Association Givernance Test — Renamed",
+        bic: "POFICHBE", // canonical PostFinance BIC, 8 chars
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { holderName: string; bic: string | null } }>();
+    expect(body.data.holderName).toContain("Renamed");
+    expect(body.data.bic).toBe("POFICHBE");
+  });
+
+  it("PATCH /v1/bank-accounts/:id rejects EUR on a QR-IBAN account", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/bank-accounts/${qrIbanAccountId}`,
+      headers: authHeader(token),
+      payload: { currency: "EUR" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ detail: string }>();
+    expect(body.detail).toMatch(/EUR/);
+  });
+
+  it("POST duplicate active IBAN within the same org returns 409", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+      payload: {
+        ...BASE_HOLDER,
+        iban: VALID_CH_IBAN, // already taken by regularAccountId
+        bankName: "PostFinance",
+        currency: "CHF",
+      },
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("Tenant isolation: ORG_B cannot read ORG_A's account", async () => {
+    const tokenB = signTokenB(app);
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/bank-accounts/${regularAccountId}`,
+      headers: authHeader(tokenB),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("Tenant isolation: ORG_B cannot patch ORG_A's account", async () => {
+    const tokenB = signTokenB(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/bank-accounts/${regularAccountId}`,
+      headers: authHeader(tokenB),
+      payload: { holderName: "Hijacked" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("Tenant isolation: ORG_B's list omits ORG_A's accounts entirely", async () => {
+    const tokenB = signTokenB(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/bank-accounts",
+      headers: authHeader(tokenB),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: Array<{ id: string }> }>();
+    expect(body.data.every((a) => a.id !== regularAccountId)).toBe(true);
+    expect(body.data.every((a) => a.id !== qrIbanAccountId)).toBe(true);
+  });
+
+  it("GET /v1/bank-accounts/:id/usage returns 0/0 before any swiss_qr_references rows exist", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/bank-accounts/${regularAccountId}/usage`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { swissQrReferenceCount: number; linkedCampaignCount: number };
+    }>();
+    expect(body.data.swissQrReferenceCount).toBe(0);
+    expect(body.data.linkedCampaignCount).toBe(0);
+  });
+
+  it("DELETE /v1/bank-accounts/:id soft-deletes + unlinks campaigns", async () => {
+    // Pre-create the link so we can verify the FK cascade clears it.
+    // Postgres doesn't support LIMIT directly on UPDATE — go via a
+    // subselect.
+    await db.execute(
+      sql`UPDATE campaigns SET bank_account_id = ${regularAccountId}
+          WHERE id IN (SELECT id FROM campaigns WHERE org_id = ${ORG_A} LIMIT 1)`,
+    );
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/bank-accounts/${regularAccountId}`,
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { id: string; deletedAt: string | null } }>();
+    expect(body.data.id).toBe(regularAccountId);
+    expect(body.data.deletedAt).not.toBeNull();
+
+    // Verify the soft-deleted row no longer surfaces in default list.
+    const listRes = await app.inject({
+      method: "GET",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+    });
+    const list = listRes.json<{ data: Array<{ id: string }> }>();
+    expect(list.data.find((a) => a.id === regularAccountId)).toBeUndefined();
+
+    // Verify no campaign in ORG_A still points at the soft-deleted account.
+    const stillLinked = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(campaigns)
+      .where(and(eq(campaigns.orgId, ORG_A), eq(campaigns.bankAccountId, regularAccountId)));
+    expect(Number(stillLinked[0]?.count ?? 0)).toBe(0);
+  });
+
+  it("Re-create the same IBAN after soft-delete succeeds (partial unique WHERE deleted_at IS NULL)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+      payload: {
+        ...BASE_HOLDER,
+        iban: VALID_CH_IBAN, // freed by the soft-delete above
+        bankName: "PostFinance — Re-registered",
+        currency: "CHF",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("includeDeleted=true surfaces soft-deleted rows in the list", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/bank-accounts?includeDeleted=true",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: Array<{ id: string; deletedAt: string | null }>;
+    }>();
+    expect(body.data.some((a) => a.id === regularAccountId && a.deletedAt !== null)).toBe(true);
+  });
+
+  it("DELETE on already-deleted account returns 404", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/bank-accounts/${regularAccountId}`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("Bank Accounts — IBAN canonical CHECK", () => {
+  it("the DB rejects an IBAN with whitespace if the service is bypassed (last-line-of-defence)", async () => {
+    // Direct DB path — owner role bypasses RLS but the CHECK constraint
+    // catches anything that escapes service-level canonicalisation.
+    await expect(
+      db
+        .insert(bankAccounts)
+        .values({
+          orgId: ORG_A,
+          holderName: "Test",
+          holderStreet: "Street",
+          holderPostalCode: "1003",
+          holderTown: "Lausanne",
+          holderCountryCode: "CH",
+          iban: "ch 9300 0762 0116 2385 2957", // lowercase + spaces
+          ibanKind: "iban",
+          bankName: "Test",
+          currency: "CHF",
+        })
+        .returning(),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/web/src/app/(app)/settings/bank-accounts/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/settings/bank-accounts/[id]/edit/page.tsx
@@ -1,0 +1,59 @@
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { BankAccountForm } from "@/components/settings/bank-account-form";
+import { SettingsNavigation } from "@/components/settings/settings-navigation";
+import { PageHeader } from "@/components/shared/page-header";
+import { ApiProblem } from "@/lib/api";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import type { BankAccount } from "@/models/bank-account";
+import { BankAccountService } from "@/services/BankAccountService";
+
+interface EditBankAccountPageProps {
+  params: Promise<{ id: string }>;
+}
+
+async function fetchBankAccountOrNotFound(id: string): Promise<BankAccount> {
+  const client = await createServerApiClient();
+  try {
+    return await BankAccountService.getBankAccount(client, id);
+  } catch (err) {
+    if (err instanceof ApiProblem && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+}
+
+export default async function EditBankAccountPage({ params }: EditBankAccountPageProps) {
+  const auth = await requireAuth();
+  const { id } = await params;
+  const bankAccount = await fetchBankAccountOrNotFound(id);
+
+  const t = await getTranslations("settings.bankAccounts");
+  const tSettings = await getTranslations("settings");
+  const tForm = await getTranslations("settings.bankAccounts.form");
+
+  return (
+    <>
+      <PageHeader
+        title={tForm("editTitle")}
+        description={tForm("editSubtitle")}
+        breadcrumbs={[
+          { label: tSettings("breadcrumbRoot"), href: "/dashboard" },
+          { label: t("settings"), href: "/settings" },
+          { label: t("title"), href: "/settings/bank-accounts" },
+          { label: bankAccount.bankName },
+          { label: tForm("breadcrumbEdit") },
+        ]}
+      />
+      <SettingsNavigation />
+      <BankAccountForm
+        mode="edit"
+        bankAccount={bankAccount}
+        canManage={auth.roles.includes("org_admin")}
+      />
+    </>
+  );
+}

--- a/packages/web/src/app/(app)/settings/bank-accounts/bank-accounts-table.tsx
+++ b/packages/web/src/app/(app)/settings/bank-accounts/bank-accounts-table.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { Banknote, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useState, useTransition } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { BankAccount, BankAccountIbanKind } from "@/models/bank-account";
+import { BankAccountService } from "@/services/BankAccountService";
+
+interface BankAccountsTableProps {
+  bankAccounts: BankAccount[];
+  canManage: boolean;
+}
+
+/**
+ * Format an IBAN for display: insert a space every 4 chars per ISO 13616
+ * presentation guidance, e.g. `CH93 0076 2011 6238 5295 7`.
+ */
+function formatIbanForDisplay(iban: string): string {
+  return iban.replace(/(.{4})/g, "$1 ").trim();
+}
+
+const KIND_VARIANT: Record<BankAccountIbanKind, "success" | "info"> = {
+  qr_iban: "success",
+  iban: "info",
+};
+
+export function BankAccountsTable({ bankAccounts, canManage }: BankAccountsTableProps) {
+  const router = useRouter();
+  const t = useTranslations("settings.bankAccounts");
+  const [accountToDelete, setAccountToDelete] = useState<BankAccount | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [_isPending, startTransition] = useTransition();
+
+  async function confirmDelete() {
+    if (!accountToDelete) return;
+    setIsDeleting(true);
+    try {
+      await BankAccountService.deleteBankAccount(createClientApiClient(), accountToDelete.id);
+      toast.success(t("actions.deleteSuccess"));
+      setAccountToDelete(null);
+      startTransition(() => router.refresh());
+    } catch (error) {
+      const message =
+        error instanceof ApiProblem
+          ? (error.detail ?? error.title ?? t("actions.deleteError"))
+          : t("actions.deleteError");
+      toast.error(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="overflow-hidden rounded-2xl bg-surface-container-lowest shadow-card">
+        <table className="w-full text-sm">
+          <thead className="border-b border-outline-variant bg-surface-container">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-on-surface-variant">
+                {t("table.bank")}
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-on-surface-variant">
+                {t("table.iban")}
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-on-surface-variant">
+                {t("table.kind")}
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-on-surface-variant">
+                {t("table.currency")}
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-on-surface-variant">
+                {t("table.holder")}
+              </th>
+              <th className="px-4 py-3" aria-label={t("table.actionsLabel")} />
+            </tr>
+          </thead>
+          <tbody>
+            {bankAccounts.map((account) => (
+              <tr
+                key={account.id}
+                className="border-b border-outline-variant last:border-b-0 hover:bg-surface-container/40"
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <Banknote size={16} aria-hidden="true" className="text-on-surface-variant" />
+                    <span className="font-medium text-on-surface">{account.bankName}</span>
+                  </div>
+                </td>
+                <td className="px-4 py-3 font-mono text-xs text-on-surface-variant">
+                  {formatIbanForDisplay(account.iban)}
+                </td>
+                <td className="px-4 py-3">
+                  <Badge variant={KIND_VARIANT[account.ibanKind]}>
+                    {t(`kind.${account.ibanKind}`)}
+                  </Badge>
+                </td>
+                <td className="px-4 py-3 text-on-surface">{account.currency}</td>
+                <td className="px-4 py-3 text-on-surface-variant">{account.holderName}</td>
+                <td className="px-4 py-3 text-right">
+                  {canManage ? (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={t("table.openActions", { name: account.bankName })}
+                        >
+                          <MoreHorizontal size={16} aria-hidden="true" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem asChild>
+                          <Link href={`/settings/bank-accounts/${account.id}/edit`}>
+                            <Pencil size={14} className="mr-2" aria-hidden="true" />
+                            {t("actions.edit")}
+                          </Link>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={(e) => {
+                            e.preventDefault();
+                            setAccountToDelete(account);
+                          }}
+                          className="text-error focus:text-error"
+                        >
+                          <Trash2 size={14} className="mr-2" aria-hidden="true" />
+                          {t("actions.delete")}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <AlertDialog
+        open={accountToDelete !== null}
+        onOpenChange={(open) => !open && setAccountToDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("delete.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {accountToDelete
+                ? t("delete.description", {
+                    bankName: accountToDelete.bankName,
+                    iban: formatIbanForDisplay(accountToDelete.iban),
+                  })
+                : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>{t("delete.cancel")}</AlertDialogCancel>
+            <Button type="button" variant="primary" onClick={confirmDelete} disabled={isDeleting}>
+              {isDeleting ? t("delete.deleting") : t("delete.confirm")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/packages/web/src/app/(app)/settings/bank-accounts/new/page.tsx
+++ b/packages/web/src/app/(app)/settings/bank-accounts/new/page.tsx
@@ -1,0 +1,30 @@
+import { getTranslations } from "next-intl/server";
+
+import { BankAccountForm } from "@/components/settings/bank-account-form";
+import { SettingsNavigation } from "@/components/settings/settings-navigation";
+import { PageHeader } from "@/components/shared/page-header";
+import { requireAuth } from "@/lib/auth/guards";
+
+export default async function NewBankAccountPage() {
+  const auth = await requireAuth();
+  const t = await getTranslations("settings.bankAccounts");
+  const tSettings = await getTranslations("settings");
+  const tForm = await getTranslations("settings.bankAccounts.form");
+
+  return (
+    <>
+      <PageHeader
+        title={tForm("createTitle")}
+        description={tForm("createSubtitle")}
+        breadcrumbs={[
+          { label: tSettings("breadcrumbRoot"), href: "/dashboard" },
+          { label: t("settings"), href: "/settings" },
+          { label: t("title"), href: "/settings/bank-accounts" },
+          { label: tForm("breadcrumbNew") },
+        ]}
+      />
+      <SettingsNavigation />
+      <BankAccountForm mode="create" canManage={auth.roles.includes("org_admin")} />
+    </>
+  );
+}

--- a/packages/web/src/app/(app)/settings/bank-accounts/page.tsx
+++ b/packages/web/src/app/(app)/settings/bank-accounts/page.tsx
@@ -1,0 +1,71 @@
+import { Banknote, Plus } from "lucide-react";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { SettingsNavigation } from "@/components/settings/settings-navigation";
+import { EmptyState } from "@/components/shared/empty-state";
+import { PageHeader } from "@/components/shared/page-header";
+import { Button } from "@/components/ui/button";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import { BankAccountService } from "@/services/BankAccountService";
+
+import { BankAccountsTable } from "./bank-accounts-table";
+
+const DEFAULT_PER_PAGE = 20;
+
+export default async function BankAccountsPage() {
+  const auth = await requireAuth();
+  const t = await getTranslations("settings.bankAccounts");
+  const tSettings = await getTranslations("settings");
+
+  const canManage = auth.roles.includes("org_admin");
+
+  const client = await createServerApiClient();
+  const result = await BankAccountService.listBankAccounts(client, {
+    page: 1,
+    perPage: DEFAULT_PER_PAGE,
+    sort: "createdAt",
+    order: "desc",
+  });
+
+  const hasAny = result.pagination.total > 0;
+
+  return (
+    <>
+      <PageHeader
+        title={t("title")}
+        description={
+          hasAny ? t("subtitleWithCount", { count: result.pagination.total }) : t("subtitleEmpty")
+        }
+        breadcrumbs={[
+          { label: tSettings("breadcrumbRoot"), href: "/dashboard" },
+          { label: t("settings"), href: "/settings" },
+          { label: t("title") },
+        ]}
+        actions={
+          canManage ? (
+            <Button asChild variant="primary" size="sm">
+              <Link href="/settings/bank-accounts/new">
+                <Plus size={16} aria-hidden="true" />
+                {t("actions.new")}
+              </Link>
+            </Button>
+          ) : null
+        }
+      />
+      <SettingsNavigation />
+
+      {hasAny ? (
+        <BankAccountsTable bankAccounts={result.data} canManage={canManage} />
+      ) : (
+        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+          <EmptyState
+            icon={Banknote}
+            title={t("empty.title")}
+            description={t("empty.description")}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/web/src/components/settings/bank-account-form.tsx
+++ b/packages/web/src/components/settings/bank-account-form.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { classifyIban } from "@givernance/shared/validators";
+import { Lock } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useForm } from "react-hook-form";
+
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/shared/form-field";
+import { FormSection } from "@/components/shared/form-section";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { ApiProblem } from "@/lib/api";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import type { BankAccount, BankAccountCurrency } from "@/models/bank-account";
+import { BankAccountService } from "@/services/BankAccountService";
+
+interface BankAccountFormValues {
+  holderName: string;
+  holderStreet: string;
+  holderBuildingNumber: string;
+  holderPostalCode: string;
+  holderTown: string;
+  holderCountryCode: string;
+  iban: string;
+  bic: string;
+  bankName: string;
+  currency: BankAccountCurrency;
+}
+
+type CreateMode = { mode: "create"; bankAccount?: undefined };
+type EditMode = { mode: "edit"; bankAccount: BankAccount };
+
+interface BankAccountFormBaseProps {
+  canManage: boolean;
+}
+
+export type BankAccountFormProps = BankAccountFormBaseProps & (CreateMode | EditMode);
+
+const CURRENCIES: readonly BankAccountCurrency[] = ["CHF", "EUR"];
+const COUNTRIES: readonly { value: string; key: string }[] = [
+  { value: "CH", key: "CH" },
+  { value: "LI", key: "LI" },
+];
+
+export function BankAccountForm(props: BankAccountFormProps) {
+  const { canManage, mode } = props;
+  const router = useRouter();
+  const t = useTranslations("settings.bankAccounts.form");
+  const tBankAccounts = useTranslations("settings.bankAccounts");
+
+  const form = useForm<BankAccountFormValues>({
+    mode: "onBlur",
+    defaultValues: {
+      holderName: props.bankAccount?.holderName ?? "",
+      holderStreet: props.bankAccount?.holderStreet ?? "",
+      holderBuildingNumber: props.bankAccount?.holderBuildingNumber ?? "",
+      holderPostalCode: props.bankAccount?.holderPostalCode ?? "",
+      holderTown: props.bankAccount?.holderTown ?? "",
+      holderCountryCode: props.bankAccount?.holderCountryCode ?? "CH",
+      iban: props.bankAccount?.iban ?? "",
+      bic: props.bankAccount?.bic ?? "",
+      bankName: props.bankAccount?.bankName ?? "",
+      currency: props.bankAccount?.currency ?? "CHF",
+    },
+  });
+
+  const ibanValue = form.watch("iban");
+  const currencyValue = form.watch("currency");
+  // Live IBAN classification — gives the operator real-time feedback
+  // that their typed IBAN will route through QRR (QR-IBAN) vs SCOR
+  // (regular). EUR + QR-IBAN is the most common pitfall (illegal under
+  // IG QR-bill v2.4) — surfaced inline before they hit submit.
+  const ibanKind = ibanValue ? classifyIban(ibanValue) : "invalid";
+  const eurOnQrIban = ibanKind === "qr_iban" && currencyValue === "EUR";
+
+  async function onSubmit(values: BankAccountFormValues) {
+    if (!canManage) return;
+    form.clearErrors("root");
+    try {
+      if (mode === "create") {
+        await BankAccountService.createBankAccount(createClientApiClient(), {
+          holderName: values.holderName.trim(),
+          holderStreet: values.holderStreet.trim(),
+          holderBuildingNumber: values.holderBuildingNumber.trim() || null,
+          holderPostalCode: values.holderPostalCode.trim(),
+          holderTown: values.holderTown.trim(),
+          holderCountryCode: values.holderCountryCode,
+          iban: values.iban.trim(),
+          bic: values.bic.trim() || null,
+          bankName: values.bankName.trim(),
+          currency: values.currency,
+        });
+        toast.success(t("success.created"));
+      } else {
+        // IBAN is immutable on edit (financial-record integrity).
+        await BankAccountService.updateBankAccount(createClientApiClient(), props.bankAccount.id, {
+          holderName: values.holderName.trim(),
+          holderStreet: values.holderStreet.trim(),
+          holderBuildingNumber: values.holderBuildingNumber.trim() || null,
+          holderPostalCode: values.holderPostalCode.trim(),
+          holderTown: values.holderTown.trim(),
+          holderCountryCode: values.holderCountryCode,
+          bic: values.bic.trim() || null,
+          bankName: values.bankName.trim(),
+          currency: values.currency,
+        });
+        toast.success(t("success.updated"));
+      }
+      router.push("/settings/bank-accounts");
+      router.refresh();
+    } catch (error) {
+      if (!(error instanceof ApiProblem)) {
+        console.error("BankAccountForm submit failed:", error);
+      }
+      const message =
+        error instanceof ApiProblem
+          ? (error.detail ?? error.title ?? t("errors.generic"))
+          : t("errors.generic");
+      form.setError("root", { type: "server", message });
+      toast.error(message);
+    }
+  }
+
+  const isSubmitting = form.formState.isSubmitting;
+  const rootError = form.formState.errors.root?.message;
+
+  if (!canManage) {
+    return (
+      <Card>
+        <div className="inline-flex items-center gap-2 rounded-xl bg-surface-container px-4 py-3 text-sm text-on-surface-variant">
+          <Lock size={16} aria-hidden="true" />
+          <span>{tBankAccounts("readOnly")}</span>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
+        noValidate
+      >
+        <FormSection
+          title={t("sections.account.title")}
+          description={t("sections.account.description")}
+        >
+          <div className="grid gap-5 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="iban"
+              rules={{
+                required: t("errors.ibanRequired"),
+                validate: (value) =>
+                  classifyIban(value) === "invalid" ? t("errors.ibanInvalid") : true,
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.iban")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder={t("fields.ibanPlaceholder")}
+                      maxLength={42}
+                      disabled={mode === "edit"}
+                      aria-describedby="iban-kind-hint"
+                    />
+                  </FormControl>
+                  <FormDescription id="iban-kind-hint">
+                    {mode === "edit"
+                      ? t("fields.ibanImmutable")
+                      : ibanKind === "qr_iban"
+                        ? t("fields.ibanHintQrIban")
+                        : ibanKind === "iban"
+                          ? t("fields.ibanHintRegular")
+                          : t("fields.ibanHintDefault")}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="bankName"
+              rules={{
+                required: t("errors.bankNameRequired"),
+                maxLength: { value: 100, message: t("errors.bankNameTooLong") },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.bankName")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder={t("fields.bankNamePlaceholder")}
+                      maxLength={100}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="bic"
+              rules={{
+                validate: (value) => {
+                  const v = value.replace(/\s+/g, "").toUpperCase();
+                  if (v.length === 0) return true;
+                  return v.length === 8 || v.length === 11 ? true : t("errors.bicLength");
+                },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("fields.bic")}</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder={t("fields.bicPlaceholder")} maxLength={13} />
+                  </FormControl>
+                  <FormDescription>{t("fields.bicHint")}</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="currency"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.currency")}</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={(value) => field.onChange(value as BankAccountCurrency)}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {CURRENCIES.map((c) => (
+                        <SelectItem key={c} value={c}>
+                          {c}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    {eurOnQrIban ? (
+                      <span className="text-error">{t("fields.currencyEurQrIbanError")}</span>
+                    ) : (
+                      t("fields.currencyHint")
+                    )}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        <FormSection
+          title={t("sections.holder.title")}
+          description={t("sections.holder.description")}
+        >
+          <div className="grid gap-5 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="holderName"
+              rules={{
+                required: t("errors.holderNameRequired"),
+                maxLength: { value: 70, message: t("errors.holderNameTooLong") },
+              }}
+              render={({ field }) => (
+                <FormItem className="md:col-span-2">
+                  <FormLabel required>{t("fields.holderName")}</FormLabel>
+                  <FormControl>
+                    <Input {...field} maxLength={70} />
+                  </FormControl>
+                  <FormDescription>{t("fields.holderNameHint")}</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="holderStreet"
+              rules={{
+                required: t("errors.holderStreetRequired"),
+                maxLength: { value: 70, message: t("errors.holderStreetTooLong") },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.holderStreet")}</FormLabel>
+                  <FormControl>
+                    <Input {...field} maxLength={70} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="holderBuildingNumber"
+              rules={{
+                maxLength: { value: 16, message: t("errors.holderBuildingNumberTooLong") },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("fields.holderBuildingNumber")}</FormLabel>
+                  <FormControl>
+                    <Input {...field} maxLength={16} />
+                  </FormControl>
+                  <FormDescription>{t("fields.holderBuildingNumberHint")}</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="holderPostalCode"
+              rules={{
+                required: t("errors.holderPostalCodeRequired"),
+                maxLength: { value: 16, message: t("errors.holderPostalCodeTooLong") },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.holderPostalCode")}</FormLabel>
+                  <FormControl>
+                    <Input {...field} maxLength={16} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="holderTown"
+              rules={{
+                required: t("errors.holderTownRequired"),
+                maxLength: { value: 35, message: t("errors.holderTownTooLong") },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.holderTown")}</FormLabel>
+                  <FormControl>
+                    <Input {...field} maxLength={35} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="holderCountryCode"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel required>{t("fields.holderCountryCode")}</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {COUNTRIES.map((c) => (
+                        <SelectItem key={c.value} value={c.value}>
+                          {c.value}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>{t("fields.holderCountryHint")}</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </FormSection>
+
+        <div className="flex flex-col gap-4 py-8">
+          <div className="min-h-5 text-sm text-error">{rootError}</div>
+          <div className="flex flex-wrap justify-end gap-2">
+            <Button asChild variant="ghost">
+              <Link href="/settings/bank-accounts">{t("actions.cancel")}</Link>
+            </Button>
+            <Button type="submit" disabled={isSubmitting || eurOnQrIban}>
+              {isSubmitting
+                ? t("actions.submitting")
+                : mode === "create"
+                  ? t("actions.submitCreate")
+                  : t("actions.submitUpdate")}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/packages/web/src/components/settings/settings-navigation.tsx
+++ b/packages/web/src/components/settings/settings-navigation.tsx
@@ -22,6 +22,11 @@ const SETTINGS_NAV_ITEMS = [
     key: "funds",
     match: (pathname: string) => pathname.startsWith("/settings/funds"),
   },
+  {
+    href: "/settings/bank-accounts",
+    key: "bankAccounts",
+    match: (pathname: string) => pathname.startsWith("/settings/bank-accounts"),
+  },
 ] as const;
 
 export function SettingsNavigation() {

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -852,7 +852,8 @@
       "label": "Organisation settings navigation",
       "organization": "Organisation",
       "members": "Members",
-      "funds": "Funds"
+      "funds": "Funds",
+      "bankAccounts": "Bank accounts"
     },
     "branding": {
       "title": "Organisation logo",
@@ -1101,6 +1102,114 @@
         "success": {
           "created": "Fund created.",
           "updated": "Fund updated."
+        }
+      }
+    },
+    "bankAccounts": {
+      "settings": "Settings",
+      "title": "Bank accounts",
+      "subtitleEmpty": "Register a Swiss bank account (IBAN or QR-IBAN) to enable Swiss QR-bill mode on your postal campaigns.",
+      "subtitleWithCount": "{count, plural, one {# bank account} other {# bank accounts}} configured",
+      "readOnly": "Only organisation admins can manage bank accounts.",
+      "empty": {
+        "title": "No bank accounts yet",
+        "description": "Add your first Swiss operating account to mint Swiss QR-bills on postal mailings. CHF or EUR, regular IBAN or QR-IBAN — Givernance derives the reference type automatically."
+      },
+      "kind": {
+        "iban": "Regular IBAN",
+        "qr_iban": "QR-IBAN"
+      },
+      "table": {
+        "bank": "Bank",
+        "iban": "IBAN",
+        "kind": "Type",
+        "currency": "Currency",
+        "holder": "Holder",
+        "actionsLabel": "Row actions",
+        "openActions": "Open actions for {name}"
+      },
+      "actions": {
+        "new": "Add bank account",
+        "edit": "Edit",
+        "delete": "Soft-delete",
+        "deleteSuccess": "Bank account removed. Linked campaigns degraded to standard mode.",
+        "deleteError": "Failed to remove the bank account. Please try again."
+      },
+      "delete": {
+        "title": "Remove bank account?",
+        "description": "{bankName} ({iban}) will be soft-deleted. Any campaign currently linked to it will fall back to standard postal mode (no QR-bill). The audit history is preserved — past QR-bills and reconciliations remain accessible.",
+        "cancel": "Cancel",
+        "confirm": "Remove",
+        "deleting": "Removing…"
+      },
+      "form": {
+        "createTitle": "New bank account",
+        "createSubtitle": "IBAN holder data prints on every QR-bill. The IG QR-bill v2.4 structured address (street + building number + postal code + town) — combined-address shapes are no longer supported.",
+        "breadcrumbNew": "New",
+        "editTitle": "Edit bank account",
+        "editSubtitle": "Holder data and currency can be updated. The IBAN is immutable to preserve financial-record integrity — soft-delete and re-create to change it.",
+        "breadcrumbEdit": "Edit",
+        "sections": {
+          "account": {
+            "title": "Account details",
+            "description": "IBAN, bank name and currency. The IBAN kind (QR-IBAN vs regular IBAN) is derived automatically from the IID range."
+          },
+          "holder": {
+            "title": "Holder address",
+            "description": "Printed on the QR-bill in the IG structured-address (S) shape. Restricted to CH or LI per IG QR-bill v2.4."
+          }
+        },
+        "fields": {
+          "iban": "IBAN",
+          "ibanPlaceholder": "CH93 0076 2011 6238 5295 7",
+          "ibanHintDefault": "CH or LI only. Whitespace and case are normalised on save.",
+          "ibanHintQrIban": "Detected: QR-IBAN — Swiss QR-bills will use a 27-digit QRR reference (mod-10).",
+          "ibanHintRegular": "Detected: regular IBAN — Swiss QR-bills will use a SCOR reference (RF + mod-97).",
+          "ibanImmutable": "IBAN is immutable after creation (financial-record integrity).",
+          "bic": "BIC / SWIFT (optional)",
+          "bicPlaceholder": "POFICHBE",
+          "bicHint": "8 or 11 characters per ISO 9362. Optional — most Swiss e-banking flows don't require it for QR-bill payments.",
+          "bankName": "Bank name",
+          "bankNamePlaceholder": "PostFinance, UBS Switzerland AG, Raiffeisen…",
+          "currency": "Currency",
+          "currencyHint": "CHF or EUR. EUR + QR-IBAN is illegal under IG QR-bill v2.4 — use a regular IBAN with SCOR for EUR donations.",
+          "currencyEurQrIbanError": "EUR + QR-IBAN is illegal under IG QR-bill v2.4. Switch to CHF or use a regular (non-QR) IBAN.",
+          "holderName": "Holder name",
+          "holderNameHint": "Printed at the top of the QR-bill. Up to 70 characters.",
+          "holderStreet": "Street",
+          "holderBuildingNumber": "Building number",
+          "holderBuildingNumberHint": "Optional. Up to 16 characters (e.g. \"12\" or \"12b\").",
+          "holderPostalCode": "Postal code",
+          "holderTown": "Town / City",
+          "holderCountryCode": "Country",
+          "holderCountryHint": "CH or LI only — IG QR-bill applies to those two jurisdictions."
+        },
+        "actions": {
+          "cancel": "Cancel",
+          "submitCreate": "Create bank account",
+          "submitUpdate": "Save changes",
+          "submitting": "Saving…"
+        },
+        "errors": {
+          "ibanRequired": "IBAN is required.",
+          "ibanInvalid": "IBAN failed mod-97 / format validation.",
+          "bicLength": "BIC must be exactly 8 or 11 characters when present (ISO 9362).",
+          "bankNameRequired": "Bank name is required.",
+          "bankNameTooLong": "Bank name must be at most 100 characters.",
+          "holderNameRequired": "Holder name is required.",
+          "holderNameTooLong": "Holder name must be at most 70 characters (IG QR-bill cap).",
+          "holderStreetRequired": "Street is required.",
+          "holderStreetTooLong": "Street must be at most 70 characters.",
+          "holderBuildingNumberTooLong": "Building number must be at most 16 characters.",
+          "holderPostalCodeRequired": "Postal code is required.",
+          "holderPostalCodeTooLong": "Postal code must be at most 16 characters.",
+          "holderTownRequired": "Town is required.",
+          "holderTownTooLong": "Town must be at most 35 characters (IG QR-bill cap).",
+          "generic": "Something went wrong while saving. Please try again."
+        },
+        "success": {
+          "created": "Bank account created.",
+          "updated": "Bank account updated."
         }
       }
     },

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -852,7 +852,8 @@
       "label": "Navigation des paramètres de l'organisation",
       "organization": "Organisation",
       "members": "Membres",
-      "funds": "Fonds"
+      "funds": "Fonds",
+      "bankAccounts": "Comptes bancaires"
     },
     "branding": {
       "title": "Logo de l'organisation",
@@ -1101,6 +1102,114 @@
         "success": {
           "created": "Fonds créé.",
           "updated": "Fonds mis à jour."
+        }
+      }
+    },
+    "bankAccounts": {
+      "settings": "Paramètres",
+      "title": "Comptes bancaires",
+      "subtitleEmpty": "Enregistrez un compte bancaire suisse (IBAN ou QR-IBAN) pour activer la génération de BVR sur vos campagnes postales.",
+      "subtitleWithCount": "{count, plural, one {# compte bancaire} other {# comptes bancaires}} configuré(s)",
+      "readOnly": "Seuls les administrateurs de l'organisation peuvent gérer les comptes bancaires.",
+      "empty": {
+        "title": "Aucun compte bancaire enregistré",
+        "description": "Ajoutez votre premier compte bancaire pour générer des BVR sur vos lettres postales. CHF ou EUR, IBAN classique ou QR-IBAN — Givernance détermine automatiquement le type de référence."
+      },
+      "kind": {
+        "iban": "IBAN classique",
+        "qr_iban": "QR-IBAN"
+      },
+      "table": {
+        "bank": "Banque",
+        "iban": "IBAN",
+        "kind": "Type",
+        "currency": "Devise",
+        "holder": "Titulaire",
+        "actionsLabel": "Actions de ligne",
+        "openActions": "Actions pour {name}"
+      },
+      "actions": {
+        "new": "Ajouter un compte",
+        "edit": "Modifier",
+        "delete": "Archiver",
+        "deleteSuccess": "Compte archivé. Les campagnes liées repassent en mode postal standard.",
+        "deleteError": "Échec de l'archivage. Veuillez réessayer."
+      },
+      "delete": {
+        "title": "Archiver ce compte ?",
+        "description": "{bankName} ({iban}) sera archivé (soft-delete). Les campagnes actuellement liées reviendront au mode postal standard (sans BVR). L'historique d'audit reste intact — les BVR émis et les réconciliations restent accessibles.",
+        "cancel": "Annuler",
+        "confirm": "Archiver",
+        "deleting": "Archivage…"
+      },
+      "form": {
+        "createTitle": "Nouveau compte bancaire",
+        "createSubtitle": "Les coordonnées du titulaire sont imprimées sur chaque BVR. Adresse structurée IG QR-bill v2.4 (rue + numéro + code postal + ville) — les adresses combinées ne sont plus prises en charge.",
+        "breadcrumbNew": "Nouveau",
+        "editTitle": "Modifier le compte bancaire",
+        "editSubtitle": "Les coordonnées du titulaire et la devise sont modifiables. L'IBAN est immuable pour préserver l'intégrité de l'historique financier — archivez et recréez pour le changer.",
+        "breadcrumbEdit": "Modifier",
+        "sections": {
+          "account": {
+            "title": "Coordonnées du compte",
+            "description": "IBAN, nom de la banque et devise. Le type d'IBAN (QR-IBAN vs IBAN classique) est dérivé automatiquement de la plage IID."
+          },
+          "holder": {
+            "title": "Adresse du titulaire",
+            "description": "Imprimée sur le BVR au format structuré (S) prescrit par IG QR-bill v2.4. Restreint à CH ou LI."
+          }
+        },
+        "fields": {
+          "iban": "IBAN",
+          "ibanPlaceholder": "CH93 0076 2011 6238 5295 7",
+          "ibanHintDefault": "CH ou LI uniquement. Les espaces et la casse sont normalisés à l'enregistrement.",
+          "ibanHintQrIban": "Détecté : QR-IBAN — les BVR utiliseront une référence QRR à 27 chiffres (mod-10).",
+          "ibanHintRegular": "Détecté : IBAN classique — les BVR utiliseront une référence SCOR (RF + mod-97).",
+          "ibanImmutable": "L'IBAN est immuable après création (intégrité financière).",
+          "bic": "BIC / SWIFT (optionnel)",
+          "bicPlaceholder": "POFICHBE",
+          "bicHint": "8 ou 11 caractères (ISO 9362). Optionnel — la plupart des e-banking suisses n'en ont pas besoin pour un paiement par QR.",
+          "bankName": "Nom de la banque",
+          "bankNamePlaceholder": "PostFinance, UBS Switzerland AG, Raiffeisen…",
+          "currency": "Devise",
+          "currencyHint": "CHF ou EUR. EUR + QR-IBAN est interdit par IG QR-bill v2.4 — utilisez un IBAN classique avec SCOR pour les dons en EUR.",
+          "currencyEurQrIbanError": "EUR + QR-IBAN est interdit par IG QR-bill v2.4. Passez en CHF ou utilisez un IBAN classique (non QR-IBAN).",
+          "holderName": "Nom du titulaire",
+          "holderNameHint": "Imprimé en haut du BVR. Jusqu'à 70 caractères.",
+          "holderStreet": "Rue",
+          "holderBuildingNumber": "Numéro",
+          "holderBuildingNumberHint": "Optionnel. Jusqu'à 16 caractères (ex. « 12 » ou « 12b »).",
+          "holderPostalCode": "Code postal",
+          "holderTown": "Ville",
+          "holderCountryCode": "Pays",
+          "holderCountryHint": "CH ou LI uniquement — le QR-bill IG s'applique à ces deux juridictions."
+        },
+        "actions": {
+          "cancel": "Annuler",
+          "submitCreate": "Créer le compte",
+          "submitUpdate": "Enregistrer",
+          "submitting": "Enregistrement…"
+        },
+        "errors": {
+          "ibanRequired": "L'IBAN est obligatoire.",
+          "ibanInvalid": "L'IBAN n'a pas passé la validation mod-97 ou de format.",
+          "bicLength": "Le BIC doit faire exactement 8 ou 11 caractères s'il est renseigné (ISO 9362).",
+          "bankNameRequired": "Le nom de la banque est obligatoire.",
+          "bankNameTooLong": "Le nom de la banque doit faire au plus 100 caractères.",
+          "holderNameRequired": "Le nom du titulaire est obligatoire.",
+          "holderNameTooLong": "Le nom du titulaire doit faire au plus 70 caractères (limite IG QR-bill).",
+          "holderStreetRequired": "La rue est obligatoire.",
+          "holderStreetTooLong": "La rue doit faire au plus 70 caractères.",
+          "holderBuildingNumberTooLong": "Le numéro doit faire au plus 16 caractères.",
+          "holderPostalCodeRequired": "Le code postal est obligatoire.",
+          "holderPostalCodeTooLong": "Le code postal doit faire au plus 16 caractères.",
+          "holderTownRequired": "La ville est obligatoire.",
+          "holderTownTooLong": "La ville doit faire au plus 35 caractères (limite IG QR-bill).",
+          "generic": "Une erreur est survenue pendant l'enregistrement. Veuillez réessayer."
+        },
+        "success": {
+          "created": "Compte bancaire créé.",
+          "updated": "Compte bancaire mis à jour."
         }
       }
     },

--- a/packages/web/src/models/bank-account.ts
+++ b/packages/web/src/models/bank-account.ts
@@ -1,0 +1,90 @@
+import type { Pagination } from "@/models/constituent";
+
+/** Discriminator derived from the IBAN's IID range — never set by the operator. */
+export type BankAccountIbanKind = "iban" | "qr_iban";
+
+/** Currencies allowed by IG QR-bill v2.4. EUR + QRR is illegal (euroSIC). */
+export type BankAccountCurrency = "CHF" | "EUR";
+
+/**
+ * Operator-configured Swiss operating account (Epic #318). IG QR-bill
+ * v2.4 / v2.5 **structured address (S)** shape — combined-address (K)
+ * is not supported.
+ */
+export interface BankAccount {
+  id: string;
+  orgId: string;
+  holderName: string;
+  /** IG `StrtNm` — street name only. */
+  holderStreet: string;
+  /** IG `BldgNb` — building / house number, nullable. */
+  holderBuildingNumber: string | null;
+  holderPostalCode: string;
+  /** IG `TwnNm` — town / city. */
+  holderTown: string;
+  /** ISO 3166-1 alpha-2; restricted to CH or LI server-side. */
+  holderCountryCode: string;
+  /** Canonical form: uppercase, no spaces. */
+  iban: string;
+  ibanKind: BankAccountIbanKind;
+  bic: string | null;
+  bankName: string;
+  currency: BankAccountCurrency;
+  deletedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type BankAccountSortField = "bankName" | "currency" | "createdAt";
+export type BankAccountSortOrder = "asc" | "desc";
+
+export interface BankAccountListQuery {
+  page?: number;
+  perPage?: number;
+  sort?: BankAccountSortField;
+  order?: BankAccountSortOrder;
+  includeDeleted?: boolean;
+}
+
+export interface BankAccountListResponse {
+  data: BankAccount[];
+  pagination: Pagination;
+}
+
+export interface BankAccountDetailResponse {
+  data: BankAccount;
+}
+
+export interface BankAccountCreateInput {
+  holderName: string;
+  holderStreet: string;
+  holderBuildingNumber?: string | null;
+  holderPostalCode: string;
+  holderTown: string;
+  holderCountryCode?: string;
+  iban: string;
+  bic?: string | null;
+  bankName: string;
+  currency?: BankAccountCurrency;
+}
+
+export interface BankAccountUpdateInput {
+  holderName?: string;
+  holderStreet?: string;
+  holderBuildingNumber?: string | null;
+  holderPostalCode?: string;
+  holderTown?: string;
+  holderCountryCode?: string;
+  bic?: string | null;
+  bankName?: string;
+  currency?: BankAccountCurrency;
+}
+
+export interface BankAccountUsage {
+  swissQrReferenceCount: number;
+  linkedCampaignCount: number;
+}
+
+export interface BankAccountUsageResponse {
+  data: BankAccountUsage;
+}

--- a/packages/web/src/services/BankAccountService.ts
+++ b/packages/web/src/services/BankAccountService.ts
@@ -1,0 +1,133 @@
+import type { ApiClient } from "@/lib/api";
+import type {
+  BankAccount,
+  BankAccountCreateInput,
+  BankAccountDetailResponse,
+  BankAccountListQuery,
+  BankAccountListResponse,
+  BankAccountUpdateInput,
+  BankAccountUsage,
+  BankAccountUsageResponse,
+} from "@/models/bank-account";
+
+export const BankAccountService = {
+  async listBankAccounts(
+    client: ApiClient,
+    query: BankAccountListQuery = {},
+  ): Promise<BankAccountListResponse> {
+    const response = await client.get<BankAccountListResponse>("/v1/bank-accounts", {
+      params: {
+        page: query.page ?? 1,
+        perPage: query.perPage ?? 20,
+        sort: query.sort,
+        order: query.order,
+        includeDeleted: query.includeDeleted,
+      },
+    });
+
+    return {
+      data: response.data.map(mapBankAccount),
+      pagination: response.pagination,
+    };
+  },
+
+  async createBankAccount(client: ApiClient, input: BankAccountCreateInput): Promise<BankAccount> {
+    const response = await client.post<BankAccountDetailResponse>(
+      "/v1/bank-accounts",
+      toCreateBody(input),
+    );
+    return mapBankAccount(response.data);
+  },
+
+  async getBankAccount(client: ApiClient, id: string): Promise<BankAccount> {
+    const response = await client.get<BankAccountDetailResponse>(
+      `/v1/bank-accounts/${encodeURIComponent(id)}`,
+    );
+    return mapBankAccount(response.data);
+  },
+
+  async getBankAccountUsage(client: ApiClient, id: string): Promise<BankAccountUsage> {
+    const response = await client.get<BankAccountUsageResponse>(
+      `/v1/bank-accounts/${encodeURIComponent(id)}/usage`,
+    );
+    return response.data;
+  },
+
+  async updateBankAccount(
+    client: ApiClient,
+    id: string,
+    input: BankAccountUpdateInput,
+  ): Promise<BankAccount> {
+    const response = await client.patch<BankAccountDetailResponse>(
+      `/v1/bank-accounts/${encodeURIComponent(id)}`,
+      toUpdateBody(input),
+    );
+    return mapBankAccount(response.data);
+  },
+
+  async deleteBankAccount(client: ApiClient, id: string): Promise<BankAccount> {
+    const response = await client.delete<BankAccountDetailResponse>(
+      `/v1/bank-accounts/${encodeURIComponent(id)}`,
+    );
+    return mapBankAccount(response.data);
+  },
+};
+
+function mapBankAccount(raw: BankAccount): BankAccount {
+  return {
+    id: raw.id,
+    orgId: raw.orgId,
+    holderName: raw.holderName,
+    holderStreet: raw.holderStreet,
+    holderBuildingNumber: raw.holderBuildingNumber,
+    holderPostalCode: raw.holderPostalCode,
+    holderTown: raw.holderTown,
+    holderCountryCode: raw.holderCountryCode,
+    iban: raw.iban,
+    ibanKind: raw.ibanKind,
+    bic: raw.bic,
+    bankName: raw.bankName,
+    currency: raw.currency,
+    deletedAt: raw.deletedAt,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function toCreateBody(input: BankAccountCreateInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    holderName: input.holderName,
+    holderStreet: input.holderStreet,
+    holderPostalCode: input.holderPostalCode,
+    holderTown: input.holderTown,
+    iban: input.iban,
+    bankName: input.bankName,
+  };
+  if (input.holderBuildingNumber !== undefined) {
+    body.holderBuildingNumber = input.holderBuildingNumber ?? null;
+  }
+  if (input.holderCountryCode !== undefined) body.holderCountryCode = input.holderCountryCode;
+  if (input.bic !== undefined) body.bic = input.bic ?? null;
+  if (input.currency !== undefined) body.currency = input.currency;
+  return body;
+}
+
+function toUpdateBody(input: BankAccountUpdateInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  for (const key of [
+    "holderName",
+    "holderStreet",
+    "holderPostalCode",
+    "holderTown",
+    "holderCountryCode",
+    "bankName",
+    "currency",
+  ] as const) {
+    if (input[key] !== undefined) body[key] = input[key];
+  }
+  if (input.holderBuildingNumber !== undefined) {
+    body.holderBuildingNumber = input.holderBuildingNumber ?? null;
+  }
+  if (input.bic !== undefined) body.bic = input.bic ?? null;
+  return body;
+}


### PR DESCRIPTION
## Summary

PR #2 of Epic #318 (Swiss QR-bill). Adds the operator surface to register Swiss bank accounts that back QR-bill issuance.

PR #319 (foundation) shipped the schema + validators + ADRs + docs. This PR ships **what the operator actually touches**: the `/settings/bank-accounts` tab + the underlying API.

## What's in

**API** — `packages/api/src/modules/bank-accounts/`
- 6 endpoints under `requireOrgAdmin` (writes) + `requireAuth` (reads): list / create / get / usage / patch / soft-delete
- Tenant-scoped via `withTenantContext` (RLS)
- IBAN canonicalised at the service boundary (uppercase, strip whitespace) — matches the DB CHECK from PR #319
- `iban_kind` derived automatically from the IID range (no operator input)
- IG QR-bill v2.4 invariants enforced: CH/LI scope, BIC length 8/11 (ISO 9362), EUR + QR-IBAN rejected, address-cap validation
- Soft-delete: cascades to `campaigns.bank_account_id` → NULL (degrades to standard postal mode), preserves audit trail
- Partial unique on `(org_id, iban) WHERE deleted_at IS NULL` lets the same IBAN be re-added after soft-delete
- Audit log captured automatically by the existing `audit` plugin (URL-pattern extraction in `plugins/audit.ts`)
- **20 new integration tests** covering canonicalisation, QR-IBAN detection, RLS isolation, soft-delete + cascade, re-create-after-soft-delete, 404 on cross-tenant, mod-97 rejection, BIC length, EUR + QR-IBAN

**Web** — `/settings/bank-accounts/`
- List page with empty state + populated table
- New / edit forms (IBAN immutable on edit — financial-record integrity)
- IG S-address shape (street + buildingNumber + postalCode + town + country)
- **Live IBAN classification** via `@givernance/shared/validators` — shows real-time "QR-IBAN → QRR" or "regular → SCOR" hint as the operator types
- **Inline EUR + QR-IBAN error** (disables submit) — same rule as the server, but caught before round-trip
- BIC length validated client-side (ISO 9362)
- Settings navigation gains a "Bank accounts" tab
- Full FR + EN i18n

**Mockups** (per CLAUDE.md mockup-first rule)
- `docs/design/settings/bank-accounts-list.html`
- `docs/design/settings/bank-accounts-form.html`

## CI

`pnpm install + build + format + lint + typecheck + test` all green.
**967 / 967** tests pass (api 746 · web 113 · worker 41 · shared 61 · relay 6).

## Out of scope (deferred)

- **PR #3** — Campaign-form bank-account picker + worker QR-bill PDF rendering (`swissqrbill` v4)
- **PR #4** — camt.053 upload + reconciliation worker + unreconciled queue
- **PR #5** — Tracking widget extension (3-stage personalised / 2-stage door-drop funnels)

## Test plan

- [x] Local: `pnpm dev:up && pnpm db:migrate && pnpm --filter @givernance/api test -- --run bank-accounts` → 20/20
- [x] `pnpm typecheck` clean across 6 workspaces
- [x] `pnpm run lint` no errors
- [x] Web build emits the 3 new routes (`/settings/bank-accounts`, `/new`, `/[id]/edit`)
- [ ] Reviewer: click through `pnpm dev`, verify create / edit / soft-delete + the QR-IBAN/SCOR live-detection hint + the EUR-QR-IBAN warning
- [ ] Reviewer: open both mockups under `docs/design/settings/` and verify alignment with the rendered pages

close #325 — when this lands, PR #3 (campaign-picker + PDF rendering) is unblocked. Epic #318 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)