### PR TITLE
fix(deploy-staging): force registry login + pull before accessory boot

### DIFF
--- a/.github/actions/reboot-kamal-accessory/action.yml
+++ b/.github/actions/reboot-kamal-accessory/action.yml
@@ -26,6 +26,33 @@ inputs:
 runs:
   using: composite
   steps:
+    # Refresh the GHCR login on the host before pulling. Two reasons:
+    #   - The token stored in /root/.docker/config.json from a previous
+    #     `kamal setup` can become stale or be overwritten by ad-hoc
+    #     operator logins. A `kamal deploy` does NOT re-run registry
+    #     login, so without this step a single accidental
+    #     `docker login` on the VPS leaves the host unable to pull
+    #     until the next `kamal setup`.
+    #   - The runner's job has `packages: write` on the auto-issued
+    #     GITHUB_TOKEN, so this always re-establishes good creds via
+    #     `registry:` in the kamal config (server: ghcr.io,
+    #     password: GITHUB_TOKEN).
+    - name: Refresh registry login on host
+      shell: bash
+      run: bundle exec kamal registry login -c "${{ inputs.config }}"
+
+    # `kamal accessory boot` runs plain `docker run` on the host without
+    # `--pull=always`, so a fresh image pushed to GHCR earlier in this
+    # job is ignored if the host has the same tag locally cached. That
+    # produced a silent regression on 2026-05-13 where the Keycloak
+    # theme rebuild succeeded in CI, the container was recreated, but
+    # the running image was the prior-day's cached `:latest`. Force a
+    # pull before the boot so the reboot step is self-healing for image
+    # bumps that reuse a tag (`:latest`, `:staging`).
+    - name: Pull latest accessory image on host
+      shell: bash
+      run: bundle exec kamal accessory pull "${{ inputs.accessory }}" -c "${{ inputs.config }}"
+
     # `kamal accessory reboot` issues `kamal-proxy remove <service>`
     # unconditionally, which fails with "Error: service not found" the
     # first time a `proxy:` block is added to an existing accessory —


### PR DESCRIPTION
## Summary

- PR #367 merged and the staging deploy reported success, but the Keycloak login page never picked up the new theme.
- Root cause: `kamal accessory boot` runs plain `docker run` on the host without `--pull=always`. The runner rebuilt and pushed `ghcr.io/purposestack/givernance-keycloak:latest` to GHCR, but the VPS kept using the prior-day's cached `:latest`.
- Verified by SSHing into the VPS and listing the theme assets inside the running container: no `resources/js/auth-background.js`, no `newsreader-400-*.woff2`, mtimes from the previous deploy.

## What changed

Patched the shared `reboot-kamal-accessory` composite action so every reboot now does:

1. **`kamal registry login`** — re-establishes good GHCR creds on the host. A `kamal deploy` doesn't re-run registry login, so any accidental `docker login` on the VPS (operator debugging, hotfix scripts) can leave the host unable to pull until the next `kamal setup`. The job already has `packages: write` on its auto-issued `GITHUB_TOKEN`, so this always recovers cleanly.
2. **`kamal accessory pull <name>`** — force-pull the freshly-pushed image before recreating the container. Self-heals for image bumps that reuse a tag (`:latest`, `:staging`).

The composite action is the single source of truth used by both `deploy-staging.yml` (every keycloak-touching push) and `staging-accessory-reboot.yml` (out-of-band reboots), so both callers benefit.

## Rollout plan after merge

1. Merge this PR onto `main`.
2. Trigger **Deploy to Staging** via `workflow_dispatch` (any mode) — the dispatch path already forces `run_keycloak=true`, so the rebuild + pull + reboot chain re-runs and the staging Keycloak picks up the PR #367 theme.
3. Hard-refresh the Keycloak login page to bypass the browser cache on `givernance.css`.

## Test plan

- [ ] After merge + dispatch: `ssh root@<vps> "docker exec givernance-keycloak ls /opt/keycloak/themes/givernance/login/resources/js/"` returns `auth-background.js`.
- [ ] Hitting the staging Keycloak login URL shows the falling-icons animation, the SPA-matching subtitle weight/size, and the mouse-wheel speed control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)