### PR TITLE
fix(deploy-staging): correct kamal accessory subcommand (pull_image)

### DIFF
--- a/.github/actions/reboot-kamal-accessory/action.yml
+++ b/.github/actions/reboot-kamal-accessory/action.yml
@@ -49,9 +49,15 @@ runs:
     # the running image was the prior-day's cached `:latest`. Force a
     # pull before the boot so the reboot step is self-healing for image
     # bumps that reuse a tag (`:latest`, `:staging`).
+    #
+    # NOTE: the kamal subcommand is `pull_image` (not `pull`) — kamal 2.x
+    # exposes the accessory pull verb under that name; see
+    # https://github.com/basecamp/kamal/blob/v2.11.0/lib/kamal/cli/accessory.rb
+    # PR #368 originally shipped this as `pull` and broke the staging
+    # deploy with "Could not find command pull".
     - name: Pull latest accessory image on host
       shell: bash
-      run: bundle exec kamal accessory pull "${{ inputs.accessory }}" -c "${{ inputs.config }}"
+      run: bundle exec kamal accessory pull_image "${{ inputs.accessory }}" -c "${{ inputs.config }}"
 
     # `kamal accessory reboot` issues `kamal-proxy remove <service>`
     # unconditionally, which fails with "Error: service not found" the


### PR DESCRIPTION
## Summary

- Follow-up to #368. The pull step landed as `kamal accessory pull`, but kamal 2.11 doesn't expose a `pull` subcommand under `accessory`.
- Staging redeploy failed at the reboot composite action with `Could not find command "pull"`.
- The correct verb is `pull_image` — see [kamal 2.11.0 `lib/kamal/cli/accessory.rb`](https://github.com/basecamp/kamal/blob/v2.11.0/lib/kamal/cli/accessory.rb). Other accessory verbs in 2.11: `boot`, `reboot`, `start`, `stop`, `restart`, `details`, `exec`, `logs`, `pull_image`, `remove`, `remove_image`, …

## Test plan

- [ ] Merge, then trigger **Deploy to Staging** via `workflow_dispatch` (any mode — `dispatch` forces `run_keycloak=true`).
- [ ] The "Pull latest accessory image on host" step succeeds.
- [ ] `ssh root@<vps> "docker exec givernance-keycloak ls /opt/keycloak/themes/givernance/login/resources/js/"` returns `auth-background.js`.
- [ ] Hard-refresh the staging Keycloak login URL — the icon-rain animation runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)