### PR TITLE
tweak(auth-bg): shrink background sprites by ~25%

### DIFF
--- a/infra/keycloak/themes/givernance/login/resources/js/auth-background.js
+++ b/infra/keycloak/themes/givernance/login/resources/js/auth-background.js
@@ -375,7 +375,7 @@
       y: aboveScreen
         ? -SPRITE_SIZE - Math.random() * height * 0.6
         : Math.random() * height,
-      scale: 0.55 + Math.random() * 0.55,
+      scale: 0.4 + Math.random() * 0.45,
       speed: 12 + Math.random() * 28,
       sway: 6 + Math.random() * 12,
       swayPhase: Math.random() * Math.PI * 2,

--- a/packages/web/src/components/auth/auth-background.tsx
+++ b/packages/web/src/components/auth/auth-background.tsx
@@ -411,7 +411,7 @@ function makeParticle(width: number, height: number, aboveScreen: boolean): Part
   return {
     x: Math.random() * width,
     y: aboveScreen ? -SPRITE_SIZE - Math.random() * height * 0.6 : Math.random() * height,
-    scale: 0.55 + Math.random() * 0.55,
+    scale: 0.4 + Math.random() * 0.45,
     speed: 12 + Math.random() * 28, // px/s
     sway: 6 + Math.random() * 12, // px amplitude
     swayPhase: Math.random() * Math.PI * 2,


### PR DESCRIPTION
## Summary

Sprites in the auth-page icon-rain background read a bit big behind the auth card — they competed for attention with the card content. Drop the per-particle `scale` range from `0.55–1.10` to `0.40–0.85` so the rain reads as decorative texture rather than foreground content.

Sprite source size (`SPRITE_SIZE = 90`) is unchanged so icon detail stays crisp; only the draw size shrinks.

Mirrored 1:1 in the Keycloak theme renderer.

## Test plan

- [ ] `/login`, `/signup`, `/forgot-password` — icons feel like background texture, card stays the visual anchor.
- [ ] After the next staging deploy: same check on the Keycloak login page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)