### PR TITLE
feat(api,web,worker): batched follow-up fixes (#149, #150, #152, #155, #156)

### DIFF
--- a/packages/api/src/modules/invitations/routes.ts
+++ b/packages/api/src/modules/invitations/routes.ts
@@ -260,12 +260,26 @@ export async function invitationRoutes(app: FastifyInstance) {
    * Per-invitation rate limiting protects against an admin accidentally
    * spamming a single invitee — the service rotates the token on every
    * call, so a tight loop here would invalidate just-delivered links.
+   *
+   * keyGenerator scopes the bucket to (ip, org, invitation). The fastify
+   * default (`req.ip` only) lets a single source IP burn through 5
+   * resends across distinct tenants and invitations per window, which
+   * with PR #154's first-admin path becomes a single-IP fan-out into
+   * the email worker (issue #156). Scoping the key forces the cap to
+   * apply per-(tenant, invitation) instead of globally per IP.
    */
   app.post(
     "/invitations/:id/resend",
     {
       preHandler: requireOrgAdmin,
-      config: { rateLimit: { max: 5, timeWindow: "15 minutes" } },
+      config: {
+        rateLimit: {
+          max: 5,
+          timeWindow: "15 minutes",
+          keyGenerator: (req) =>
+            `${req.ip}:${req.auth?.orgId ?? "anon"}:${(req.params as { id?: string }).id ?? "none"}`,
+        },
+      },
       schema: {
         tags: ["Invitations"],
         params: IdParams,
@@ -292,6 +306,17 @@ export async function invitationRoutes(app: FastifyInstance) {
       if (!result.ok) {
         if (result.error === "not_found") {
           return reply.status(404).send(problemDetail(404, "Not Found", "Invitation not found."));
+        }
+        if (result.error === "rate_limited") {
+          // Issue #149 — collapse the per-email cap into a success-shaped
+          // 204 so the bucket can't be probed via status-code timing.
+          // Service-side `invitation.resend_rate_limited` warn gives SRE
+          // the breadcrumb.
+          request.log.warn(
+            { event: "invitation.resend_rate_limited", invitationId: id, orgId },
+            "invitation resend skipped: per-email cap reached",
+          );
+          return reply.status(204).send();
         }
         return reply
           .status(409)

--- a/packages/api/src/modules/invitations/routes.ts
+++ b/packages/api/src/modules/invitations/routes.ts
@@ -286,6 +286,7 @@ export async function invitationRoutes(app: FastifyInstance) {
         response: {
           204: Type.Null(),
           409: ProblemDetailSchema,
+          429: ProblemDetailSchema,
           ...ErrorResponses,
         },
       },
@@ -308,15 +309,32 @@ export async function invitationRoutes(app: FastifyInstance) {
           return reply.status(404).send(problemDetail(404, "Not Found", "Invitation not found."));
         }
         if (result.error === "rate_limited") {
-          // Issue #149 — collapse the per-email cap into a success-shaped
-          // 204 so the bucket can't be probed via status-code timing.
-          // Service-side `invitation.resend_rate_limited` warn gives SRE
-          // the breadcrumb.
+          // Issue #149 — per-recipient cap. We return a real 429 instead
+          // of the signup-resend silent 204 because this path is org_admin-
+          // authenticated and operating on a resource they own: a
+          // success-shaped status would mislead the operator into
+          // believing the email went out (PR #358 review M3). The body
+          // is RFC 9457 + neutral so it doesn't leak whether the bucket
+          // is full because of this specific invitee or because of
+          // another recent resend to the same email.
           request.log.warn(
-            { event: "invitation.resend_rate_limited", invitationId: id, orgId },
+            {
+              event: "invitation.resend_rate_limited",
+              invitationId: id,
+              orgId,
+              actorKeycloakId: userId,
+            },
             "invitation resend skipped: per-email cap reached",
           );
-          return reply.status(204).send();
+          return reply
+            .status(429)
+            .send(
+              problemDetail(
+                429,
+                "Resend limit reached",
+                "A recent invitation was already sent to this address. The existing link is still valid; please wait before resending.",
+              ),
+            );
         }
         return reply
           .status(409)

--- a/packages/api/src/modules/invitations/service.ts
+++ b/packages/api/src/modules/invitations/service.ts
@@ -62,6 +62,7 @@ import {
   KeycloakUserExistsError,
   keycloakAdmin,
 } from "../../lib/keycloak-admin.js";
+import { redis } from "../../lib/redis.js";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -531,7 +532,32 @@ export interface ResendInvitationInput {
 
 export type ResendInvitationResult =
   | { ok: true; data: { id: string; expiresAt: Date } }
-  | { ok: false; error: "not_found" | "already_accepted" };
+  | { ok: false; error: "not_found" | "already_accepted" | "rate_limited" };
+
+/**
+ * Per-recipient resend cap (issue #149). The fastify per-IP limit on
+ * the route only stops one IP; a compromised org_admin (or a botnet of
+ * admins) could still rotate tokens against the same invitee 5× per
+ * 15min per source IP, burning inbox quota + invalidating just-
+ * delivered links. This bucket caps the inbox-side blast radius at
+ * 3 resends per email per hour regardless of source IP, mirroring the
+ * signup-resend pattern in `signup/routes.ts`.
+ *
+ * Returns true when the request is allowed, false when the bucket is
+ * full. Bucket key normalises the email so case + whitespace drift
+ * across re-invites can't be used to bypass the cap.
+ */
+const INVITATION_RESEND_CAP = 3;
+const INVITATION_RESEND_WINDOW_SECONDS = 60 * 60;
+
+async function acceptResendForInvitationEmail(email: string): Promise<boolean> {
+  const key = `invitation:resend:email:${email.trim().toLowerCase()}`;
+  const hits = await redis.incr(key);
+  if (hits === 1) {
+    await redis.expire(key, INVITATION_RESEND_WINDOW_SECONDS);
+  }
+  return hits <= INVITATION_RESEND_CAP;
+}
 
 /**
  * Rotate the token + expiry on a pending invitation and re-emit the
@@ -573,6 +599,16 @@ export async function resendTeamInvitation(
     if (!row) return { ok: false as const, error: "not_found" as const };
     if (row.acceptedAt) {
       return { ok: false as const, error: "already_accepted" as const };
+    }
+
+    // Issue #149 — per-recipient cap, evaluated AFTER the row lookup so a
+    // bad invitation id still returns 404 instead of 204 (preserves the
+    // "missing invitation" diagnostic). The route translates rate_limited
+    // into a silent 204 so an angry operator can't probe the bucket from
+    // status-code deltas.
+    const allowed = await acceptResendForInvitationEmail(row.email);
+    if (!allowed) {
+      return { ok: false as const, error: "rate_limited" as const };
     }
 
     const newToken = randomUUID();

--- a/packages/api/src/modules/invitations/service.ts
+++ b/packages/api/src/modules/invitations/service.ts
@@ -569,10 +569,48 @@ async function acceptResendForInvitationEmail(email: string): Promise<boolean> {
  * never arrived" — if the invitee only just received the original and
  * the operator clicks resend in parallel, we want only the most recent
  * link to be live to keep audit trails unambiguous.
+ *
+ * Three phases — split so the Redis cap check (issue #149) doesn't run
+ * while a Postgres transaction is held open (PR #358 review M5):
+ *   1. Probe tx (read-only): resolve email + acceptedAt to decide
+ *      whether the cap should be charged at all.
+ *   2. Cap check (Redis only, no tx).
+ *   3. Rotation tx (read-modify-write): re-fetch the row to guard
+ *      against TOCTOU with a concurrent accept, then rotate.
  */
 export async function resendTeamInvitation(
   input: ResendInvitationInput,
 ): Promise<ResendInvitationResult> {
+  // ── Phase 1: probe ──────────────────────────────────────────────────
+  const probe = await withTenantContext(input.orgId, async (tx) => {
+    const [row] = await tx
+      .select({ acceptedAt: invitations.acceptedAt, email: invitations.email })
+      .from(invitations)
+      .where(
+        and(
+          eq(invitations.id, input.invitationId),
+          eq(invitations.orgId, input.orgId),
+          eq(invitations.purpose, "team_invite"),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  });
+
+  if (!probe) return { ok: false as const, error: "not_found" as const };
+  if (probe.acceptedAt) {
+    return { ok: false as const, error: "already_accepted" as const };
+  }
+
+  // ── Phase 2: per-recipient cap (issue #149) ────────────────────────
+  // Evaluated AFTER the probe so an invalid id still returns 404
+  // instead of 429 (preserves the "missing invitation" diagnostic).
+  const allowed = await acceptResendForInvitationEmail(probe.email);
+  if (!allowed) {
+    return { ok: false as const, error: "rate_limited" as const };
+  }
+
+  // ── Phase 3: rotation tx ───────────────────────────────────────────
   return withTenantContext(input.orgId, async (tx) => {
     const [row] = await tx
       .select({
@@ -596,19 +634,13 @@ export async function resendTeamInvitation(
       )
       .limit(1);
 
+    // Re-check state after the cap charge — TOCTOU guard against a
+    // concurrent accept between the probe and the rotation tx. The
+    // cap leak (one increment with no actual resend) is bounded at
+    // one bucket unit per race; acceptable.
     if (!row) return { ok: false as const, error: "not_found" as const };
     if (row.acceptedAt) {
       return { ok: false as const, error: "already_accepted" as const };
-    }
-
-    // Issue #149 — per-recipient cap, evaluated AFTER the row lookup so a
-    // bad invitation id still returns 404 instead of 204 (preserves the
-    // "missing invitation" diagnostic). The route translates rate_limited
-    // into a silent 204 so an angry operator can't probe the bucket from
-    // status-code deltas.
-    const allowed = await acceptResendForInvitationEmail(row.email);
-    if (!allowed) {
-      return { ok: false as const, error: "rate_limited" as const };
     }
 
     const newToken = randomUUID();

--- a/packages/api/src/modules/tenant-admin/routes.ts
+++ b/packages/api/src/modules/tenant-admin/routes.ts
@@ -656,7 +656,17 @@ export async function tenantAdminRoutes(app: FastifyInstance) {
     "/superadmin/tenants/:id/first-admin-invitations/:invitationId/resend",
     {
       preHandler: requireSuperAdmin,
-      config: { rateLimit: { max: 5, timeWindow: "15 minutes" } },
+      // keyGenerator scopes the bucket to (ip, tenant) instead of just ip
+      // so a single super-admin IP can't burn through 5 resends across
+      // distinct tenants per window (issue #156). orgId isn't on the
+      // super-admin auth context, so `:id` is the per-target piece.
+      config: {
+        rateLimit: {
+          max: 5,
+          timeWindow: "15 minutes",
+          keyGenerator: (req) => `${req.ip}:${(req.params as { id?: string }).id ?? "none"}`,
+        },
+      },
       schema: {
         tags: ["Tenant Admin"],
         params: FirstAdminInvitationParams,

--- a/packages/api/src/tests/integration/team-invitations.test.ts
+++ b/packages/api/src/tests/integration/team-invitations.test.ts
@@ -554,9 +554,7 @@ describe("POST /v1/invitations/:id/resend", () => {
     // distinct invitation ids, we insert the second invitation row
     // directly — same shape the service would have created.
     const inviteBId = randomUUID();
-    await db.execute(
-      sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`,
-    );
+    await db.execute(sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`);
     await db.execute(sql`
       INSERT INTO invitations (id, org_id, email, role, token, purpose, expires_at, created_at)
       VALUES (

--- a/packages/api/src/tests/integration/team-invitations.test.ts
+++ b/packages/api/src/tests/integration/team-invitations.test.ts
@@ -179,6 +179,10 @@ beforeEach(async () => {
 
   const keys = await redis.keys("*rate-limit*");
   if (keys.length > 0) await redis.del(...keys);
+  // Issue #149 — per-recipient resend bucket lives outside fastify rate-limit
+  // namespace; wipe it explicitly so tests don't bleed.
+  const resendKeys = await redis.keys("invitation:resend:email:*");
+  if (resendKeys.length > 0) await redis.del(...resendKeys);
 });
 
 afterAll(async () => {
@@ -444,6 +448,65 @@ describe("POST /v1/invitations/:id/resend", () => {
       sql`SELECT type FROM outbox_events WHERE tenant_id = ${f.orgId} AND type = 'invitation.resent'`,
     );
     expect(events).toHaveLength(1);
+  });
+
+  it("caps resends to one inbox at 3/hour (issue #149) and 4th attempt silently 204s without rotating the token", async () => {
+    const f = await makeFixture();
+    const email = `cap+${f.slug}@example.org`;
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const created = create.json<{ data: { id: string } }>().data;
+
+    // Three successful resends rotate the token each time.
+    const tokens: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const res = await app.inject({
+        method: "POST",
+        url: `/v1/invitations/${created.id}/resend`,
+        headers: authHeader(f.inviterToken),
+      });
+      expect(res.statusCode).toBe(204);
+      const [row] = await db
+        .select({ token: invitations.token })
+        .from(invitations)
+        .where(eq(invitations.id, created.id));
+      tokens.push(row?.token ?? "");
+    }
+    // Each successful resend MUST rotate the token — anything else
+    // means the per-recipient cap leaked into the success path.
+    expect(new Set(tokens).size).toBe(3);
+
+    // 4th call is over the per-recipient cap. Response shape is 204
+    // (matches the success path so a bucket-full state can't be
+    // detected from status-code timing) but the token does NOT rotate
+    // and no fresh `invitation.resent` outbox row is written.
+    const before = tokens[2];
+    const eventsBefore = await db.execute<{ c: number }>(
+      sql`SELECT COUNT(*)::int AS c FROM outbox_events WHERE tenant_id = ${f.orgId} AND type = 'invitation.resent'`,
+    );
+
+    const fourth = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${created.id}/resend`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(fourth.statusCode).toBe(204);
+
+    const [afterRow] = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, created.id));
+    expect(afterRow?.token).toBe(before);
+
+    const eventsAfter = await db.execute<{ c: number }>(
+      sql`SELECT COUNT(*)::int AS c FROM outbox_events WHERE tenant_id = ${f.orgId} AND type = 'invitation.resent'`,
+    );
+    expect(eventsAfter.rows[0]?.c).toBe(eventsBefore.rows[0]?.c);
   });
 
   it("returns 404 for an unknown id and 409 for an accepted invitation", async () => {

--- a/packages/api/src/tests/integration/team-invitations.test.ts
+++ b/packages/api/src/tests/integration/team-invitations.test.ts
@@ -450,7 +450,7 @@ describe("POST /v1/invitations/:id/resend", () => {
     expect(events).toHaveLength(1);
   });
 
-  it("caps resends to one inbox at 3/hour (issue #149) and 4th attempt silently 204s without rotating the token", async () => {
+  it("caps resends to one inbox at 3/hour (issue #149) and 4th attempt returns 429 without rotating the token or writing an audit row", async () => {
     const f = await makeFixture();
     const email = `cap+${f.slug}@example.org`;
 
@@ -481,13 +481,20 @@ describe("POST /v1/invitations/:id/resend", () => {
     // means the per-recipient cap leaked into the success path.
     expect(new Set(tokens).size).toBe(3);
 
-    // 4th call is over the per-recipient cap. Response shape is 204
-    // (matches the success path so a bucket-full state can't be
-    // detected from status-code timing) but the token does NOT rotate
-    // and no fresh `invitation.resent` outbox row is written.
+    // 4th call is over the per-recipient cap. The PR #358 multi-agent
+    // review (M3) replaced the original silent-204 plan with a real
+    // 429 + RFC 9457 body so an authenticated org_admin acting on a
+    // resource they own gets an honest signal instead of a misleading
+    // green toast. The token MUST NOT rotate, no fresh
+    // `invitation.resent` outbox row is written, and no `audit_logs`
+    // entry is added (M6 — guard a future refactor from leaking an
+    // audit row on the no-op path).
     const before = tokens[2];
     const eventsBefore = await db.execute<{ c: number }>(
       sql`SELECT COUNT(*)::int AS c FROM outbox_events WHERE tenant_id = ${f.orgId} AND type = 'invitation.resent'`,
+    );
+    const auditBefore = await db.execute<{ c: number }>(
+      sql`SELECT COUNT(*)::int AS c FROM audit_logs WHERE org_id = ${f.orgId} AND action = 'invitation.resent'`,
     );
 
     const fourth = await app.inject({
@@ -495,7 +502,18 @@ describe("POST /v1/invitations/:id/resend", () => {
       url: `/v1/invitations/${created.id}/resend`,
       headers: authHeader(f.inviterToken),
     });
-    expect(fourth.statusCode).toBe(204);
+    expect(fourth.statusCode).toBe(429);
+    // Lock the RFC 9457 body shape so a regression to a plain-string
+    // body or `{error: ...}` payload trips the test (per the repo
+    // `feedback_lock_rfc9457_body_in_tests.md` rule).
+    const problem = fourth.json<{
+      status: number;
+      title: string;
+      detail: string;
+    }>();
+    expect(problem.status).toBe(429);
+    expect(problem.title).toBe("Resend limit reached");
+    expect(typeof problem.detail).toBe("string");
 
     const [afterRow] = await db
       .select({ token: invitations.token })
@@ -507,6 +525,78 @@ describe("POST /v1/invitations/:id/resend", () => {
       sql`SELECT COUNT(*)::int AS c FROM outbox_events WHERE tenant_id = ${f.orgId} AND type = 'invitation.resent'`,
     );
     expect(eventsAfter.rows[0]?.c).toBe(eventsBefore.rows[0]?.c);
+
+    const auditAfter = await db.execute<{ c: number }>(
+      sql`SELECT COUNT(*)::int AS c FROM audit_logs WHERE org_id = ${f.orgId} AND action = 'invitation.resent'`,
+    );
+    expect(auditAfter.rows[0]?.c).toBe(auditBefore.rows[0]?.c);
+  });
+
+  it("keys the resend bucket by EMAIL (not invitation id) — distinct invitations to the same inbox share one cap (issue #149 C1)", async () => {
+    // The headline of #149 is "per-recipient". A regression that named
+    // the redis key `invitation:resend:id:${invitationId}` would still
+    // pass the single-invitation cap test above because (email, id)
+    // is fixed. This test creates TWO distinct invitations to the same
+    // email and proves the cap is shared.
+    const f = await makeFixture();
+    const email = `shared+${f.slug}@example.org`;
+
+    const createA = await app.inject({
+      method: "POST",
+      url: "/v1/invitations",
+      headers: authHeader(f.inviterToken),
+      payload: { email },
+    });
+    const inviteA = createA.json<{ data: { id: string } }>().data;
+
+    // Service guards against a second pending invitation to the same
+    // email through the route. To exercise the per-EMAIL key from two
+    // distinct invitation ids, we insert the second invitation row
+    // directly — same shape the service would have created.
+    const inviteBId = randomUUID();
+    await db.execute(
+      sql`SELECT set_config('app.current_organization_id', ${f.orgId}, true)`,
+    );
+    await db.execute(sql`
+      INSERT INTO invitations (id, org_id, email, role, token, purpose, expires_at, created_at)
+      VALUES (
+        ${inviteBId}::uuid,
+        ${f.orgId}::uuid,
+        ${email},
+        'user',
+        ${randomUUID()}::uuid,
+        'team_invite',
+        ${new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)},
+        ${new Date()}
+      )
+    `);
+
+    // 2 successful resends against invitation A.
+    for (let i = 0; i < 2; i++) {
+      const r = await app.inject({
+        method: "POST",
+        url: `/v1/invitations/${inviteA.id}/resend`,
+        headers: authHeader(f.inviterToken),
+      });
+      expect(r.statusCode).toBe(204);
+    }
+    // 1 successful resend against invitation B — same email, so the
+    // bucket has now consumed 3 of 3 hits.
+    const thirdHit = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${inviteBId}/resend`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(thirdHit.statusCode).toBe(204);
+
+    // 4th hit on EITHER invitation must 429 — proves the cap key is
+    // the email, not the invitation id.
+    const overcap = await app.inject({
+      method: "POST",
+      url: `/v1/invitations/${inviteA.id}/resend`,
+      headers: authHeader(f.inviterToken),
+    });
+    expect(overcap.statusCode).toBe(429);
   });
 
   it("returns 404 for an unknown id and 409 for an accepted invitation", async () => {

--- a/packages/web/src/app/(auth)/invite/accept/page.tsx
+++ b/packages/web/src/app/(auth)/invite/accept/page.tsx
@@ -204,7 +204,8 @@ function AcceptContent() {
         // that the realm's mapper turns into the JWT claim the callback
         // requires. `?hint=<slug>` is forwarded as `kc_idp_hint` so
         // federated tenants land directly on their IdP (issue #150);
-        // KC ignores it for non-federated aliases.
+        // KC ignores it for non-federated or unmatched aliases — useful
+        // breadcrumb for operators debugging "why didn't the IdP open".
         window.location.href = `/api/auth/login?hint=${encodeURIComponent(res.data.slug)}`;
         return;
       }

--- a/packages/web/src/app/(auth)/invite/accept/page.tsx
+++ b/packages/web/src/app/(auth)/invite/accept/page.tsx
@@ -202,14 +202,9 @@ function AcceptContent() {
         // Redirect to Keycloak login. The API has already attached us as
         // an Organization member and stamped the `org_id` user attribute
         // that the realm's mapper turns into the JWT claim the callback
-        // requires.
-        //
-        // NOTE: `?hint=<slug>` is currently a no-op — the `/api/auth/login`
-        // route handler doesn't read query params, so the slug round-trip
-        // doesn't actually drive `kc_idp_hint`/`login_hint`. Kept for
-        // structural parity with `/signup/verify` (same dead query string)
-        // until both can be wired or removed together. Tracked as a
-        // follow-up to issue #145 (review F1).
+        // requires. `?hint=<slug>` is forwarded as `kc_idp_hint` so
+        // federated tenants land directly on their IdP (issue #150);
+        // KC ignores it for non-federated aliases.
         window.location.href = `/api/auth/login?hint=${encodeURIComponent(res.data.slug)}`;
         return;
       }

--- a/packages/web/src/app/(auth)/signup/verify/page.tsx
+++ b/packages/web/src/app/(auth)/signup/verify/page.tsx
@@ -154,7 +154,8 @@ function VerifyContent() {
         // realm's mapper turns into the JWT claim the callback requires.
         // `?hint=<slug>` is forwarded as `kc_idp_hint` so federated
         // tenants land directly on their IdP (issue #150); KC ignores
-        // it for non-federated aliases.
+        // it for non-federated or unmatched aliases — useful breadcrumb
+        // for operators debugging "why didn't the IdP open".
         window.location.href = `/api/auth/login?hint=${encodeURIComponent(res.data.slug)}`;
         return;
       }

--- a/packages/web/src/app/(auth)/signup/verify/page.tsx
+++ b/packages/web/src/app/(auth)/signup/verify/page.tsx
@@ -152,6 +152,9 @@ function VerifyContent() {
         // Organization, the user with the chosen password, and the
         // membership, plus stamped the `org_id` user attribute that the
         // realm's mapper turns into the JWT claim the callback requires.
+        // `?hint=<slug>` is forwarded as `kc_idp_hint` so federated
+        // tenants land directly on their IdP (issue #150); KC ignores
+        // it for non-federated aliases.
         window.location.href = `/api/auth/login?hint=${encodeURIComponent(res.data.slug)}`;
         return;
       }

--- a/packages/web/src/app/api/auth/login/route.ts
+++ b/packages/web/src/app/api/auth/login/route.ts
@@ -16,6 +16,7 @@ import {
   safeReturnToPath,
 } from "@/lib/auth/keycloak";
 import { logAuthEvent } from "@/lib/auth/log";
+import { validateLoginHint } from "@/lib/auth/login-hint";
 import { STEP_UP_ACR_VALUE } from "@/lib/auth/step-up";
 
 /**
@@ -98,6 +99,20 @@ export async function GET(request: NextRequest) {
     params.set("kc_org", orgAlias);
   }
 
+  // Post-verify / post-accept redirect carries `?hint=<tenant-slug>` so KC
+  // can route federated/SAML tenants straight to their IdP without an
+  // extra picker click (issue #150). Forwarded as `kc_idp_hint`: KC
+  // matches the alias to a configured IdP and redirects directly when
+  // it exists, silently ignoring the hint otherwise — so non-federated
+  // tenants are unaffected. Validated as a tenant-slug shape (the same
+  // pattern enforced on the signup side) to prevent injection of
+  // arbitrary IdP aliases by a malicious caller.
+  const url = new URL(request.url);
+  const hint = validateLoginHint(url.searchParams.get("hint"));
+  if (hint) {
+    params.set("kc_idp_hint", hint);
+  }
+
   // Step-up MFA support (issue #250). The impersonation form redirects
   // here with `acr_values=2` + `prompt=login` to force a fresh MFA-backed
   // re-auth. Both params are pass-throughs to Keycloak — the realm's
@@ -106,7 +121,6 @@ export async function GET(request: NextRequest) {
   // malicious caller can't smuggle arbitrary OIDC params into the
   // upstream auth request. The literal acr value lives in step-up.ts so
   // a future LoA bump (`"3"`, `"high"`) lands in one place.
-  const url = new URL(request.url);
   const acrValues = url.searchParams.get("acr_values");
   const stepUpRequested = acrValues === STEP_UP_ACR_VALUE;
   if (stepUpRequested) {

--- a/packages/web/src/app/api/auth/login/route.ts
+++ b/packages/web/src/app/api/auth/login/route.ts
@@ -104,13 +104,21 @@ export async function GET(request: NextRequest) {
   // extra picker click (issue #150). Forwarded as `kc_idp_hint`: KC
   // matches the alias to a configured IdP and redirects directly when
   // it exists, silently ignoring the hint otherwise — so non-federated
-  // tenants are unaffected. Validated as a tenant-slug shape (the same
-  // pattern enforced on the signup side) to prevent injection of
-  // arbitrary IdP aliases by a malicious caller.
+  // tenants are unaffected. Validated via the shared tenant-slug
+  // checker so the punycode + reserved-slug rejects stay aligned with
+  // signup. Rejected hints emit a warn log mirroring the
+  // `auth.return_to.rejected` pattern below, so attacker probes are
+  // visible on Cockpit instead of failing silently (PR #358 review m2).
   const url = new URL(request.url);
-  const hint = validateLoginHint(url.searchParams.get("hint"));
-  if (hint) {
-    params.set("kc_idp_hint", hint);
+  const rawHint = url.searchParams.get("hint");
+  const hint = validateLoginHint(rawHint);
+  if (hint.kind === "valid") {
+    params.set("kc_idp_hint", hint.slug);
+  } else if (hint.kind === "rejected" && rawHint) {
+    logAuthEvent("warn", "auth.login_hint.rejected", {
+      raw: rawHint.slice(0, 256),
+      reason: hint.reason,
+    });
   }
 
   // Step-up MFA support (issue #250). The impersonation form redirects

--- a/packages/web/src/components/shared/form-field.test.tsx
+++ b/packages/web/src/components/shared/form-field.test.tsx
@@ -1,0 +1,75 @@
+import { useForm } from "react-hook-form";
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/shared/form-field";
+import { render, screen, userEvent } from "../../tests/test-utils";
+
+interface SignupFormValues {
+  email: string;
+}
+
+/**
+ * Minimal harness that mirrors the production `FormField` wiring — controlled
+ * input, onBlur validation, and a `<FormMessage>` next to the control. The
+ * tests below assert the primitive's a11y contract for issue #155 (validation
+ * errors must announce immediately so AT users don't have to re-focus the
+ * field to hear why it stayed invalid).
+ */
+function HarnessForm() {
+  const form = useForm<SignupFormValues>({
+    mode: "onBlur",
+    defaultValues: { email: "" },
+  });
+
+  return (
+    <Form {...form}>
+      <form>
+        <FormField
+          control={form.control}
+          name="email"
+          rules={{ required: "Email is required" }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <input type="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  );
+}
+
+describe("FormMessage — a11y (issue #155)", () => {
+  it("announces validation errors via role=alert + aria-live=assertive", async () => {
+    const user = userEvent.setup();
+    render(<HarnessForm />);
+
+    const input = screen.getByLabelText("Email");
+    await user.click(input);
+    await user.tab(); // onBlur triggers validation → error renders
+
+    // role=alert is what fires the live-region announcement on AT.
+    // Without it, the error stays silent until the user re-focuses
+    // the field — the exact bug #155 captures.
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Email is required");
+    // Belt-and-suspenders for the legacy screen readers that honour
+    // aria-live without recognising the implicit role mapping.
+    expect(alert).toHaveAttribute("aria-live", "assertive");
+  });
+
+  it("does not render an alert region when there is no error", () => {
+    render(<HarnessForm />);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/packages/web/src/components/shared/form-field.test.tsx
+++ b/packages/web/src/components/shared/form-field.test.tsx
@@ -50,26 +50,54 @@ function HarnessForm() {
 }
 
 describe("FormMessage — a11y (issue #155)", () => {
-  it("announces validation errors via role=alert + aria-live=assertive", async () => {
+  it("announces validation errors via a polite status live-region", async () => {
     const user = userEvent.setup();
     render(<HarnessForm />);
 
     const input = screen.getByLabelText("Email");
     await user.click(input);
-    await user.tab(); // onBlur triggers validation → error renders
+    await user.tab(); // onBlur triggers validation → error text appears
 
-    // role=alert is what fires the live-region announcement on AT.
-    // Without it, the error stays silent until the user re-focuses
-    // the field — the exact bug #155 captures.
-    const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent("Email is required");
-    // Belt-and-suspenders for the legacy screen readers that honour
-    // aria-live without recognising the implicit role mapping.
-    expect(alert).toHaveAttribute("aria-live", "assertive");
+    // `role=status` (which implies `aria-live=polite` + `aria-atomic=true`)
+    // queues the message after the current screen-reader speech rather
+    // than pre-empting it — the assertive variant turned out to flood
+    // over the curated `rootError` summary that 9 forms render alongside
+    // FormMessage (multi-agent review M1 on PR #358).
+    const status = await screen.findByRole("status");
+    expect(status).toHaveTextContent("Email is required");
+    expect(status).toHaveAttribute("aria-live", "polite");
   });
 
-  it("does not render an alert region when there is no error", () => {
+  it("keeps the live region mounted across error → clear → re-error transitions", async () => {
+    // AT combinations (NVDA + Firefox in particular) skip the re-
+    // announce when the live region itself mounts and unmounts every
+    // time the error toggles. Keeping the `<p>` in the DOM (sr-only
+    // when empty) turns each transition into a *content change* on a
+    // stable region, which is what assistive tech reliably fires on.
+    const user = userEvent.setup();
     render(<HarnessForm />);
-    expect(screen.queryByRole("alert")).toBeNull();
+
+    const input = screen.getByLabelText("Email");
+    // Initial render: region exists, body is empty.
+    const initialStatus = screen.getByRole("status", { hidden: true });
+    expect(initialStatus.id).toBeTruthy();
+    expect(initialStatus.textContent).toBe("");
+    const stableId = initialStatus.id;
+
+    // Trigger validation → same node carries the message (same id).
+    await user.click(input);
+    await user.tab();
+    const errored = await screen.findByRole("status");
+    expect(errored.id).toBe(stableId);
+    expect(errored).toHaveTextContent("Email is required");
+
+    // Clear by typing then blurring with a valid value — region stays
+    // mounted, body empties.
+    await user.click(input);
+    await user.type(input, "valid@example.org");
+    await user.tab();
+    const cleared = screen.getByRole("status", { hidden: true });
+    expect(cleared.id).toBe(stableId);
+    expect(cleared.textContent).toBe("");
   });
 });

--- a/packages/web/src/components/shared/form-field.tsx
+++ b/packages/web/src/components/shared/form-field.tsx
@@ -137,20 +137,32 @@ export function FormMessage({
 }: HTMLAttributes<HTMLParagraphElement>) {
   const { formMessageId, error } = useFormField();
   const body = error ? String(error.message ?? "") : children;
-  if (!body) return null;
+  // Always mount the live region — even when empty. Several screen-reader
+  // combinations (NVDA + Firefox in particular) skip the announcement
+  // when the element mounts together with its content in the same tick;
+  // keeping the node in the DOM with a stable id turns the AT
+  // notification into a *content change* on a known region, which is
+  // reliably announced on every error → clear → re-error cycle.
+  //
+  // `aria-live="polite"` is the default — the assertive level would
+  // pre-empt any concurrent `role=alert` rootError summary (used on the
+  // signup / new-tenant / donation / etc. forms) and turn submit-with-
+  // errors into a flood that drowns the curated summary. Call sites
+  // that need to interrupt the user (payment failure, session expiry)
+  // can override `aria-live` via the spread props.
   return (
     <p
       id={formMessageId}
-      // role=alert + aria-live=assertive announce the validation message
-      // immediately when react-hook-form's onBlur cycle attaches an error
-      // — AT users were otherwise required to re-focus the field to hear
-      // why it stayed invalid (issue #155). `role=alert` already implies
-      // `aria-live=assertive`, but a few legacy screen readers honour
-      // only one or the other; spelling both out costs nothing and
-      // covers the matrix.
-      role="alert"
-      aria-live="assertive"
-      className={cn("text-xs font-medium text-error", className)}
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "text-xs font-medium text-error",
+        // Reserve the row when empty so screen readers see content
+        // changes on a stable region; visually hidden when there's
+        // nothing to read.
+        !body && "sr-only",
+        className,
+      )}
       {...props}
     >
       {body}

--- a/packages/web/src/components/shared/form-field.tsx
+++ b/packages/web/src/components/shared/form-field.tsx
@@ -139,7 +139,20 @@ export function FormMessage({
   const body = error ? String(error.message ?? "") : children;
   if (!body) return null;
   return (
-    <p id={formMessageId} className={cn("text-xs font-medium text-error", className)} {...props}>
+    <p
+      id={formMessageId}
+      // role=alert + aria-live=assertive announce the validation message
+      // immediately when react-hook-form's onBlur cycle attaches an error
+      // — AT users were otherwise required to re-focus the field to hear
+      // why it stayed invalid (issue #155). `role=alert` already implies
+      // `aria-live=assertive`, but a few legacy screen readers honour
+      // only one or the other; spelling both out costs nothing and
+      // covers the matrix.
+      role="alert"
+      aria-live="assertive"
+      className={cn("text-xs font-medium text-error", className)}
+      {...props}
+    >
       {body}
     </p>
   );

--- a/packages/web/src/lib/auth/login-hint.test.ts
+++ b/packages/web/src/lib/auth/login-hint.test.ts
@@ -3,51 +3,58 @@ import { describe, expect, it } from "vitest";
 import { validateLoginHint } from "./login-hint";
 
 describe("validateLoginHint", () => {
-  // Accepted shapes mirror `validateTenantSlug` (shared/validators) — the
-  // signup-verify and invite-accept pages forward `response.slug` directly,
-  // so the accept criteria here is "round-trips a server-issued slug".
-  it("accepts canonical lowercase slugs", () => {
-    expect(validateLoginHint("acme")).toBe("acme");
-    expect(validateLoginHint("foo-bar")).toBe("foo-bar");
-    expect(validateLoginHint("a1")).toBe("a1");
+  // The validator delegates to the canonical `validateTenantSlug`, so its
+  // shape rules — regex, 2–50 char length, `xn--` punycode reject, and
+  // the reserved-slug list — are inherited. The cases below cover the
+  // discriminated-result contract the login route now consumes.
+
+  it("returns `valid` with the canonical (trimmed + lowercased) slug for accepted shapes", () => {
+    expect(validateLoginHint("acme")).toEqual({ kind: "valid", slug: "acme" });
+    expect(validateLoginHint("foo-bar")).toEqual({ kind: "valid", slug: "foo-bar" });
+    expect(validateLoginHint("  Acme-Foundation  ")).toEqual({
+      kind: "valid",
+      slug: "acme-foundation",
+    });
   });
 
-  it("normalises trimmed + mixed-case input", () => {
-    expect(validateLoginHint("  Acme-Foundation  ")).toBe("acme-foundation");
+  it("returns `absent` when the input is missing or empty (no warn log fires)", () => {
+    expect(validateLoginHint(null)).toEqual({ kind: "absent" });
+    expect(validateLoginHint(undefined)).toEqual({ kind: "absent" });
+    expect(validateLoginHint("")).toEqual({ kind: "absent" });
+    expect(validateLoginHint("   ")).toEqual({ kind: "absent" });
   });
 
-  it("returns null when absent", () => {
-    expect(validateLoginHint(null)).toBeNull();
-    expect(validateLoginHint(undefined)).toBeNull();
-    expect(validateLoginHint("")).toBeNull();
+  it("returns `rejected` with `syntax` for shape violations", () => {
+    expect(validateLoginHint("a")).toEqual({ kind: "rejected", reason: "syntax" });
+    expect(validateLoginHint("-acme")).toEqual({ kind: "rejected", reason: "syntax" });
+    expect(validateLoginHint("acme-")).toEqual({ kind: "rejected", reason: "syntax" });
+    expect(validateLoginHint("Acme Foundation")).toEqual({
+      kind: "rejected",
+      reason: "syntax",
+    });
+    expect(validateLoginHint("acme/etc")).toEqual({ kind: "rejected", reason: "syntax" });
+    expect(validateLoginHint("acme&kc_idp_hint=other")).toEqual({
+      kind: "rejected",
+      reason: "syntax",
+    });
+    expect(validateLoginHint("a".repeat(51))).toEqual({ kind: "rejected", reason: "syntax" });
   });
 
-  // Each rejection below would otherwise reach Keycloak as a literal
-  // `kc_idp_hint` value and probe for alias matches. Dropping them
-  // server-side keeps upstream logs free of attacker probes.
-  it("rejects single-character slugs (< 2 chars violates the shared pattern)", () => {
-    expect(validateLoginHint("a")).toBeNull();
+  it("returns `rejected` with `punycode` for IDNA-prefixed values", () => {
+    // Without delegation to validateTenantSlug, a local regex would
+    // accept `xn--paypal` as a valid slug shape and forward it to
+    // Keycloak as a `kc_idp_hint` value — low blast radius but exactly
+    // the kind of probe the multi-agent review M7 flagged. Pinning the
+    // reason discriminator here so a future regression is loud.
+    expect(validateLoginHint("xn--paypal")).toEqual({ kind: "rejected", reason: "punycode" });
   });
 
-  it("rejects leading or trailing hyphens", () => {
-    expect(validateLoginHint("-acme")).toBeNull();
-    expect(validateLoginHint("acme-")).toBeNull();
-  });
-
-  it("rejects uppercase that doesn't normalise to a valid slug", () => {
-    // Uppercase WITH characters that don't survive lowercasing (e.g. spaces)
-    expect(validateLoginHint("Acme Foundation")).toBeNull();
-  });
-
-  it("rejects slug-injection attempts (spaces, slashes, query separators)", () => {
-    expect(validateLoginHint("acme/etc")).toBeNull();
-    expect(validateLoginHint("acme&kc_idp_hint=other")).toBeNull();
-    expect(validateLoginHint("acme?x=1")).toBeNull();
-    expect(validateLoginHint("acme foundation")).toBeNull();
-  });
-
-  it("rejects slugs longer than the 50-char shared cap", () => {
-    const tooLong = "a".repeat(51);
-    expect(validateLoginHint(tooLong)).toBeNull();
+  it("returns `rejected` with `reserved` for platform-reserved slugs", () => {
+    // `admin`, `api`, `www`, … are reserved by the platform (see
+    // `packages/shared/src/constants/reserved-slugs.ts`). Forwarding
+    // them as a hint to KC is harmless (no IdP alias will match) but
+    // probing for them belongs in the warn log, not the upstream URL.
+    expect(validateLoginHint("admin")).toEqual({ kind: "rejected", reason: "reserved" });
+    expect(validateLoginHint("api")).toEqual({ kind: "rejected", reason: "reserved" });
   });
 });

--- a/packages/web/src/lib/auth/login-hint.test.ts
+++ b/packages/web/src/lib/auth/login-hint.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { validateLoginHint } from "./login-hint";
+
+describe("validateLoginHint", () => {
+  // Accepted shapes mirror `validateTenantSlug` (shared/validators) — the
+  // signup-verify and invite-accept pages forward `response.slug` directly,
+  // so the accept criteria here is "round-trips a server-issued slug".
+  it("accepts canonical lowercase slugs", () => {
+    expect(validateLoginHint("acme")).toBe("acme");
+    expect(validateLoginHint("foo-bar")).toBe("foo-bar");
+    expect(validateLoginHint("a1")).toBe("a1");
+  });
+
+  it("normalises trimmed + mixed-case input", () => {
+    expect(validateLoginHint("  Acme-Foundation  ")).toBe("acme-foundation");
+  });
+
+  it("returns null when absent", () => {
+    expect(validateLoginHint(null)).toBeNull();
+    expect(validateLoginHint(undefined)).toBeNull();
+    expect(validateLoginHint("")).toBeNull();
+  });
+
+  // Each rejection below would otherwise reach Keycloak as a literal
+  // `kc_idp_hint` value and probe for alias matches. Dropping them
+  // server-side keeps upstream logs free of attacker probes.
+  it("rejects single-character slugs (< 2 chars violates the shared pattern)", () => {
+    expect(validateLoginHint("a")).toBeNull();
+  });
+
+  it("rejects leading or trailing hyphens", () => {
+    expect(validateLoginHint("-acme")).toBeNull();
+    expect(validateLoginHint("acme-")).toBeNull();
+  });
+
+  it("rejects uppercase that doesn't normalise to a valid slug", () => {
+    // Uppercase WITH characters that don't survive lowercasing (e.g. spaces)
+    expect(validateLoginHint("Acme Foundation")).toBeNull();
+  });
+
+  it("rejects slug-injection attempts (spaces, slashes, query separators)", () => {
+    expect(validateLoginHint("acme/etc")).toBeNull();
+    expect(validateLoginHint("acme&kc_idp_hint=other")).toBeNull();
+    expect(validateLoginHint("acme?x=1")).toBeNull();
+    expect(validateLoginHint("acme foundation")).toBeNull();
+  });
+
+  it("rejects slugs longer than the 50-char shared cap", () => {
+    const tooLong = "a".repeat(51);
+    expect(validateLoginHint(tooLong)).toBeNull();
+  });
+});

--- a/packages/web/src/lib/auth/login-hint.ts
+++ b/packages/web/src/lib/auth/login-hint.ts
@@ -1,6 +1,9 @@
-import { TENANT_SLUG_PATTERN } from "@givernance/shared/validators";
+import { validateTenantSlug } from "@givernance/shared/validators";
 
-const SLUG_REGEX = new RegExp(TENANT_SLUG_PATTERN);
+export type LoginHintResult =
+  | { kind: "absent" }
+  | { kind: "valid"; slug: string }
+  | { kind: "rejected"; reason: "syntax" | "reserved" | "punycode" };
 
 /**
  * Validate the optional `?hint=<slug>` parameter on `GET /api/auth/login`
@@ -8,21 +11,22 @@ const SLUG_REGEX = new RegExp(TENANT_SLUG_PATTERN);
  * tenant slug so the downstream Keycloak request can carry it as
  * `kc_idp_hint`, routing federated tenants straight to their IdP.
  *
- * Returns the canonical (trimmed + lowercased) slug on success, or
- * `null` when the value is absent or fails the tenant-slug shape — same
- * pattern enforced server-side on signup, so a hint that wouldn't be a
- * valid tenant slug is dropped instead of forwarded to Keycloak.
+ * Delegates to the canonical `validateTenantSlug` (`@givernance/shared/
+ * validators`) so the shape rules — regex, length, `xn--` punycode
+ * reject, reserved-slug list — stay in one place. PR #358 multi-agent
+ * review M7 caught that the original local regex skipped the punycode
+ * and reserved-slug checks, allowing `xn--paypal` / `admin` to reach
+ * Keycloak as a `kc_idp_hint` value (low blast radius — KC ignores
+ * unmatched aliases — but worth keeping the surface tight).
  *
- * Anti-injection: KC's `kc_idp_hint` is matched against configured IdP
- * aliases. An attacker can't trigger arbitrary KC behaviour from a
- * crafted hint because the value is wrapped by `URLSearchParams.set`
- * (no separator smuggling), but rejecting non-slug shapes early keeps
- * the upstream request log tight and prevents probing for unintended
- * alias matches.
+ * Returns a discriminated result so the route can distinguish "no
+ * hint provided" (silent) from "hint rejected" (worth a warn log so
+ * probes are visible on Cockpit — review m2). Anti-injection is
+ * already handled by `URLSearchParams.set` at the call site.
  */
-export function validateLoginHint(raw: string | null | undefined): string | null {
-  if (!raw) return null;
-  const normalised = raw.trim().toLowerCase();
-  if (!SLUG_REGEX.test(normalised)) return null;
-  return normalised;
+export function validateLoginHint(raw: string | null | undefined): LoginHintResult {
+  if (!raw || raw.trim() === "") return { kind: "absent" };
+  const result = validateTenantSlug(raw);
+  if (result.ok) return { kind: "valid", slug: result.slug };
+  return { kind: "rejected", reason: result.reason };
 }

--- a/packages/web/src/lib/auth/login-hint.ts
+++ b/packages/web/src/lib/auth/login-hint.ts
@@ -1,0 +1,28 @@
+import { TENANT_SLUG_PATTERN } from "@givernance/shared/validators";
+
+const SLUG_REGEX = new RegExp(TENANT_SLUG_PATTERN);
+
+/**
+ * Validate the optional `?hint=<slug>` parameter on `GET /api/auth/login`
+ * (issue #150). The signup-verify and invite-accept pages forward the
+ * tenant slug so the downstream Keycloak request can carry it as
+ * `kc_idp_hint`, routing federated tenants straight to their IdP.
+ *
+ * Returns the canonical (trimmed + lowercased) slug on success, or
+ * `null` when the value is absent or fails the tenant-slug shape — same
+ * pattern enforced server-side on signup, so a hint that wouldn't be a
+ * valid tenant slug is dropped instead of forwarded to Keycloak.
+ *
+ * Anti-injection: KC's `kc_idp_hint` is matched against configured IdP
+ * aliases. An attacker can't trigger arbitrary KC behaviour from a
+ * crafted hint because the value is wrapped by `URLSearchParams.set`
+ * (no separator smuggling), but rejecting non-slug shapes early keeps
+ * the upstream request log tight and prevents probing for unintended
+ * alias matches.
+ */
+export function validateLoginHint(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const normalised = raw.trim().toLowerCase();
+  if (!SLUG_REGEX.test(normalised)) return null;
+  return normalised;
+}

--- a/packages/worker/src/lib/route-domain-event.test.ts
+++ b/packages/worker/src/lib/route-domain-event.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+
+import { routeDomainEvent } from "./route-domain-event.js";
+
+/**
+ * Issue #152 — guards the type-routing decision of `processDomainEvent`.
+ *
+ * The integration-level processor suites (signup-email, team-invite-email,
+ * receipt, campaigns, stripe-webhook) each stub their own underlying
+ * function, so a typo in one of the dispatch strings — or accidentally
+ * dropping an OR clause — would silently fall through to the `unhandled`
+ * branch with no test failure. These pure-function assertions pin the
+ * dispatch matrix instead.
+ */
+describe("routeDomainEvent (issue #152)", () => {
+  const tenantId = "11111111-1111-1111-1111-111111111111";
+  const id = "22222222-2222-2222-2222-222222222222";
+  const traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+  it("routes donation.created → donation-receipt with the donationId and trace", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "donation.created",
+      payload: { donationId: "donation-1" },
+      traceparent,
+    });
+    expect(decision).toEqual({
+      kind: "donation-receipt",
+      donationId: "donation-1",
+      orgId: tenantId,
+      traceparent,
+    });
+  });
+
+  it("routes campaign.documents_requested → campaign-documents", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "campaign.documents_requested",
+      payload: { campaignId: "c-1", constituentIds: ["x", "y"] },
+      traceparent,
+    });
+    expect(decision).toEqual({
+      kind: "campaign-documents",
+      campaignId: "c-1",
+      orgId: tenantId,
+      constituentIds: ["x", "y"],
+      traceparent,
+    });
+  });
+
+  it("collapses both signup verification types into a single signup-email decision", () => {
+    // The function MUST treat the two outbox types as the same downstream
+    // dispatch — the email shape is identical (`SignupEmailJobPayload`)
+    // and the processor handles either path the same way. Without this
+    // assertion, accidentally dropping the `||` from the OR-branch
+    // would silently route resend events to `unhandled`.
+    const requested = routeDomainEvent({
+      id,
+      tenantId,
+      type: "tenant.signup_verification_requested",
+      payload: { invitationId: "inv-1", expiresAt: "2026-06-01T00:00:00Z", locale: "fr" },
+      traceparent,
+    });
+    const resent = routeDomainEvent({
+      id,
+      tenantId,
+      type: "tenant.signup_verification_resent",
+      payload: { invitationId: "inv-1", expiresAt: "2026-06-01T00:00:00Z", locale: "fr" },
+      traceparent,
+    });
+    expect(requested).toEqual({
+      kind: "signup-email",
+      tenantId,
+      invitationId: "inv-1",
+      expiresAt: "2026-06-01T00:00:00Z",
+      locale: "fr",
+    });
+    expect(resent).toEqual(requested);
+  });
+
+  it("falls back to APP_DEFAULT_LOCALE (fr) when the signup payload omits locale", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "tenant.signup_verification_requested",
+      payload: { invitationId: "inv-1", expiresAt: "2026-06-01T00:00:00Z" },
+      traceparent,
+    });
+    expect(decision).toMatchObject({ kind: "signup-email", locale: "fr" });
+  });
+
+  it.each([
+    ["invitation.created", "team-invite for a brand-new invite"],
+    ["invitation.resent", "team-invite for a rotated invite"],
+    ["tenant.first_admin_invited", "team-invite for the super-admin first-admin path"],
+  ])("collapses %s → team-invite-email (%s)", (type) => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type,
+      payload: {
+        invitationId: "inv-1",
+        inviterUserId: "u-1",
+        locale: "en",
+      },
+      traceparent,
+    });
+    expect(decision).toEqual({
+      kind: "team-invite-email",
+      tenantId,
+      invitationId: "inv-1",
+      inviterUserId: "u-1",
+      locale: "en",
+    });
+  });
+
+  it("preserves null inviterUserId on team-invite when the field is missing or non-string", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "invitation.created",
+      payload: { invitationId: "inv-1", locale: "en" },
+      traceparent,
+    });
+    expect(decision).toMatchObject({ kind: "team-invite-email", inviterUserId: null });
+  });
+
+  it("routes platform_admin.invited → platform-admin-invite (separate from team-invite)", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "platform_admin.invited",
+      payload: { invitationId: "inv-1", locale: "en" },
+      traceparent,
+    });
+    expect(decision).toEqual({
+      kind: "platform-admin-invite",
+      invitationId: "inv-1",
+      locale: "en",
+    });
+  });
+
+  it("routes campaign.postal_export_requested → postal-export", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "campaign.postal_export_requested",
+      payload: { exportId: "exp-1", campaignId: "c-1", mode: "personalized" },
+      traceparent,
+    });
+    expect(decision).toEqual({
+      kind: "postal-export",
+      exportId: "exp-1",
+      campaignId: "c-1",
+      orgId: tenantId,
+      mode: "personalized",
+      traceparent,
+    });
+  });
+
+  it("routes communication.bulk_email_requested → bulk-email and keeps the outbox id", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "communication.bulk_email_requested",
+      payload: { bulkEmailJobId: "be-1" },
+      traceparent,
+    });
+    expect(decision).toEqual({
+      kind: "bulk-email",
+      outboxId: id,
+      orgId: tenantId,
+      bulkEmailJobId: "be-1",
+      traceparent,
+    });
+  });
+
+  it.each([
+    ["branding.process_asset", "branding-process-asset"],
+    ["branding.activate_logo", "branding-activate-logo"],
+  ])("routes %s → %s", (type, kind) => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type,
+      payload: { assetId: "a-1" },
+      traceparent,
+    });
+    expect(decision).toMatchObject({ kind, assetId: "a-1", orgId: tenantId });
+  });
+
+  it("routes branding.gc_asset → branding-gc-asset with the prefix", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "branding.gc_asset",
+      payload: { assetId: "a-1", prefix: `${tenantId}/logo/a-1/` },
+      traceparent,
+    });
+    expect(decision).toEqual({
+      kind: "branding-gc-asset",
+      assetId: "a-1",
+      orgId: tenantId,
+      prefix: `${tenantId}/logo/a-1/`,
+      traceparent,
+    });
+  });
+
+  it("routes keycloak.sync_org_logo → keycloak-sync-org-logo", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "keycloak.sync_org_logo",
+      payload: {},
+      traceparent,
+    });
+    expect(decision).toEqual({
+      kind: "keycloak-sync-org-logo",
+      orgId: tenantId,
+      traceparent,
+    });
+  });
+
+  it("returns unhandled for an unknown type so the worker logs a breadcrumb instead of throwing", () => {
+    const decision = routeDomainEvent({
+      id,
+      tenantId,
+      type: "definitely.not.a.real.event",
+      payload: {},
+      traceparent,
+    });
+    expect(decision).toEqual({ kind: "unhandled", type: "definitely.not.a.real.event" });
+  });
+});

--- a/packages/worker/src/lib/route-domain-event.ts
+++ b/packages/worker/src/lib/route-domain-event.ts
@@ -1,0 +1,233 @@
+/**
+ * Pure routing decision for outbox events (issue #152).
+ *
+ * Translates the `(type, payload)` pair emitted by the API's transactional
+ * outbox into a discriminated union describing which downstream side
+ * effect the worker should perform. The function is intentionally pure
+ * (no Redis, no BullMQ, no DB) so the type-routing decisions can be
+ * exercised in unit tests without booting the worker singletons in
+ * `worker.ts`.
+ *
+ * What lives here:
+ * - Mapping outbox `type` strings → routing kinds (collapsing the
+ *   3-type team-invite family and 2-type signup family into single
+ *   kinds so the worker switch stays small).
+ * - Payload destructuring with the same `as string` / cast pattern the
+ *   worker used inline.
+ * - Locale resolution (already a pure helper) for email-bearing kinds.
+ *
+ * What does NOT live here:
+ * - Queue name picks, job id derivation, BullMQ `add(...)` calls — those
+ *   are side-effecting and stay in `worker.ts`.
+ * - Time-dependent values (e.g. donation receipt `fiscalYear =
+ *   new Date().getFullYear()`) — those are computed in the worker so
+ *   the routing decision stays deterministic for a given input.
+ */
+
+import type { Locale } from "@givernance/shared/i18n";
+import { BRANDING_EVENT_TYPES } from "@givernance/shared/jobs";
+import { resolvePayloadLocale } from "./payload-locale.js";
+
+export interface RoutingInput {
+  /** Outbox event id (used downstream as a job-id suffix for some kinds). */
+  id: string;
+  /** Tenant scope captured at outbox write time. */
+  tenantId: string;
+  /** Discriminator — the `outbox_events.type` column. */
+  type: string;
+  /** Untyped payload column; cast at the boundary. */
+  payload: Record<string, unknown>;
+  /** W3C trace context to thread through child jobs. */
+  traceparent?: string;
+}
+
+export type RoutingDecision =
+  | {
+      kind: "donation-receipt";
+      donationId: string;
+      orgId: string;
+      traceparent?: string;
+    }
+  | {
+      kind: "campaign-documents";
+      campaignId: string;
+      orgId: string;
+      constituentIds: string[];
+      traceparent?: string;
+    }
+  | {
+      kind: "postal-export";
+      exportId: string;
+      campaignId: string;
+      orgId: string;
+      mode: "door_drop" | "personalized";
+      traceparent?: string;
+    }
+  | {
+      kind: "bulk-email";
+      outboxId: string;
+      orgId: string;
+      bulkEmailJobId: string;
+      traceparent?: string;
+    }
+  | {
+      kind: "signup-email";
+      tenantId: string;
+      invitationId: string;
+      expiresAt: string;
+      locale: Locale;
+    }
+  | {
+      kind: "team-invite-email";
+      tenantId: string;
+      invitationId: string;
+      inviterUserId: string | null;
+      locale: Locale;
+    }
+  | {
+      kind: "platform-admin-invite";
+      invitationId: string;
+      locale: Locale;
+    }
+  | {
+      kind: "branding-process-asset";
+      assetId: string;
+      orgId: string;
+      traceparent?: string;
+    }
+  | {
+      kind: "branding-activate-logo";
+      assetId: string;
+      orgId: string;
+      traceparent?: string;
+    }
+  | {
+      kind: "branding-gc-asset";
+      assetId: string;
+      orgId: string;
+      prefix: string;
+      traceparent?: string;
+    }
+  | {
+      kind: "keycloak-sync-org-logo";
+      orgId: string;
+      traceparent?: string;
+    }
+  | { kind: "unhandled"; type: string };
+
+export function routeDomainEvent(input: RoutingInput): RoutingDecision {
+  const { id, tenantId, type, payload, traceparent } = input;
+
+  if (type === "donation.created") {
+    return {
+      kind: "donation-receipt",
+      donationId: payload.donationId as string,
+      orgId: tenantId,
+      traceparent,
+    };
+  }
+
+  if (type === "campaign.documents_requested") {
+    return {
+      kind: "campaign-documents",
+      campaignId: payload.campaignId as string,
+      orgId: tenantId,
+      constituentIds: payload.constituentIds as string[],
+      traceparent,
+    };
+  }
+
+  if (type === "campaign.postal_export_requested") {
+    return {
+      kind: "postal-export",
+      exportId: payload.exportId as string,
+      campaignId: payload.campaignId as string,
+      orgId: tenantId,
+      mode: payload.mode as "door_drop" | "personalized",
+      traceparent,
+    };
+  }
+
+  if (type === "communication.bulk_email_requested") {
+    return {
+      kind: "bulk-email",
+      outboxId: id,
+      orgId: tenantId,
+      bulkEmailJobId: payload.bulkEmailJobId as string,
+      traceparent,
+    };
+  }
+
+  if (
+    type === "tenant.signup_verification_requested" ||
+    type === "tenant.signup_verification_resent"
+  ) {
+    return {
+      kind: "signup-email",
+      tenantId,
+      invitationId: payload.invitationId as string,
+      expiresAt: payload.expiresAt as string,
+      locale: resolvePayloadLocale(payload),
+    };
+  }
+
+  if (
+    type === "invitation.created" ||
+    type === "invitation.resent" ||
+    type === "tenant.first_admin_invited"
+  ) {
+    return {
+      kind: "team-invite-email",
+      tenantId,
+      invitationId: payload.invitationId as string,
+      inviterUserId: typeof payload.inviterUserId === "string" ? payload.inviterUserId : null,
+      locale: resolvePayloadLocale(payload),
+    };
+  }
+
+  if (type === "platform_admin.invited") {
+    return {
+      kind: "platform-admin-invite",
+      invitationId: payload.invitationId as string,
+      locale: resolvePayloadLocale(payload),
+    };
+  }
+
+  if (type === BRANDING_EVENT_TYPES.PROCESS_ASSET) {
+    return {
+      kind: "branding-process-asset",
+      assetId: payload.assetId as string,
+      orgId: tenantId,
+      traceparent,
+    };
+  }
+
+  if (type === BRANDING_EVENT_TYPES.ACTIVATE_LOGO) {
+    return {
+      kind: "branding-activate-logo",
+      assetId: payload.assetId as string,
+      orgId: tenantId,
+      traceparent,
+    };
+  }
+
+  if (type === BRANDING_EVENT_TYPES.GC_ASSET) {
+    return {
+      kind: "branding-gc-asset",
+      assetId: payload.assetId as string,
+      orgId: tenantId,
+      prefix: payload.prefix as string,
+      traceparent,
+    };
+  }
+
+  if (type === BRANDING_EVENT_TYPES.KEYCLOAK_SYNC_ORG_LOGO) {
+    return {
+      kind: "keycloak-sync-org-logo",
+      orgId: tenantId,
+      traceparent,
+    };
+  }
+
+  return { kind: "unhandled", type };
+}

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -6,7 +6,7 @@ import { Queue, Worker } from "bullmq";
 import Redis from "ioredis";
 import { env } from "./env.js";
 import { jobLogger, logger } from "./lib/logger.js";
-import { resolvePayloadLocale } from "./lib/payload-locale.js";
+import { routeDomainEvent } from "./lib/route-domain-event.js";
 import { extractTraceId } from "./lib/trace-context.js";
 import { processBrandingActivateLogo } from "./processors/branding-activate-logo.js";
 import { processBrandingGcAsset } from "./processors/branding-gc-asset.js";
@@ -18,15 +18,9 @@ import { processKeycloakSyncOrgLogo } from "./processors/keycloak-sync-org-logo.
 import { processPlatformAdminInviteEmail } from "./processors/platform-admin-invite-email.js";
 import { processGeneratePostalExport } from "./processors/postal-export.js";
 import { processSendBulkEmail } from "./processors/send-bulk-email.js";
-import {
-  processSignupVerificationEmail,
-  type SignupEmailJobPayload,
-} from "./processors/signup-email.js";
+import { processSignupVerificationEmail } from "./processors/signup-email.js";
 import { processStripeWebhook } from "./processors/stripe-webhook.js";
-import {
-  processTeamInviteEmail,
-  type TeamInviteEmailJobPayload,
-} from "./processors/team-invite-email.js";
+import { processTeamInviteEmail } from "./processors/team-invite-email.js";
 import { processTenantLifecycle } from "./processors/tenant-lifecycle.js";
 
 /** Create a fresh ioredis connection — BullMQ requires separate connections for Queue vs Worker */
@@ -70,71 +64,14 @@ async function scheduleRepeatableJobs() {
 }
 
 /**
- * Route the four branding-related outbox events to their queues.
- * Returns `true` when the event was handled (the caller short-circuits)
- * and `false` when the type doesn't match — keeps `processDomainEvent`
- * under Biome's cognitive complexity ceiling.
- */
-async function routeBrandingEvent(args: {
-  type: string;
-  payload: Record<string, unknown>;
-  tenantId: string;
-  traceparent?: string;
-  log: ReturnType<typeof jobLogger>;
-}): Promise<boolean> {
-  const { type, payload, tenantId, traceparent, log } = args;
-  if (type === BRANDING_EVENT_TYPES.PROCESS_ASSET) {
-    const assetId = payload.assetId as string;
-    await brandingQueue.add(
-      BRANDING_EVENT_TYPES.PROCESS_ASSET,
-      { assetId, orgId: tenantId, traceparent },
-      { jobId: `branding-process-${assetId}` },
-    );
-    log.info({ assetId }, "Enqueued branding asset pipeline");
-    return true;
-  }
-  if (type === BRANDING_EVENT_TYPES.ACTIVATE_LOGO) {
-    const assetId = payload.assetId as string;
-    await brandingQueue.add(
-      BRANDING_EVENT_TYPES.ACTIVATE_LOGO,
-      { assetId, orgId: tenantId, traceparent },
-      { jobId: `branding-activate-${assetId}` },
-    );
-    log.info({ assetId }, "Enqueued branding activate logo");
-    return true;
-  }
-  if (type === BRANDING_EVENT_TYPES.GC_ASSET) {
-    const assetId = payload.assetId as string;
-    const prefix = payload.prefix as string;
-    await brandingQueue.add(
-      BRANDING_EVENT_TYPES.GC_ASSET,
-      { assetId, orgId: tenantId, prefix, traceparent },
-      { jobId: `branding-gc-${assetId}` },
-    );
-    log.info({ assetId, prefix }, "Enqueued branding asset GC");
-    return true;
-  }
-  if (type === BRANDING_EVENT_TYPES.KEYCLOAK_SYNC_ORG_LOGO) {
-    await keycloakSyncQueue.add(
-      BRANDING_EVENT_TYPES.KEYCLOAK_SYNC_ORG_LOGO,
-      { orgId: tenantId, traceparent },
-      // Per-tenant jobId so a flurry of activations + gc on the same
-      // tenant collapses to a single sync (last-write-wins).
-      { jobId: `kc-sync-org-logo-${tenantId}` },
-    );
-    log.info({ tenantId }, "Enqueued KC org logo sync");
-    return true;
-  }
-  return false;
-}
-
-/**
  * Process a domain event from the transactional outbox relay.
- * Routes events to specific handlers based on type.
  *
- * Locale-resolution helper extracted to `./lib/payload-locale.ts` so it
- * can be unit-tested without booting the worker singletons below
- * (issue #153 / PR #158 review).
+ * Type-routing decisions live in the pure `routeDomainEvent` helper
+ * (issue #152) so they can be unit-tested without booting any of the
+ * worker singletons or Redis/BullMQ infrastructure below. This wrapper
+ * keeps the side-effecting concerns — BullMQ enqueues, inline
+ * processor invocations, log lines — and just dispatches on the
+ * decision shape.
  */
 async function processDomainEvent(job: Job): Promise<void> {
   const { id, tenantId, type, payload, traceparent } = job.data as {
@@ -154,149 +91,182 @@ async function processDomainEvent(job: Job): Promise<void> {
 
   log.info({ eventType: type }, "Processing domain event");
 
-  if (type === "donation.created") {
-    const donationId = payload.donationId as string;
-    const fiscalYear = new Date().getFullYear();
+  const decision = routeDomainEvent({ id, tenantId, type, payload, traceparent });
 
-    // Forward traceparent so the child job's jobLogger inherits the same
-    // trace-id — Loki can reconstruct "API request → event → receipt".
-    await receiptsQueue.add(
-      "generate-receipt",
-      {
-        donationId,
-        orgId: tenantId,
-        fiscalYear,
-        locale: "en",
-        traceparent,
-      },
-      { jobId: `receipt-${donationId}` },
-    );
+  switch (decision.kind) {
+    case "donation-receipt": {
+      // Forward traceparent so the child job's jobLogger inherits the same
+      // trace-id — Loki can reconstruct "API request → event → receipt".
+      await receiptsQueue.add(
+        "generate-receipt",
+        {
+          donationId: decision.donationId,
+          orgId: decision.orgId,
+          fiscalYear: new Date().getFullYear(),
+          locale: "en",
+          traceparent: decision.traceparent,
+        },
+        { jobId: `receipt-${decision.donationId}` },
+      );
+      log.info({ donationId: decision.donationId }, "Enqueued receipt generation");
+      return;
+    }
 
-    log.info({ donationId }, "Enqueued receipt generation");
-    return;
+    case "campaign-documents": {
+      await campaignsQueue.add(
+        "generate-campaign-documents",
+        {
+          campaignId: decision.campaignId,
+          orgId: decision.orgId,
+          constituentIds: decision.constituentIds,
+          traceparent: decision.traceparent,
+        },
+        { jobId: `campaign-docs-${decision.campaignId}` },
+      );
+      log.info({ campaignId: decision.campaignId }, "Enqueued campaign document generation");
+      return;
+    }
+
+    case "postal-export": {
+      await postalExportsQueue.add(
+        "generate-postal-export",
+        {
+          exportId: decision.exportId,
+          campaignId: decision.campaignId,
+          orgId: decision.orgId,
+          mode: decision.mode,
+          traceparent: decision.traceparent,
+        },
+        { jobId: `postal-export-${decision.exportId}` },
+      );
+      log.info(
+        { exportId: decision.exportId, campaignId: decision.campaignId, mode: decision.mode },
+        "Enqueued postal export job",
+      );
+      return;
+    }
+
+    case "bulk-email": {
+      // Issue #326 — the outbox payload only carries the bulk_email_jobs
+      // row id. The processor reads subject/body/constituent_ids from that
+      // row at job start so PII never lives in Redis and a resume job
+      // picks up the freshest `delivered_constituent_ids` snapshot when
+      // it computes "remaining".
+      await emailsQueue.add(
+        "send-bulk-email",
+        {
+          orgId: decision.orgId,
+          bulkEmailJobId: decision.bulkEmailJobId,
+          traceparent: decision.traceparent,
+        },
+        // Per-payload job id so a transactional retry of the outbox row
+        // doesn't fan-out into duplicate sends.
+        { jobId: `bulk-email-${decision.outboxId}` },
+      );
+      log.info(
+        { outboxId: decision.outboxId, bulkEmailJobId: decision.bulkEmailJobId },
+        "Enqueued bulk email dispatch",
+      );
+      return;
+    }
+
+    case "signup-email": {
+      const result = await processSignupVerificationEmail({
+        tenantId: decision.tenantId,
+        invitationId: decision.invitationId,
+        expiresAt: decision.expiresAt,
+        locale: decision.locale,
+      });
+      // `not_found` / `already_accepted` are terminal no-ops (old token
+      // rotated, or user already verified) — do not throw, the outbox
+      // event is done.
+      log.info({ invitationId: decision.invitationId, ...result }, "Signup email dispatched");
+      return;
+    }
+
+    case "team-invite-email": {
+      const result = await processTeamInviteEmail({
+        tenantId: decision.tenantId,
+        invitationId: decision.invitationId,
+        inviterUserId: decision.inviterUserId,
+        locale: decision.locale,
+      });
+      log.info(
+        { invitationId: decision.invitationId, eventType: type, ...result },
+        "Team-invite email dispatched",
+      );
+      return;
+    }
+
+    case "platform-admin-invite": {
+      // Issue #254 — distinct from `team_invite` because the accept URL
+      // points at `/admin/platform-admins/accept` (super-admin
+      // onboarding), not `/invite/accept`.
+      const result = await processPlatformAdminInviteEmail({
+        invitationId: decision.invitationId,
+        locale: decision.locale,
+      });
+      log.info(
+        { invitationId: decision.invitationId, eventType: type, ...result },
+        "Platform-admin invite dispatched",
+      );
+      return;
+    }
+
+    case "branding-process-asset": {
+      await brandingQueue.add(
+        BRANDING_EVENT_TYPES.PROCESS_ASSET,
+        { assetId: decision.assetId, orgId: decision.orgId, traceparent: decision.traceparent },
+        { jobId: `branding-process-${decision.assetId}` },
+      );
+      log.info({ assetId: decision.assetId }, "Enqueued branding asset pipeline");
+      return;
+    }
+
+    case "branding-activate-logo": {
+      await brandingQueue.add(
+        BRANDING_EVENT_TYPES.ACTIVATE_LOGO,
+        { assetId: decision.assetId, orgId: decision.orgId, traceparent: decision.traceparent },
+        { jobId: `branding-activate-${decision.assetId}` },
+      );
+      log.info({ assetId: decision.assetId }, "Enqueued branding activate logo");
+      return;
+    }
+
+    case "branding-gc-asset": {
+      await brandingQueue.add(
+        BRANDING_EVENT_TYPES.GC_ASSET,
+        {
+          assetId: decision.assetId,
+          orgId: decision.orgId,
+          prefix: decision.prefix,
+          traceparent: decision.traceparent,
+        },
+        { jobId: `branding-gc-${decision.assetId}` },
+      );
+      log.info(
+        { assetId: decision.assetId, prefix: decision.prefix },
+        "Enqueued branding asset GC",
+      );
+      return;
+    }
+
+    case "keycloak-sync-org-logo": {
+      await keycloakSyncQueue.add(
+        BRANDING_EVENT_TYPES.KEYCLOAK_SYNC_ORG_LOGO,
+        { orgId: decision.orgId, traceparent: decision.traceparent },
+        // Per-tenant jobId so a flurry of activations + gc on the same
+        // tenant collapses to a single sync (last-write-wins).
+        { jobId: `kc-sync-org-logo-${decision.orgId}` },
+      );
+      log.info({ tenantId: decision.orgId }, "Enqueued KC org logo sync");
+      return;
+    }
+
+    case "unhandled":
+      log.warn({ eventType: decision.type }, "Unhandled event type");
+      return;
   }
-
-  if (type === "campaign.documents_requested") {
-    const campaignId = payload.campaignId as string;
-    const constituentIds = payload.constituentIds as string[];
-
-    await campaignsQueue.add(
-      "generate-campaign-documents",
-      {
-        campaignId,
-        orgId: tenantId,
-        constituentIds,
-        traceparent,
-      },
-      { jobId: `campaign-docs-${campaignId}` },
-    );
-
-    log.info({ campaignId }, "Enqueued campaign document generation");
-    return;
-  }
-
-  if (type === "campaign.postal_export_requested") {
-    const campaignId = payload.campaignId as string;
-    const exportId = payload.exportId as string;
-    const mode = payload.mode as "door_drop" | "personalized";
-
-    await postalExportsQueue.add(
-      "generate-postal-export",
-      {
-        exportId,
-        campaignId,
-        orgId: tenantId,
-        mode,
-        traceparent,
-      },
-      { jobId: `postal-export-${exportId}` },
-    );
-
-    log.info({ exportId, campaignId, mode }, "Enqueued postal export job");
-    return;
-  }
-
-  if (type === "communication.bulk_email_requested") {
-    // Issue #326 — the outbox payload only carries the bulk_email_jobs
-    // row id. The processor reads subject/body/constituent_ids from that
-    // row at job start so:
-    //   - PII (email, name) never lives in Redis — same GDPR Art. 5(1)(e)
-    //     posture as before, just via a smaller payload.
-    //   - A resume job picks up the freshest `delivered_constituent_ids`
-    //     snapshot when computing "remaining", not a stale outbox copy.
-    const bulkEmailJobId = payload.bulkEmailJobId as string;
-    await emailsQueue.add(
-      "send-bulk-email",
-      {
-        orgId: tenantId,
-        bulkEmailJobId,
-        traceparent,
-      },
-      // Per-payload job id so a transactional retry of the outbox row
-      // doesn't fan-out into duplicate sends.
-      { jobId: `bulk-email-${id}` },
-    );
-
-    log.info({ outboxId: id, bulkEmailJobId }, "Enqueued bulk email dispatch");
-    return;
-  }
-
-  if (
-    type === "tenant.signup_verification_requested" ||
-    type === "tenant.signup_verification_resent"
-  ) {
-    const emailPayload: SignupEmailJobPayload = {
-      tenantId,
-      invitationId: payload.invitationId as string,
-      expiresAt: payload.expiresAt as string,
-      locale: resolvePayloadLocale(payload),
-    };
-    const result = await processSignupVerificationEmail(emailPayload);
-    // `not_found` / `already_accepted` are terminal no-ops (old token rotated,
-    // or user already verified) — do not throw, the outbox event is done.
-    log.info({ invitationId: emailPayload.invitationId, ...result }, "Signup email dispatched");
-    return;
-  }
-
-  if (
-    type === "invitation.created" ||
-    type === "invitation.resent" ||
-    type === "tenant.first_admin_invited"
-  ) {
-    const invitationId = payload.invitationId as string;
-    const inviterUserId = typeof payload.inviterUserId === "string" ? payload.inviterUserId : null;
-    const emailPayload: TeamInviteEmailJobPayload = {
-      tenantId,
-      invitationId,
-      inviterUserId,
-      locale: resolvePayloadLocale(payload),
-    };
-    const result = await processTeamInviteEmail(emailPayload);
-    log.info({ invitationId, eventType: type, ...result }, "Team-invite email dispatched");
-    return;
-  }
-
-  // ── Org branding (Epic #286) ───────────────────────────────────────
-  // Routed through a helper so the parent function's cognitive
-  // complexity stays under the Biome cap.
-  if (await routeBrandingEvent({ type, payload, tenantId, traceparent, log })) {
-    return;
-  }
-
-  // Issue #254 — platform-admin invitation. Distinct from `team_invite`
-  // because the accept URL points at `/admin/platform-admins/accept`
-  // (super-admin onboarding), not `/invite/accept`.
-  if (type === "platform_admin.invited") {
-    const invitationId = payload.invitationId as string;
-    const result = await processPlatformAdminInviteEmail({
-      invitationId,
-      locale: resolvePayloadLocale(payload),
-    });
-    log.info({ invitationId, eventType: type, ...result }, "Platform-admin invite dispatched");
-    return;
-  }
-
-  log.warn({ eventType: type }, "Unhandled event type");
 }
 
 /** Start all queue workers */

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -266,6 +266,21 @@ async function processDomainEvent(job: Job): Promise<void> {
     case "unhandled":
       log.warn({ eventType: decision.type }, "Unhandled event type");
       return;
+
+    default: {
+      // Exhaustiveness check (PR #358 review M4). If a new `kind` is
+      // added to `RoutingDecision` and a matching `case` isn't added
+      // here, TypeScript fails to narrow `decision` to `never` and
+      // surfaces a compile error — turning "I added a routing kind
+      // and forgot to wire it" into a build failure rather than a
+      // silent no-op at runtime.
+      const _exhaustive: never = decision;
+      log.error(
+        { decision: _exhaustive },
+        "routeDomainEvent returned an unhandled RoutingDecision kind — switch is non-exhaustive",
+      );
+      return;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Five tightly-scoped follow-ups from the 2026-05-12 issue audit, each <1h of work, batched into one review cycle. None of them collide with @Onigam's Swiss QR-bill or branding-cleanup work, or with @pjdauvert's donations-UX PR #297.

| Issue | Theme | Files touched |
|---|---|---|
| #150 | Wire `?hint=<slug>` → `kc_idp_hint` on `/api/auth/login` | `packages/web/src/lib/auth/login-hint.ts` (new) + login route + verify/accept pages |
| #152 | Extract pure `routeDomainEvent` + unit test type-routing | `packages/worker/src/lib/route-domain-event.ts` (new) + `worker.ts` refactor |
| #155 | `role="alert"` + `aria-live="assertive"` on `FormMessage` primitive | `packages/web/src/components/shared/form-field.tsx` (every form benefits) |
| #156 | `keyGenerator` on resend rate limits → `(ip, org, invitation)` / `(ip, tenant)` | `invitations/routes.ts`, `tenant-admin/routes.ts` |
| #149 | Per-recipient 3/h Redis bucket on team-invite resend | `invitations/service.ts` + route 204 translation |

## Manual acceptance checklist

### #150 — `?hint=` wire-through
- [ ] `GET /api/auth/login?hint=acme` redirects to KC with `kc_idp_hint=acme` in the auth URL
- [ ] `GET /api/auth/login?hint=ACME%20bad` drops the hint silently (validation rejects the shape)
- [ ] Post-verify redirect from `/signup/verify` carries the slug through to KC
- [ ] Post-accept redirect from `/invite/accept` does the same
- [ ] Stale "no-op" comment on `invite/accept/page.tsx` is gone

### #152 — Pure `routeDomainEvent`
- [ ] `routeDomainEvent` lives in `packages/worker/src/lib/route-domain-event.ts` and pulls in **no** Redis/BullMQ/DB
- [ ] Unit test covers: `donation.created`, `campaign.documents_requested`, `campaign.postal_export_requested`, `communication.bulk_email_requested`, `tenant.signup_verification_requested`, `tenant.signup_verification_resent`, `invitation.created`, `invitation.resent`, `tenant.first_admin_invited`, `platform_admin.invited`, all 4 `branding.*` types, + unknown
- [ ] `worker.ts` `processDomainEvent` is now a pure-switch on `decision.kind` — no per-type string literal compares in the side-effect path
- [ ] Existing processor integration tests (signup-email, team-invite-email, receipts, campaigns, stripe-webhook) still pass

### #155 — `FormMessage` a11y
- [ ] Focus a required field in any form (e.g. signup), blur without typing — VoiceOver/NVDA reads the error immediately
- [ ] DOM inspector confirms `<p role="alert" aria-live="assertive">` on the rendered message
- [ ] No regression on existing FormMessage usage across signup, invitations, donations, constituents, campaigns, settings

### #156 — Resend `keyGenerator`
- [ ] org_admin from one IP cannot burn through 5 resends across two distinct invitations (cap now applies per-invitation)
- [ ] super_admin from one IP cannot burn through 5 first-admin resends across two distinct tenants (cap now applies per-tenant)

### #149 — Per-recipient resend cap
- [ ] 3rd resend on the same invitee → 204 + token rotated + outbox row written
- [ ] 4th resend within 1h → 204 silently, **no** token rotation, **no** new outbox row
- [ ] `invitation.resend_rate_limited` shows up in worker/api logs on the cap-hit path
- [ ] Cap key (`invitation:resend:email:<email>`) is wiped between tests; no cross-suite pollution

## Local pipeline

```
pnpm install --frozen-lockfile  ✓
pnpm build                       ✓ (all packages, including next/web)
pnpm run format                  ✓ (2 files reformatted, both staged)
pnpm run lint                    ✓ (0 errors; 2 pre-existing warnings in postal-export.ts + swiss-qr-bill.ts unchanged)
pnpm typecheck                   ✓
pnpm test                        ✓ shared 69 · api 790 · relay 6 · web 127 · worker 65
```

## Out of scope

- #144 (same email across multiple tenants) — closed 2026-05-12, no longer on the roadmap.
- #146 → #357 (signup-hardening F-items) — separate batch, not in this PR.
- #76 PR-1 (account menu UX) — blocked on Onigam mockup, not addressed here.

close #150
close #152
close #155
close #156
close #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
