### PR TITLE
feat(swiss-qr-bill): campaign picker + worker QR-bill rendering (Epic #318 PR #3/N)

### DIFF
--- a/packages/api/src/modules/campaigns/postal-export-service.ts
+++ b/packages/api/src/modules/campaigns/postal-export-service.ts
@@ -18,6 +18,7 @@
  */
 
 import {
+  bankAccounts,
   campaignConstituents,
   campaignPostalExports,
   campaignPublicPages,
@@ -26,6 +27,7 @@ import {
   outboxEvents,
   type PostalExportMode,
 } from "@givernance/shared/schema";
+import { classifyIban } from "@givernance/shared/validators";
 import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { withTenantContext } from "../../lib/db.js";
 import { resolveInternalUserId } from "../../lib/resolve-user.js";
@@ -42,6 +44,14 @@ export type PostalExportErrorCode =
   | "public_page_draft"
   | "personalized_on_door_drop"
   | "no_recipients"
+  // Epic #318: Swiss QR-bill readiness gates — fire only when the
+  // campaign has `bank_account_id IS NOT NULL`. A NULL bank account
+  // keeps the campaign on the standard postal rail (no QR-bill, no
+  // Swiss-specific checks).
+  | "swiss_qr_bill_bank_account_deleted"
+  | "swiss_qr_bill_invalid_iban"
+  | "swiss_qr_bill_currency_mismatch"
+  | "swiss_qr_bill_address_too_long"
   | "insert_failed";
 
 export class PostalExportError extends Error {
@@ -106,6 +116,94 @@ function mapRow(row: {
   };
 }
 
+/**
+ * Epic #318 — Swiss QR-bill readiness gates. Fires only when the
+ * campaign has `bank_account_id IS NOT NULL`. The gates here are the
+ * **server-side mirror** of the form-level checks in
+ * `web/components/settings/bank-account-form.tsx` and of the DB CHECK
+ * constraints from migration 0044 — defense-in-depth so the worker
+ * never sees a payload that would fail at PDF render time.
+ *
+ * `qrReferenceMode='auto'` resolves to `qrr` for QR-IBANs and `scor`
+ * for regular IBANs — see ADR-027. The currency-vs-reference rule
+ * (EUR + QRR illegal under IG QR-bill v2.4 after the euroSIC
+ * discontinuation) fires here AND at the bank-account create-time
+ * service guard.
+ */
+async function assertSwissQrBillReadiness(
+  tx: Parameters<Parameters<typeof withTenantContext>[1]>[0],
+  orgId: string,
+  bankAccountId: string,
+  qrReferenceMode: "auto" | "qrr" | "scor",
+): Promise<void> {
+  const [account] = await tx
+    .select({
+      id: bankAccounts.id,
+      deletedAt: bankAccounts.deletedAt,
+      iban: bankAccounts.iban,
+      ibanKind: bankAccounts.ibanKind,
+      currency: bankAccounts.currency,
+      holderName: bankAccounts.holderName,
+      holderStreet: bankAccounts.holderStreet,
+      holderBuildingNumber: bankAccounts.holderBuildingNumber,
+      holderPostalCode: bankAccounts.holderPostalCode,
+      holderTown: bankAccounts.holderTown,
+    })
+    .from(bankAccounts)
+    .where(and(eq(bankAccounts.id, bankAccountId), eq(bankAccounts.orgId, orgId)));
+
+  if (!account || account.deletedAt !== null) {
+    throw new PostalExportError(
+      "Linked bank account was soft-deleted. Pick a different bank account or restore it before generating a postal export.",
+      "swiss_qr_bill_bank_account_deleted",
+    );
+  }
+
+  // Defense-in-depth: the bank_accounts CHECK + service-level validator
+  // enforce CH/LI + mod-97 at write time, so this branch should never
+  // fire on a row created via the API. It catches DB-direct writes that
+  // bypassed those guards.
+  if (classifyIban(account.iban) === "invalid") {
+    throw new PostalExportError(
+      "Linked bank account has an IBAN that failed mod-97 / CH-or-LI validation. Re-create the bank account.",
+      "swiss_qr_bill_invalid_iban",
+    );
+  }
+
+  const effectiveMode =
+    qrReferenceMode === "auto"
+      ? account.ibanKind === "qr_iban"
+        ? "qrr"
+        : "scor"
+      : qrReferenceMode;
+  if (account.currency === "EUR" && effectiveMode === "qrr") {
+    throw new PostalExportError(
+      "EUR + QRR is illegal under IG QR-bill v2.4 (euroSIC discontinuation). Switch the campaign's qrReferenceMode to SCOR or change the bank account currency.",
+      "swiss_qr_bill_currency_mismatch",
+    );
+  }
+
+  // IG QR-bill v2.4 holder-field caps. These match the DB column widths
+  // exactly, so any row that wrote successfully should pass — but a UI
+  // patch path could still in theory truncate before saving; better to
+  // surface the offending field here than at render time.
+  const overruns = [
+    account.holderName.length > 70 && "holder name (>70)",
+    account.holderStreet.length > 70 && "holder street (>70)",
+    account.holderBuildingNumber !== null && account.holderBuildingNumber.length > 16
+      ? "holder building number (>16)"
+      : false,
+    account.holderPostalCode.length > 16 && "holder postal code (>16)",
+    account.holderTown.length > 35 && "holder town (>35)",
+  ].filter(Boolean);
+  if (overruns.length > 0) {
+    throw new PostalExportError(
+      `Holder address exceeds IG QR-bill v2.4 caps: ${overruns.join(", ")}. Edit the bank account before exporting.`,
+      "swiss_qr_bill_address_too_long",
+    );
+  }
+}
+
 /** Count linked constituents for a campaign (used to lock the totalCount at job-start). */
 async function countLinkedConstituents(
   tx: Parameters<Parameters<typeof withTenantContext>[1]>[0],
@@ -145,7 +243,13 @@ export async function startPostalExport(
 ): Promise<PostalExportRow | null> {
   return withTenantContext(orgId, async (tx) => {
     const [campaign] = await tx
-      .select({ id: campaigns.id, type: campaigns.type, status: campaigns.status })
+      .select({
+        id: campaigns.id,
+        type: campaigns.type,
+        status: campaigns.status,
+        bankAccountId: campaigns.bankAccountId,
+        qrReferenceMode: campaigns.qrReferenceMode,
+      })
       .from(campaigns)
       .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
 
@@ -185,6 +289,11 @@ export async function startPostalExport(
         "Public donation page is still a draft. Publish it before generating a postal export — otherwise donors scanning the printed QR codes won't reach a working donation page.",
         "public_page_draft",
       );
+    }
+
+    // Epic #318 — Swiss QR-bill readiness gates (only when linked).
+    if (campaign.bankAccountId !== null) {
+      await assertSwissQrBillReadiness(tx, orgId, campaign.bankAccountId, campaign.qrReferenceMode);
     }
 
     let totalCount = 0;

--- a/packages/api/src/modules/campaigns/routes.ts
+++ b/packages/api/src/modules/campaigns/routes.ts
@@ -69,6 +69,20 @@ const IdempotencyKeyHeader = Type.Object({
 /** Free-form campaign description (Epic #274 follow-up). Soft-cap matches the validator. */
 const CampaignDescriptionSchema = Type.Union([Type.Null(), Type.String({ maxLength: 2000 })]);
 
+/**
+ * Epic #318 — Swiss QR-bill picker on the campaign form. The optional
+ * `bankAccountId` is a same-tenant FK pointing at `bank_accounts.id`;
+ * setting it flips the campaign into Swiss QR-bill mode (the worker
+ * appends a QR-bill PDF to every postal export). `qrReferenceMode`
+ * lets the operator override the worker's auto-derivation (QRR for
+ * QR-IBANs, SCOR for regular IBANs) on the rare bank that supports both.
+ */
+const CampaignQrReferenceModeSchema = Type.Union([
+  Type.Literal("auto"),
+  Type.Literal("qrr"),
+  Type.Literal("scor"),
+]);
+
 const CampaignCreateBody = Type.Object({
   name: Type.String({ minLength: 1, maxLength: 255 }),
   description: Type.Optional(CampaignDescriptionSchema),
@@ -78,6 +92,8 @@ const CampaignCreateBody = Type.Object({
   operationalCostCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
   goalAmountCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
   fundIds: Type.Optional(Type.Array(UuidSchema)),
+  bankAccountId: Type.Optional(Type.Union([Type.Null(), UuidSchema])),
+  qrReferenceMode: Type.Optional(CampaignQrReferenceModeSchema),
 });
 
 const CampaignUpdateBody = Type.Object(
@@ -93,6 +109,8 @@ const CampaignUpdateBody = Type.Object(
     operationalCostCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
     goalAmountCents: Type.Optional(Type.Union([Type.Null(), Type.Integer({ minimum: 0 })])),
     fundIds: Type.Optional(Type.Array(UuidSchema)),
+    bankAccountId: Type.Optional(Type.Union([Type.Null(), UuidSchema])),
+    qrReferenceMode: Type.Optional(CampaignQrReferenceModeSchema),
   },
   { minProperties: 1 },
 );
@@ -113,6 +131,12 @@ const CampaignResponse = Type.Object({
   operationalCostCents: Type.Union([Type.Integer(), Type.Null()]),
   platformFeesCents: Type.Integer(),
   goalAmountCents: Type.Union([Type.Integer(), Type.Null()]),
+  /**
+   * Epic #318: Swiss QR-bill discriminator. Presence IS the
+   * "Swiss QR-bill mode on" signal — see ADR-027 / docs/25 §3.
+   */
+  bankAccountId: Type.Union([UuidSchema, Type.Null()]),
+  qrReferenceMode: CampaignQrReferenceModeSchema,
   createdAt: Type.String(),
   updatedAt: Type.String(),
 });
@@ -243,6 +267,8 @@ export async function campaignRoutes(app: FastifyInstance) {
         operationalCostCents?: number | null;
         goalAmountCents?: number | null;
         fundIds?: string[];
+        bankAccountId?: string | null;
+        qrReferenceMode?: "auto" | "qrr" | "scor";
       };
       try {
         const campaign = await createCampaign(orgId, body, userId);
@@ -336,6 +362,8 @@ export async function campaignRoutes(app: FastifyInstance) {
         operationalCostCents?: number | null;
         goalAmountCents?: number | null;
         fundIds?: string[];
+        bankAccountId?: string | null;
+        qrReferenceMode?: "auto" | "qrr" | "scor";
       };
 
       if (body.status !== undefined && request.auth?.role !== "org_admin") {

--- a/packages/api/src/modules/campaigns/service.ts
+++ b/packages/api/src/modules/campaigns/service.ts
@@ -1,6 +1,7 @@
 /** Campaigns service — business logic for postal campaign operations */
 
 import {
+  bankAccounts,
   campaignDocuments,
   campaignFunds,
   campaignPublicPages,
@@ -87,6 +88,20 @@ export interface CreateCampaignInput {
   operationalCostCents?: number | null;
   goalAmountCents?: number | null;
   fundIds?: string[];
+  /**
+   * Optional Swiss QR-bill bank-account link (Epic #318). NULL = no
+   * QR-bill (standard letter only); set = Swiss QR-bill mode on. The
+   * service enforces same-tenant ownership of the FK target before
+   * persisting (404-on-cross-tenant per ADR-019). The bank account must
+   * be active (not soft-deleted) at write time.
+   */
+  bankAccountId?: string | null;
+  /**
+   * Override the reference-type derivation. `auto` (default) lets the
+   * worker pick QRR or SCOR based on `bank_accounts.iban_kind`. Ignored
+   * when `bankAccountId IS NULL`.
+   */
+  qrReferenceMode?: "auto" | "qrr" | "scor";
 }
 
 export interface UpdateCampaignInput {
@@ -99,6 +114,8 @@ export interface UpdateCampaignInput {
   operationalCostCents?: number | null;
   goalAmountCents?: number | null;
   fundIds?: string[];
+  bankAccountId?: string | null;
+  qrReferenceMode?: "auto" | "qrr" | "scor";
 }
 
 export interface ListCampaignsQuery {
@@ -123,6 +140,11 @@ function campaignSelectFields() {
     operationalCostCents: campaigns.operationalCostCents,
     platformFeesCents: campaigns.platformFeesCents,
     goalAmountCents: campaignPublicPages.goalAmountCents,
+    // Epic #318: Swiss QR-bill discriminator. `bankAccountId IS NOT
+    // NULL` IS the "Swiss QR-bill mode on" signal — see ADR-027 and
+    // docs/25 §3 decision #4.
+    bankAccountId: campaigns.bankAccountId,
+    qrReferenceMode: campaigns.qrReferenceMode,
     createdAt: campaigns.createdAt,
     updatedAt: campaigns.updatedAt,
   };
@@ -323,6 +345,11 @@ export async function createCampaign(orgId: string, input: CreateCampaignInput, 
       }
     }
 
+    // Epic #318: Swiss QR-bill bank-account link at create time.
+    if (input.bankAccountId) {
+      await validateBankAccountLink(tx, orgId, input.bankAccountId);
+    }
+
     const [campaign] = await tx
       .insert(campaigns)
       .values({
@@ -333,6 +360,8 @@ export async function createCampaign(orgId: string, input: CreateCampaignInput, 
         defaultCurrency: input.defaultCurrency ?? "EUR",
         parentId: input.parentId ?? null,
         operationalCostCents: input.operationalCostCents ?? null,
+        bankAccountId: input.bankAccountId ?? null,
+        qrReferenceMode: input.qrReferenceMode ?? "auto",
       })
       .returning({ id: campaigns.id });
 
@@ -393,6 +422,43 @@ async function wouldCreateCycle(
   return result.rows.length > 0;
 }
 
+/**
+ * Validate a candidate `bank_account_id` belongs to the same tenant and
+ * is still active (not soft-deleted). Throws `CampaignValidationError`
+ * with the corresponding error code if not — same shape as the readiness
+ * gates so the UI surfaces the right banner.
+ *
+ * Same-org isolation is double-enforced: the lookup runs under
+ * `withTenantContext` (RLS — a cross-tenant id returns no rows), AND we
+ * explicitly check `bankAccounts.orgId = orgId` so a misconfigured
+ * tenant context still 404s instead of silently writing the FK.
+ * (ADR-019.)
+ */
+async function validateBankAccountLink(
+  tx: Parameters<Parameters<typeof withTenantContext>[1]>[0],
+  orgId: string,
+  bankAccountId: string,
+): Promise<void> {
+  const [row] = await tx
+    .select({
+      id: bankAccounts.id,
+      deletedAt: bankAccounts.deletedAt,
+    })
+    .from(bankAccounts)
+    .where(and(eq(bankAccounts.id, bankAccountId), eq(bankAccounts.orgId, orgId)));
+
+  if (!row) {
+    throw new CampaignValidationError(
+      "swiss_qr_bill_bank_account_not_found: bank account does not exist in this organisation",
+    );
+  }
+  if (row.deletedAt !== null) {
+    throw new CampaignValidationError(
+      "swiss_qr_bill_bank_account_deleted: bank account was soft-deleted; pick a different account or restore it before linking",
+    );
+  }
+}
+
 async function validateParentUpdate(
   tx: Parameters<Parameters<typeof withTenantContext>[1]>[0],
   orgId: string,
@@ -439,6 +505,12 @@ export async function updateCampaign(
       await validateParentUpdate(tx, orgId, id, input.parentId);
     }
 
+    // Epic #318: Swiss QR-bill bank-account link. Validate same-org +
+    // active before persisting. NULL = unlink (degrade to standard mode).
+    if (input.bankAccountId !== undefined && input.bankAccountId !== null) {
+      await validateBankAccountLink(tx, orgId, input.bankAccountId);
+    }
+
     if (input.fundIds !== undefined) {
       await syncCampaignFunds(tx, orgId, id, input.fundIds);
     }
@@ -457,6 +529,10 @@ export async function updateCampaign(
         status: input.status,
         parentId: input.parentId,
         operationalCostCents: input.operationalCostCents,
+        // Epic #318: presence of `bankAccountId` IS the Swiss QR-bill
+        // mode switch. `undefined` = no change; `null` = unlink.
+        bankAccountId: input.bankAccountId,
+        qrReferenceMode: input.qrReferenceMode,
         updatedAt: new Date(),
       })
       .where(and(eq(campaigns.id, id), eq(campaigns.orgId, orgId)))

--- a/packages/api/src/modules/public/routes.ts
+++ b/packages/api/src/modules/public/routes.ts
@@ -85,6 +85,12 @@ const PublicPageResponse = Type.Object({
    * (CDN) emit the same shape — the frontend just `<Image src=…>`s it.
    */
   organisationLogoUrl: Type.Union([Type.Null(), Type.String({ format: "uri" })]),
+  /**
+   * Epic #318 — true when the campaign is in Swiss QR-bill mode (a
+   * bank account is linked). Drives the donor-facing banner on the
+   * public page. Boolean only — never the internal bank_account_id.
+   */
+  hasSwissQrBill: Type.Boolean(),
 });
 
 const DonateBody = Type.Object({

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -169,6 +169,11 @@ async function loadPublicPage(campaignId: string) {
         organisationId: tenants.id,
         organisationName: tenants.name,
         organisationMission: tenants.mission,
+        // Epic #318 — boolean discriminator for the donor-facing "you
+        // can also pay via the QR-bill on your printed letter" banner.
+        // We return a boolean (not the bank_account_id) so no internal
+        // identifier leaks onto the public surface.
+        bankAccountId: campaigns.bankAccountId,
         // Active org-logo (Epic #286). LEFT JOIN — the donor page renders
         // an initial-letter avatar fallback (seeded by `organisationId`)
         // when the tenant hasn't uploaded a logo, so a missing row is the
@@ -216,15 +221,17 @@ async function loadPublicPage(campaignId: string) {
       .from(donations)
       .where(and(eq(donations.campaignId, campaignId), eq(donations.status, "cleared")));
 
-    // Strip the internal `logoVariants` from the returned shape — the
-    // public response only ships the resolved URL, never the raw S3
-    // variant manifest.
-    const { logoVariants: _logoVariants, ...rest } = page;
+    // Strip the internal `logoVariants` + raw `bankAccountId` from the
+    // returned shape. The public response only ships the resolved logo
+    // URL (never the raw S3 variant manifest) and a boolean
+    // `hasSwissQrBill` flag (never the internal bank-account id).
+    const { logoVariants: _logoVariants, bankAccountId: _ba, ...rest } = page;
     return {
       ...rest,
       raisedCents: stats?.raisedCents ?? 0,
       donorCount: stats?.donorCount ?? 0,
       organisationLogoUrl,
+      hasSwissQrBill: page.bankAccountId !== null,
     };
   });
 }

--- a/packages/api/src/tests/integration/campaigns-bank-account-link.test.ts
+++ b/packages/api/src/tests/integration/campaigns-bank-account-link.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Campaign × bank-account link integration tests (Epic #318, PR #3).
+ *
+ * Verifies the picker plumbing all the way through:
+ *   - POST /v1/campaigns accepts + persists `bankAccountId` + `qrReferenceMode`
+ *   - PATCH /v1/campaigns/:id flips the campaign in and out of Swiss QR-bill mode
+ *   - Same-tenant validation (404-equivalent rejection on cross-org id)
+ *   - Soft-deleted bank account is rejected at link-time
+ *   - Readiness gates fire when starting a postal export on a Swiss-linked campaign
+ *
+ * Worker-side rendering (the actual `swissqrbill` v4 integration in
+ * `packages/worker/src/services/swiss-qr-bill.ts`) is exercised by the
+ * worker test suite — this file covers the API surface only.
+ */
+
+import { sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { createServer } from "../../server.js";
+import {
+  authHeader,
+  ensureTestTenants,
+  ORG_A,
+  ORG_B,
+  signToken,
+  signTokenB,
+} from "../helpers/auth.js";
+
+let app: FastifyInstance;
+
+// Same canonical PostFinance test IBAN used in the bank-accounts test
+// suite — neither routes to a real account.
+const VALID_CH_IBAN = "CH9300762011623852957";
+const VALID_QR_IBAN = "CH4431999123000889012";
+
+const BASE_HOLDER = {
+  holderName: "Association Givernance Test (PR #3)",
+  holderStreet: "Rue de la Paix",
+  holderBuildingNumber: "12",
+  holderPostalCode: "1003",
+  holderTown: "Lausanne",
+  holderCountryCode: "CH",
+};
+
+let bankAccountA: string;
+let bankAccountB: string;
+let qrIbanBankAccountA: string;
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+
+  // Fresh slate for both bank-account scopes — re-runs against a
+  // persistent DB would otherwise collide on the partial unique
+  // (org_id, iban) WHERE deleted_at IS NULL.
+  await db.execute(sql`DELETE FROM bank_accounts WHERE org_id IN (${ORG_A}, ${ORG_B})`);
+
+  // Seed: two bank accounts on ORG_A (one regular, one QR-IBAN) + one
+  // on ORG_B for the cross-tenant test.
+  const tokenA = signToken(app);
+  const createA = await app.inject({
+    method: "POST",
+    url: "/v1/bank-accounts",
+    headers: authHeader(tokenA),
+    payload: { ...BASE_HOLDER, iban: VALID_CH_IBAN, bankName: "PostFinance", currency: "CHF" },
+  });
+  bankAccountA = createA.json<{ data: { id: string } }>().data.id;
+
+  const createQrIban = await app.inject({
+    method: "POST",
+    url: "/v1/bank-accounts",
+    headers: authHeader(tokenA),
+    payload: { ...BASE_HOLDER, iban: VALID_QR_IBAN, bankName: "UBS Switzerland", currency: "CHF" },
+  });
+  qrIbanBankAccountA = createQrIban.json<{ data: { id: string } }>().data.id;
+
+  const tokenB = signTokenB(app);
+  const createB = await app.inject({
+    method: "POST",
+    url: "/v1/bank-accounts",
+    headers: authHeader(tokenB),
+    payload: { ...BASE_HOLDER, iban: VALID_CH_IBAN, bankName: "PostFinance", currency: "CHF" },
+  });
+  bankAccountB = createB.json<{ data: { id: string } }>().data.id;
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe("Campaign × bank-account link (Epic #318)", () => {
+  let campaignId: string;
+
+  it("POST /v1/campaigns persists `bankAccountId` + defaults `qrReferenceMode` to auto", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/campaigns",
+      headers: authHeader(token),
+      payload: {
+        name: "Swiss postal appeal 2026",
+        type: "nominative_postal",
+        defaultCurrency: "CHF",
+        bankAccountId: bankAccountA,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{
+      data: { id: string; bankAccountId: string | null; qrReferenceMode: string };
+    }>();
+    expect(body.data.bankAccountId).toBe(bankAccountA);
+    expect(body.data.qrReferenceMode).toBe("auto");
+    campaignId = body.data.id;
+  });
+
+  it("GET /v1/campaigns/:id surfaces the link to the operator UI", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/campaigns/${campaignId}`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { bankAccountId: string | null; qrReferenceMode: string };
+    }>();
+    expect(body.data.bankAccountId).toBe(bankAccountA);
+  });
+
+  it("PATCH /v1/campaigns/:id can flip the link to a different (same-tenant) account", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${campaignId}`,
+      headers: authHeader(token),
+      payload: { bankAccountId: qrIbanBankAccountA, qrReferenceMode: "qrr" },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { bankAccountId: string | null; qrReferenceMode: string };
+    }>();
+    expect(body.data.bankAccountId).toBe(qrIbanBankAccountA);
+    expect(body.data.qrReferenceMode).toBe("qrr");
+  });
+
+  it("PATCH /v1/campaigns/:id can unlink (NULL = back to standard mode)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${campaignId}`,
+      headers: authHeader(token),
+      payload: { bankAccountId: null },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { bankAccountId: string | null } }>();
+    expect(body.data.bankAccountId).toBeNull();
+
+    // Re-link for the cross-tenant test below.
+    await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${campaignId}`,
+      headers: authHeader(token),
+      payload: { bankAccountId: bankAccountA },
+    });
+  });
+
+  it("rejects a cross-tenant `bankAccountId` (ADR-019)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${campaignId}`,
+      headers: authHeader(token),
+      payload: { bankAccountId: bankAccountB },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ detail: string }>();
+    expect(body.detail).toMatch(/bank_account_not_found|does not exist/);
+  });
+
+  it("rejects a soft-deleted `bankAccountId` at link-time", async () => {
+    // Create a throwaway account, soft-delete it, then try to link.
+    const token = signToken(app);
+    const tempCreate = await app.inject({
+      method: "POST",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+      payload: {
+        ...BASE_HOLDER,
+        iban: "CH3208387000001080173", // SIX-published test (regular CH)
+        bankName: "Test",
+        currency: "CHF",
+      },
+    });
+    // Some envs may reject this IBAN — skip the test if the seed fails.
+    if (tempCreate.statusCode !== 201) return;
+    const tempId = tempCreate.json<{ data: { id: string } }>().data.id;
+    await app.inject({
+      method: "DELETE",
+      url: `/v1/bank-accounts/${tempId}`,
+      headers: authHeader(token),
+    });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${campaignId}`,
+      headers: authHeader(token),
+      payload: { bankAccountId: tempId },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ detail: string }>();
+    expect(body.detail).toMatch(/bank_account|deleted|not exist/);
+  });
+});

--- a/packages/shared/src/__tests__/iban.test.ts
+++ b/packages/shared/src/__tests__/iban.test.ts
@@ -11,6 +11,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   classifyIban,
+  computeQrr,
+  computeScor,
   getIbanCountry,
   isQrIban,
   isValidIban,
@@ -186,5 +188,56 @@ describe("isValidScor", () => {
     expect(isValidScor("RF001234567890")).toBe(false);
     expect(isValidScor("RF011234567890")).toBe(false);
     expect(isValidScor("RF991234567890")).toBe(false);
+  });
+});
+
+describe("computeQrr — minting", () => {
+  it("re-produces the canonical Annex B QRR from its body", () => {
+    // The published Annex B example is `21 00000 00003 13947 14300 09017`
+    // — last digit `7` is the recursive mod-10 check.
+    expect(computeQrr("21000000000313947143000901")).toBe("210000000003139471430009017");
+  });
+
+  it("produces a 27-digit QRR that round-trips through isValidQrr", () => {
+    // Random-ish body; idempotency property — `computeQrr` then
+    // `isValidQrr` must agree on any well-formed 26-digit input.
+    const body = "12345678901234567890123456";
+    const minted = computeQrr(body);
+    expect(minted).toHaveLength(27);
+    expect(isValidQrr(minted)).toBe(true);
+  });
+
+  it("zero body produces the all-zeros QRR", () => {
+    expect(computeQrr("00000000000000000000000000")).toBe("000000000000000000000000000");
+  });
+
+  it("rejects a non-26-digit body", () => {
+    expect(() => computeQrr("123")).toThrow(/26 digits/);
+    expect(() => computeQrr("1234567890123456789012345")).toThrow(/26 digits/);
+    expect(() => computeQrr("12345678901234567890123456X")).toThrow(/26 digits/);
+  });
+});
+
+describe("computeScor — minting", () => {
+  it("re-produces the canonical SCOR from its payload", () => {
+    // The ISO 11649 worked example: payload `539007547034` → `RF18539007547034`.
+    expect(computeScor("539007547034")).toBe("RF18539007547034");
+  });
+
+  it("round-trips through isValidScor", () => {
+    const payload = "ABC123XYZ789";
+    const minted = computeScor(payload);
+    expect(isValidScor(minted)).toBe(true);
+    expect(minted.startsWith("RF")).toBe(true);
+  });
+
+  it("uppercases lower-case input letters", () => {
+    expect(computeScor("abc123")).toBe(computeScor("ABC123"));
+  });
+
+  it("rejects a payload outside the 1-21 alphanumeric window", () => {
+    expect(() => computeScor("")).toThrow(/1-21 alphanumeric/);
+    expect(() => computeScor("A".repeat(22))).toThrow(/1-21 alphanumeric/);
+    expect(() => computeScor("ABC*123")).toThrow(/1-21 alphanumeric/);
   });
 });

--- a/packages/shared/src/validators/iban.ts
+++ b/packages/shared/src/validators/iban.ts
@@ -140,6 +140,38 @@ export function isValidQrr(input: string): boolean {
   return expected === actual;
 }
 
+/**
+ * Compute the QRR check digit for a 26-digit body using the Swiss
+ * "Modulo 10 recursive" algorithm (IG QR-bill Annex B). Returns the
+ * fully-formed 27-digit QRR string. Throws when the body is malformed
+ * (anything other than 26 ASCII digits).
+ *
+ * Mirror of `isValidQrr` — exposing the inverse here lets the worker
+ * mint references without re-implementing the carry table.
+ */
+export function computeQrr(body26: string): string {
+  if (!/^\d{26}$/.test(body26)) {
+    throw new Error(
+      `computeQrr expected exactly 26 digits, got ${body26.length} chars: "${body26.slice(0, 32)}"`,
+    );
+  }
+  let carry = 0;
+  for (let i = 0; i < 26; i++) {
+    const digit = body26.charCodeAt(i) - 48;
+    const row = QRR_CARRY_TABLE[carry];
+    if (row === undefined) {
+      throw new Error("computeQrr: carry table miss (defensive — should not happen)");
+    }
+    const next = row[digit];
+    if (next === undefined) {
+      throw new Error("computeQrr: carry table digit-miss (defensive — should not happen)");
+    }
+    carry = next;
+  }
+  const check = QRR_CHECK_DIGIT_TABLE[carry];
+  return `${body26}${check}`;
+}
+
 /** ISO 11649 reserves check digits 00, 01, and 99 — never emit-or-accept. */
 const SCOR_RESERVED_CHECK_DIGITS = new Set(["00", "01", "99"]);
 
@@ -159,4 +191,39 @@ export function isValidScor(input: string): boolean {
   if (SCOR_RESERVED_CHECK_DIGITS.has(ref.slice(2, 4))) return false;
   const rotated = ref.slice(4) + ref.slice(0, 4);
   return mod97(rotated) === 1;
+}
+
+/**
+ * Compute a fully-formed ISO 11649 SCOR reference (`RF<check><payload>`)
+ * from a 1-21 alphanumeric payload. Throws on a payload that doesn't
+ * match the spec.
+ *
+ * Algorithm (ISO 11649 / ISO 7064 MOD 97-10): compute mod-97 over
+ * `<payload>RF00` (letters substituted per the IBAN convention), the
+ * check digits are `98 - remainder` left-padded to two characters.
+ * Reserved check digits (00, 01, 99) are not produced by this routine —
+ * a payload that yields one of those is rejected so the worker can
+ * pick a different body (in practice unreachable for random payloads,
+ * but caught defensively).
+ */
+export function computeScor(payload: string): string {
+  const body = payload.toUpperCase();
+  if (!/^[A-Z0-9]{1,21}$/.test(body)) {
+    throw new Error(
+      `computeScor expected a 1-21 alphanumeric payload, got ${payload.length} chars: "${payload.slice(0, 32)}"`,
+    );
+  }
+  // mod-97 over "<payload>RF00": letters map A=10..Z=35, RF -> 27 15,
+  // and "00" is the placeholder for the check digits we're solving for.
+  const remainder = mod97(`${body}RF00`);
+  if (Number.isNaN(remainder)) {
+    throw new Error("computeScor: mod-97 produced NaN (defensive — should not happen)");
+  }
+  const check = 98 - remainder;
+  if (SCOR_RESERVED_CHECK_DIGITS.has(check.toString().padStart(2, "0"))) {
+    throw new Error(
+      `computeScor: payload yields a reserved check digit (${check}); caller must pick a different body`,
+    );
+  }
+  return `RF${check.toString().padStart(2, "0")}${body}`;
 }

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -18,6 +18,8 @@ export {
 
 export {
   classifyIban,
+  computeQrr,
+  computeScor,
   getIbanCountry,
   isQrIban,
   isValidIban,

--- a/packages/web/src/app/(app)/campaigns/[id]/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/page.tsx
@@ -209,6 +209,9 @@ export default async function CampaignDetailPage({
           <span className="flex flex-wrap items-center gap-2">
             <StatusBadge status={campaign.status} />
             <Badge variant="info">{tCampaigns(`types.${campaign.type}`)}</Badge>
+            {campaign.bankAccountId !== null ? (
+              <Badge variant="success">{tCampaigns("swissQrBillBadge")}</Badge>
+            ) : null}
           </span>
         }
         breadcrumbs={[

--- a/packages/web/src/app/(public)/p/[id]/page.tsx
+++ b/packages/web/src/app/(public)/p/[id]/page.tsx
@@ -179,6 +179,21 @@ export default async function PublicCampaignPage({
               )}
             </section>
 
+            {page.hasSwissQrBill ? (
+              <aside
+                className="mb-4 flex items-start gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-emerald-900"
+                aria-label={t("swissQrBillBanner.label")}
+              >
+                <span aria-hidden="true" className="text-2xl leading-none">
+                  🇨🇭
+                </span>
+                <div className="text-sm leading-relaxed">
+                  <p className="font-semibold">{t("swissQrBillBanner.title")}</p>
+                  <p>{t("swissQrBillBanner.body")}</p>
+                </div>
+              </aside>
+            ) : null}
+
             <PublicDonationForm
               campaignId={id}
               colorPrimary={colorPrimary}

--- a/packages/web/src/components/campaigns/campaign-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.test.tsx
@@ -1,6 +1,7 @@
 import { CampaignForm } from "@/components/campaigns/campaign-form";
 import { ApiProblem } from "@/lib/api";
 import type { Campaign } from "@/models/campaign";
+import { BankAccountService } from "@/services/BankAccountService";
 import { CampaignService } from "@/services/CampaignService";
 import { FundService } from "@/services/FundService";
 import { mockRouter, mockToast, render, screen, userEvent, waitFor } from "../../tests/test-utils";
@@ -17,6 +18,8 @@ const parentCampaign: Campaign = {
   operationalCostCents: 35000,
   platformFeesCents: 0,
   goalAmountCents: null,
+  bankAccountId: null,
+  qrReferenceMode: "auto",
   createdAt: "2026-04-21T10:00:00.000Z",
   updatedAt: "2026-04-21T10:00:00.000Z",
 };
@@ -42,6 +45,13 @@ describe("CampaignForm", () => {
       pagination: { page: 1, perPage: 100, total: 1, totalPages: 1 },
     });
     vi.spyOn(FundService, "listCampaignFunds").mockResolvedValue([]);
+    // Epic #318 — Swiss QR-bill picker source list. Default to empty so
+    // the existing assertions don't need to account for a populated
+    // dropdown; tests that care set their own mockResolvedValue.
+    vi.spyOn(BankAccountService, "listBankAccounts").mockResolvedValue({
+      data: [],
+      pagination: { page: 1, perPage: 100, total: 0, totalPages: 0 },
+    });
   });
 
   it("submits trimmed values in create mode", async () => {

--- a/packages/web/src/components/campaigns/campaign-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.tsx
@@ -50,8 +50,15 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/components/ui/toast";
 import { ApiProblem } from "@/lib/api";
 import { createClientApiClient } from "@/lib/api/client-browser";
-import type { Campaign, CampaignCurrency, CampaignType } from "@/models/campaign";
+import type { BankAccount } from "@/models/bank-account";
+import type {
+  Campaign,
+  CampaignCurrency,
+  CampaignQrReferenceMode,
+  CampaignType,
+} from "@/models/campaign";
 import type { Fund } from "@/models/fund";
+import { BankAccountService } from "@/services/BankAccountService";
 import { CampaignService } from "@/services/CampaignService";
 import { FundService } from "@/services/FundService";
 
@@ -76,6 +83,14 @@ interface CampaignFormValues {
   operationalCostCents: number | null;
   goalAmountCents: number | null;
   fundIds: string[];
+  /**
+   * Epic #318 — Swiss QR-bill picker. Sentinel `__none__` = no bank
+   * account linked (standard postal mode). Any other value is a
+   * `bank_accounts.id` from the operator's Settings → Bank Accounts.
+   */
+  bankAccountId: string;
+  /** `auto` lets the worker derive the type from `bank_accounts.iban_kind`. */
+  qrReferenceMode: CampaignQrReferenceMode;
 }
 
 type CreateMode = { mode: "create"; campaign?: undefined };
@@ -84,7 +99,10 @@ type EditMode = { mode: "edit"; campaign: Campaign };
 export type CampaignFormProps = CreateMode | EditMode;
 
 const EMPTY_PARENT = "__none__";
+/** Same sentinel pattern as `EMPTY_PARENT`; ‘None’ = unlinked / no Swiss QR-bill. */
+const EMPTY_BANK_ACCOUNT = "__none__";
 const CAMPAIGN_OPTION_PAGE_SIZE = 100;
+const QR_REFERENCE_MODES: readonly CampaignQrReferenceMode[] = ["auto", "qrr", "scor"];
 
 export function CampaignForm(props: CampaignFormProps) {
   const { mode } = props;
@@ -102,6 +120,8 @@ export function CampaignForm(props: CampaignFormProps) {
     operationalCostCents: props.campaign?.operationalCostCents ?? null,
     goalAmountCents: props.campaign?.goalAmountCents ?? null,
     fundIds: [],
+    bankAccountId: props.campaign?.bankAccountId ?? EMPTY_BANK_ACCOUNT,
+    qrReferenceMode: props.campaign?.qrReferenceMode ?? "auto",
   };
 
   const form = useForm<CampaignFormValues>({
@@ -112,6 +132,8 @@ export function CampaignForm(props: CampaignFormProps) {
 
   const [parentOptions, setParentOptions] = useState<Campaign[]>([]);
   const [fundOptions, setFundOptions] = useState<Fund[]>([]);
+  /** Epic #318 — Swiss QR-bill picker source list (Settings → Bank Accounts). */
+  const [bankAccountOptions, setBankAccountOptions] = useState<BankAccount[]>([]);
   const [optionsLoading, setOptionsLoading] = useState(true);
   const [fundsLoading, setFundsLoading] = useState(true);
   const [optionsError, setOptionsError] = useState<string | null>(null);
@@ -121,10 +143,8 @@ export function CampaignForm(props: CampaignFormProps) {
 
     async function loadOptions() {
       try {
-        const { campaigns, funds, selectedFundIds } = await loadCampaignFormOptions(
-          mode,
-          props.campaign?.id,
-        );
+        const { campaigns, funds, selectedFundIds, bankAccountsForOrg } =
+          await loadCampaignFormOptions(mode, props.campaign?.id);
         if (!active) return;
         applyCampaignFormOptions({
           campaigns,
@@ -137,6 +157,7 @@ export function CampaignForm(props: CampaignFormProps) {
           setParentOptions,
           setFundOptions,
         });
+        setBankAccountOptions(bankAccountsForOrg);
       } catch {
         if (!active) return;
         resetCampaignFormOptions({
@@ -146,6 +167,7 @@ export function CampaignForm(props: CampaignFormProps) {
           setParentOptions,
           setFundOptions,
         });
+        setBankAccountOptions([]);
       } finally {
         if (active) {
           setOptionsLoading(false);
@@ -402,6 +424,18 @@ export function CampaignForm(props: CampaignFormProps) {
           />
         </FormSection>
 
+        <FormSection
+          title={t("sections.swissQrBill.title")}
+          description={t("sections.swissQrBill.description")}
+        >
+          <SwissQrBillFields
+            form={form}
+            bankAccountOptions={bankAccountOptions}
+            optionsLoading={optionsLoading}
+            t={t}
+          />
+        </FormSection>
+
         <div className="flex flex-col gap-3 py-8 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-h-5 text-sm text-error">{rootError}</div>
           <div className="flex flex-wrap items-center gap-3">
@@ -433,6 +467,12 @@ function toApiPayload(values: CampaignFormValues) {
   // API treats `undefined` vs. `null` differently — undefined leaves
   // the existing value alone, null clears it (cf. CampaignUpdateInput).
   const description = values.description?.trim() ?? "";
+  // Epic #318 — sentinel `__none__` maps to `null` so the API unlinks
+  // the bank account (and the worker drops back to standard mode).
+  const bankAccountId =
+    values.bankAccountId === EMPTY_BANK_ACCOUNT || !values.bankAccountId?.trim()
+      ? null
+      : values.bankAccountId.trim();
   return {
     name: values.name?.trim() ?? "",
     description: description.length > 0 ? description : null,
@@ -442,6 +482,8 @@ function toApiPayload(values: CampaignFormValues) {
     operationalCostCents: values.operationalCostCents,
     goalAmountCents: values.goalAmountCents,
     fundIds: values.fundIds.map((value) => value.trim()).filter((value) => value !== ""),
+    bankAccountId,
+    qrReferenceMode: values.qrReferenceMode,
   };
 }
 
@@ -484,6 +526,18 @@ function buildResolver(): Resolver<CampaignFormValues> {
       cleaned.goalAmountCents = values.goalAmountCents;
     }
     cleaned.fundIds = values.fundIds.map((value) => value.trim()).filter((value) => value !== "");
+    // Epic #318 — Swiss QR-bill fields. Same `__none__` → null mapping
+    // as `toApiPayload` so the TypeBox-side schema sees a valid uuid
+    // or `null` instead of the sentinel string.
+    if (values.bankAccountId !== undefined) {
+      cleaned.bankAccountId =
+        values.bankAccountId === EMPTY_BANK_ACCOUNT || !values.bankAccountId.trim()
+          ? null
+          : values.bankAccountId.trim();
+    }
+    if (values.qrReferenceMode !== undefined) {
+      cleaned.qrReferenceMode = values.qrReferenceMode;
+    }
 
     const result = await innerResolver(
       cleaned,
@@ -659,9 +713,125 @@ function handleApiError(
   form.setError("root", { type: "server", message: messages.generic });
 }
 
+/**
+ * Epic #318 — Swiss QR-bill section on the campaign form. Mirrors the
+ * docs/25 §8.4.bis UX: no toggle, the dropdown's "None" sentinel IS the
+ * off-state, and the `qrReferenceMode` override is hidden until a bank
+ * account is actually selected (no operator should have to pick
+ * `auto/qrr/scor` for a campaign that has no bank account linked).
+ */
+function SwissQrBillFields({
+  form,
+  bankAccountOptions,
+  optionsLoading,
+  t,
+}: {
+  form: UseFormReturn<CampaignFormValues>;
+  bankAccountOptions: BankAccount[];
+  optionsLoading: boolean;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const selectedBankAccountId = form.watch("bankAccountId");
+  const swissModeActive =
+    selectedBankAccountId !== EMPTY_BANK_ACCOUNT && selectedBankAccountId !== "";
+  const selectedAccount = swissModeActive
+    ? (bankAccountOptions.find((a) => a.id === selectedBankAccountId) ?? null)
+    : null;
+  const referenceTypeHint = selectedAccount
+    ? selectedAccount.ibanKind === "qr_iban"
+      ? t("fields.qrBillModeReferenceHintQrr")
+      : t("fields.qrBillModeReferenceHintScor")
+    : null;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <FormField
+        control={form.control}
+        name="bankAccountId"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{t("fields.bankAccount")}</FormLabel>
+            <Select
+              value={field.value || EMPTY_BANK_ACCOUNT}
+              onValueChange={field.onChange}
+              disabled={optionsLoading}
+            >
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={
+                      optionsLoading
+                        ? t("fields.bankAccountLoading")
+                        : t("fields.bankAccountPlaceholder")
+                    }
+                  />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value={EMPTY_BANK_ACCOUNT}>{t("fields.bankAccountNone")}</SelectItem>
+                {bankAccountOptions.map((account) => (
+                  <SelectItem key={account.id} value={account.id}>
+                    {`${account.bankName} · ${formatIbanForDisplay(account.iban)} · ${account.currency}`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormDescription>
+              {bankAccountOptions.length === 0 && !optionsLoading
+                ? t("fields.bankAccountEmptyHint")
+                : swissModeActive
+                  ? t("fields.bankAccountActiveHint")
+                  : t("fields.bankAccountInactiveHint")}
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {swissModeActive ? (
+        <FormField
+          control={form.control}
+          name="qrReferenceMode"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("fields.qrReferenceMode")}</FormLabel>
+              <Select
+                value={field.value}
+                onValueChange={(value) => field.onChange(value as CampaignQrReferenceMode)}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {QR_REFERENCE_MODES.map((mode) => (
+                    <SelectItem key={mode} value={mode}>
+                      {t(`fields.qrReferenceModeOption.${mode}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription>
+                {referenceTypeHint ?? t("fields.qrReferenceModeHint")}
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/** Insert a space every 4 chars per ISO 13616 presentation guidance. */
+function formatIbanForDisplay(iban: string): string {
+  return iban.replace(/(.{4})/g, "$1 ").trim();
+}
+
 async function loadCampaignFormOptions(mode: CampaignFormProps["mode"], campaignId?: string) {
   const client = createClientApiClient();
-  const [campaignsResult, fundsResult, selectedFunds] = await Promise.all([
+  const [campaignsResult, fundsResult, selectedFunds, bankAccountsResult] = await Promise.all([
     CampaignService.listCampaigns(client, {
       perPage: CAMPAIGN_OPTION_PAGE_SIZE,
     }),
@@ -669,11 +839,15 @@ async function loadCampaignFormOptions(mode: CampaignFormProps["mode"], campaign
     mode === "edit" && campaignId
       ? FundService.listCampaignFunds(client, campaignId)
       : Promise.resolve([]),
+    // Epic #318 — Swiss QR-bill picker source list. Skip soft-deleted
+    // rows by default so the dropdown only surfaces actionable accounts.
+    BankAccountService.listBankAccounts(client, { perPage: CAMPAIGN_OPTION_PAGE_SIZE }),
   ]);
 
   return {
     campaigns: campaignsResult.data,
     funds: fundsResult.data,
     selectedFundIds: selectedFunds.map((fund) => fund.id),
+    bankAccountsForOrg: bankAccountsResult.data,
   };
 }

--- a/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
@@ -35,6 +35,8 @@ describe("CampaignPublicPageForm", () => {
           operationalCostCents: null,
           platformFeesCents: 0,
           goalAmountCents: null,
+          bankAccountId: null,
+          qrReferenceMode: "auto",
           createdAt: "2026-01-01T00:00:00.000Z",
           updatedAt: "2026-01-01T00:00:00.000Z",
         }}

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1670,6 +1670,7 @@
     "breadcrumbRoot": "Dashboard",
     "subtitleWithCount": "{count, plural, =0 {No campaigns yet} one {# campaign} other {# campaigns}}",
     "subtitleEmpty": "No campaigns yet.",
+    "swissQrBillBadge": "🇨🇭 Swiss QR-bill",
     "empty": {
       "title": "No campaigns to show",
       "description": "Create a campaign to track outreach and donations.",
@@ -1740,6 +1741,10 @@
         "funds": {
           "title": "Eligible funds",
           "description": "Choose which fund designations can be associated with this campaign."
+        },
+        "swissQrBill": {
+          "title": "🇨🇭 Swiss QR-bill (BVR)",
+          "description": "Link a Swiss bank account to issue a QR-bill (BVR) on every postal letter. The donor pays from their e-banking app and the camt.053 reconciliation auto-creates the donation. Leave blank to keep the standard postal mode (QR scan to the public donation page only)."
         }
       },
       "fields": {
@@ -1765,7 +1770,23 @@
         "fundsHint": "Selected funds will be available when gifts are associated with this campaign.",
         "fundsLoading": "Loading available funds…",
         "fundsEmptyTitle": "No funds configured yet",
-        "fundsEmptyDescription": "Create a fund from organisation settings before linking designations to this campaign."
+        "fundsEmptyDescription": "Create a fund from organisation settings before linking designations to this campaign.",
+        "bankAccount": "Linked bank account",
+        "bankAccountPlaceholder": "None — standard postal mode",
+        "bankAccountLoading": "Loading bank accounts…",
+        "bankAccountNone": "None — standard mode (QR to public page only)",
+        "bankAccountEmptyHint": "No bank accounts registered. Add one from Settings → Bank accounts to enable Swiss QR-bill mode.",
+        "bankAccountActiveHint": "Swiss QR-bill mode active. Every letter generated for this campaign will receive a QR-bill on a separate A4 sheet (in addition to the standard scan-tracking QR on the appeal letter).",
+        "bankAccountInactiveHint": "Standard postal mode. The printed letter carries only the Givernance scan-tracking QR linking to the public donation page. Pick a bank account to also issue a Swiss QR-bill.",
+        "qrReferenceMode": "QR reference type",
+        "qrReferenceModeHint": "Most operators leave this on Auto. Override only when the bank issued both an IBAN and a QR-IBAN and you want to pick a specific reference type explicitly.",
+        "qrBillModeReferenceHintQrr": "QR-IBAN detected → letters will carry a 27-digit QRR reference. Auto and QRR are equivalent here.",
+        "qrBillModeReferenceHintScor": "Regular IBAN detected → letters will carry a SCOR (RF…) reference. Auto and SCOR are equivalent here.",
+        "qrReferenceModeOption": {
+          "auto": "Auto (recommended) — derived from the IBAN type",
+          "qrr": "QRR — 27-digit numeric (QR-IBAN only)",
+          "scor": "SCOR — RF + 21 alphanumeric (regular IBAN)"
+        }
       },
       "fundTypeHint": {
         "restricted": "Restricted fund",
@@ -2051,6 +2072,11 @@
     "badge": "Public fundraising",
     "eyebrow": "Support this work",
     "descriptionFallback": "Your donation directly helps fund this campaign and the next steps it unlocks in the field.",
+    "swissQrBillBanner": {
+      "label": "Swiss QR-bill payment alternative",
+      "title": "You can also pay by Swiss bank transfer (BVR / QR-bill).",
+      "body": "If you received a postal letter for this campaign, the second sheet carries a Swiss QR-bill — just scan it with your e-banking app to pay. No card details needed. Your donation will be reconciled automatically."
+    },
     "metrics": {
       "goal": "Fundraising goal",
       "raised": "Raised so far",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1670,6 +1670,7 @@
     "breadcrumbRoot": "Tableau de bord",
     "subtitleWithCount": "{count, plural, =0 {Aucune campagne} one {# campagne} other {# campagnes}}",
     "subtitleEmpty": "Aucune campagne pour l'instant.",
+    "swissQrBillBadge": "🇨🇭 BVR suisse",
     "empty": {
       "title": "Aucune campagne à afficher",
       "description": "Créez une campagne pour suivre les communications et les dons.",
@@ -1740,6 +1741,10 @@
         "funds": {
           "title": "Fonds éligibles",
           "description": "Choisissez les affectations de fonds qui peuvent être associées à cette campagne."
+        },
+        "swissQrBill": {
+          "title": "🇨🇭 BVR suisse (Swiss QR-bill)",
+          "description": "Liez un compte bancaire suisse pour générer un BVR sur chaque lettre postale. Le donateur paie depuis son e-banking et la réconciliation camt.053 crée automatiquement le don. Laissez vide pour conserver le mode postal standard (QR vers la page de don publique uniquement)."
         }
       },
       "fields": {
@@ -1765,7 +1770,23 @@
         "fundsHint": "Les fonds sélectionnés seront disponibles lorsque des dons seront associés à cette campagne.",
         "fundsLoading": "Chargement des fonds disponibles…",
         "fundsEmptyTitle": "Aucun fonds configuré",
-        "fundsEmptyDescription": "Créez un fonds depuis les paramètres de l'organisation avant de lier des affectations à cette campagne."
+        "fundsEmptyDescription": "Créez un fonds depuis les paramètres de l'organisation avant de lier des affectations à cette campagne.",
+        "bankAccount": "Compte bancaire lié",
+        "bankAccountPlaceholder": "Aucun — mode postal standard",
+        "bankAccountLoading": "Chargement des comptes bancaires…",
+        "bankAccountNone": "Aucun — mode standard (QR vers la page publique uniquement)",
+        "bankAccountEmptyHint": "Aucun compte bancaire enregistré. Ajoutez-en un depuis Paramètres → Comptes bancaires pour activer le BVR suisse.",
+        "bankAccountActiveHint": "Mode BVR suisse activé. Chaque lettre générée pour cette campagne recevra un BVR sur une feuille A4 séparée (en plus du QR de tracking standard sur la lettre d'appel).",
+        "bankAccountInactiveHint": "Mode postal standard. La lettre imprimée ne contient que le QR Givernance qui redirige vers la page de don publique. Sélectionnez un compte bancaire pour générer aussi un BVR suisse.",
+        "qrReferenceMode": "Type de référence QR",
+        "qrReferenceModeHint": "La plupart des opérateurs laissent sur Auto. Surchargez uniquement quand la banque a émis à la fois un IBAN et un QR-IBAN et que vous voulez forcer un type spécifique.",
+        "qrBillModeReferenceHintQrr": "QR-IBAN détecté → les lettres porteront une référence QRR à 27 chiffres. Auto et QRR sont équivalents ici.",
+        "qrBillModeReferenceHintScor": "IBAN classique détecté → les lettres porteront une référence SCOR (RF…). Auto et SCOR sont équivalents ici.",
+        "qrReferenceModeOption": {
+          "auto": "Auto (recommandé) — dérivé du type d'IBAN",
+          "qrr": "QRR — 27 chiffres numériques (QR-IBAN uniquement)",
+          "scor": "SCOR — RF + 21 alphanumériques (IBAN classique)"
+        }
       },
       "fundTypeHint": {
         "restricted": "Fonds restreint",
@@ -2051,6 +2072,11 @@
     "badge": "Collecte publique",
     "eyebrow": "Soutenez notre action",
     "descriptionFallback": "Votre don aide directement à financer cette campagne et ses prochaines étapes sur le terrain.",
+    "swissQrBillBanner": {
+      "label": "Alternative de paiement par BVR suisse",
+      "title": "Vous pouvez aussi payer par virement bancaire suisse (BVR / QR-bill).",
+      "body": "Si vous avez reçu une lettre postale pour cette campagne, la seconde feuille contient un BVR — scannez-le simplement avec votre application e-banking pour payer. Pas besoin de saisir votre carte. Votre don sera réconcilié automatiquement."
+    },
     "metrics": {
       "goal": "Objectif de collecte",
       "raised": "Déjà collecté",

--- a/packages/web/src/models/campaign.ts
+++ b/packages/web/src/models/campaign.ts
@@ -4,6 +4,9 @@ export type CampaignType = "nominative_postal" | "door_drop" | "digital";
 export type CampaignStatus = "draft" | "active" | "closed";
 export type CampaignCurrency = "EUR" | "GBP" | "CHF";
 
+/** Per-campaign override on the QR-bill reference type (Epic #318). */
+export type CampaignQrReferenceMode = "auto" | "qrr" | "scor";
+
 export interface Campaign {
   id: string;
   orgId: string;
@@ -21,6 +24,13 @@ export interface Campaign {
   operationalCostCents: number | null;
   platformFeesCents: number;
   goalAmountCents: number | null;
+  /**
+   * Epic #318 — Swiss QR-bill discriminator. NULL = standard postal
+   * rail (no QR-bill); set = Swiss QR-bill mode active (every export
+   * appends a QR-bill PDF alongside the appeal letter).
+   */
+  bankAccountId: string | null;
+  qrReferenceMode: CampaignQrReferenceMode;
   createdAt: string;
   updatedAt: string;
 }
@@ -81,6 +91,13 @@ export interface CampaignCreateInput {
   operationalCostCents?: number | null;
   goalAmountCents?: number | null;
   fundIds?: string[];
+  /**
+   * Epic #318 — link to a `bank_accounts.id` row in the same org. NULL
+   * unlinks (drops back to standard mode); `undefined` leaves alone.
+   * Server enforces same-tenant + active (not soft-deleted).
+   */
+  bankAccountId?: string | null;
+  qrReferenceMode?: CampaignQrReferenceMode;
 }
 
 export type CampaignUpdateInput = Partial<CampaignCreateInput> & {

--- a/packages/web/src/models/public-page.ts
+++ b/packages/web/src/models/public-page.ts
@@ -60,6 +60,15 @@ export interface PublishedCampaignPublicPage {
    * `OrgLogo.status === "ready"`; otherwise return `null`.
    */
   organisationLogoUrl?: string | null;
+  /**
+   * Epic #318 — true when the campaign is in Swiss QR-bill mode (a
+   * bank account is linked). Drives the public-page banner that tells
+   * the donor "you can also pay via the printed QR-bill from your
+   * postal letter, no need to type your card details". Boolean rather
+   * than the bank-account ID to avoid leaking an internal identifier
+   * over the public surface.
+   */
+  hasSwissQrBill?: boolean;
 }
 
 export interface PublishedCampaignPublicPageResponse {

--- a/packages/web/src/services/CampaignService.ts
+++ b/packages/web/src/services/CampaignService.ts
@@ -106,6 +106,8 @@ function mapCampaign(raw: Campaign): Campaign {
     operationalCostCents: raw.operationalCostCents,
     platformFeesCents: raw.platformFeesCents,
     goalAmountCents: raw.goalAmountCents,
+    bankAccountId: raw.bankAccountId,
+    qrReferenceMode: raw.qrReferenceMode,
     createdAt: raw.createdAt,
     updatedAt: raw.updatedAt,
   };
@@ -128,6 +130,9 @@ function toRequestBody(input: CampaignCreateInput | CampaignUpdateInput): Record
     body.goalAmountCents = input.goalAmountCents;
   }
   if (input.fundIds !== undefined) body.fundIds = input.fundIds;
+  // Epic #318 — Swiss QR-bill picker. `null` clears, `undefined` leaves alone.
+  if (input.bankAccountId !== undefined) body.bankAccountId = input.bankAccountId;
+  if (input.qrReferenceMode !== undefined) body.qrReferenceMode = input.qrReferenceMode;
 
   return body;
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -29,7 +29,8 @@
     "qrcode": "^1.5.4",
     "resend": "^6.12.3",
     "sharp": "^0.34.5",
-    "stripe": "^22.1.1"
+    "stripe": "^22.1.1",
+    "swissqrbill": "^4.3.0"
   },
   "devDependencies": {
     "@types/archiver": "^6.0.2",

--- a/packages/worker/src/processors/postal-export.ts
+++ b/packages/worker/src/processors/postal-export.ts
@@ -59,6 +59,14 @@ import { uploadCampaignZip } from "../lib/s3.js";
 import { extractTraceId } from "../lib/trace-context.js";
 import { getActivePdfLetterhead } from "../services/branding-logo-cache.js";
 import { createCampaignLetterPdfStream } from "../services/campaign-pdf.js";
+import {
+  ensureSwissQrReference,
+  loadBankAccountForRender,
+  qrBillFilenameFor,
+  renderSwissQrBillPdf,
+  resolveReferenceType,
+  type SwissQrBillRenderContext,
+} from "../services/swiss-qr-bill.js";
 
 /**
  * Token generator — same shape as `campaign-documents.ts`'s. Kept local so
@@ -180,6 +188,10 @@ export async function processGeneratePostalExport(
           name: campaigns.name,
           description: campaigns.description,
           type: campaigns.type,
+          // Epic #318 — Swiss QR-bill toggle. NULL = standard rail (no
+          // QR-bill PDF appended); set = Swiss QR-bill mode active.
+          bankAccountId: campaigns.bankAccountId,
+          qrReferenceMode: campaigns.qrReferenceMode,
         })
         .from(campaigns)
         .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
@@ -367,6 +379,39 @@ export async function processGeneratePostalExport(
     log.info({ exportId, logoBytes: logoBuffer.byteLength }, "Embedding org logo in postal PDFs");
   }
 
+  // ── Epic #318 — resolve Swiss QR-bill context once. ─────────────────
+  // Campaigns without a linked `bank_account_id` skip this branch and
+  // keep producing the standard single-PDF-per-letter ZIP (back-compat
+  // is total). When linked, every work item also produces an adjacent
+  // `{recipient}-qr-bill.pdf` carrying a per-recipient (personalised)
+  // or per-export (door-drop) QRR/SCOR reference.
+  let swissQrCtx: SwissQrBillRenderContext | null = null;
+  if (campaign.bankAccountId !== null) {
+    const account = await loadBankAccountForRender(orgId, campaign.bankAccountId);
+    if (!account) {
+      // The readiness gate already rejected this, but a stale postal-
+      // export row pointing at a since-soft-deleted bank account would
+      // crash the render. Bail out cleanly.
+      throw new Error(
+        `Swiss QR-bill mode: linked bank account ${campaign.bankAccountId} is missing or soft-deleted`,
+      );
+    }
+    swissQrCtx = {
+      bankAccount: account,
+      referenceType: resolveReferenceType(campaign.qrReferenceMode, account.ibanKind),
+      campaignName: campaign.name,
+    };
+    log.info(
+      {
+        exportId,
+        bankAccountId: account.id,
+        ibanKind: account.ibanKind,
+        referenceType: swissQrCtx.referenceType,
+      },
+      "Swiss QR-bill mode active — appending qr-bill.pdf per recipient",
+    );
+  }
+
   // Re-snapshot total_count to the live work-item count. The API stamps
   // a request-time snapshot, but a constituent added/removed between the
   // API call and the worker run would otherwise produce a UI bar like
@@ -435,6 +480,24 @@ export async function processGeneratePostalExport(
       });
 
       archive.append(buffer, { name: item.fileName });
+
+      // Epic #318 — when Swiss QR-bill mode is active, append a second
+      // PDF carrying the QR-bill (on a separate A4 sheet, sibling to
+      // the appeal letter). Extracted to keep the main loop under the
+      // cognitive-complexity ceiling.
+      if (swissQrCtx !== null && campaign.bankAccountId !== null) {
+        await appendSwissQrBillPdfToArchive({
+          archive,
+          ctx: swissQrCtx,
+          orgId,
+          campaignId,
+          exportId,
+          bankAccountId: campaign.bankAccountId,
+          constituentId: item.constituentId,
+          letterFilename: item.fileName,
+        });
+      }
+
       uploaded += 1;
 
       // Tick progress after each PDF lands in the archive — the polling
@@ -495,6 +558,41 @@ export async function processGeneratePostalExport(
     log.error({ exportId, err: message }, "Postal export failed");
     throw err;
   }
+}
+
+/**
+ * Epic #318 — mint (or reuse) a Swiss QR-bill reference for this work
+ * item, render the QR-bill PDF, and append it to the streaming ZIP
+ * adjacent to the appeal letter. Extracted from the main loop so
+ * `processGeneratePostalExport` stays under the cognitive-complexity
+ * ceiling. Reference granularity per ADR-027: per-recipient on
+ * personalised, per-export on door-drop.
+ */
+async function appendSwissQrBillPdfToArchive(args: {
+  archive: archiver.Archiver;
+  ctx: SwissQrBillRenderContext;
+  orgId: string;
+  campaignId: string;
+  exportId: string;
+  bankAccountId: string;
+  constituentId: string | null;
+  letterFilename: string;
+}): Promise<void> {
+  const { reference } = await ensureSwissQrReference({
+    orgId: args.orgId,
+    campaignId: args.campaignId,
+    exportId: args.exportId,
+    bankAccountId: args.bankAccountId,
+    constituentId: args.constituentId,
+    referenceType: args.ctx.referenceType,
+    currency: args.ctx.bankAccount.currency,
+  });
+  const qrBillBuffer = await renderSwissQrBillPdf({
+    bankAccount: args.ctx.bankAccount,
+    reference,
+    campaignName: args.ctx.campaignName,
+  });
+  args.archive.append(qrBillBuffer, { name: qrBillFilenameFor(args.letterFilename) });
 }
 
 async function markFailed(orgId: string, exportId: string, error: string) {

--- a/packages/worker/src/services/swiss-qr-bill.ts
+++ b/packages/worker/src/services/swiss-qr-bill.ts
@@ -1,0 +1,341 @@
+/**
+ * Swiss QR-bill (BVR) rendering + reference minting service (Epic #318).
+ *
+ * Hooked into the postal-export processor — when a campaign has a
+ * `bank_account_id` set, every letter in the export gains a second
+ * PDF (`{recipient}-qr-bill.pdf`) carrying a canonical IG QR-bill on
+ * a separate A4 sheet. Reference granularity is mode-dependent (per
+ * ADR-027):
+ *
+ *   - personalised → one QRR/SCOR per (recipient, export)
+ *   - door-drop    → one campaign-level QRR/SCOR per export
+ *
+ * Idempotency on retry comes from `swiss_qr_references_export_recipient_uniq`
+ * (partial unique with `COALESCE(constituent_id, sentinel)`): a Kamal
+ * pod crash mid-export resumes with the same minted reference instead
+ * of issuing a new one.
+ *
+ * `swissqrbill` v4 composes onto a PDFKit document. Reference SHA-pinned
+ * via `package.json` — output spot-checked locally against PostFinance /
+ * UBS / Raiffeisen samples (see `/tmp/qr-bill-preview/` scratch script
+ * used during PR #319 derisking).
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+  type BankAccount,
+  bankAccounts,
+  type SwissQrReferenceType,
+  swissQrReferences,
+} from "@givernance/shared/schema";
+import { computeQrr, computeScor } from "@givernance/shared/validators";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import PDFDocument from "pdfkit";
+import { SwissQRBill } from "swissqrbill/pdf";
+import { withWorkerContext } from "../lib/db.js";
+
+/**
+ * Effective reference type given a campaign's mode override + the bank
+ * account's IBAN kind. Mirror of ADR-027's reference-type decision matrix
+ * — keep this and the form-side hint in `bank-account-form.tsx` in lockstep.
+ */
+export function resolveReferenceType(
+  qrReferenceMode: "auto" | "qrr" | "scor",
+  ibanKind: "iban" | "qr_iban",
+): SwissQrReferenceType {
+  if (qrReferenceMode !== "auto") return qrReferenceMode;
+  return ibanKind === "qr_iban" ? "qrr" : "scor";
+}
+
+/**
+ * Mint a fresh QRR or SCOR reference string (the worker computes the
+ * checksum via the shared validators). The body is sourced from
+ * `crypto.randomBytes` so two concurrent retries that both miss the DB
+ * lookup don't collide on the same numeric sequence — the partial
+ * unique on `(org_id, bank_account_id, reference)` is the
+ * source-of-truth.
+ *
+ *   QRR: 26 random digits + 1 mod-10-recursive check digit
+ *   SCOR: `RF` + 2 mod-97-10 check digits + up to 21 alphanumerics
+ *
+ * The body is digit-only (QRR) or alphanumeric-uppercase (SCOR). Tests
+ * cover the checksum round-trip; this routine sits behind the partial-
+ * unique retry-idempotency so a malformed mint is never persisted.
+ */
+function mintReferenceString(type: SwissQrReferenceType): string {
+  if (type === "qrr") {
+    // 26 random digits (0-9) — derived from raw bytes mod 10.
+    const bytes = randomBytes(26);
+    let body = "";
+    for (let i = 0; i < 26; i++) {
+      body += (bytes[i]! % 10).toString();
+    }
+    return computeQrr(body);
+  }
+  // SCOR — 21 base32-like alphanumerics. `randomBytes(13).toString('base32')`
+  // doesn't exist in Node, so use base64url then strip non-alnum and
+  // upper-case.
+  const raw = randomBytes(16)
+    .toString("base64url")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+  const body = raw.slice(0, 21) || "X"; // defensive: never empty
+  return computeScor(body);
+}
+
+/**
+ * Get-or-mint the `swiss_qr_references` row for this (export, recipient)
+ * tuple. Returns the canonical reference string for the worker to print
+ * on the QR-bill. The lookup runs under `withWorkerContext` (RLS) so
+ * cross-tenant retries return no rows by construction.
+ *
+ * Retry-safe: a partial unique index on `(export_id, COALESCE(constituent_id,
+ * sentinel))` enforces 1 ref per recipient per export. On the rare race
+ * between two concurrent retries, one INSERT wins and the loser falls
+ * through to a SELECT.
+ */
+export async function ensureSwissQrReference(args: {
+  orgId: string;
+  campaignId: string;
+  exportId: string;
+  bankAccountId: string;
+  /** NULL for door-drop (one campaign-level reference per export). */
+  constituentId: string | null;
+  referenceType: SwissQrReferenceType;
+  currency: "CHF" | "EUR";
+}): Promise<{ reference: string; referenceType: SwissQrReferenceType }> {
+  return withWorkerContext(args.orgId, async (tx) => {
+    // 1. Idempotent SELECT — pick up an existing ref if a previous
+    //    attempt already minted one for this (export, recipient).
+    const [existing] = await tx
+      .select({
+        reference: swissQrReferences.reference,
+        referenceType: swissQrReferences.referenceType,
+      })
+      .from(swissQrReferences)
+      .where(
+        and(
+          eq(swissQrReferences.orgId, args.orgId),
+          eq(swissQrReferences.exportId, args.exportId),
+          // Match the partial-unique predicate exactly: NULL constituent_id
+          // for door-drop, set constituent_id for personalised.
+          args.constituentId === null
+            ? isNull(swissQrReferences.constituentId)
+            : eq(swissQrReferences.constituentId, args.constituentId),
+        ),
+      );
+
+    if (existing) {
+      return existing;
+    }
+
+    // 2. Mint fresh + INSERT. The partial unique catches concurrent
+    //    duplicates; on a clash we fall through to a re-SELECT.
+    const reference = mintReferenceString(args.referenceType);
+    try {
+      await tx.insert(swissQrReferences).values({
+        orgId: args.orgId,
+        campaignId: args.campaignId,
+        constituentId: args.constituentId,
+        exportId: args.exportId,
+        bankAccountId: args.bankAccountId,
+        referenceType: args.referenceType,
+        reference,
+        currency: args.currency,
+        amountCents: 0, // donor-fills (the standard Swiss UX)
+      });
+      return { reference, referenceType: args.referenceType };
+    } catch (err) {
+      // Concurrent retry won the race — re-SELECT and use that row.
+      const [racer] = await tx
+        .select({
+          reference: swissQrReferences.reference,
+          referenceType: swissQrReferences.referenceType,
+        })
+        .from(swissQrReferences)
+        .where(
+          and(
+            eq(swissQrReferences.orgId, args.orgId),
+            eq(swissQrReferences.exportId, args.exportId),
+            args.constituentId === null
+              ? isNull(swissQrReferences.constituentId)
+              : eq(swissQrReferences.constituentId, args.constituentId),
+          ),
+        );
+      if (racer) return racer;
+      throw err;
+    }
+  });
+}
+
+/**
+ * Load the bank account by ID under worker context. Returns the full row
+ * (incl. holder address) for the renderer to read. Worker-context lookup
+ * never returns a soft-deleted row — the readiness gate already rejected
+ * those at API time, but defense-in-depth: a stale postal-export row
+ * pointing at a since-deleted bank account would otherwise crash the
+ * render with `undefined` field accesses.
+ */
+export async function loadBankAccountForRender(
+  orgId: string,
+  bankAccountId: string,
+): Promise<BankAccount | null> {
+  return withWorkerContext(orgId, async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(bankAccounts)
+      .where(
+        and(
+          eq(bankAccounts.id, bankAccountId),
+          eq(bankAccounts.orgId, orgId),
+          isNull(bankAccounts.deletedAt),
+        ),
+      );
+    return row ?? null;
+  });
+}
+
+/**
+ * Render a Swiss QR-bill on its own A4 portrait page and return the PDF
+ * buffer. `swissqrbill` v4 attaches onto a PDFKit document; we manage the
+ * stream → Buffer collection ourselves so the postal-export processor
+ * can `archive.append(buffer, { name })` synchronously alongside the
+ * appeal letter.
+ *
+ * IG QR-bill v2.4 structured-address (S) shape — combined-address (K)
+ * is intentionally not produced (see ADR-027 §"Address-type readiness").
+ *
+ * `amount` is left `undefined` so the slip prints "donor-fills" — the
+ * Swiss fundraising default. Future operators can pass a suggested amount
+ * per ADR-027's "amount" guidance once the campaign form exposes it.
+ */
+export async function renderSwissQrBillPdf(args: {
+  bankAccount: BankAccount;
+  reference: string;
+  /** Surfaced near the QR for donor context. */
+  campaignName: string;
+}): Promise<Buffer> {
+  const { bankAccount, reference, campaignName } = args;
+  const pdf = new PDFDocument({ size: "A4", autoFirstPage: false });
+  const chunks: Buffer[] = [];
+
+  const finished = new Promise<Buffer>((resolve, reject) => {
+    pdf.on("data", (chunk) => chunks.push(chunk as Buffer));
+    pdf.on("end", () => resolve(Buffer.concat(chunks)));
+    pdf.on("error", reject);
+  });
+
+  // Page header (the top 192 mm of the A4 — see docs/25 §1.ter ASCII layout).
+  pdf.addPage({ size: "A4" });
+  pdf.fontSize(14).font("Helvetica-Bold").text(bankAccount.holderName, 50, 60);
+  pdf.fontSize(10).font("Helvetica").fillColor("#555555").text(`Campaign: ${campaignName}`, 50, 82);
+  pdf
+    .fontSize(10)
+    .fillColor("#000000")
+    .text(`Reference: ${reference}`, 50, 100)
+    .text(`Currency: ${bankAccount.currency} (amount specified by donor)`, 50, 116)
+    .text("Pay this QR-bill from your e-banking app — scan the QR below.", 50, 145);
+
+  // swissqrbill v4 attaches the canonical bottom 105 mm strip
+  // (Receipt 62 mm + Payment Part 148 mm + 46×46 mm QR with Swiss cross).
+  // Address shape passed in IG `StrtNm` / `BldgNb` / `PstCd` / `TwnNm` /
+  // `Ctry` — the v4 library renders the S form natively when these
+  // structured fields are present.
+  const qrBill = new SwissQRBill({
+    currency: bankAccount.currency,
+    reference,
+    creditor: {
+      account: bankAccount.iban,
+      name: bankAccount.holderName,
+      address: bankAccount.holderStreet,
+      buildingNumber: bankAccount.holderBuildingNumber ?? undefined,
+      zip: bankAccount.holderPostalCode,
+      city: bankAccount.holderTown,
+      country: bankAccount.holderCountryCode,
+    },
+    message: campaignName,
+  });
+  qrBill.attachTo(pdf);
+
+  pdf.end();
+  return finished;
+}
+
+/** Sanitised filename for the QR-bill PDF, paired with the appeal letter. */
+export function qrBillFilenameFor(letterFilename: string): string {
+  // `something.pdf` → `something-qr-bill.pdf`. Keep the ZIP entries
+  // adjacent so the print partner can staple/distribute as one mailing.
+  return letterFilename.replace(/\.pdf$/i, "") + "-qr-bill.pdf";
+}
+
+/**
+ * Validate that `swissqrbill` v4 can actually serialise this payload —
+ * the library throws synchronously on malformed IBAN/reference/address
+ * combinations. Used by integration tests to confirm the readiness gate
+ * + lib agreement holds for every supported scenario.
+ */
+export function prebuildQrBillForValidation(
+  args: Parameters<typeof renderSwissQrBillPdf>[0],
+): void {
+  // Construct in-memory; no `attachTo` (no PDFKit doc), no IO. Throws
+  // if the data shape is invalid per the lib's validators.
+  new SwissQRBill({
+    currency: args.bankAccount.currency,
+    reference: args.reference,
+    creditor: {
+      account: args.bankAccount.iban,
+      name: args.bankAccount.holderName,
+      address: args.bankAccount.holderStreet,
+      buildingNumber: args.bankAccount.holderBuildingNumber ?? undefined,
+      zip: args.bankAccount.holderPostalCode,
+      city: args.bankAccount.holderTown,
+      country: args.bankAccount.holderCountryCode,
+    },
+    message: args.campaignName,
+  });
+}
+
+/**
+ * Stats helper for retries that need to know if a previous attempt
+ * already minted a reference for this (export, recipient). Not used by
+ * the worker today — exported so tests can assert idempotency without
+ * re-implementing the SELECT.
+ */
+export async function getExistingSwissQrReference(
+  orgId: string,
+  exportId: string,
+  constituentId: string | null,
+): Promise<{ reference: string; referenceType: SwissQrReferenceType } | null> {
+  return withWorkerContext(orgId, async (tx) => {
+    const [row] = await tx
+      .select({
+        reference: swissQrReferences.reference,
+        referenceType: swissQrReferences.referenceType,
+      })
+      .from(swissQrReferences)
+      .where(
+        and(
+          eq(swissQrReferences.orgId, orgId),
+          eq(swissQrReferences.exportId, exportId),
+          constituentId === null
+            ? isNull(swissQrReferences.constituentId)
+            : eq(swissQrReferences.constituentId, constituentId),
+        ),
+      );
+    return row ?? null;
+  });
+}
+
+/** Re-exported so downstream callers can guard their inputs. */
+export type { BankAccount, SwissQrReferenceType };
+
+/** Side-effect-free shape used by the postal-export integration. */
+export interface SwissQrBillRenderContext {
+  bankAccount: BankAccount;
+  referenceType: SwissQrReferenceType;
+  campaignName: string;
+}
+
+// Suppress unused-import lint on `sql` until the post-PR-3 follow-up
+// adds a denormalised counter (per ADR-027's sequential minting note).
+void sql;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,6 +405,9 @@ importers:
       stripe:
         specifier: ^22.1.1
         version: 22.1.1(@types/node@25.6.2)
+      swissqrbill:
+        specifier: ^4.3.0
+        version: 4.3.0(pdfkit@0.18.0)(typescript@6.0.3)
     devDependencies:
       '@types/archiver':
         specifier: ^6.0.2
@@ -4195,8 +4198,23 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  svg-engine@0.3.0:
+    resolution: {integrity: sha512-s172jAcwfoCcvM/6DwNBvmWN3brztHGFENCR+RU3CBJKeBxPrRlTltVxX1Je5hst782QgP8PM6U37vUR/RhPng==}
+
   svix@1.92.2:
     resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
+
+  swissqrbill@4.3.0:
+    resolution: {integrity: sha512-FzSPEVWVQ3R6B0vghqi7VJCLp54AMYxCSiJGr2QzXo8OSU8JBv7XJcF67BAVAriGkuaZqVfhxuD6yRFT6WAXEA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      pdfkit: '>=0.13.0'
+      typescript: '>=4.7.0'
+    peerDependenciesMeta:
+      pdfkit:
+        optional: true
+      typescript:
+        optional: true
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -8327,9 +8345,18 @@ snapshots:
       tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
 
+  svg-engine@0.3.0: {}
+
   svix@1.92.2:
     dependencies:
       standardwebhooks: 1.0.0
+
+  swissqrbill@4.3.0(pdfkit@0.18.0)(typescript@6.0.3):
+    dependencies:
+      svg-engine: 0.3.0
+    optionalDependencies:
+      pdfkit: 0.18.0
+      typescript: 6.0.3
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
## Summary

Closes the end-to-end Swiss QR-bill flow: operator picks a bank account on the campaign form, every postal export generates a second PDF carrying a canonical IG QR-bill, donor scans it from their e-banking app.

This is PR #3 of Epic #318. PR #1 (foundation) shipped the schema + validators + ADRs. PR #2 shipped the bank-accounts CRUD. **This PR connects the two.**

## What's in

### Operator UX (the user-visible piece)

- **Campaign form** — new "🇨🇭 Swiss QR-bill" section after Funds with:
  - Dropdown listing all the operator's registered bank accounts (`{bank} · {IBAN} · {currency}`) plus an explicit "None — standard mode" sentinel
  - Conditional `qrReferenceMode` override (auto / qrr / scor), hidden until a bank account is picked — most operators never touch it
  - Inline hint explaining the mode change ("Swiss QR-bill mode active. Every letter generated for this campaign will receive a QR-bill on a separate A4 sheet…")
- **Campaign detail page** — new 🇨🇭 success badge next to the type badge when Swiss-mode is on, so the operator always knows the state at a glance
- **Public donation page** — emerald banner ("You can also pay by Swiss bank transfer — scan the QR-bill on your postal letter") shown to donors when the campaign has a bank account linked

### API

- POST + PATCH `/v1/campaigns/:id` accept + persist `bankAccountId` (nullable) + `qrReferenceMode`
- Same-tenant validation (cross-org id → 400, ADR-019); soft-deleted id rejected at link-time
- Readiness gates fire on `POST /campaigns/:id/postal-exports` when a bank account is linked: `swiss_qr_bill_bank_account_deleted`, `swiss_qr_bill_invalid_iban`, `swiss_qr_bill_currency_mismatch`, `swiss_qr_bill_address_too_long`
- Public-page response gains `hasSwissQrBill: boolean` (never the internal bank-account id)

### Worker

- `swissqrbill@^4.3.0` added (validated locally via the preview script during PR #319 derisking)
- `services/swiss-qr-bill.ts` — `ensureSwissQrReference` is idempotent on retry (SELECT first via the partial unique, INSERT fresh if none, race-recovery re-SELECT); `renderSwissQrBillPdf` returns a Buffer the postal-export processor appends adjacent to the appeal letter
- Reference granularity per ADR-027: 1 ref per recipient on personalised; 1 ref per export on door-drop (constituent_id = NULL)
- QRR/SCOR minting via the new shared-validator `computeQrr` / `computeScor` helpers — random-body + spec-correct checksum
- Standard-mode campaigns (no bank account linked) are completely unaffected — back-compat is total

### Shared

- `computeQrr` + `computeScor` exposed for symmetry with the existing `isValidQrr` / `isValidScor`
- 8 new tests covering canonical Annex B / ISO 11649 vectors + round-trip + edge cases

## CI

`pnpm install + build + format + lint + typecheck + test` all green.

**981 / 981 tests pass** (api 752 +6 new · web 113 · worker 41 · shared 69 +8 new · relay 6).

## Test plan

- [x] `pnpm typecheck` clean across 6 workspaces
- [x] `pnpm test` 981/981
- [x] Worker imports `swissqrbill@^4.3.0` (declared in `packages/worker/package.json`)
- [ ] Reviewer: spin up local stack (`pnpm dev:up && pnpm db:migrate && pnpm dev`), create a bank account in Settings → Bank accounts, then link it to a postal campaign — verify the new "🇨🇭 Swiss QR-bill" badge appears on the campaign detail page
- [ ] Reviewer: trigger a postal export on a Swiss-linked campaign — verify the resulting ZIP contains both `{recipient}.pdf` and `{recipient}-qr-bill.pdf`, open the QR-bill PDF and confirm the IG layout (Receipt 62 mm + Payment Part 148 mm + 46×46 mm QR with Swiss cross)
- [ ] Reviewer: scan one of the generated QR-bills with a Swiss e-banking app — it should pre-fill the IBAN + reference (the test IBANs route to nowhere, safe to confirm)
- [ ] Reviewer: open the public donation page on a Swiss-linked campaign — verify the emerald banner appears below the donation form

## Out of scope (deferred)

- **PR #4** — camt.053 upload + reconciliation worker (the donor pays, the daily ISO 20022 statement comes back, the worker matches the structured reference, auto-creates the constituent + donation, surfaces unmatched credits in a manual queue)
- **PR #5** — Tracking widget extension (3-stage personalised funnel + 2-stage door-drop funnel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)