### PR TITLE
feat(signup): test gaps + cleanup follow-ups from PR #143 (close #357)

### DIFF
--- a/packages/api/src/lib/captcha.test.ts
+++ b/packages/api/src/lib/captcha.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the CAPTCHA verifier (F5).
+ *
+ * Every signup integration test bypasses captcha via the `NODE_ENV=test
+ * → mode=disabled` default, so the helper itself had no direct coverage
+ * for its fail-open / fail-closed branches. This file pins:
+ *  - `disabled` mode accepts an undefined token (dev/CI / preview).
+ *  - `prod` mode rejects with `missing_secret` when no secret is wired.
+ *  - `prod` mode rejects with `missing_token` when the request omits one.
+ *  - `prod` mode forwards to the provider and surfaces `provider_rejected`
+ *    on `success: false`.
+ *  - `prod` mode reports `provider_unreachable` when the provider 5xxes
+ *    or fetch throws.
+ *  - Explicit `CAPTCHA_MODE=prod` overrides the `NODE_ENV` default so a
+ *    non-prod environment (staging, preview) can opt-in to real captcha.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCaptchaVerifier } from "./captcha.js";
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_CAPTCHA_MODE = process.env.CAPTCHA_MODE;
+
+afterEach(() => {
+  process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  if (ORIGINAL_CAPTCHA_MODE === undefined) {
+    delete process.env.CAPTCHA_MODE;
+  } else {
+    process.env.CAPTCHA_MODE = ORIGINAL_CAPTCHA_MODE;
+  }
+});
+
+describe("createCaptchaVerifier — disabled mode (dev/CI fail-open)", () => {
+  it("accepts an undefined token", async () => {
+    const verifier = createCaptchaVerifier({ mode: "disabled" });
+    const result = await verifier.verify(undefined);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts an arbitrary token without contacting the provider", async () => {
+    const fetchSpy = vi.fn(() => {
+      throw new Error("provider must not be called in disabled mode");
+    });
+    const verifier = createCaptchaVerifier({
+      mode: "disabled",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fetch stub for the test
+      fetchImpl: fetchSpy as any,
+    });
+    const result = await verifier.verify("anything");
+    expect(result.ok).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("createCaptchaVerifier — prod mode fail-closed gates", () => {
+  it("rejects with missing_secret when no secret is configured", async () => {
+    const verifier = createCaptchaVerifier({ mode: "prod", secret: undefined });
+    const result = await verifier.verify("some-token");
+    expect(result).toEqual({ ok: false, reason: "missing_secret" });
+  });
+
+  it("rejects with missing_token when the request carries no captcha token", async () => {
+    const verifier = createCaptchaVerifier({ mode: "prod", secret: "hcaptcha-secret" });
+    const result = await verifier.verify(undefined);
+    expect(result).toEqual({ ok: false, reason: "missing_token" });
+  });
+
+  it("surfaces provider_rejected when hCaptcha returns success:false", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ success: false }), { status: 200 }),
+    );
+    const verifier = createCaptchaVerifier({
+      mode: "prod",
+      secret: "hcaptcha-secret",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fetch stub for the test
+      fetchImpl: fetchImpl as any,
+    });
+    const result = await verifier.verify("rejected-token");
+    expect(result).toEqual({ ok: false, reason: "provider_rejected" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces provider_unreachable on a 5xx response", async () => {
+    const fetchImpl = vi.fn(async () => new Response("", { status: 503 }));
+    const verifier = createCaptchaVerifier({
+      mode: "prod",
+      secret: "hcaptcha-secret",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fetch stub for the test
+      fetchImpl: fetchImpl as any,
+    });
+    const result = await verifier.verify("token");
+    expect(result).toEqual({ ok: false, reason: "provider_unreachable" });
+  });
+
+  it("surfaces provider_unreachable when fetch throws (network outage)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNRESET");
+    });
+    const verifier = createCaptchaVerifier({
+      mode: "prod",
+      secret: "hcaptcha-secret",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fetch stub for the test
+      fetchImpl: fetchImpl as any,
+    });
+    const result = await verifier.verify("token");
+    expect(result).toEqual({ ok: false, reason: "provider_unreachable" });
+  });
+
+  it("forwards the remoteip when provided", async () => {
+    let captured: URLSearchParams | undefined;
+    const fetchImpl = vi.fn(async (_url: unknown, init: RequestInit) => {
+      captured = new URLSearchParams(init.body as string);
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    });
+    const verifier = createCaptchaVerifier({
+      mode: "prod",
+      secret: "hcaptcha-secret",
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fetch stub for the test
+      fetchImpl: fetchImpl as any,
+    });
+    const result = await verifier.verify("token", "203.0.113.5");
+    expect(result.ok).toBe(true);
+    expect(captured?.get("secret")).toBe("hcaptcha-secret");
+    expect(captured?.get("response")).toBe("token");
+    expect(captured?.get("remoteip")).toBe("203.0.113.5");
+  });
+});
+
+describe("createCaptchaVerifier — mode precedence", () => {
+  // The default resolver checks: explicit config > CAPTCHA_MODE env >
+  // NODE_ENV-based default. These tests pin that staging / preview envs
+  // can opt-in to real captcha by setting CAPTCHA_MODE=prod even though
+  // NODE_ENV is "development" or "test".
+  beforeEach(() => {
+    // Force a non-prod NODE_ENV so the default would be `disabled` —
+    // a CAPTCHA_MODE=prod override must still win.
+    process.env.NODE_ENV = "development";
+  });
+
+  it("CAPTCHA_MODE=prod overrides NODE_ENV=development", async () => {
+    process.env.CAPTCHA_MODE = "prod";
+    const verifier = createCaptchaVerifier({ secret: undefined });
+    const result = await verifier.verify("token");
+    // Hits the fail-closed branch (no secret) instead of the disabled
+    // fail-open branch — proves CAPTCHA_MODE took precedence.
+    expect(result).toEqual({ ok: false, reason: "missing_secret" });
+  });
+
+  it("explicit config.mode overrides CAPTCHA_MODE env", async () => {
+    process.env.CAPTCHA_MODE = "prod";
+    const verifier = createCaptchaVerifier({ mode: "disabled" });
+    const result = await verifier.verify(undefined);
+    expect(result.ok).toBe(true);
+  });
+
+  it("CAPTCHA_MODE=disabled overrides a production NODE_ENV", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.CAPTCHA_MODE = "disabled";
+    const verifier = createCaptchaVerifier();
+    const result = await verifier.verify(undefined);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/api/src/lib/keycloak-admin.test.ts
+++ b/packages/api/src/lib/keycloak-admin.test.ts
@@ -702,41 +702,91 @@ describe("updateUser", () => {
 });
 
 describe("getOrganizationByAlias", () => {
-  it("GETs /organizations?search=alias and returns the EXACT-alias match (filters substring matches client-side)", async () => {
+  it("GETs /organizations?search=alias&exact=true and returns the server-side exact match (F7)", async () => {
     const h = makeHarness();
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
-    h.enqueue(() =>
-      okJson([
-        // Substring-match drift — KC's `search` does substring matching, so
-        // a query for `acme` returns both. The client MUST pick the exact one.
-        { id: "org-foundation", name: "Acme Foundation", alias: "acme-foundation" },
-        { id: "org-acme", name: "Acme", alias: "acme" },
-      ]),
-    );
+    // With `&exact=true` (Keycloak 26.1+) the server-side filter already
+    // restricts to alias matches, so the client trusts the first row instead
+    // of post-filtering substring noise client-side.
+    h.enqueue(() => okJson([{ id: "org-acme", name: "Acme", alias: "acme" }]));
 
     const result = await h.client.getOrganizationByAlias("acme");
     expect(result?.id).toBe("org-acme");
     expect(h.calls[1]?.url).toBe(
-      "http://kc.test/admin/realms/givernance/organizations?search=acme",
+      "http://kc.test/admin/realms/givernance/organizations?search=acme&exact=true",
     );
   });
 
-  it("returns null when no exact alias matches (substring matches alone don't qualify)", async () => {
+  it("returns null when the server returns an empty list", async () => {
     const h = makeHarness();
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
-    h.enqueue(() =>
-      okJson([{ id: "org-foundation", name: "Acme Foundation", alias: "acme-foundation" }]),
-    );
+    h.enqueue(() => okJson([]));
 
     expect(await h.client.getOrganizationByAlias("acme")).toBeNull();
   });
 
-  it("normalises the alias (trim + lowercase) before matching", async () => {
+  it("normalises the alias (trim + lowercase) before issuing the request", async () => {
     const h = makeHarness();
     h.enqueue(() => tokenResponse({ expires_in: 300 }));
     h.enqueue(() => okJson([{ id: "org-acme", name: "Acme", alias: "acme" }]));
 
     const result = await h.client.getOrganizationByAlias("  ACME  ");
     expect(result?.id).toBe("org-acme");
+    expect(h.calls[1]?.url).toBe(
+      "http://kc.test/admin/realms/givernance/organizations?search=acme&exact=true",
+    );
+  });
+});
+
+// F2 — Defense in depth for the JWT leak the `organization` scope mapper
+// (with `addOrganizationAttributes: true`) would otherwise create whenever
+// a developer added a new Organization attribute "for worker convenience".
+// Every attribute on a KC Organization is emitted into every member's
+// access / ID / introspection JWT; without a code-side allowlist, a
+// `stripe_customer_id` or `secret_token` would silently leak to every
+// browser. Locked at the admin-client boundary so the next attribute
+// addition has to go through code review.
+describe("Organization attribute allowlist (F2 — JWT leak guard)", () => {
+  it("createOrganization refuses to write a stranger attribute", async () => {
+    const h = makeHarness();
+    // No fetch stubs queued — the guard must throw BEFORE any HTTP call.
+    await expect(
+      h.client.createOrganization({
+        name: "Acme",
+        alias: "acme",
+        attributes: { org_id: ["tenant-uuid"], secret_token: ["leak-me"] },
+      }),
+    ).rejects.toThrow(/secret_token/);
+    expect(h.calls.length).toBe(0);
+  });
+
+  it("createOrganization accepts the allowlisted attribute keys (org_id, logo_url, theme_primary_color)", async () => {
+    const h = makeHarness();
+    h.enqueue(() => tokenResponse({ expires_in: 300 }));
+    h.enqueue(
+      () =>
+        new Response(JSON.stringify({ id: "org-x", name: "Acme", alias: "acme" }), { status: 201 }),
+    );
+
+    const result = await h.client.createOrganization({
+      name: "Acme",
+      alias: "acme",
+      attributes: {
+        org_id: ["tenant-uuid"],
+        logo_url: ["https://cdn.example/org.png"],
+        theme_primary_color: ["#123456"],
+      },
+    });
+    expect(result.id).toBe("org-x");
+  });
+
+  it("updateOrganization refuses to write a stranger attribute", async () => {
+    const h = makeHarness();
+    await expect(
+      h.client.updateOrganization("org-x", {
+        attributes: { stripe_customer_id: ["cus_abc"] },
+      }),
+    ).rejects.toThrow(/stripe_customer_id/);
+    expect(h.calls.length).toBe(0);
   });
 });

--- a/packages/api/src/lib/keycloak-admin.ts
+++ b/packages/api/src/lib/keycloak-admin.ts
@@ -34,7 +34,7 @@
  * test ships with issue #114 once the realm is upgraded.
  */
 
-import { PINO_REDACT_PATHS } from "@givernance/shared/constants";
+import { assertSafeOrgAttributes, PINO_REDACT_PATHS } from "@givernance/shared/constants";
 import pino from "pino";
 import { env } from "../env.js";
 
@@ -59,48 +59,10 @@ export interface KeycloakOrganization {
   domains?: Array<{ name: string; verified: boolean }>;
 }
 
-/**
- * F2 — Allowlist of Organization attribute keys that are safe to set from
- * Givernance code. The realm's `organization` client scope is wired to
- * `oidc-organization-membership-mapper` with `addOrganizationAttributes:
- * true`, which means **every** Organization attribute is emitted into the
- * access, ID, and introspection JWT of every member of that org. Any key
- * not in this set is treated as a secret-leak risk and the admin client
- * refuses to write it.
- *
- * Why an allowlist (not a denylist): the mapper has no per-attribute filter,
- * so the only line of defence is what our code chooses to write. A
- * developer adding `stripe_customer_id` "for worker convenience" would
- * leak it to every browser; with this allowlist, the next attribute
- * addition is forced through code review.
- */
-export const SAFE_ORG_ATTRIBUTES: ReadonlySet<string> = new Set([
-  // Canonical tenant id — also emitted as a designated JWT claim via the
-  // `oidc-usermodel-attribute-mapper`. Mirrored on the org so we can find a
-  // half-created org by id during recovery (signup verify 409 path).
-  "org_id",
-  // Used by `tenant-admin.createOrganization`. Public information (the
-  // tenant URL) but kept on the allowlist for explicitness.
-  "org_slug",
-  // Public branding rendered on the Keycloak login template. Epic #286.
-  "logo_url",
-  // Public branding rendered on the Keycloak login template. Epic #286.
-  "theme_primary_color",
-]);
-
-function assertSafeOrgAttributes(attributes: Record<string, string[]> | undefined): void {
-  if (!attributes) return;
-  for (const key of Object.keys(attributes)) {
-    if (!SAFE_ORG_ATTRIBUTES.has(key)) {
-      throw new Error(
-        `Refusing to write Keycloak Organization attribute "${key}" — it is not in SAFE_ORG_ATTRIBUTES. ` +
-          `The realm's organization mapper emits every attribute into the JWT of every member; adding a ` +
-          `new attribute requires opting in via SAFE_ORG_ATTRIBUTES in keycloak-admin.ts after confirming ` +
-          `it is safe to leak to all browsers.`,
-      );
-    }
-  }
-}
+// F2 — `SAFE_ORG_ATTRIBUTES` + `assertSafeOrgAttributes` live in
+// `@givernance/shared/constants/keycloak-org-attributes` so the api and
+// worker copies cannot drift. See that file for the rationale and the
+// review checklist for additions.
 
 export interface KeycloakIdentityProvider {
   alias: string;

--- a/packages/api/src/lib/keycloak-admin.ts
+++ b/packages/api/src/lib/keycloak-admin.ts
@@ -59,6 +59,49 @@ export interface KeycloakOrganization {
   domains?: Array<{ name: string; verified: boolean }>;
 }
 
+/**
+ * F2 — Allowlist of Organization attribute keys that are safe to set from
+ * Givernance code. The realm's `organization` client scope is wired to
+ * `oidc-organization-membership-mapper` with `addOrganizationAttributes:
+ * true`, which means **every** Organization attribute is emitted into the
+ * access, ID, and introspection JWT of every member of that org. Any key
+ * not in this set is treated as a secret-leak risk and the admin client
+ * refuses to write it.
+ *
+ * Why an allowlist (not a denylist): the mapper has no per-attribute filter,
+ * so the only line of defence is what our code chooses to write. A
+ * developer adding `stripe_customer_id` "for worker convenience" would
+ * leak it to every browser; with this allowlist, the next attribute
+ * addition is forced through code review.
+ */
+export const SAFE_ORG_ATTRIBUTES: ReadonlySet<string> = new Set([
+  // Canonical tenant id — also emitted as a designated JWT claim via the
+  // `oidc-usermodel-attribute-mapper`. Mirrored on the org so we can find a
+  // half-created org by id during recovery (signup verify 409 path).
+  "org_id",
+  // Used by `tenant-admin.createOrganization`. Public information (the
+  // tenant URL) but kept on the allowlist for explicitness.
+  "org_slug",
+  // Public branding rendered on the Keycloak login template. Epic #286.
+  "logo_url",
+  // Public branding rendered on the Keycloak login template. Epic #286.
+  "theme_primary_color",
+]);
+
+function assertSafeOrgAttributes(attributes: Record<string, string[]> | undefined): void {
+  if (!attributes) return;
+  for (const key of Object.keys(attributes)) {
+    if (!SAFE_ORG_ATTRIBUTES.has(key)) {
+      throw new Error(
+        `Refusing to write Keycloak Organization attribute "${key}" — it is not in SAFE_ORG_ATTRIBUTES. ` +
+          `The realm's organization mapper emits every attribute into the JWT of every member; adding a ` +
+          `new attribute requires opting in via SAFE_ORG_ATTRIBUTES in keycloak-admin.ts after confirming ` +
+          `it is safe to leak to all browsers.`,
+      );
+    }
+  }
+}
+
 export interface KeycloakIdentityProvider {
   alias: string;
   providerId: "oidc" | "saml";
@@ -592,6 +635,10 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
 
   return {
     createOrganization: async ({ name, alias, attributes }) => {
+      // F2 — fail closed when a caller passes an attribute outside the
+      // allowlist. The realm mapper emits every attribute into every
+      // member's JWT, so a stray `secret_token` would leak to all browsers.
+      assertSafeOrgAttributes(attributes);
       const out = await adminRequest<KeycloakOrganization & { __locationHeader?: string }>(
         "POST",
         `/organizations`,
@@ -638,6 +685,9 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
     },
 
     updateOrganization: async (id, updates) => {
+      // F2 — same SAFE_ORG_ATTRIBUTES gate as create (every attribute is
+      // surfaced into every member's JWT via the realm mapper).
+      assertSafeOrgAttributes(updates.attributes);
       // GET-then-PUT so we don't clobber attributes the API never set
       // (e.g. `theme_primary_color` already on the org from issue #114).
       // Mirrors `setUserAttributes` / `updateUser` exactly so the same
@@ -857,13 +907,15 @@ export function createKeycloakAdminClient(config: ClientConfig): KeycloakAdminCl
 
     getOrganizationByAlias: async (alias) => {
       const normalised = alias.trim().toLowerCase();
+      // Keycloak 26.1 added `&exact=true` for the org search endpoint
+      // (mirrors what `getUserByEmail` does above); rely on the server-side
+      // exact-match instead of a substring-then-client-filter dance so the
+      // recovery path doesn't shift if KC's `search` semantics evolve (F7).
       const rows = await adminRequest<KeycloakOrganization[]>(
         "GET",
-        `/organizations?search=${e(normalised)}`,
+        `/organizations?search=${e(normalised)}&exact=true`,
       );
-      // `search` is substring-match on Keycloak's side. Filter to exact alias
-      // so a tenant named `acme` doesn't collide with `acme-foundation`.
-      return rows?.find((o) => o.alias?.toLowerCase() === normalised) ?? null;
+      return rows?.[0] ?? null;
     },
 
     createIdentityProvider: async (idp) => {

--- a/packages/api/src/modules/admin/platform-admins-routes.ts
+++ b/packages/api/src/modules/admin/platform-admins-routes.ts
@@ -22,6 +22,7 @@
  * change with a specific operator session.
  */
 
+import { PASSWORD_MIN_LENGTH } from "@givernance/shared/constants";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { requireSuperAdmin } from "../../lib/guards.js";
@@ -114,7 +115,7 @@ const PublicInvitationSchema = Type.Object({
 });
 
 const AcceptBody = Type.Object({
-  password: Type.String({ minLength: 12, maxLength: 255 }),
+  password: Type.String({ minLength: PASSWORD_MIN_LENGTH, maxLength: 255 }),
   firstName: Type.String({ minLength: 1, maxLength: 255 }),
   lastName: Type.String({ minLength: 1, maxLength: 255 }),
 });

--- a/packages/api/src/modules/admin/platform-admins-routes.ts
+++ b/packages/api/src/modules/admin/platform-admins-routes.ts
@@ -22,7 +22,7 @@
  * change with a specific operator session.
  */
 
-import { PASSWORD_MIN_LENGTH } from "@givernance/shared/constants";
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "@givernance/shared/constants";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { requireSuperAdmin } from "../../lib/guards.js";
@@ -115,7 +115,7 @@ const PublicInvitationSchema = Type.Object({
 });
 
 const AcceptBody = Type.Object({
-  password: Type.String({ minLength: PASSWORD_MIN_LENGTH, maxLength: 255 }),
+  password: Type.String({ minLength: PASSWORD_MIN_LENGTH, maxLength: PASSWORD_MAX_LENGTH }),
   firstName: Type.String({ minLength: 1, maxLength: 255 }),
   lastName: Type.String({ minLength: 1, maxLength: 255 }),
 });

--- a/packages/api/src/modules/invitations/routes.ts
+++ b/packages/api/src/modules/invitations/routes.ts
@@ -16,6 +16,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "@givernance/shared/constants";
 import { SUPPORTED_LOCALES } from "@givernance/shared/i18n";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance, FastifyRequest } from "fastify";
@@ -67,11 +68,11 @@ const AcceptInvitationBody = Type.Object({
   firstName: Type.String({ minLength: 1, maxLength: 255 }),
   lastName: Type.String({ minLength: 1, maxLength: 255 }),
   /**
-   * Cleartext password the invitee picks. Min 12 to comply with the
-   * realm's brute-force protection without leaking exact policy back to
-   * the frontend (matches the signup verify endpoint).
+   * Cleartext password the invitee picks. Min/max sourced from
+   * `@givernance/shared/constants` so accept-form and signup-verify
+   * never drift apart (F11).
    */
-  password: Type.String({ minLength: 12, maxLength: 128 }),
+  password: Type.String({ minLength: PASSWORD_MIN_LENGTH, maxLength: PASSWORD_MAX_LENGTH }),
   /**
    * Optional BCP-47 locale picked at acceptance (issue #153). Persisted
    * to `users.locale` only when it differs from the tenant's

--- a/packages/api/src/modules/signup/queue.ts
+++ b/packages/api/src/modules/signup/queue.ts
@@ -19,18 +19,24 @@ const tenantLifecycleQueue = new Queue(QUEUE_NAMES.TENANT_LIFECYCLE, { connectio
  * Enqueue a deferred resend-verification job. The handler runs in the
  * worker so the public HTTP response stays constant-time across the
  * "matches a candidate" and "no match" branches.
+ *
+ * `attempts: 1` is deliberate — the processor commits a token rotation
+ * (UPDATE invitations) and an outbox INSERT in a single tx. If BullMQ
+ * retried after a commit-then-crash mid-ack, the retry would rotate the
+ * token again and emit a second `tenant.signup_verification_resent`
+ * event, so the user would receive two emails with the first one now
+ * carrying a dead token. The per-email rate-limit and the user's own
+ * "Try a different email" path are the recovery channels; we'd rather
+ * drop a single resend than ship a stale-token email.
  */
 export async function enqueueSignupResend(email: string): Promise<void> {
   await tenantLifecycleQueue.add(
     TENANT_LIFECYCLE_JOBS.SIGNUP_RESEND,
     { email: email.trim().toLowerCase() },
     {
+      attempts: 1,
       removeOnComplete: 1000,
       removeOnFail: 5000,
-      // The HTTP per-email bucket (`signup:resend:email:<email>`) already
-      // caps fan-out at 3/h, so we don't need a queue-level dedup. A
-      // generated jobId keeps each enqueue distinct so a legitimate
-      // rotation-after-failure isn't accidentally swallowed.
     },
   );
 }

--- a/packages/api/src/modules/signup/queue.ts
+++ b/packages/api/src/modules/signup/queue.ts
@@ -1,0 +1,36 @@
+/**
+ * BullMQ queue handle for deferred public-signup work.
+ *
+ * F3 — The resend endpoint enqueues onto this queue and returns 204 in
+ * constant HTTP time, regardless of whether the email matches a pending
+ * tenant. The actual lookup-and-rotate work runs in the worker
+ * (`processors/signup-resend.ts`), closing the timing-side-channel that
+ * would otherwise let an attacker tell "email matches" from "no match" by
+ * comparing response latencies.
+ */
+
+import { QUEUE_NAMES, TENANT_LIFECYCLE_JOBS } from "@givernance/shared/jobs";
+import { Queue } from "bullmq";
+import { redis } from "../../lib/redis.js";
+
+const tenantLifecycleQueue = new Queue(QUEUE_NAMES.TENANT_LIFECYCLE, { connection: redis });
+
+/**
+ * Enqueue a deferred resend-verification job. The handler runs in the
+ * worker so the public HTTP response stays constant-time across the
+ * "matches a candidate" and "no match" branches.
+ */
+export async function enqueueSignupResend(email: string): Promise<void> {
+  await tenantLifecycleQueue.add(
+    TENANT_LIFECYCLE_JOBS.SIGNUP_RESEND,
+    { email: email.trim().toLowerCase() },
+    {
+      removeOnComplete: 1000,
+      removeOnFail: 5000,
+      // The HTTP per-email bucket (`signup:resend:email:<email>`) already
+      // caps fan-out at 3/h, so we don't need a queue-level dedup. A
+      // generated jobId keeps each enqueue distinct so a legitimate
+      // rotation-after-failure isn't accidentally swallowed.
+    },
+  );
+}

--- a/packages/api/src/modules/signup/routes.ts
+++ b/packages/api/src/modules/signup/routes.ts
@@ -17,6 +17,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "@givernance/shared/constants";
 import { SUPPORTED_LOCALES } from "@givernance/shared/i18n";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance, FastifyRequest } from "fastify";
@@ -29,13 +30,8 @@ import {
   problemDetail,
   UuidSchema,
 } from "../../lib/schemas.js";
-import {
-  lookupTenantForEmail,
-  openDomainDispute,
-  resendVerification,
-  signup,
-  verifySignup,
-} from "./service.js";
+import { enqueueSignupResend } from "./queue.js";
+import { lookupTenantForEmail, openDomainDispute, signup, verifySignup } from "./service.js";
 
 // ─── Request / response shapes ──────────────────────────────────────────────
 
@@ -73,11 +69,11 @@ const VerifyBody = Type.Object({
   /**
    * The password the user picks on the verify form — provisioned as their
    * non-temporary Keycloak credential so they can log in immediately after
-   * the post-verify redirect (issue #109 follow-up). Min 12 to comply with
-   * the realm's brute-force protection without leaking exact policy back to
-   * the frontend.
+   * the post-verify redirect (issue #109 follow-up). Min/max sourced from
+   * `@givernance/shared/constants` so server-side validation, web signup,
+   * invite-accept, and platform-admin-accept never drift apart (F11).
    */
-  password: Type.String({ minLength: 12, maxLength: 128 }),
+  password: Type.String({ minLength: PASSWORD_MIN_LENGTH, maxLength: PASSWORD_MAX_LENGTH }),
 });
 
 const SignupResponse = Type.Object({
@@ -329,7 +325,13 @@ export async function signupRoutes(app: FastifyInstance) {
         // spam-amplification oracle.
         return reply.status(204).send();
       }
-      await resendVerification(email);
+      // F3 — Hand the lookup-and-rotate work to the BullMQ worker so the
+      // public HTTP response is constant-time across both branches
+      // ("email matches a pending tenant" vs. "no match"). Doing the DB tx
+      // synchronously here would let an attacker compare latencies and tell
+      // a registered email from an unknown one, defeating the
+      // anti-enumeration property the silent-204 contract was designed for.
+      await enqueueSignupResend(email);
       return reply.status(204).send();
     },
   );

--- a/packages/api/src/modules/signup/routes.ts
+++ b/packages/api/src/modules/signup/routes.ts
@@ -22,7 +22,6 @@ import { SUPPORTED_LOCALES } from "@givernance/shared/i18n";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { defaultCaptchaVerifier } from "../../lib/captcha.js";
-import { redis } from "../../lib/redis.js";
 import {
   DataResponse,
   ErrorResponses,
@@ -122,19 +121,12 @@ function clientIp(request: FastifyRequest): string | undefined {
   return request.ip ?? undefined;
 }
 
-/**
- * Per-email rate limit for the resend endpoint, on top of the per-IP Fastify
- * limit. Defends against a botnet spamming a single victim's inbox (SEC-10).
- * Returns `true` when the request is allowed, `false` when the bucket is full.
- */
-async function acceptResendForEmail(email: string): Promise<boolean> {
-  const key = `signup:resend:email:${email.trim().toLowerCase()}`;
-  const hits = await redis.incr(key);
-  if (hits === 1) {
-    await redis.expire(key, 60 * 60); // 1h window
-  }
-  return hits <= 3; // max 3 resends per email per hour globally
-}
+// Per-email rate-limit (SEC-10) was moved to the worker after F3 review —
+// keeping it on the HTTP route would re-introduce a timing asymmetry
+// between "bucket full → 204 fast" and "bucket open → 204 slow because
+// of enqueue". The worker enforces the cap now; the Fastify per-IP
+// limiter on this route still bounds queue fan-out from any single
+// source.
 
 // ─── Routes ─────────────────────────────────────────────────────────────────
 
@@ -319,18 +311,12 @@ export async function signupRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const { email } = request.body as { email: string };
-      const allowed = await acceptResendForEmail(email);
-      if (!allowed) {
-        // Silently accept — the endpoint cannot be used as an enumeration or
-        // spam-amplification oracle.
-        return reply.status(204).send();
-      }
-      // F3 — Hand the lookup-and-rotate work to the BullMQ worker so the
-      // public HTTP response is constant-time across both branches
-      // ("email matches a pending tenant" vs. "no match"). Doing the DB tx
-      // synchronously here would let an attacker compare latencies and tell
-      // a registered email from an unknown one, defeating the
-      // anti-enumeration property the silent-204 contract was designed for.
+      // F3 — Always enqueue. The worker enforces the per-email
+      // SEC-10 cap and runs the lookup-and-rotate tx. Keeping a
+      // synchronous branch here (e.g. for the bucket-full "fast 204"
+      // path) would re-open the timing asymmetry the BullMQ hand-off
+      // was meant to close. The Fastify per-IP rate-limiter on this
+      // route bounds queue fan-out from any single source.
       await enqueueSignupResend(email);
       return reply.status(204).send();
     },

--- a/packages/api/src/modules/signup/service.ts
+++ b/packages/api/src/modules/signup/service.ts
@@ -53,12 +53,7 @@
 
 import { randomUUID } from "node:crypto";
 import { isPersonalEmailDomain, PINO_REDACT_PATHS } from "@givernance/shared/constants";
-import {
-  APP_DEFAULT_LOCALE,
-  isSupportedLocale,
-  type Locale,
-  localeFromCountry,
-} from "@givernance/shared/i18n";
+import { isSupportedLocale, type Locale, localeFromCountry } from "@givernance/shared/i18n";
 import {
   auditLogs,
   invitations,
@@ -98,20 +93,15 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * so a Fastify-bound `request.log` isn't always available. PII is masked
  * via the same redact list every other service uses.
  */
-// Pass `process.stdout` as the destination so the logger writes via the
-// Writable stream's `write()` method instead of pino's default sonic-boom
-// path (which bypasses `process.stdout.write` via `fs.writeSync` on fd 1).
-// Behaviour is identical in production (both end up on stdout); the
-// difference matters in tests, where `vi.spyOn(process.stdout, "write")`
-// can intercept the JSON line to assert structured warns like
-// `signup.kc_user_exists` actually fire (F4).
-const log = pino(
-  {
-    name: "signup-service",
-    redact: { paths: [...PINO_REDACT_PATHS], censor: "[REDACTED]" },
-  },
-  process.stdout,
-);
+// Exported so integration tests can `vi.spyOn(log, "warn")` to pin
+// SRE-visible breadcrumbs like `signup.kc_user_exists` (F4). Pino logger
+// instances expose level methods as own-properties, so the spy attaches
+// to *this* instance — the service's call sites are captured because
+// they use the same imported binding.
+export const log = pino({
+  name: "signup-service",
+  redact: { paths: [...PINO_REDACT_PATHS], censor: "[REDACTED]" },
+});
 
 const PROVISIONAL_GRACE_DAYS = 7;
 const VERIFICATION_TTL_HOURS = 24;
@@ -332,142 +322,12 @@ export async function signup(input: SignupInput): Promise<SignupResult> {
   }
 }
 
-// ─── Resend verification ────────────────────────────────────────────────────
-
-export type ResendResult =
-  | { ok: true; tenantId: string; email: string; verificationToken: string }
-  | { ok: false };
-
-/**
- * Re-emit a verification token. Matches three recoverable states so a
- * half-failed signup isn't a dead-end:
- *
- *  1. **Pending verify.** Tenant `provisional`, invitation not yet accepted —
- *     the original happy-path resend.
- *  2. **No Keycloak credential yet.** Tenant `active` but the user's
- *     `keycloak_id` is NULL — what self-serve signups looked like before
- *     the verify endpoint started provisioning the Keycloak user.
- *  3. **No Keycloak Organization yet.** Tenant `active`, user has a
- *     `keycloak_id`, but `tenant.keycloak_org_id` is NULL — what they look
- *     like after the credential-only fix landed but before the Organization
- *     wiring did. Without an Org the realm's user-attribute mapper has no
- *     `org_id` to emit and the web auth callback bounces with
- *     `missing_org_id`.
- *
- * Cases (2) and (3) both resolve by clearing `acceptedAt` on the latest
- * `signup_verification` invitation and letting the next verify call run —
- * `verifySignup` is idempotent for every step (org get-or-create, user
- * create-or-update with attribute merge, member attach with 409 swallow).
- *
- * Silently returns `{ok: false}` for everything else (fully-bound users,
- * unknown emails) — the route always responds 204 so this cannot be used
- * as an email-enumeration oracle.
- */
-export async function resendVerification(email: string): Promise<ResendResult> {
-  const normalised = email.trim().toLowerCase();
-
-  // Owner role: same justification as verifySignup — no org context yet, and
-  // the app role would have RLS filter the invitation join to zero rows.
-  // Match all recoverable states in one query, ordered so a still-valid
-  // pending invitation wins over an older half-provisioned row.
-  // Case-insensitive email join: `invitations.email` is normalised
-  // lowercase at INSERT (signup() / resend()), but `users.email` has no
-  // schema-level case-folding constraint. Mixed-case future writes to
-  // users.email would silently break this join under `eq(...)`. Compare
-  // both sides via lower() so the recovery match stays robust.
-  const rows = await systemDb
-    .select({
-      tenantId: tenants.id,
-      status: tenants.status,
-      // Issue #153: read default_locale directly from the row so the resend
-      // payload can stamp the right `locale` without walking the outbox.
-      // Populated at signup time (or backfilled by migration 0027) so a NULL
-      // here only happens for legacy archived tenants the resend wouldn't
-      // match anyway.
-      defaultLocale: tenants.defaultLocale,
-      invitationId: invitations.id,
-      invitationToken: invitations.token,
-      expiresAt: invitations.expiresAt,
-      createdAt: invitations.createdAt,
-    })
-    .from(invitations)
-    .innerJoin(tenants, eq(invitations.orgId, tenants.id))
-    .leftJoin(
-      users,
-      and(
-        eq(users.orgId, invitations.orgId),
-        sql`lower(${users.email}) = lower(${invitations.email})`,
-      ),
-    )
-    .where(
-      and(
-        eq(invitations.email, normalised),
-        eq(invitations.purpose, "signup_verification"),
-        eq(tenants.createdVia, "self_serve"),
-        sql`(
-          (${tenants.status} = 'provisional' AND ${invitations.acceptedAt} IS NULL)
-          OR
-          (${tenants.status} = 'active'
-            AND (${users.keycloakId} IS NULL OR ${tenants.keycloakOrgId} IS NULL))
-        )`,
-      ),
-    )
-    .orderBy(sql`${invitations.createdAt} DESC`)
-    .limit(1);
-
-  if (rows.length === 0) {
-    log.info({ event: "signup.resend", matched: false }, "resend silent no-match");
-    return { ok: false };
-  }
-
-  const row = rows[0];
-  if (!row) return { ok: false };
-
-  // Issue #153: `tenants.default_locale` is the durable source of truth for
-  // template selection — `lookupTenantCountry`'s outbox-walking helper has
-  // been removed. There's no signed-up user yet at this point in the flow
-  // (the verify form hasn't been submitted), so the per-user locale layer
-  // doesn't apply; the tenant default is the right value to stamp.
-  const localeForResend: Locale = isSupportedLocale(row.defaultLocale)
-    ? row.defaultLocale
-    : APP_DEFAULT_LOCALE;
-
-  const newToken = generateVerificationToken();
-  const expiresAt = new Date(Date.now() + VERIFICATION_TTL_HOURS * 60 * 60 * 1000);
-
-  await systemDb.transaction(async (tx) => {
-    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${row.tenantId}, true)`);
-
-    // Half-provisioned rows have `acceptedAt` set from the prior verify;
-    // clearing it lets verifySignup's invitation-validity guard accept the
-    // fresh token. The pre-existing audit_logs row preserves the original
-    // acceptance event, so this isn't a history rewrite.
-    await tx
-      .update(invitations)
-      .set({ token: newToken, expiresAt, acceptedAt: null })
-      .where(eq(invitations.id, row.invitationId));
-
-    await tx.insert(outboxEvents).values({
-      tenantId: row.tenantId,
-      type: "tenant.signup_verification_resent",
-      payload: {
-        tenantId: row.tenantId,
-        invitationId: row.invitationId,
-        expiresAt: expiresAt.toISOString(),
-        locale: localeForResend,
-      },
-    });
-  });
-
-  log.info(
-    { event: "signup.resend", matched: true, tenantId: row.tenantId, status: row.status },
-    "resend rotated invitation token",
-  );
-
-  return { ok: true, tenantId: row.tenantId, email: normalised, verificationToken: newToken };
-}
-
 // ─── Verify ─────────────────────────────────────────────────────────────────
+// Resend lookup-and-rotate lives in `@givernance/shared/signup`
+// (`resendSignupVerification`) — invoked from the worker's
+// `processSignupResend`. The HTTP route enqueues a BullMQ job; nothing in
+// the API package calls into it synchronously. This keeps the api +
+// worker sides on one canonical implementation (F3b cleanup).
 
 export type VerifyResult =
   | {

--- a/packages/api/src/modules/signup/service.ts
+++ b/packages/api/src/modules/signup/service.ts
@@ -98,10 +98,20 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * so a Fastify-bound `request.log` isn't always available. PII is masked
  * via the same redact list every other service uses.
  */
-const log = pino({
-  name: "signup-service",
-  redact: { paths: [...PINO_REDACT_PATHS], censor: "[REDACTED]" },
-});
+// Pass `process.stdout` as the destination so the logger writes via the
+// Writable stream's `write()` method instead of pino's default sonic-boom
+// path (which bypasses `process.stdout.write` via `fs.writeSync` on fd 1).
+// Behaviour is identical in production (both end up on stdout); the
+// difference matters in tests, where `vi.spyOn(process.stdout, "write")`
+// can intercept the JSON line to assert structured warns like
+// `signup.kc_user_exists` actually fire (F4).
+const log = pino(
+  {
+    name: "signup-service",
+    redact: { paths: [...PINO_REDACT_PATHS], censor: "[REDACTED]" },
+  },
+  process.stdout,
+);
 
 const PROVISIONAL_GRACE_DAYS = 7;
 const VERIFICATION_TTL_HOURS = 24;

--- a/packages/api/src/tests/integration/signup.test.ts
+++ b/packages/api/src/tests/integration/signup.test.ts
@@ -5,13 +5,13 @@
  * the real test DB (migration 0021 applied). CAPTCHA fails open in
  * NODE_ENV=test so no external provider is hit.
  *
- * F3 — `POST /v1/public/signup/resend` now enqueues a BullMQ job and
- * returns 204 in constant time; the lookup-and-rotate work happens in
- * the worker process. To keep the integration test fast and isolated
- * from a live worker, we mock the enqueue helper to call the existing
- * `resendVerification` service inline. This preserves the previous
- * "assert DB state after the 204" pattern while still exercising the
- * production route. Worker-side coverage of the same logic lives in
+ * F3 — `POST /v1/public/signup/resend` enqueues a BullMQ job and returns
+ * 204 in constant time; the lookup-and-rotate work happens in the worker
+ * via `@givernance/shared/signup`. To keep the integration test fast and
+ * self-contained, the vi.mock below replaces the enqueue helper with an
+ * inline call into the same shared function so DB state can be asserted
+ * immediately after the 204. Worker-side coverage of the cap + rate
+ * limit lives in
  * `packages/worker/src/tests/integration/signup-resend.test.ts`.
  */
 
@@ -24,26 +24,44 @@ import {
   tenants,
   users,
 } from "@givernance/shared/schema";
+import { resendSignupVerification } from "@givernance/shared/signup";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { db } from "../../lib/db.js";
+import { db, systemDb } from "../../lib/db.js";
 import {
   _resetKeycloakAdminSingleton,
   _setKeycloakAdminSingleton,
   type KeycloakAdminClient,
 } from "../../lib/keycloak-admin.js";
 import { redis } from "../../lib/redis.js";
-import { cleanupUnverifiedTenants, resendVerification } from "../../modules/signup/service.js";
+import { cleanupUnverifiedTenants, log as signupLog } from "../../modules/signup/service.js";
 import { createServer } from "../../server.js";
 
-// F3 — replace the BullMQ enqueue with an inline call to the legacy
-// service so the existing integration tests can keep asserting DB state
-// immediately after `POST /v1/public/signup/resend` without spinning up
-// a worker. Equivalent flow shape: route → "enqueue" → handler → DB tx.
+// F3 — route the in-process "enqueue" back through the same shared
+// `resendSignupVerification` helper the worker uses so DB state remains
+// assertable immediately after the 204. The production shape (route →
+// enqueue → worker processor → shared helper → DB tx) is identical;
+// only the BullMQ hop is collapsed. The per-email rate-limit gate
+// lives on the worker side (it was moved off the HTTP route to close
+// the timing oracle) — we faithfully replicate that step here so the
+// existing "caps outbox emission at 3 per email per hour" test stays
+// meaningful in this file. Worker-side coverage of the same rate-limit
+// + lookup logic lives in
+// `packages/worker/src/tests/integration/signup-resend.test.ts`.
 vi.mock("../../modules/signup/queue.js", () => ({
   enqueueSignupResend: async (email: string) => {
-    await resendVerification(email);
+    const normalised = email.trim().toLowerCase();
+    const key = `signup:resend:email:${normalised}`;
+    const hits = await redis.incr(key);
+    if (hits === 1) {
+      await redis.expire(key, 60 * 60);
+    }
+    if (hits > 3) {
+      // Worker-side rate-limit cap exhausted — silent drop, no DB writes.
+      return;
+    }
+    await resendSignupVerification(systemDb, normalised, randomUUID());
   },
 }));
 
@@ -146,13 +164,34 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  // Reset the KC stub spies so per-test assertions on call counts are clean.
-  kcCreateUser.mockClear();
-  kcCreateOrganization.mockClear();
-  kcAttachUserToOrg.mockClear();
-  kcGetOrganizationByAlias.mockClear();
-  kcResetUserPassword.mockClear();
-  kcSetUserAttributes.mockClear();
+  // `mockReset` (not `mockClear`) — also drains any unconsumed
+  // `mockRejectedValueOnce` / `mockResolvedValueOnce` queued by a
+  // previous test that threw before reaching the inject. With plain
+  // `mockClear`, a leftover `Once` rejection silently leaks into the
+  // next test and corrupts the assertion (we hit this exact failure
+  // mode during PR #359 review).
+  //
+  // `mockReset` wipes the default implementation too, so we re-install
+  // the per-fn defaults the rest of the suite assumes.
+  kcCreateUser.mockReset();
+  kcCreateUser.mockImplementation(async (input) => ({
+    id: `kc-${input.email}-${randomUUID().slice(0, 8)}`,
+  }));
+  kcCreateOrganization.mockReset();
+  kcCreateOrganization.mockImplementation(async ({ name, alias, attributes }) => ({
+    id: randomUUID(),
+    name,
+    alias,
+    attributes,
+  }));
+  kcAttachUserToOrg.mockReset();
+  kcAttachUserToOrg.mockImplementation(async () => {});
+  kcGetOrganizationByAlias.mockReset();
+  kcGetOrganizationByAlias.mockImplementation(async () => null);
+  kcResetUserPassword.mockReset();
+  kcResetUserPassword.mockImplementation(async () => {});
+  kcSetUserAttributes.mockReset();
+  kcSetUserAttributes.mockImplementation(async () => {});
   // Clear any rate-limiter + per-email signup counters from Redis so the
   // 5/hour limits don't poison successive tests. Scoped deletes only — a
   // full `flushdb` would destroy unrelated test fixtures (ENG-3).
@@ -925,24 +964,18 @@ describe("POST /v1/public/signup/verify", () => {
       ),
     );
 
-    // F4 — Pin SRE-visible behaviour: the service-side `signup.kc_user_exists`
-    // warn must fire (so the on-call paging signal isn't silently dropped),
-    // and we must NOT have called `kcResetUserPassword` on the existing KC
-    // user. A regression that "helpfully" re-wired the hijack branch to
-    // reset-and-attach would silently take over a stranger's credential
-    // while still surfacing 410 — both assertions are needed to catch it.
+    // F4 — Pin SRE-visible behaviour and the hijack defence:
+    //  1. `signup.kc_user_exists` warn fires so on-call gets paged.
+    //  2. `kcResetUserPassword` is NOT called — proves inbox-control didn't
+    //     overwrite the existing realm credential.
+    //  3. `kcAttachUserToOrg` is NOT called — proves no silent "create-and-
+    //     attach to our org" path snuck in past the throw.
     //
-    // The signup service's module-scoped pino is configured with
-    // `process.stdout` as its destination (see signup/service.ts) so the
-    // logger writes via the Writable stream's `write()` method —
-    // `vi.spyOn(process.stdout, "write")` then captures the JSON line.
-    // Restore immediately after `inject` so unrelated logging during
-    // cleanup hooks isn't disturbed.
-    const captured: string[] = [];
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
-      captured.push(typeof chunk === "string" ? chunk : String(chunk));
-      return true;
-    });
+    // The pino logger is exported from signup/service.ts so we spy on its
+    // `warn` method directly (logger instances expose level methods as
+    // own properties), avoiding test-only knobs in the production pino
+    // destination.
+    const warnSpy = vi.spyOn(signupLog, "warn");
 
     const res = await app.inject({
       method: "POST",
@@ -954,21 +987,23 @@ describe("POST /v1/public/signup/verify", () => {
         password: TEST_PASSWORD,
       },
     });
-    writeSpy.mockRestore();
     expect(res.statusCode).toBe(410);
     const [tenant] = await db.select().from(tenants).where(eq(tenants.id, tenantId));
     expect(tenant?.status).toBe("provisional");
     const userRows = await db.select().from(users).where(eq(users.orgId, tenantId));
     expect(userRows.length).toBe(0);
 
-    // The hijack-defence path must NOT have touched the existing KC user's
-    // password. If it had, an attacker who proved inbox control could
-    // silently overwrite the realm credential of an enterprise SSO user or
-    // a seeded super-admin (the exact attack the guard exists for).
     expect(kcResetUserPassword).not.toHaveBeenCalled();
+    expect(kcAttachUserToOrg).not.toHaveBeenCalled();
 
-    const warnedHijack = captured.some((line) => line.includes('"event":"signup.kc_user_exists"'));
+    const warnedHijack = warnSpy.mock.calls.some(
+      ([fields]) =>
+        fields !== null &&
+        typeof fields === "object" &&
+        (fields as { event?: string }).event === "signup.kc_user_exists",
+    );
     expect(warnedHijack).toBe(true);
+    warnSpy.mockRestore();
   });
 
   it("rolls back when attachUserToOrg fails (verifies the orphan KC user gap)", async () => {
@@ -1017,12 +1052,25 @@ describe("POST /v1/public/signup/verify", () => {
     expect(kcCreateUser).not.toHaveBeenCalled();
   });
 
-  // F1 — Concurrent verify race. The service comment says the duplicate-row
-  // catch is "no longer reachable in practice" thanks to `FOR UPDATE` on
-  // the invitation row. Fire two verify calls in parallel with the same
-  // token and assert exactly ONE creates a users row (status `[201, 410]`
-  // after sort). A regression that dropped `FOR UPDATE` would let both
-  // SELECTs see acceptedAt=NULL and race past the guard.
+  // F1 — Concurrent verify race. The service comment says the duplicate-
+  // row catch is "no longer reachable in practice" thanks to `FOR UPDATE`
+  // on the invitation row. Fire two verify calls in parallel with the
+  // same token and assert:
+  //
+  //   - One returns 201, the other 410.
+  //   - `kcCreateOrganization` and `kcCreateUser` were each called EXACTLY
+  //     ONCE. If FOR UPDATE were dropped, both verifies would race past
+  //     the acceptedAt check, each calling createOrg + createUser, and
+  //     the loser would only fail later (on the partial-unique
+  //     `users_one_first_admin_per_org` constraint). That backstop was
+  //     kept on purpose, so without these call-count assertions the test
+  //     would silently pass against a missing-FOR-UPDATE regression.
+  //   - Exactly one `users` row exists.
+  //
+  // Pool size: `db.ts` configures `max: 20`, so the two txs get distinct
+  // connections and the lock contention happens at the row level, not at
+  // the pool level (a future shrink to `max: 1` would invalidate this
+  // test silently — flagged in the comment so a reader notices).
   it("serialises two concurrent verify calls on the same token (FOR UPDATE)", async () => {
     const { tenantId, token } = await createSignup("verify-race");
 
@@ -1052,8 +1100,13 @@ describe("POST /v1/public/signup/verify", () => {
     const codes = [r1.statusCode, r2.statusCode].sort();
     expect(codes).toEqual([201, 410]);
 
-    // Exactly one users row was created (the FOR UPDATE serialised the
-    // SELECT, so the loser saw `acceptedAt !== NULL` and short-circuited).
+    // FOR UPDATE serialised the SELECT — the loser saw `acceptedAt != NULL`
+    // and short-circuited before any KC call. Without the lock both would
+    // have made the round-trip.
+    expect(kcCreateOrganization).toHaveBeenCalledTimes(1);
+    expect(kcCreateUser).toHaveBeenCalledTimes(1);
+
+    // Exactly one users row was created.
     const userRows = await db.select().from(users).where(eq(users.orgId, tenantId));
     expect(userRows.length).toBe(1);
 

--- a/packages/api/src/tests/integration/signup.test.ts
+++ b/packages/api/src/tests/integration/signup.test.ts
@@ -4,6 +4,15 @@
  * Exercises the four endpoints + the cleanup helper end-to-end against
  * the real test DB (migration 0021 applied). CAPTCHA fails open in
  * NODE_ENV=test so no external provider is hit.
+ *
+ * F3 — `POST /v1/public/signup/resend` now enqueues a BullMQ job and
+ * returns 204 in constant time; the lookup-and-rotate work happens in
+ * the worker process. To keep the integration test fast and isolated
+ * from a live worker, we mock the enqueue helper to call the existing
+ * `resendVerification` service inline. This preserves the previous
+ * "assert DB state after the 204" pattern while still exercising the
+ * production route. Worker-side coverage of the same logic lives in
+ * `packages/worker/src/tests/integration/signup-resend.test.ts`.
  */
 
 import { randomUUID } from "node:crypto";
@@ -25,8 +34,18 @@ import {
   type KeycloakAdminClient,
 } from "../../lib/keycloak-admin.js";
 import { redis } from "../../lib/redis.js";
-import { cleanupUnverifiedTenants } from "../../modules/signup/service.js";
+import { cleanupUnverifiedTenants, resendVerification } from "../../modules/signup/service.js";
 import { createServer } from "../../server.js";
+
+// F3 — replace the BullMQ enqueue with an inline call to the legacy
+// service so the existing integration tests can keep asserting DB state
+// immediately after `POST /v1/public/signup/resend` without spinning up
+// a worker. Equivalent flow shape: route → "enqueue" → handler → DB tx.
+vi.mock("../../modules/signup/queue.js", () => ({
+  enqueueSignupResend: async (email: string) => {
+    await resendVerification(email);
+  },
+}));
 
 let app: FastifyInstance;
 
@@ -905,6 +924,26 @@ describe("POST /v1/public/signup/verify", () => {
         "kc-existing@example.org",
       ),
     );
+
+    // F4 — Pin SRE-visible behaviour: the service-side `signup.kc_user_exists`
+    // warn must fire (so the on-call paging signal isn't silently dropped),
+    // and we must NOT have called `kcResetUserPassword` on the existing KC
+    // user. A regression that "helpfully" re-wired the hijack branch to
+    // reset-and-attach would silently take over a stranger's credential
+    // while still surfacing 410 — both assertions are needed to catch it.
+    //
+    // The signup service's module-scoped pino is configured with
+    // `process.stdout` as its destination (see signup/service.ts) so the
+    // logger writes via the Writable stream's `write()` method —
+    // `vi.spyOn(process.stdout, "write")` then captures the JSON line.
+    // Restore immediately after `inject` so unrelated logging during
+    // cleanup hooks isn't disturbed.
+    const captured: string[] = [];
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      captured.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    });
+
     const res = await app.inject({
       method: "POST",
       url: "/v1/public/signup/verify",
@@ -915,11 +954,21 @@ describe("POST /v1/public/signup/verify", () => {
         password: TEST_PASSWORD,
       },
     });
+    writeSpy.mockRestore();
     expect(res.statusCode).toBe(410);
     const [tenant] = await db.select().from(tenants).where(eq(tenants.id, tenantId));
     expect(tenant?.status).toBe("provisional");
     const userRows = await db.select().from(users).where(eq(users.orgId, tenantId));
     expect(userRows.length).toBe(0);
+
+    // The hijack-defence path must NOT have touched the existing KC user's
+    // password. If it had, an attacker who proved inbox control could
+    // silently overwrite the realm credential of an enterprise SSO user or
+    // a seeded super-admin (the exact attack the guard exists for).
+    expect(kcResetUserPassword).not.toHaveBeenCalled();
+
+    const warnedHijack = captured.some((line) => line.includes('"event":"signup.kc_user_exists"'));
+    expect(warnedHijack).toBe(true);
   });
 
   it("rolls back when attachUserToOrg fails (verifies the orphan KC user gap)", async () => {
@@ -966,6 +1015,51 @@ describe("POST /v1/public/signup/verify", () => {
     // contacted.
     expect(res.statusCode).toBe(400);
     expect(kcCreateUser).not.toHaveBeenCalled();
+  });
+
+  // F1 — Concurrent verify race. The service comment says the duplicate-row
+  // catch is "no longer reachable in practice" thanks to `FOR UPDATE` on
+  // the invitation row. Fire two verify calls in parallel with the same
+  // token and assert exactly ONE creates a users row (status `[201, 410]`
+  // after sort). A regression that dropped `FOR UPDATE` would let both
+  // SELECTs see acceptedAt=NULL and race past the guard.
+  it("serialises two concurrent verify calls on the same token (FOR UPDATE)", async () => {
+    const { tenantId, token } = await createSignup("verify-race");
+
+    const [r1, r2] = await Promise.all([
+      app.inject({
+        method: "POST",
+        url: "/v1/public/signup/verify",
+        payload: {
+          token,
+          firstName: "Race",
+          lastName: "One",
+          password: TEST_PASSWORD,
+        },
+      }),
+      app.inject({
+        method: "POST",
+        url: "/v1/public/signup/verify",
+        payload: {
+          token,
+          firstName: "Race",
+          lastName: "Two",
+          password: TEST_PASSWORD,
+        },
+      }),
+    ]);
+
+    const codes = [r1.statusCode, r2.statusCode].sort();
+    expect(codes).toEqual([201, 410]);
+
+    // Exactly one users row was created (the FOR UPDATE serialised the
+    // SELECT, so the loser saw `acceptedAt !== NULL` and short-circuited).
+    const userRows = await db.select().from(users).where(eq(users.orgId, tenantId));
+    expect(userRows.length).toBe(1);
+
+    // Tenant flipped exactly once.
+    const [tenant] = await db.select().from(tenants).where(eq(tenants.id, tenantId));
+    expect(tenant?.status).toBe("active");
   });
 
   it("returns 410 when the same token is used twice", async () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,8 @@
     "./validators": "./src/validators/index.ts",
     "./constants": "./src/constants/index.ts",
     "./i18n": "./src/i18n/locales.ts",
-    "./contracts/branding": "./src/contracts/branding.ts"
+    "./contracts/branding": "./src/contracts/branding.ts",
+    "./signup": "./src/signup/index.ts"
   },
   "scripts": {
     "build": "tsup src/index.ts --format esm",

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -16,6 +16,7 @@ export {
   type ImpersonationEndReason,
   type ImpersonationMode,
 } from "./impersonation";
+export { assertSafeOrgAttributes, SAFE_ORG_ATTRIBUTES } from "./keycloak-org-attributes";
 export { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "./password";
 export { isPersonalEmailDomain, PERSONAL_EMAIL_DOMAINS } from "./personal-email-domains";
 export { PINO_REDACT_PATHS } from "./pino-redact";

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -16,6 +16,7 @@ export {
   type ImpersonationEndReason,
   type ImpersonationMode,
 } from "./impersonation";
+export { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "./password";
 export { isPersonalEmailDomain, PERSONAL_EMAIL_DOMAINS } from "./personal-email-domains";
 export { PINO_REDACT_PATHS } from "./pino-redact";
 export { isReservedSlug, RESERVED_SLUGS } from "./reserved-slugs";

--- a/packages/shared/src/constants/keycloak-org-attributes.ts
+++ b/packages/shared/src/constants/keycloak-org-attributes.ts
@@ -1,0 +1,47 @@
+/**
+ * F2 — Allowlist of Keycloak Organization attribute keys that Givernance
+ * code may set. The realm's `organization` client scope is wired with
+ * `oidc-organization-membership-mapper` configured with
+ * `addOrganizationAttributes: true`, which emits **every** Organization
+ * attribute into the access / ID / introspection JWT of every member of
+ * that org. The mapper has no per-key filter, so the only line of defence
+ * is what our code chooses to write.
+ *
+ * Hoisted to `@givernance/shared/constants` so the api and worker copies
+ * stay in lockstep — a developer adding `theme_secondary_color` shouldn't
+ * be able to land it on one side and silently leave the other side
+ * rejecting (which would surface as a confusing branding-sync error in
+ * prod, not as a security regression).
+ *
+ * Pure constants only — no runtime deps — so this stays inside ADR-013's
+ * type-boundary rules for `@givernance/shared`.
+ */
+
+export const SAFE_ORG_ATTRIBUTES: ReadonlySet<string> = new Set([
+  // Canonical tenant id — already emitted as a designated JWT claim by the
+  // `oidc-usermodel-attribute-mapper`. Mirrored on the org so we can find
+  // a half-created org by id during recovery (signup verify 409 path).
+  "org_id",
+  // Tenant slug — public (it's in the URL). Set by
+  // `tenant-admin.createOrganization`. Kept on the allowlist for
+  // explicitness rather than because exclusion would matter.
+  "org_slug",
+  // Public branding rendered on the Keycloak login template. Epic #286.
+  "logo_url",
+  // Public branding rendered on the Keycloak login template. Epic #286.
+  "theme_primary_color",
+]);
+
+export function assertSafeOrgAttributes(attributes: Record<string, string[]> | undefined): void {
+  if (!attributes) return;
+  for (const key of Object.keys(attributes)) {
+    if (!SAFE_ORG_ATTRIBUTES.has(key)) {
+      throw new Error(
+        `Refusing to write Keycloak Organization attribute "${key}" — not in SAFE_ORG_ATTRIBUTES. ` +
+          `The realm's organization mapper emits every attribute into every member's JWT; ` +
+          `add this key to SAFE_ORG_ATTRIBUTES (packages/shared/src/constants/keycloak-org-attributes.ts) ` +
+          `only after confirming it is safe to leak to all browsers.`,
+      );
+    }
+  }
+}

--- a/packages/shared/src/constants/password.ts
+++ b/packages/shared/src/constants/password.ts
@@ -1,0 +1,24 @@
+/**
+ * Password policy constants shared across the API route validators (Fastify
+ * TypeBox schemas) and the web client forms (signup verify, team-invite
+ * accept, platform-admin accept). A bump here propagates to all four sites in
+ * one place so the policy can't drift between server and the three client
+ * surfaces.
+ *
+ * Mirror these in any new credential-acceptance page; do NOT redeclare a local
+ * const.
+ */
+
+/**
+ * Minimum length for end-user-chosen passwords. Set to comply with the
+ * realm's brute-force protection without leaking the exact policy back to
+ * the frontend.
+ */
+export const PASSWORD_MIN_LENGTH = 12;
+
+/**
+ * Maximum length for end-user-chosen passwords. Caps how much keyspace any
+ * single bcrypt/Argon2 hash has to chew, and keeps the password field
+ * comparable to Keycloak's default policy upper bound.
+ */
+export const PASSWORD_MAX_LENGTH = 128;

--- a/packages/shared/src/jobs/index.ts
+++ b/packages/shared/src/jobs/index.ts
@@ -151,6 +151,20 @@ export interface KeycloakSyncOrgLogoJob {
   };
 }
 
+/**
+ * Defer the signup-resend lookup-and-rotate work onto BullMQ so the public
+ * resend endpoint takes constant HTTP time whether or not the email matches
+ * a pending/half-provisioned tenant (F3 — close the timing-side-channel that
+ * defeats the resend route's anti-enumeration property).
+ */
+export interface SignupResendJob {
+  name: "tenant.signup-resend";
+  data: {
+    /** Email submitted to `POST /v1/public/signup/resend` (lowercased / trimmed). */
+    email: string;
+  };
+}
+
 /** Union of all job types */
 export type JobDefinition =
   | GenerateReceiptJob
@@ -163,7 +177,8 @@ export type JobDefinition =
   | BrandingProcessAssetJob
   | BrandingActivateLogoJob
   | BrandingGcAssetJob
-  | KeycloakSyncOrgLogoJob;
+  | KeycloakSyncOrgLogoJob
+  | SignupResendJob;
 
 /** Queue names */
 export const QUEUE_NAMES = {
@@ -197,4 +212,10 @@ export const QUEUE_NAMES = {
 /** Repeatable job names inside TENANT_LIFECYCLE queue. */
 export const TENANT_LIFECYCLE_JOBS = {
   PROVISIONAL_ADMIN_EXPIRE: "tenant.provisional-admin-expire",
+  /**
+   * F3 — Defer the public resend endpoint's lookup-and-rotate work onto the
+   * worker so the HTTP response is constant-time across the
+   * "matches a pending tenant" and "no match" branches.
+   */
+  SIGNUP_RESEND: "tenant.signup-resend",
 } as const;

--- a/packages/shared/src/signup/index.ts
+++ b/packages/shared/src/signup/index.ts
@@ -1,0 +1,1 @@
+export { type ResendSignupResult, resendSignupVerification } from "./resend";

--- a/packages/shared/src/signup/resend.ts
+++ b/packages/shared/src/signup/resend.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared lookup-and-rotate helper for `POST /v1/public/signup/resend`.
+ *
+ * Hoisted to `@givernance/shared` so the API package (used by integration
+ * tests) and the worker package (the production handler invoked from
+ * BullMQ) operate on a single implementation. The previous arrangement —
+ * api/src/modules/signup/service.ts:resendVerification +
+ * worker/src/processors/signup-resend.ts:processSignupResendPayload —
+ * carried two ~50-line copies of the same SELECT + UPDATE + outbox INSERT
+ * with no shared source, and a drift in recovery predicates / locale
+ * fallback / FOR-UPDATE choice would have only surfaced after a real
+ * customer hit the half-state.
+ *
+ * Matches three recoverable states (same as the original service-level
+ * code, see signup/service.ts module header for the full history):
+ *   1. Pending verify (tenant=provisional, acceptedAt=null).
+ *   2. No Keycloak credential (active tenant, users.keycloak_id IS NULL).
+ *   3. No Keycloak Organization (active tenant, keycloak_org_id IS NULL).
+ *
+ * Cases (2) and (3) clear `acceptedAt` so the next verify can complete the
+ * missing bind step. Everything else silently no-ops — the route never
+ * surfaces the matched/no-match bit, so this isn't an enumeration oracle.
+ */
+
+import { invitations, outboxEvents, tenants, users } from "@givernance/shared/schema";
+import { and, eq, sql } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { APP_DEFAULT_LOCALE, isSupportedLocale, type Locale } from "../i18n/locales";
+
+const VERIFICATION_TTL_HOURS = 24;
+
+/** Pino-shaped log methods. Both api + worker pass real pino loggers. */
+interface MinimalLogger {
+  info(fields: Record<string, unknown>, msg?: string): void;
+}
+
+export type ResendSignupResult =
+  | { matched: true; tenantId: string; status: string }
+  | { matched: false };
+
+// biome-ignore lint/suspicious/noExplicitAny: drizzle's generic schema parameter — we don't constrain it because both api and worker package the same `@givernance/shared/schema` instance and any narrower type binds us to one package's type-resolution path.
+type Db = NodePgDatabase<any>;
+
+/**
+ * Look up a resend candidate by email and, if found, rotate the
+ * invitation token + insert a `tenant.signup_verification_resent` outbox
+ * event for the worker to pick up.
+ *
+ * Caller responsibilities:
+ *  - Pass a `db` that's allowed to read across tenants (system / owner
+ *    role). The candidate SELECT joins `users` + `tenants` + `invitations`
+ *    with no org context; the unauthenticated route has none and the
+ *    unguessable invitation token is the security boundary.
+ *  - Generate `newToken` via `randomUUID()`. Passing the token in keeps
+ *    `@givernance/shared` free of `node:crypto` so the web bundle can
+ *    import the package without breaking ADR-013.
+ *  - Treat `{ matched: false }` as a silent no-op (no log line worth
+ *    pinning beyond the optional debug info — surfaces upstream).
+ */
+export async function resendSignupVerification(
+  db: Db,
+  email: string,
+  newToken: string,
+  log?: MinimalLogger,
+): Promise<ResendSignupResult> {
+  const normalised = email.trim().toLowerCase();
+
+  const rows = await db
+    .select({
+      tenantId: tenants.id,
+      status: tenants.status,
+      defaultLocale: tenants.defaultLocale,
+      invitationId: invitations.id,
+    })
+    .from(invitations)
+    .innerJoin(tenants, eq(invitations.orgId, tenants.id))
+    .leftJoin(
+      users,
+      and(
+        eq(users.orgId, invitations.orgId),
+        sql`lower(${users.email}) = lower(${invitations.email})`,
+      ),
+    )
+    .where(
+      and(
+        eq(invitations.email, normalised),
+        eq(invitations.purpose, "signup_verification"),
+        eq(tenants.createdVia, "self_serve"),
+        sql`(
+          (${tenants.status} = 'provisional' AND ${invitations.acceptedAt} IS NULL)
+          OR
+          (${tenants.status} = 'active'
+            AND (${users.keycloakId} IS NULL OR ${tenants.keycloakOrgId} IS NULL))
+        )`,
+      ),
+    )
+    .orderBy(sql`${invitations.createdAt} DESC`)
+    .limit(1);
+
+  if (rows.length === 0) {
+    log?.info({ event: "signup.resend", matched: false }, "resend silent no-match");
+    return { matched: false };
+  }
+
+  const row = rows[0];
+  if (!row) return { matched: false };
+
+  const localeForResend: Locale = isSupportedLocale(row.defaultLocale)
+    ? row.defaultLocale
+    : APP_DEFAULT_LOCALE;
+
+  const expiresAt = new Date(Date.now() + VERIFICATION_TTL_HOURS * 60 * 60 * 1000);
+
+  await db.transaction(async (tx) => {
+    // Half-provisioned rows have `acceptedAt` set from the prior verify;
+    // clearing it lets verifySignup's invitation-validity guard accept the
+    // fresh token. The pre-existing audit_logs row preserves the original
+    // acceptance event, so this isn't a history rewrite.
+    await tx
+      .update(invitations)
+      .set({ token: newToken, expiresAt, acceptedAt: null })
+      .where(eq(invitations.id, row.invitationId));
+
+    await tx.insert(outboxEvents).values({
+      tenantId: row.tenantId,
+      type: "tenant.signup_verification_resent",
+      payload: {
+        tenantId: row.tenantId,
+        invitationId: row.invitationId,
+        expiresAt: expiresAt.toISOString(),
+        locale: localeForResend,
+      },
+    });
+  });
+
+  log?.info(
+    { event: "signup.resend", matched: true, tenantId: row.tenantId, status: row.status },
+    "resend rotated invitation token",
+  );
+
+  return { matched: true, tenantId: row.tenantId, status: row.status };
+}

--- a/packages/web/src/app/(auth)/admin/platform-admins/accept/page.tsx
+++ b/packages/web/src/app/(auth)/admin/platform-admins/accept/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PASSWORD_MIN_LENGTH } from "@givernance/shared/constants";
 import { CheckCircle2, LogOut, TriangleAlert } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -14,7 +15,6 @@ import {
   probePlatformAdminInvitation,
 } from "@/services/PlatformAdminInvitationService";
 
-const PASSWORD_MIN_LENGTH = 12;
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "/api";
 
 interface SignedInUser {

--- a/packages/web/src/app/(auth)/invite/accept/page.tsx
+++ b/packages/web/src/app/(auth)/invite/accept/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PASSWORD_MIN_LENGTH } from "@givernance/shared/constants";
 import {
   APP_DEFAULT_LOCALE,
   LOCALE_NATIVE_NAMES,
@@ -24,7 +25,6 @@ import {
 } from "@/components/ui/select";
 import { acceptInvitation, probeInvitation } from "@/services/InvitationService";
 
-const PASSWORD_MIN_LENGTH = 12;
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "/api";
 
 interface SignedInUser {

--- a/packages/web/src/app/(auth)/signup/verify/page.tsx
+++ b/packages/web/src/app/(auth)/signup/verify/page.tsx
@@ -5,9 +5,10 @@ import { CheckCircle2, LogIn, Mail, TriangleAlert } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { type FormEvent, Suspense, useCallback, useId, useState } from "react";
+import { type FormEvent, Suspense, useCallback, useEffect, useId, useRef, useState } from "react";
 import { AuthCard } from "@/components/auth/auth-card";
 import { AuthLogo } from "@/components/auth/auth-logo";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { resendVerification, verifySignup } from "@/services/SignupService";
@@ -38,12 +39,22 @@ function validateVerifyForm(f: VerifyFormFields): ValidationKey | null {
  * UI can't distinguish "sent" from "no match" without leaking enumeration
  * signal. We always show the same "if your email matches, we've sent a new
  * link" confirmation.
+ *
+ * F13 surfaces a "Try a different email" reset so a typo'd address isn't a
+ * dead-end. The live region stays mounted across both states so screen
+ * readers reliably announce subsequent submits (re-mounting a fresh
+ * `aria-live` element on each submit is unreliable across SRs).
  */
 function ResendForm() {
   const t = useTranslations("auth.signupVerify");
   const inputId = useId();
   const [email, setEmail] = useState("");
   const [state, setState] = useState<"idle" | "submitting" | "sent">("idle");
+  const emailInputRef = useRef<HTMLInputElement>(null);
+  // Tracks whether the user has been through a successful submit at least
+  // once, so the "back to idle" useEffect only re-focuses the input on a
+  // user-initiated reset — not on the initial render of the form.
+  const wasSentRef = useRef(false);
 
   const onSubmit = useCallback(
     async (e: FormEvent<HTMLFormElement>) => {
@@ -52,62 +63,75 @@ function ResendForm() {
       setState("submitting");
       await resendVerification(email.trim());
       setState("sent");
+      wasSentRef.current = true;
     },
     [email],
   );
 
-  if (state === "sent") {
-    // F13 — Once the user lands here after typing a typo'd address, the
-    // anti-enumeration confirmation copy ("if your email matches…") makes
-    // a refresh-the-page retry the only obvious recourse. Surface an
-    // explicit "Try a different email" reset so they can correct it
-    // without losing the verify-page context.
-    return (
-      <div className="mt-3 space-y-2">
-        <p className="text-sm text-text-secondary" role="status" aria-live="polite">
-          {t("resend.sent")}
-        </p>
-        <button
-          type="button"
-          onClick={() => {
-            setEmail("");
-            setState("idle");
-          }}
-          className="text-sm font-medium text-primary underline-offset-2 hover:underline focus-visible:underline focus-visible:outline-none"
-        >
-          {t("resend.tryDifferent")}
-        </button>
-      </div>
-    );
-  }
+  const onReset = useCallback(() => {
+    setEmail("");
+    setState("idle");
+  }, []);
+
+  // F13 — restore focus to the email input after a reset so keyboard /
+  // SR users don't tab from the page root all the way back through the
+  // alert and label. Gated on `wasSentRef` so the initial mount doesn't
+  // steal focus on page load.
+  useEffect(() => {
+    if (state === "idle" && wasSentRef.current) {
+      emailInputRef.current?.focus();
+    }
+  }, [state]);
 
   return (
-    <form onSubmit={onSubmit} className="mt-3 space-y-2">
-      <Label htmlFor={inputId}>{t("resend.label")}</Label>
-      <div className="flex gap-2">
-        <Input
-          id={inputId}
-          type="email"
-          autoComplete="email"
-          required
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder={t("resend.placeholder")}
-        />
-        <button
-          type="submit"
-          disabled={state === "submitting"}
-          className="inline-flex h-[var(--btn-height-md)] shrink-0 items-center justify-center gap-2 rounded-button bg-primary px-4 text-sm font-medium text-on-primary transition-opacity duration-normal ease-out hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {state === "submitting" ? (
-            <span className="h-4 w-4 animate-spin rounded-full border-2 border-on-primary border-t-transparent" />
-          ) : (
-            <Mail className="h-4 w-4" aria-hidden="true" />
-          )}
-          {t("resend.submit")}
-        </button>
-      </div>
-    </form>
+    <div className="mt-3 space-y-2">
+      <form onSubmit={onSubmit} className="space-y-2" hidden={state === "sent"}>
+        <Label htmlFor={inputId}>{t("resend.label")}</Label>
+        <div className="flex gap-2">
+          <Input
+            id={inputId}
+            ref={emailInputRef}
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder={t("resend.placeholder")}
+          />
+          <Button
+            type="submit"
+            variant="primary"
+            size="default"
+            disabled={state === "submitting"}
+            className="shrink-0 px-4"
+          >
+            {state === "submitting" ? (
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-on-primary border-t-transparent" />
+            ) : (
+              <Mail className="h-4 w-4" aria-hidden="true" />
+            )}
+            {t("resend.submit")}
+          </Button>
+        </div>
+      </form>
+
+      {/*
+        Persistent live region — kept mounted in BOTH states so subsequent
+        successful submits are reliably announced. `aria-live="polite"`
+        will only re-announce when the *content* of the region changes,
+        which is why unmounting the <p> on reset (and remounting on send)
+        loses the second announcement.
+      */}
+      <p className="text-sm text-text-secondary" role="status" aria-live="polite">
+        {state === "sent" ? t("resend.sent") : ""}
+      </p>
+
+      {state === "sent" && (
+        <Button type="button" variant="link" size="inline" onClick={onReset}>
+          {t("resend.tryDifferent")}
+        </Button>
+      )}
+    </div>
   );
 }
 

--- a/packages/web/src/app/(auth)/signup/verify/page.tsx
+++ b/packages/web/src/app/(auth)/signup/verify/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PASSWORD_MIN_LENGTH } from "@givernance/shared/constants";
 import { CheckCircle2, LogIn, Mail, TriangleAlert } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -10,8 +11,6 @@ import { AuthLogo } from "@/components/auth/auth-logo";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { resendVerification, verifySignup } from "@/services/SignupService";
-
-const PASSWORD_MIN_LENGTH = 12;
 
 type ValidationKey = "invalid" | "namesRequired" | "passwordTooShort" | "passwordMismatch";
 
@@ -58,10 +57,27 @@ function ResendForm() {
   );
 
   if (state === "sent") {
+    // F13 — Once the user lands here after typing a typo'd address, the
+    // anti-enumeration confirmation copy ("if your email matches…") makes
+    // a refresh-the-page retry the only obvious recourse. Surface an
+    // explicit "Try a different email" reset so they can correct it
+    // without losing the verify-page context.
     return (
-      <p className="mt-3 text-sm text-text-secondary" role="status" aria-live="polite">
-        {t("resend.sent")}
-      </p>
+      <div className="mt-3 space-y-2">
+        <p className="text-sm text-text-secondary" role="status" aria-live="polite">
+          {t("resend.sent")}
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setEmail("");
+            setState("idle");
+          }}
+          className="text-sm font-medium text-primary underline-offset-2 hover:underline focus-visible:underline focus-visible:outline-none"
+        >
+          {t("resend.tryDifferent")}
+        </button>
+      </div>
     );
   }
 

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -19,11 +19,23 @@ const buttonVariants = cva(
         ghost:
           "bg-transparent text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface",
         destructive: "bg-error text-on-error hover:opacity-90",
+        // Inline text-link affordance — used for "Try a different email"
+        // style resets that sit inside surface/error containers and
+        // shouldn't carry a button background. Preserves the standard
+        // `focus-visible:shadow-ring` outline so keyboard users still see
+        // focus (a raw `<button>` styled with only an underline-on-focus
+        // is an a11y regression flagged in PR #359 review).
+        link: "bg-transparent text-primary underline-offset-2 hover:underline px-0",
       },
       size: {
         sm: "h-[var(--btn-height-sm)] px-4 text-xs",
         default: "h-[var(--btn-height-md)] px-6 text-sm",
         lg: "h-[var(--btn-height-lg)] px-8 text-base",
+        // The link variant overrides padding to 0; this height stays so
+        // the focus ring has a predictable shape, but most consumers
+        // will combine `variant="link"` with `size="inline"` to opt out
+        // of the fixed button height entirely.
+        inline: "h-auto px-0 text-sm",
       },
     },
     defaultVariants: {

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -181,7 +181,8 @@
         "label": "Get a new verification link",
         "placeholder": "you@example.org",
         "submit": "Send link",
-        "sent": "If the email matches an account, we've sent a fresh verification link. Please check your inbox."
+        "sent": "If the email matches an account, we've sent a fresh verification link. Please check your inbox.",
+        "tryDifferent": "Try a different email"
       }
     },
     "inviteAccept": {

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -181,7 +181,8 @@
         "label": "Recevoir un nouveau lien de vérification",
         "placeholder": "vous@exemple.org",
         "submit": "Envoyer le lien",
-        "sent": "Si l'adresse correspond à un compte, nous avons envoyé un nouveau lien. Pensez à vérifier votre boîte de réception."
+        "sent": "Si l'adresse correspond à un compte, nous avons envoyé un nouveau lien. Pensez à vérifier votre boîte de réception.",
+        "tryDifferent": "Essayer une autre adresse"
       }
     },
     "inviteAccept": {

--- a/packages/worker/src/lib/keycloak-admin.ts
+++ b/packages/worker/src/lib/keycloak-admin.ts
@@ -15,6 +15,7 @@
  * GET-then-PUT for attribute merges, idempotent on 404.
  */
 
+import { assertSafeOrgAttributes } from "@givernance/shared/constants";
 import { env } from "../env.js";
 import { logger } from "./logger.js";
 
@@ -134,31 +135,8 @@ export async function getOrganization(id: string): Promise<KeycloakOrganization 
   return adminRequest<KeycloakOrganization>("GET", `/organizations/${e(id)}`);
 }
 
-/**
- * Allowlist of Organization attribute keys the worker may write. Mirrors
- * `SAFE_ORG_ATTRIBUTES` in `packages/api/src/lib/keycloak-admin.ts` —
- * duplicated here to keep the worker free of api imports (see file header).
- * The realm mapper emits every Organization attribute into the JWT of
- * every member; a stray secret-shaped key would leak to all browsers.
- */
-const SAFE_ORG_ATTRIBUTES: ReadonlySet<string> = new Set([
-  "org_id",
-  "org_slug",
-  "logo_url",
-  "theme_primary_color",
-]);
-
-function assertSafeOrgAttributes(attributes: Record<string, string[]> | undefined): void {
-  if (!attributes) return;
-  for (const key of Object.keys(attributes)) {
-    if (!SAFE_ORG_ATTRIBUTES.has(key)) {
-      throw new Error(
-        `Refusing to write Keycloak Organization attribute "${key}" — not in SAFE_ORG_ATTRIBUTES. ` +
-          `The realm's organization mapper emits every attribute into the JWT of every member.`,
-      );
-    }
-  }
-}
+// F2 — Allowlist + guard sourced from `@givernance/shared/constants` so the
+// api and worker copies of this guard cannot drift apart.
 
 /**
  * Merge attributes onto an organization via GET-then-PUT. Identical

--- a/packages/worker/src/lib/keycloak-admin.ts
+++ b/packages/worker/src/lib/keycloak-admin.ts
@@ -135,6 +135,32 @@ export async function getOrganization(id: string): Promise<KeycloakOrganization 
 }
 
 /**
+ * Allowlist of Organization attribute keys the worker may write. Mirrors
+ * `SAFE_ORG_ATTRIBUTES` in `packages/api/src/lib/keycloak-admin.ts` —
+ * duplicated here to keep the worker free of api imports (see file header).
+ * The realm mapper emits every Organization attribute into the JWT of
+ * every member; a stray secret-shaped key would leak to all browsers.
+ */
+const SAFE_ORG_ATTRIBUTES: ReadonlySet<string> = new Set([
+  "org_id",
+  "org_slug",
+  "logo_url",
+  "theme_primary_color",
+]);
+
+function assertSafeOrgAttributes(attributes: Record<string, string[]> | undefined): void {
+  if (!attributes) return;
+  for (const key of Object.keys(attributes)) {
+    if (!SAFE_ORG_ATTRIBUTES.has(key)) {
+      throw new Error(
+        `Refusing to write Keycloak Organization attribute "${key}" — not in SAFE_ORG_ATTRIBUTES. ` +
+          `The realm's organization mapper emits every attribute into the JWT of every member.`,
+      );
+    }
+  }
+}
+
+/**
  * Merge attributes onto an organization via GET-then-PUT. Identical
  * semantics to `KeycloakAdminClient.updateOrganization` in the api
  * package — see that file for the security rationale.
@@ -143,6 +169,7 @@ export async function updateOrganization(
   id: string,
   updates: { attributes?: Record<string, string[]> },
 ): Promise<void> {
+  assertSafeOrgAttributes(updates.attributes);
   const current = await getOrganization(id);
   if (!current) {
     logger.warn(

--- a/packages/worker/src/lib/redis.ts
+++ b/packages/worker/src/lib/redis.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared Redis connection for non-BullMQ use cases in the worker
+ * (e.g. the per-email resend rate-limit bucket, F3 post-review).
+ *
+ * BullMQ queue/worker connections live elsewhere (`worker.ts`,
+ * `queues/index.ts`) and must use their own `Redis` instances per BullMQ's
+ * best practices; this one is for ad-hoc `INCR` / `GET` / `SET` from
+ * inside processors.
+ */
+
+import Redis from "ioredis";
+import { env } from "../env.js";
+
+export const redis = new Redis(env.REDIS_URL, {
+  maxRetriesPerRequest: null,
+  enableReadyCheck: false,
+});

--- a/packages/worker/src/processors/signup-resend.ts
+++ b/packages/worker/src/processors/signup-resend.ts
@@ -1,0 +1,134 @@
+/**
+ * Signup-resend processor (F3, follow-up to ADR-016 §8 anti-enumeration).
+ *
+ * The public `POST /v1/public/signup/resend` endpoint enqueues this job and
+ * returns 204 immediately — both for matching and non-matching emails — so
+ * an attacker cannot tell "email belongs to a pending tenant" from "no
+ * match" by timing the HTTP response. This processor runs the actual
+ * lookup-and-rotate logic asynchronously.
+ *
+ * Mirrors the recovery semantics of `signup.service.resendVerification`:
+ * matches three half-states (pending verify, no Keycloak credential, no
+ * Keycloak Organization) and silently no-ops on everything else.
+ *
+ * Owner role: the matching SELECT spans tenants and the
+ * `signup_verification` invitation row joins `users` + `tenants` with no
+ * org context (the request is unauthenticated, the unguessable invitation
+ * token is the boundary). The app role would have RLS filter the join to
+ * zero rows.
+ */
+
+import { randomUUID } from "node:crypto";
+import { APP_DEFAULT_LOCALE, isSupportedLocale, type Locale } from "@givernance/shared/i18n";
+import { invitations, outboxEvents, tenants, users } from "@givernance/shared/schema";
+import type { Job } from "bullmq";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "../lib/db.js";
+import { jobLogger } from "../lib/logger.js";
+
+const VERIFICATION_TTL_HOURS = 24;
+
+export interface SignupResendJobPayload {
+  email: string;
+}
+
+export type SignupResendResult =
+  | { matched: true; tenantId: string }
+  | { matched: false; reason: "no_match" };
+
+/**
+ * Direct callable for tests — avoids spinning up the BullMQ worker.
+ *
+ * Behaviour is identical to the legacy synchronous `resendVerification`
+ * service in the API package, with the additional contract that the caller
+ * is OK with "no match" being a silent no-op (the HTTP route does not
+ * surface the matched/not-matched bit to the client).
+ */
+export async function processSignupResendPayload(
+  payload: SignupResendJobPayload,
+  log = jobLogger({ tenantId: "system" }),
+): Promise<SignupResendResult> {
+  const normalised = payload.email.trim().toLowerCase();
+
+  const rows = await db
+    .select({
+      tenantId: tenants.id,
+      status: tenants.status,
+      defaultLocale: tenants.defaultLocale,
+      invitationId: invitations.id,
+    })
+    .from(invitations)
+    .innerJoin(tenants, eq(invitations.orgId, tenants.id))
+    .leftJoin(
+      users,
+      and(
+        eq(users.orgId, invitations.orgId),
+        sql`lower(${users.email}) = lower(${invitations.email})`,
+      ),
+    )
+    .where(
+      and(
+        eq(invitations.email, normalised),
+        eq(invitations.purpose, "signup_verification"),
+        eq(tenants.createdVia, "self_serve"),
+        sql`(
+          (${tenants.status} = 'provisional' AND ${invitations.acceptedAt} IS NULL)
+          OR
+          (${tenants.status} = 'active'
+            AND (${users.keycloakId} IS NULL OR ${tenants.keycloakOrgId} IS NULL))
+        )`,
+      ),
+    )
+    .orderBy(sql`${invitations.createdAt} DESC`)
+    .limit(1);
+
+  if (rows.length === 0) {
+    log.info({ event: "signup.resend", matched: false }, "resend silent no-match");
+    return { matched: false, reason: "no_match" };
+  }
+
+  const row = rows[0];
+  if (!row) {
+    return { matched: false, reason: "no_match" };
+  }
+
+  const localeForResend: Locale = isSupportedLocale(row.defaultLocale)
+    ? row.defaultLocale
+    : APP_DEFAULT_LOCALE;
+
+  const newToken = randomUUID();
+  const expiresAt = new Date(Date.now() + VERIFICATION_TTL_HOURS * 60 * 60 * 1000);
+
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${row.tenantId}, true)`);
+
+    await tx
+      .update(invitations)
+      .set({ token: newToken, expiresAt, acceptedAt: null })
+      .where(eq(invitations.id, row.invitationId));
+
+    await tx.insert(outboxEvents).values({
+      tenantId: row.tenantId,
+      type: "tenant.signup_verification_resent",
+      payload: {
+        tenantId: row.tenantId,
+        invitationId: row.invitationId,
+        expiresAt: expiresAt.toISOString(),
+        locale: localeForResend,
+      },
+    });
+  });
+
+  log.info(
+    { event: "signup.resend", matched: true, tenantId: row.tenantId, status: row.status },
+    "resend rotated invitation token",
+  );
+
+  return { matched: true, tenantId: row.tenantId };
+}
+
+/** BullMQ processor wrapper. */
+export async function processSignupResend(job: Job<SignupResendJobPayload>): Promise<void> {
+  const log = jobLogger({ jobId: job.id, tenantId: "system" });
+  await processSignupResendPayload(job.data, log);
+}

--- a/packages/worker/src/processors/signup-resend.ts
+++ b/packages/worker/src/processors/signup-resend.ts
@@ -1,130 +1,71 @@
 /**
- * Signup-resend processor (F3, follow-up to ADR-016 §8 anti-enumeration).
+ * Signup-resend processor (F3 follow-up to ADR-016 §8 anti-enumeration).
  *
  * The public `POST /v1/public/signup/resend` endpoint enqueues this job and
- * returns 204 immediately — both for matching and non-matching emails — so
- * an attacker cannot tell "email belongs to a pending tenant" from "no
- * match" by timing the HTTP response. This processor runs the actual
- * lookup-and-rotate logic asynchronously.
+ * returns 204 immediately — both for matching and non-matching emails —
+ * so an attacker cannot tell "email belongs to a pending tenant" from
+ * "no match" by timing the HTTP response. The actual lookup-and-rotate
+ * runs here.
  *
- * Mirrors the recovery semantics of `signup.service.resendVerification`:
- * matches three half-states (pending verify, no Keycloak credential, no
- * Keycloak Organization) and silently no-ops on everything else.
+ * The lookup-and-rotate logic itself lives in
+ * `@givernance/shared/signup` so this processor and any API-side test
+ * harness share a single implementation.
  *
- * Owner role: the matching SELECT spans tenants and the
- * `signup_verification` invitation row joins `users` + `tenants` with no
- * org context (the request is unauthenticated, the unguessable invitation
- * token is the boundary). The app role would have RLS filter the join to
- * zero rows.
+ * Owner role rationale: the matching SELECT spans tenants and the
+ * `signup_verification` invitation joins `users` + `tenants` with no org
+ * context — the unauthenticated route has none and the unguessable
+ * invitation token is the security boundary. (Same justification as
+ * `verifySignup` in the API service.)
  */
 
 import { randomUUID } from "node:crypto";
-import { APP_DEFAULT_LOCALE, isSupportedLocale, type Locale } from "@givernance/shared/i18n";
-import { invitations, outboxEvents, tenants, users } from "@givernance/shared/schema";
+import { type ResendSignupResult, resendSignupVerification } from "@givernance/shared/signup";
 import type { Job } from "bullmq";
-import { and, eq, sql } from "drizzle-orm";
 import { db } from "../lib/db.js";
 import { jobLogger } from "../lib/logger.js";
-
-const VERIFICATION_TTL_HOURS = 24;
+import { redis } from "../lib/redis.js";
 
 export interface SignupResendJobPayload {
   email: string;
 }
 
-export type SignupResendResult =
-  | { matched: true; tenantId: string }
-  | { matched: false; reason: "no_match" };
+/**
+ * Per-email rate limit (SEC-10) — moved off the HTTP route so the resend
+ * endpoint's response time is constant across all branches (F3 timing
+ * oracle closure, post-review). The Fastify per-IP rate-limit on the
+ * route still caps fan-out from any single source; this bucket caps how
+ * many invitation-tokens any one inbox can be forced to rotate per hour.
+ *
+ * Returns `true` when the request may proceed.
+ */
+async function acceptResendForEmail(email: string): Promise<boolean> {
+  const key = `signup:resend:email:${email.trim().toLowerCase()}`;
+  const hits = await redis.incr(key);
+  if (hits === 1) {
+    await redis.expire(key, 60 * 60);
+  }
+  return hits <= 3;
+}
 
 /**
  * Direct callable for tests — avoids spinning up the BullMQ worker.
  *
- * Behaviour is identical to the legacy synchronous `resendVerification`
- * service in the API package, with the additional contract that the caller
- * is OK with "no match" being a silent no-op (the HTTP route does not
- * surface the matched/not-matched bit to the client).
+ * Includes the per-email rate-limit check (since that moved off the HTTP
+ * route) so tests that want to exercise the cap can call this directly.
  */
 export async function processSignupResendPayload(
   payload: SignupResendJobPayload,
   log = jobLogger({ tenantId: "system" }),
-): Promise<SignupResendResult> {
-  const normalised = payload.email.trim().toLowerCase();
-
-  const rows = await db
-    .select({
-      tenantId: tenants.id,
-      status: tenants.status,
-      defaultLocale: tenants.defaultLocale,
-      invitationId: invitations.id,
-    })
-    .from(invitations)
-    .innerJoin(tenants, eq(invitations.orgId, tenants.id))
-    .leftJoin(
-      users,
-      and(
-        eq(users.orgId, invitations.orgId),
-        sql`lower(${users.email}) = lower(${invitations.email})`,
-      ),
-    )
-    .where(
-      and(
-        eq(invitations.email, normalised),
-        eq(invitations.purpose, "signup_verification"),
-        eq(tenants.createdVia, "self_serve"),
-        sql`(
-          (${tenants.status} = 'provisional' AND ${invitations.acceptedAt} IS NULL)
-          OR
-          (${tenants.status} = 'active'
-            AND (${users.keycloakId} IS NULL OR ${tenants.keycloakOrgId} IS NULL))
-        )`,
-      ),
-    )
-    .orderBy(sql`${invitations.createdAt} DESC`)
-    .limit(1);
-
-  if (rows.length === 0) {
-    log.info({ event: "signup.resend", matched: false }, "resend silent no-match");
-    return { matched: false, reason: "no_match" };
+): Promise<ResendSignupResult> {
+  const allowed = await acceptResendForEmail(payload.email);
+  if (!allowed) {
+    log.info(
+      { event: "signup.resend", rateLimited: true },
+      "resend dropped — per-email cap exhausted",
+    );
+    return { matched: false };
   }
-
-  const row = rows[0];
-  if (!row) {
-    return { matched: false, reason: "no_match" };
-  }
-
-  const localeForResend: Locale = isSupportedLocale(row.defaultLocale)
-    ? row.defaultLocale
-    : APP_DEFAULT_LOCALE;
-
-  const newToken = randomUUID();
-  const expiresAt = new Date(Date.now() + VERIFICATION_TTL_HOURS * 60 * 60 * 1000);
-
-  await db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${row.tenantId}, true)`);
-
-    await tx
-      .update(invitations)
-      .set({ token: newToken, expiresAt, acceptedAt: null })
-      .where(eq(invitations.id, row.invitationId));
-
-    await tx.insert(outboxEvents).values({
-      tenantId: row.tenantId,
-      type: "tenant.signup_verification_resent",
-      payload: {
-        tenantId: row.tenantId,
-        invitationId: row.invitationId,
-        expiresAt: expiresAt.toISOString(),
-        locale: localeForResend,
-      },
-    });
-  });
-
-  log.info(
-    { event: "signup.resend", matched: true, tenantId: row.tenantId, status: row.status },
-    "resend rotated invitation token",
-  );
-
-  return { matched: true, tenantId: row.tenantId };
+  return resendSignupVerification(db, payload.email, randomUUID(), log);
 }
 
 /** BullMQ processor wrapper. */

--- a/packages/worker/src/tests/integration/signup-email.test.ts
+++ b/packages/worker/src/tests/integration/signup-email.test.ts
@@ -124,7 +124,13 @@ describe("processSignupVerificationEmail", () => {
     if (!call) return;
     expect(call.to).toBe("admin@acme.org");
     expect(call.subject).toContain("Acme Charity");
-    expect(call.subject).toMatch(/Confirm|Givernance/);
+    // F9 — Use an EN-only anchor. "Confirmez" (FR) contains "Confirm", so
+    // `/Confirm/` would silently match the FR template too — meaning a
+    // regression that always picked FR (or fell back to FR after a missing
+    // EN template) would NOT trip this assertion. Anchor on the EN-specific
+    // verb phrase "Confirm your" so the test fails when the wrong template
+    // is selected.
+    expect(call.subject).toMatch(/Confirm your/);
     expect(call.html).toContain(`/signup/verify?token=${INVITATION_TOKEN}`);
     expect(call.text).toContain(`/signup/verify?token=${INVITATION_TOKEN}`);
   });
@@ -145,7 +151,11 @@ describe("processSignupVerificationEmail", () => {
     expect(call).toBeDefined();
     if (!call) return;
     expect(call.subject).toContain("Assoc Demo");
-    expect(call.subject).toMatch(/Confirmez/);
+    // F9 companion anchor — `/Confirmez votre/` is FR-only; `/Confirm /`
+    // would not match the EN subject ("Confirm your Givernance workspace
+    // ..."). Locks both templates into mutually-exclusive subject anchors
+    // so a swap is loud either direction.
+    expect(call.subject).toMatch(/Confirmez votre/);
     expect(call.html).toContain(`/signup/verify?token=${INVITATION_TOKEN_FR}`);
   });
 
@@ -179,5 +189,27 @@ describe("processSignupVerificationEmail", () => {
 
     expect(result).toEqual({ sent: false, reason: "not_found" });
     expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  // F10 — Pin the contract that an SMTP outage propagates out of the
+  // processor so BullMQ's retry/backoff catches it. Silently swallowing
+  // a `sender.send` rejection would mark the job complete and an operator
+  // would never see the failed verification email.
+  it("propagates SMTP errors so BullMQ can retry the job", async () => {
+    const sender = {
+      send: vi.fn().mockRejectedValueOnce(new Error("EHOSTUNREACH smtp.example")),
+    };
+    await expect(
+      processSignupVerificationEmail(
+        {
+          tenantId: ORG_ID,
+          invitationId: INVITATION_ID,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+          locale: "en",
+        },
+        { sender },
+      ),
+    ).rejects.toThrow(/smtp\.example/);
+    expect(sender.send).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/worker/src/tests/integration/signup-resend.test.ts
+++ b/packages/worker/src/tests/integration/signup-resend.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Signup-resend processor — integration test (F3).
+ *
+ * Locks down the BullMQ-side handler that took over from the API's inline
+ * `resendVerification` call after the timing-side-channel fix. Verifies
+ * the three half-state recovery paths (pending verify, missing KC
+ * credential, missing KC org) and the no-match silent path.
+ */
+
+import { randomUUID } from "node:crypto";
+import { invitations, outboxEvents, tenants, users } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { processSignupResendPayload } from "../../processors/signup-resend.js";
+
+// Distinct ID prefixes so this file doesn't collide with signup-email.test.ts
+// fixtures, even when the workers package runs file-serially against the
+// shared DB.
+const ORG_PENDING = "00000000-0000-0000-0000-0000000000f1";
+const INV_PENDING = "00000000-0000-0000-0000-0000000000f2";
+const TOKEN_PENDING = "00000000-0000-0000-0000-0000000000f3";
+
+const ORG_NO_KC_USER = "00000000-0000-0000-0000-0000000000f4";
+const USER_NO_KC = "00000000-0000-0000-0000-0000000000f5";
+const INV_NO_KC = "00000000-0000-0000-0000-0000000000f6";
+const TOKEN_NO_KC = "00000000-0000-0000-0000-0000000000f7";
+
+const ORG_NO_KC_ORG = "00000000-0000-0000-0000-0000000000f8";
+const USER_KC_BOUND = "00000000-0000-0000-0000-0000000000f9";
+const INV_NO_KC_ORG = "00000000-0000-0000-0000-0000000000fa";
+const TOKEN_NO_KC_ORG = "00000000-0000-0000-0000-0000000000fb";
+
+const ORG_DONE = "00000000-0000-0000-0000-0000000000fc";
+const USER_DONE = "00000000-0000-0000-0000-0000000000fd";
+const INV_DONE = "00000000-0000-0000-0000-0000000000fe";
+
+const EMAIL_PENDING = "pending@resend.test";
+const EMAIL_NO_KC = "nokc@resend.test";
+const EMAIL_NO_KC_ORG = "noorg@resend.test";
+const EMAIL_DONE = "done@resend.test";
+
+const FUTURE = () => new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+beforeAll(async () => {
+  // Pending-verify tenant: provisional, no users row, no KC org.
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, status, created_via)
+        VALUES (${ORG_PENDING}, 'Pending NGO', ${`resend-pending-${randomUUID().slice(0, 8)}`}, 'provisional', 'self_serve')
+        ON CONFLICT (id) DO NOTHING`,
+  );
+  await db
+    .insert(invitations)
+    .values({
+      id: INV_PENDING,
+      orgId: ORG_PENDING,
+      email: EMAIL_PENDING,
+      role: "org_admin",
+      token: TOKEN_PENDING,
+      purpose: "signup_verification",
+      expiresAt: FUTURE(),
+    })
+    .onConflictDoNothing();
+
+  // Half-provisioned tenant (active) with a users row that has no keycloak_id —
+  // mirrors the pre-#143 build's residual state.
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, status, created_via, verified_at, keycloak_org_id)
+        VALUES (${ORG_NO_KC_USER}, 'NoKC NGO', ${`resend-nokc-${randomUUID().slice(0, 8)}`}, 'active', 'self_serve', now(), ${randomUUID()})
+        ON CONFLICT (id) DO NOTHING`,
+  );
+  await db
+    .insert(users)
+    .values({
+      id: USER_NO_KC,
+      orgId: ORG_NO_KC_USER,
+      email: EMAIL_NO_KC,
+      firstName: "No",
+      lastName: "KC",
+      role: "org_admin",
+      firstAdmin: true,
+      keycloakId: null,
+    })
+    .onConflictDoNothing();
+  await db
+    .insert(invitations)
+    .values({
+      id: INV_NO_KC,
+      orgId: ORG_NO_KC_USER,
+      email: EMAIL_NO_KC,
+      role: "org_admin",
+      token: TOKEN_NO_KC,
+      purpose: "signup_verification",
+      expiresAt: FUTURE(),
+      acceptedAt: new Date(),
+    })
+    .onConflictDoNothing();
+
+  // No-Org half-state: user has a keycloak_id, but tenants.keycloak_org_id is
+  // NULL — what the credential-only build left behind.
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, status, created_via, verified_at)
+        VALUES (${ORG_NO_KC_ORG}, 'NoOrg NGO', ${`resend-noorg-${randomUUID().slice(0, 8)}`}, 'active', 'self_serve', now())
+        ON CONFLICT (id) DO NOTHING`,
+  );
+  await db
+    .insert(users)
+    .values({
+      id: USER_KC_BOUND,
+      orgId: ORG_NO_KC_ORG,
+      email: EMAIL_NO_KC_ORG,
+      firstName: "Has",
+      lastName: "KC",
+      role: "org_admin",
+      firstAdmin: true,
+      keycloakId: randomUUID(),
+    })
+    .onConflictDoNothing();
+  await db
+    .insert(invitations)
+    .values({
+      id: INV_NO_KC_ORG,
+      orgId: ORG_NO_KC_ORG,
+      email: EMAIL_NO_KC_ORG,
+      role: "org_admin",
+      token: TOKEN_NO_KC_ORG,
+      purpose: "signup_verification",
+      expiresAt: FUTURE(),
+      acceptedAt: new Date(),
+    })
+    .onConflictDoNothing();
+
+  // Fully-provisioned tenant: active, users.keycloak_id and
+  // tenants.keycloak_org_id both set. Resend must silently no-op.
+  await db.execute(
+    sql`INSERT INTO tenants (id, name, slug, status, created_via, verified_at, keycloak_org_id)
+        VALUES (${ORG_DONE}, 'Done NGO', ${`resend-done-${randomUUID().slice(0, 8)}`}, 'active', 'self_serve', now(), ${randomUUID()})
+        ON CONFLICT (id) DO NOTHING`,
+  );
+  await db
+    .insert(users)
+    .values({
+      id: USER_DONE,
+      orgId: ORG_DONE,
+      email: EMAIL_DONE,
+      firstName: "Already",
+      lastName: "Done",
+      role: "org_admin",
+      firstAdmin: true,
+      keycloakId: randomUUID(),
+    })
+    .onConflictDoNothing();
+  await db
+    .insert(invitations)
+    .values({
+      id: INV_DONE,
+      orgId: ORG_DONE,
+      email: EMAIL_DONE,
+      role: "org_admin",
+      token: randomUUID(),
+      purpose: "signup_verification",
+      expiresAt: FUTURE(),
+      acceptedAt: new Date(),
+    })
+    .onConflictDoNothing();
+});
+
+afterAll(async () => {
+  // session_replication_role bypasses the audit-log immutability trigger
+  // (same justification as the API signup.test cleanup hook).
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL session_replication_role = 'replica'`);
+    for (const orgId of [ORG_PENDING, ORG_NO_KC_USER, ORG_NO_KC_ORG, ORG_DONE]) {
+      await tx.delete(outboxEvents).where(eq(outboxEvents.tenantId, orgId));
+      await tx.delete(users).where(eq(users.orgId, orgId));
+      await tx.delete(invitations).where(eq(invitations.orgId, orgId));
+      await tx.delete(tenants).where(eq(tenants.id, orgId));
+    }
+  });
+});
+
+describe("processSignupResendPayload", () => {
+  it("rotates the token for a pending-verify tenant", async () => {
+    const result = await processSignupResendPayload({ email: EMAIL_PENDING });
+    expect(result.matched).toBe(true);
+    if (result.matched) expect(result.tenantId).toBe(ORG_PENDING);
+
+    const [inv] = await db
+      .select({ token: invitations.token })
+      .from(invitations)
+      .where(eq(invitations.id, INV_PENDING));
+    expect(inv?.token).not.toBe(TOKEN_PENDING);
+  });
+
+  it("recovers the no-Keycloak-credential half-state by clearing accepted_at and rotating", async () => {
+    const result = await processSignupResendPayload({ email: EMAIL_NO_KC });
+    expect(result.matched).toBe(true);
+
+    const [inv] = await db
+      .select({ token: invitations.token, acceptedAt: invitations.acceptedAt })
+      .from(invitations)
+      .where(eq(invitations.id, INV_NO_KC));
+    expect(inv?.token).not.toBe(TOKEN_NO_KC);
+    expect(inv?.acceptedAt).toBeNull();
+  });
+
+  it("recovers the no-Keycloak-Organization half-state by clearing accepted_at and rotating", async () => {
+    const result = await processSignupResendPayload({ email: EMAIL_NO_KC_ORG });
+    expect(result.matched).toBe(true);
+
+    const [inv] = await db
+      .select({ token: invitations.token, acceptedAt: invitations.acceptedAt })
+      .from(invitations)
+      .where(eq(invitations.id, INV_NO_KC_ORG));
+    expect(inv?.token).not.toBe(TOKEN_NO_KC_ORG);
+    expect(inv?.acceptedAt).toBeNull();
+  });
+
+  it("is a silent no-op for a fully-provisioned tenant (no enumeration oracle)", async () => {
+    const result = await processSignupResendPayload({ email: EMAIL_DONE });
+    expect(result.matched).toBe(false);
+  });
+
+  it("is a silent no-op for an unknown email (no enumeration oracle)", async () => {
+    const result = await processSignupResendPayload({
+      email: `unknown-${randomUUID()}@resend.test`,
+    });
+    expect(result.matched).toBe(false);
+  });
+});

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -19,6 +19,7 @@ import { processPlatformAdminInviteEmail } from "./processors/platform-admin-inv
 import { processGeneratePostalExport } from "./processors/postal-export.js";
 import { processSendBulkEmail } from "./processors/send-bulk-email.js";
 import { processSignupVerificationEmail } from "./processors/signup-email.js";
+import { processSignupResend } from "./processors/signup-resend.js";
 import { processStripeWebhook } from "./processors/stripe-webhook.js";
 import { processTeamInviteEmail } from "./processors/team-invite-email.js";
 import { processTenantLifecycle } from "./processors/tenant-lifecycle.js";
@@ -342,11 +343,26 @@ function startWorkers() {
     ...defaultJobOpts,
   });
 
-  const tenantLifecycleWorker = new Worker(QUEUE_NAMES.TENANT_LIFECYCLE, processTenantLifecycle, {
-    connection: createRedisConnection(),
-    concurrency: 1,
-    ...defaultJobOpts,
-  });
+  // Tenant-lifecycle carries two job names:
+  //  - `tenant.provisional-admin-expire` — nightly repeatable expire pass.
+  //  - `tenant.signup-resend` (F3) — deferred lookup-and-rotate for the
+  //    public resend endpoint, kept off the HTTP request path so the
+  //    response is constant-time and doesn't leak a match/no-match oracle.
+  const tenantLifecycleWorker = new Worker(
+    QUEUE_NAMES.TENANT_LIFECYCLE,
+    async (job: Job) => {
+      if (job.name === TENANT_LIFECYCLE_JOBS.SIGNUP_RESEND) {
+        // biome-ignore lint/suspicious/noExplicitAny: BullMQ Job is heterogeneously typed at runtime
+        return processSignupResend(job as Job<any>);
+      }
+      return processTenantLifecycle(job);
+    },
+    {
+      connection: createRedisConnection(),
+      concurrency: 1,
+      ...defaultJobOpts,
+    },
+  );
 
   // ── Branding queue (Epic #286) ──────────────────────────────────────
   // The branding queue carries three job names — process / activate / gc.


### PR DESCRIPTION
## Summary

Tightens self-serve signup against the still-live items from PR #143's second-pass review. Re-audited against `main` on 2026-05-12 — all listed items were confirmed open. Implements all 10 follow-ups from issue #357 (F6 / F8 / F12 were explicitly dropped at issue scope).

### Security / correctness

- **F1** — Parallel verify-race test pins the `FOR UPDATE` serialisation: two concurrent verify calls on the same token sort to `[201, 410]`, exactly one `users` row, tenant flipped exactly once.
- **F2** — `SAFE_ORG_ATTRIBUTES` allowlist on `createOrganization` / `updateOrganization` (api + worker). The realm's `organization` scope mapper has `addOrganizationAttributes: true`, so every org attribute lands in every member's JWT. A stranger key now throws **before any HTTP call** — forces a conscious choice on the next attribute addition.
- **F3** — `POST /v1/public/signup/resend` enqueues a `tenant.signup-resend` BullMQ job and returns 204 in constant time. The lookup-and-rotate work runs in the worker, closing the timing oracle that let an attacker compare response latencies to tell "registered email" from "no match".
- **F4** — Hijack-defence test broadened: asserts the SRE-visible `signup.kc_user_exists` warn fires **and** `kcResetUserPassword` was never called. Catches the hypothetical regression where a future "helpful" rewrite resets the existing realm credential after only proving inbox control.
- **F5** — Captcha helper gets direct unit coverage (was previously only exercised indirectly through signup integration tests with `mode=disabled`). Covers all 5 failure reasons + IP forwarding + mode precedence (explicit > `CAPTCHA_MODE` > `NODE_ENV`).

### Brittle code paths

- **F7** — `getOrganizationByAlias` uses Keycloak 26.1+ `&exact=true` and drops the client-side substring filter so the recovery path doesn't shift with future KC `search` semantics.

### Minor code quality

- **F9** — Signup-email subject tests use mutually-exclusive locale anchors (`/Confirm your/` vs `/Confirmez votre/`). A regression that always picked the wrong template is now loud in either direction.
- **F10** — Signup-email processor test pins that SMTP errors propagate so BullMQ retries.
- **F11** — `PASSWORD_MIN_LENGTH` / `PASSWORD_MAX_LENGTH` hoisted to `@givernance/shared/constants`. One server route + three client pages now import from a single source.
- **F13** — `ResendForm` gets a "Try a different email" reset link in the post-submit state (en + fr) so a typo'd email doesn't dead-end the user.

close #357

## Manual acceptance checklist

### F3 — Resend timing
- [ ] `POST /v1/public/signup/resend` with a registered email → 204, BullMQ `tenant.signup-resend` job appears in Redis
- [ ] Same with an unregistered email → 204, BullMQ job appears (worker processes it as `matched: false`)
- [ ] Response latency is visually indistinguishable between registered and unregistered emails (no timing oracle)

### F13 — Resend form UX
- [ ] On `/signup/verify?token=expired-uuid`, submit a typo'd email → see the confirmation message + "Try a different email" link
- [ ] Click the link → form resets to idle, can submit a different email

### F2 — Org attribute guard
- [ ] Any future attempt to call `createOrganization({ attributes: { stripe_customer_id: [...] } })` throws synchronously; the error names the attribute key.

### F11 — Password policy
- [ ] Bumping `PASSWORD_MIN_LENGTH` in `packages/shared/src/constants/password.ts` from 12 to 14 propagates to: signup verify form + invite accept form + platform-admin accept form + API route schemas (all reject `< 14`).

## Test plan

- [x] `pnpm install`
- [x] `pnpm build`
- [x] `pnpm run format`
- [x] `pnpm -w run lint` (no new warnings vs. baseline)
- [x] `pnpm typecheck`
- [x] `pnpm -r run test` — 1,076 tests pass (shared 69 / relay 6 / web 124 / worker 71 / api 806)
- [x] New unit tests cover the captcha helper directly (`captcha.test.ts`)
- [x] New worker integration test covers the resend processor (`signup-resend.test.ts`)
- [x] New unit tests lock the org-attribute allowlist in `keycloak-admin.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)