### PR TITLE
feat(donation-pages): schema + theme registry + backend API (Epic #362, PR-2)

### DIFF
--- a/docs/26-public-page-styles.md
+++ b/docs/26-public-page-styles.md
@@ -1,0 +1,119 @@
+# Public donation page styles — domain stub
+
+> **Stub doc, ships with [Epic #362](https://github.com/purposestack/givernance/issues/362) PR-2.** The full canonical doc — visual mockup gallery, full archetype-to-slot mapping, permissions matrix populated against the picker UI, Mermaid user-flow diagram, GDPR posture — lands with PR-5 of the Epic. This stub covers the schema + API surface that exist *today* (after PR-2) so the spec is reviewable now rather than waiting for the picker UI.
+>
+> Related: [Epic #286 — Organisation branding](https://github.com/purposestack/givernance/issues/286) (colour + logo tokens this Epic composes with) · [Epic #39 / PR #197](https://github.com/purposestack/givernance/pull/197) (the public donation page being extended) · [ADR-030](adrs/adr-030-public-page-style-archetypes.md) (architecture) · [docs/ideas/public-page-styles-teardown.md](ideas/public-page-styles-teardown.md) (competitive teardown + the 10-archetype shortlist) · [docs/18-feature-flags.md](18-feature-flags.md) (flag posture)
+
+## 0. Why this exists — at a glance
+
+Givernance's public donation page (`/p/[campaignId]`) used to be a single layout. Operators could swap the primary colour + logo via Epic #286, but the structure, typography, and copy rhythm were identical for every NPO. Two donors landing on two different Givernance campaigns could tell they were on the same platform.
+
+This Epic adds **10 deliberately-different visual archetypes** the operator picks from — Foundation, Activist, Editorial Story, Minimal Checkout, Emergency Appeal, Neo-Brutalist, Calm Wellness, Civic Modern, Retro Print, Cosmic Gradient. Each archetype owns *structure / typography / motion*; Epic #286 still owns *colour / logo*. The operator picks **one archetype per campaign**, optionally inheriting from an **org-level default**. Donors stop perceiving Givernance pages as a uniform template.
+
+**Scope:** curated catalogue, designer-controlled. **Out of scope:** WYSIWYG editor, per-section style mixing, donor-uploaded media, A/B test framework. These are tracked in the Epic's `## 4. Out of scope` section.
+
+## 1. Schema (after PR-2)
+
+Two columns + one Postgres enum, added by migration [`0054_public_page_style_columns.sql`](../packages/api/migrations/0054_public_page_style_columns.sql). Both columns are nullable so the picker can render an "inherits from…" affordance instead of implicitly stamping a value on legacy rows.
+
+```mermaid
+erDiagram
+  tenants ||--o{ campaigns : "owns"
+  campaigns ||--o| campaign_public_pages : "publishes"
+
+  tenants {
+    uuid id PK
+    varchar name
+    text mission
+    public_page_style default_public_page_style "nullable - Epic 362"
+    uuid logo_asset_id "FK - Epic 286"
+    varchar stripe_account_id
+  }
+
+  campaigns {
+    uuid id PK
+    uuid org_id FK
+    varchar name
+    campaign_type type
+    campaign_status status
+    public_page_style public_page_style "nullable - Epic 362"
+    uuid bank_account_id "FK - Epic 318"
+  }
+
+  campaign_public_pages {
+    uuid id PK
+    uuid campaign_id FK
+    public_page_status status
+    varchar title
+    text description
+    varchar color_primary "Epic 286"
+    integer goal_amount_cents
+  }
+```
+
+The `public_page_style` enum (kept in lockstep with `PUBLIC_PAGE_STYLE_KEYS` in [`@givernance/shared/constants`](../packages/shared/src/constants/public-page-styles.ts) via a CI parity test):
+
+```
+foundation | activist | editorial-story | minimal-checkout | emergency-appeal
+| neo-brutalist | calm-wellness | civic-modern | retro-print | cosmic-gradient
+```
+
+## 2. Resolution rule
+
+The donor-facing API returns the archetype after a **three-layer fallback**:
+
+```
+campaigns.public_page_style
+  ?? tenants.default_public_page_style
+  ?? "foundation"  /* platform-wide default; matches today's layout */
+```
+
+A campaign with `public_page_style = NULL` and a tenant with `default_public_page_style = NULL` resolves to `"foundation"` — the institutional layout that shipped before this Epic, so existing campaigns keep their current look unless the operator explicitly picks something else.
+
+The resolved value is computed **outside the public-page Redis cache** (`packages/api/src/modules/public/service.ts → getPublicPage`), so a super-admin flipping the feature flag is picked up on the very next request rather than being shadowed by a 30 s cache window.
+
+A defence-in-depth filter (`isPublicPageStyleKey`) drops any stale DB value not in the current registry — so a deprecated archetype removed from the frontend bundle can't return `null`-the-page on the donor; the resolution falls all the way back to `"foundation"` instead.
+
+## 3. API contract (after PR-2)
+
+| Method | URL | Purpose | Flag posture |
+|---|---|---|---|
+| `GET` | `/v1/public/campaigns/:id/page` | Donor-facing page payload — includes resolved `publicPageStyle` (`null` when flag is off) | Field-level; route is unauthenticated and always open |
+| `GET` | `/v1/campaigns/:id/public-page` | Admin view; response includes raw `publicPageStyle` (`null` = inherits from tenant) | Always returned to authenticated admins; field is `null` when not set |
+| `PUT` | `/v1/campaigns/:id/public-page` | Admin upsert; accepts tri-state `publicPageStyle` (`undefined` = leave untouched, `null` = clear, `<key>` = set) | Field-level 400 when flag off + field in body. Legacy fields unaffected |
+| `GET` | `/v1/org/style-default` | Org-level default (read) | `requireFlag(...)` as FIRST preHandler → 404 when off |
+| `PATCH` | `/v1/org/style-default` | Org-level default (write); bulk-invalidates per-tenant public-page cache | Same gate; second preHandler is `requireOrgAdmin` |
+
+URL convention: `/v1/org/…` for caller-scoped self-service (matches `/v1/org/feature-flags` from [Epic #365](https://github.com/purposestack/givernance/issues/365)). The `/v1/tenants/:orgId/…` shape is reserved for platform-admin or tenant-id-scoped routes.
+
+## 4. RBAC (after PR-2)
+
+| Role | Read campaign style | Write campaign style | Read tenant default | Write tenant default |
+|---|---|---|---|---|
+| `super_admin` | ✅ (via tenant impersonation or admin route) | ✅ | ✅ | ✅ |
+| `org_admin` | ✅ | ✅ | ✅ | ✅ |
+| `user` | ✅ (read-only on the admin GET) | ❌ (403) | ❌ (403) | ❌ (403) |
+| Unauthenticated donor | ✅ via resolved value on `/v1/public/...` | n/a | n/a | n/a |
+
+All `403` paths use the codebase's anti-disclosure 404 *only when the flag itself is off* — i.e. when the route should appear not to exist. When the flag is on but the caller lacks role, the response is `403`, not `404`. See [docs/18-feature-flags.md § 0](18-feature-flags.md) for the rationale.
+
+## 5. Feature-flag posture
+
+| Flag key | Default | Scope | Tenant override | Public projection |
+|---|---|---|---|---|
+| `donation.public_page_styles` | `off` | `tenant` | `false` (super-admin only for the initial rollout) | `true` (settings UI + campaign editor SSR-fetch to decide whether to render the picker) |
+
+Emergency rollback: [`docs/runbooks/feature-flag-rollback.md`](runbooks/feature-flag-rollback.md). Since PR-2 the donor-facing flag-resolution moved out of the cached payload — a `UPDATE feature_flags SET enabled = false …` is picked up by donors on the next request, not after the 30 s cache window.
+
+## 6. Privacy / GDPR posture
+
+- The `publicPageStyle` value is a non-PII enum.
+- The *presence or absence* of the field on the donor-facing endpoint leaks one bit per tenant (flag on / off) to anyone scraping the public page. This is intentional — the flag is `public=true` so the picker UI in the settings page can decide whether to render itself. The flag NAME (`donation.public_page_styles`) is descriptive but doesn't tease an unannounced surprise.
+- The `org_id` join used to resolve the per-tenant flag state runs through the existing public-page query path — no new join, no new data path.
+- No donor input (keystrokes, click coordinates) is logged by the easter-egg hook (per [ADR-030 § Motion policy](adrs/adr-030-public-page-style-archetypes.md#motion-policy--ambient-and-easter-egg)).
+
+## 7. Out of scope for the canonical doc (lands in PR-5)
+
+PR-2 ships the schema + API surface. The remaining sections of the canonical doc — the picker UX flow diagram, the per-archetype slot mapping (with screenshots), the visual-regression test matrix, the "how to add a new archetype" guide, the cross-link from [`docs/14-screen-inventory.md`](14-screen-inventory.md), the operator-runbook "how to pick" — all land with PR-5 of the Epic, alongside the implementation they document.
+
+If you're reviewing PR-2 and want the long form of the operator-side picker UX, read the [teardown doc](ideas/public-page-styles-teardown.md). If you want the architecture, read [ADR-030](adrs/adr-030-public-page-style-archetypes.md). This file is the schema + API contract only.

--- a/docs/adrs/adr-030-public-page-style-archetypes.md
+++ b/docs/adrs/adr-030-public-page-style-archetypes.md
@@ -1,0 +1,131 @@
+## ADR-030: Public donation page style archetypes — hybrid shell + slot components
+
+**Status**: Proposed (Epic #362, spike, 2026-05-14)
+**Related**: ADR-011 (4-layer frontend), ADR-012 (shadcn/ui + design tokens), ADR-013 (frontend type boundary), ADR-023 (bucket topology — `branding` is public-read), `docs/18-feature-flags.md`, `docs/24-branding-assets.md`, `docs/ideas/public-page-styles-teardown.md`
+
+### Context
+
+Per [Epic #362](https://github.com/purposestack/givernance/issues/362), Givernance is adding **10 distinct visual archetypes** the operator can pick from for the public donation page (`/p/[id]`). Today the page is one shared layout; only the primary colour and the logo vary between tenants (Epic #286). The Epic requires the spike to commit to **one** of three architectures:
+
+1. **CSS theme presets** — same React component tree, swap design tokens + a few component variants per archetype.
+2. **Alternative React component trees** — route-level template selection; each archetype is its own page component.
+3. **Hybrid** — shared shell + per-archetype slot components for the hero, amount picker, and footer.
+
+The decision must be justified against:
+
+- **Bundle-size impact on the public page** — donor-facing critical path. The current `/p/[id]` first-load JS is ~120 KB gzipped. Carrying 10 archetypes in the same bundle multiplies the styling layer.
+- **Maintenance cost** — adding archetype #11 in 18 months should be cheap.
+- **A/B testability** — even though we explicitly defer multi-variant testing, the architecture shouldn't *prevent* it.
+- **Composition with Epic #286 branding tokens** — the operator's primary colour and logo MUST keep working under every archetype.
+- **a11y + Lighthouse 90+ mobile** — the public page is the conversion-critical surface; performance regressions are not negotiable.
+
+### Decision
+
+**Hybrid architecture (option 3): a shared `<PublicDonationShell>` that owns layout primitives + a tightly-scoped slot interface for archetype-specific components.**
+
+The shell is the React component tree donors load on `/p/[id]`. It is the source of truth for:
+
+- Data fetching (server component → `CampaignPublicPageService.getPublishedCampaignPublicPage`)
+- The `<PublicDonationForm>` client island (Stripe Elements, 3DS post-redirect, idempotency-key wiring) — unchanged across all archetypes
+- Skip-to-content link, language switcher, locale-aware footer
+- The CSS-variable injection for primary-colour ([Epic #286](https://github.com/purposestack/givernance/issues/286)) tokens
+- Postal-QR scan tracking ([Epic #274](https://github.com/purposestack/givernance/issues/274))
+- All accessibility scaffolding (landmarks, headings hierarchy, ARIA live regions for the amount picker)
+
+Each archetype contributes three React components via a typed registry:
+
+```ts
+type Archetype = {
+  key: ArchetypeKey;          // "foundation" | "activist" | …
+  Hero: React.ComponentType<HeroSlotProps>;
+  AmountPicker: React.ComponentType<AmountSlotProps>;
+  Footer: React.ComponentType<FooterSlotProps>;
+  tokens: ArchetypeTokens;    // CSS-variable overrides, applied at shell level
+  motion?: MotionSpec;        // optional easter-egg + ambient motion config
+};
+```
+
+The `tokens` block is plain CSS — no JS bundled per archetype. The slot components are lazy-loaded by archetype key:
+
+```ts
+const archetypeModule = await import(`@/archetypes/${stylePreset}/index.ts`);
+```
+
+This keeps the **non-selected** archetypes out of the donor's bundle entirely. A tenant on `foundation` ships ~0 KB of `cosmic-gradient` code.
+
+### Why not pure-CSS presets (option 1)
+
+The Epic asked us to honestly evaluate this. Three archetypes break the same-tree assumption:
+
+1. **`editorial-story`** needs a scroll-driven layout where the donation form reveals on scroll past the photo essay — that's a different *DOM structure*, not different colours.
+2. **`emergency-appeal`** needs the counter to *be* the hero — the amount picker drops below the fold deliberately. Same DOM tree means CSS would have to reorder via `flex order`, which fights screen-readers and tab order.
+3. **`minimal-checkout`** *removes* the hero entirely; CSS `display: none` on the hero would still leave it in the accessibility tree and ship its JS.
+
+Forcing a same-tree implementation here would mean either degrading the archetypes (visually equivalent to today's page with different colours, defeating the Epic) or smuggling structural variation behind CSS hacks that break a11y. Rejected.
+
+### Why not full per-archetype pages (option 2)
+
+Three reasons:
+
+1. **Duplication of donation-flow code.** The Stripe Elements + 3DS retry + idempotency-key handling is the most security-sensitive part of the page and has been hardened over multiple PRs (#197, #200, #274, #318). Re-implementing it 10× is a guaranteed regression source.
+2. **Branding integration.** The CSS-variable wiring for [Epic #286](https://github.com/purposestack/givernance/issues/286) primary-colour tokens and the `OrgLogo` rendering (with the `unoptimized` Next/Image and fallback `InitialLetterAvatar`) live in one place today. Forking the page 10× means 10 places to keep in sync when [Epic #286](https://github.com/purposestack/givernance/issues/286)'s Phase 2 ships per-campaign hero images.
+3. **a11y baseline drift.** Skip-link, landmark order, heading levels, ARIA live regions on the amount picker — these are easy to get wrong differently in each of 10 copies. Owning them in the shell once is the only sustainable posture.
+
+### How the hybrid composes with [Epic #286](https://github.com/purposestack/givernance/issues/286) branding
+
+The shell sets `style={{ "--brand-primary": colorPrimary, "--brand-on-primary": getReadableTextColor(colorPrimary) }}` on the root `<main>`. Every archetype's `tokens` block consumes those variables instead of hard-coding hex. Archetypes can opt to ignore the brand colour (e.g. `retro-print` may force its riso-print palette), but they MUST set `--brand-primary` on the donation-form chrome so the CTA button keeps the operator's brand colour. The `tokens` block is the single seam.
+
+### Bundle-size budget
+
+- Shell + form: ~120 KB gzipped (unchanged from today).
+- Each archetype's slot bundle: **target ≤ 8 KB gzipped, hard ceiling 15 KB.** Anything over 15 KB triggers a review — likely a sign the archetype is trying to do too much.
+- A donor on `foundation` ships shell + foundation slots. Total: ~125–128 KB gzipped, a ~5 KB regression vs. today, which we accept as the cost of the seam.
+- Lazy-loaded via dynamic `import()` keyed on `publicPageStyle` from the API response.
+
+### Visual-regression and a11y testing
+
+Each archetype's slot components get:
+
+- **Playwright screenshot test** — desktop + mobile breakpoints, in both en + fr locales.
+- **Lighthouse CI** — mobile Performance ≥ 90, Accessibility ≥ 95.
+- **axe-core integration test** — zero violations.
+
+The shell already has these tests today. Adding an archetype adds rows to the test matrix, not new infrastructure.
+
+### Easter eggs
+
+Easter eggs are owned by the archetype's `motion` spec — they're not allowed to reach into the shell. The shell exposes a tiny `useEasterEgg(predicate, callback)` hook that wires up the keyboard / click listeners and **always** short-circuits to no-op when `window.matchMedia('(prefers-reduced-motion: reduce)').matches`. Archetypes can't bypass this — the hook is the only authorised path.
+
+### Feature flag
+
+Per `docs/18-feature-flags.md`, the whole archetype system ships behind `donation.public_page_styles`, default off. With the flag off, the shell ignores `publicPageStyle` entirely and renders today's hardcoded layout — i.e. the existing tenants see no change. The flag flips to "on" per tenant once the org has visited the picker once. (See [Epic #362](https://github.com/purposestack/givernance/issues/362) for the rollout plan.)
+
+### Rejected alternatives
+
+| Alternative | Rejected because |
+|---|---|
+| **Tailwind utility-only theming** (no slot components — every archetype is a different set of Tailwind classes on the same shell). | The three archetypes above need DOM structural changes, not utility swaps. Picked this for the colour/typography axis (`tokens`), rejected for the structure axis. |
+| **CSS-in-JS runtime theming (Stitches, Vanilla Extract).** | Adds a runtime dependency on the donor-facing critical path. The shell uses plain CSS variables + Tailwind v4 `@theme`. |
+| **Per-archetype Next.js segment** (`/p/[id]/foundation/page.tsx`, `/p/[id]/activist/page.tsx`). | Forces the URL to leak the archetype, which makes the picker change a redirect rather than a re-render — bad for the donor and bad for SEO. |
+| **Server-side switch with hard-coded `if (style === "foundation") return …`** in one big page component. | Doesn't ship; the file grows past comprehension as archetypes are added. |
+| **CMS-driven schema** (each archetype is a JSON schema, slots are positions). | Re-invents [Epic #362](https://github.com/purposestack/givernance/issues/362)'s explicit out-of-scope ("no WYSIWYG editor"). |
+
+### Consequences
+
+**Pro:**
+- Donor's bundle only carries the chosen archetype.
+- Each archetype is one folder (`apps/web/src/archetypes/foundation/`) the design team can iterate on without touching the shell.
+- The shell remains the only place to harden the conversion-critical donation flow.
+- New archetypes (#11, #12 in 18 months) are additive — no existing-tenant migration needed.
+- A future A/B test framework can pick `publicPageStyle` per cohort without re-architecture.
+
+**Con:**
+- The "slot contract" needs to be documented and stable — changing it is a breaking change across 10 implementations.
+- Code splitting per archetype adds one async chunk per page load; the chunk is cached aggressively but the first donor visit per archetype pays a sub-50 ms request.
+- Designers have to think about three slots, not "the whole page" — slight cognitive overhead vs. option 2.
+
+### Revisit if
+
+- We accumulate more than ~3 archetype features that need to reach below the slot interface (e.g. archetype-specific data fetching, archetype-specific Stripe flows). At that point, "shared shell + slots" is no longer earning its keep and we should re-evaluate moving to option 2 with a shared `<DonationCore>` component.
+- Lighthouse Performance on mobile dips below 88 on any archetype despite a 15 KB slot budget. That's the signal that the lazy-load orchestration itself is the cost, and we should consider in-bundle all 10 with tree-shakable design tokens.
+- We ever ship the WYSIWYG editor (currently OUT of scope). At that point the JSON-schema alternative becomes worth revisiting and the slot interface should accommodate user-provided slot data, not just designer-built components.

--- a/docs/adrs/adr-030-public-page-style-archetypes.md
+++ b/docs/adrs/adr-030-public-page-style-archetypes.md
@@ -1,6 +1,6 @@
 ## ADR-030: Public donation page style archetypes — hybrid shell + slot components
 
-**Status**: Proposed (Epic #362, spike, 2026-05-14)
+**Status**: Proposed (Epic #362, 2026-05-14)
 **Related**: ADR-011 (4-layer frontend), ADR-012 (shadcn/ui + design tokens), ADR-013 (frontend type boundary), ADR-023 (bucket topology — `branding` is public-read), `docs/18-feature-flags.md`, `docs/24-branding-assets.md`, `docs/ideas/public-page-styles-teardown.md`
 
 ### Context
@@ -32,44 +32,77 @@ The shell is the React component tree donors load on `/p/[id]`. It is the source
 - Postal-QR scan tracking ([Epic #274](https://github.com/purposestack/givernance/issues/274))
 - All accessibility scaffolding (landmarks, headings hierarchy, ARIA live regions for the amount picker)
 
-Each archetype contributes three React components via a typed registry:
+Each archetype contributes four React components via a typed registry:
 
 ```ts
 type Archetype = {
-  key: ArchetypeKey;          // "foundation" | "activist" | …
+  key: ArchetypeKey;            // "foundation" | "activist" | …
   Hero: React.ComponentType<HeroSlotProps>;
+  Progress: React.ComponentType<ProgressSlotProps>;
   AmountPicker: React.ComponentType<AmountSlotProps>;
   Footer: React.ComponentType<FooterSlotProps>;
-  tokens: ArchetypeTokens;    // CSS-variable overrides, applied at shell level
-  motion?: MotionSpec;        // optional easter-egg + ambient motion config
+  tokens: ArchetypeTokens;      // CSS-variable overrides; tabular-nums required
+  motion: MotionSpec;            // ambient + easter-egg motion (mandatory)
+  layout: "side-by-side" | "stacked" | "scroll-reveal"; // shell layout strategy
 };
 ```
 
-The `tokens` block is plain CSS — no JS bundled per archetype. The slot components are lazy-loaded by archetype key:
+`Progress` is a fourth slot — separated from `Hero` because three archetypes (`emergency-appeal`, `cosmic-gradient`, `editorial-story`) need the progress counter in radically different positions relative to the rest of the page (hero replacement, post-scroll reveal, footer-anchored). `layout` is a shell-controlled enum, not a per-archetype DOM change — the shell maps the chosen value to one of three pre-tested grid templates, which keeps a11y scaffolding (landmark order, heading hierarchy, tab order) under shell control.
+
+The `tokens` block is plain CSS — no JS bundled per archetype. **Every `tokens` block MUST set `font-variant-numeric: tabular-nums lining-nums`** on the progress counter and amount-chip selectors, so the counter doesn't jitter as the campaign updates and amounts stay aligned across the picker grid.
+
+The slot components are lazy-loaded by archetype key through a **closed static registry** (security: see Rejected alternatives row 6):
 
 ```ts
-const archetypeModule = await import(`@/archetypes/${stylePreset}/index.ts`);
+// packages/web/src/archetypes/registry.ts
+import type { ArchetypeKey, ArchetypeModule } from "./types";
+
+export const ARCHETYPES: Record<ArchetypeKey, () => Promise<ArchetypeModule>> = {
+  foundation:       () => import("./foundation/index.js"),
+  activist:         () => import("./activist/index.js"),
+  "editorial-story":() => import("./editorial-story/index.js"),
+  // … one entry per archetype
+};
 ```
 
-This keeps the **non-selected** archetypes out of the donor's bundle entirely. A tenant on `foundation` ships ~0 KB of `cosmic-gradient` code.
+The template-literal form (`await import(\`@/archetypes/${key}/index.ts\`)`) is **prohibited** — Webpack/Turbopack expand the prefix into "anything under `@/archetypes/`", which widens the contract the moment an attacker can influence `key`. The closed `Record` makes unknown values fail at the type-system level before reaching the loader; the `ArchetypeKey` union is the only validator. This keeps non-selected archetypes out of the donor's bundle entirely. A tenant on `foundation` ships ~0 KB of `cosmic-gradient` code.
 
-### Why not pure-CSS presets (option 1)
+### Slot inventory — every archetype mapped to the slot contract
 
-The Epic asked us to honestly evaluate this. Three archetypes break the same-tree assumption:
+A common failure mode for slot-based UI is to discover, three implementations in, that the slot interface doesn't fit one of them. Mapping all 10 archetypes against the four slots + the `layout` enum before merge — and refusing to merge if any archetype breaches:
 
-1. **`editorial-story`** needs a scroll-driven layout where the donation form reveals on scroll past the photo essay — that's a different *DOM structure*, not different colours.
-2. **`emergency-appeal`** needs the counter to *be* the hero — the amount picker drops below the fold deliberately. Same DOM tree means CSS would have to reorder via `flex order`, which fights screen-readers and tab order.
-3. **`minimal-checkout`** *removes* the hero entirely; CSS `display: none` on the hero would still leave it in the accessibility tree and ship its JS.
+| Archetype | `layout` | Hero owns | Progress position | Picker mode | Footer style | Ambient motion |
+|---|---|---|---|---|---|---|
+| `foundation` | side-by-side | logo + headline + mission | inline below hero | inline chip grid + write-in | inst. sig + Givernance attribution | none |
+| `activist` | side-by-side | giant headline + tag | inline below hero | 2×2 oversized chips, recurring as second screen | inst. sig + supporters strip | static gradient |
+| `editorial-story` | scroll-reveal | full-bleed photo + drop-cap lede | post-scroll reveal | inline below story | inst. sig + author byline | none |
+| `minimal-checkout` | stacked | tiny logo, no headline | inline above CTA | the page *is* the picker | inst. sig only | none |
+| `emergency-appeal` | stacked | counter IS hero, headline below | hero-replacement | inline below counter | live-launch timestamp | none |
+| `neo-brutalist` | side-by-side | type-driven hero, no photo | inline below hero | square chips, hard borders | inst. sig in mono | none |
+| `calm-wellness` | side-by-side | lowercase headline + soft wash | inline below hero | pill chips, generous whitespace | inst. sig + breath-paced spacing | low-amplitude SVG morph (≤ 0.1 Hz; reduced-motion: none) |
+| `civic-modern` | side-by-side | headline + transparency-stat block | inline below hero | inline chips + recurring + "where does it go?" expander | inst. sig + transparency repeat | none |
+| `retro-print` | side-by-side | duotone logo + stamped headline | inline below hero | stamped-postcard chips | inst. sig + faux-print metadata | none |
+| `cosmic-gradient` | side-by-side | headline floats over animated mesh | post-scroll reveal | glassmorphism chips | inst. sig + gradient signature | animated gradient mesh (≤ 0.5 Hz; reduced-motion: static) |
 
-Forcing a same-tree implementation here would mean either degrading the archetypes (visually equivalent to today's page with different colours, defeating the Epic) or smuggling structural variation behind CSS hacks that break a11y. Rejected.
+No archetype reaches outside the four slots + `layout` enum + tokens + motion contract. If a future archetype proposal needs a fifth slot, the proposal must amend this table and ship the slot-interface change in its own PR before the archetype lands.
 
-### Why not full per-archetype pages (option 2)
+### Motion policy — ambient and easter-egg
 
-Three reasons:
+Easter eggs and ambient motion are **separate concerns** with separate guards. Conflating them, as an earlier draft did, lets an archetype ship a continuously-morphing hero that violates WCAG 2.2.2 (Pause, Stop, Hide — level A) because the easter-egg hook never fires.
 
-1. **Duplication of donation-flow code.** The Stripe Elements + 3DS retry + idempotency-key handling is the most security-sensitive part of the page and has been hardened over multiple PRs (#197, #200, #274, #318). Re-implementing it 10× is a guaranteed regression source.
-2. **Branding integration.** The CSS-variable wiring for [Epic #286](https://github.com/purposestack/givernance/issues/286) primary-colour tokens and the `OrgLogo` rendering (with the `unoptimized` Next/Image and fallback `InitialLetterAvatar`) live in one place today. Forking the page 10× means 10 places to keep in sync when [Epic #286](https://github.com/purposestack/givernance/issues/286)'s Phase 2 ships per-campaign hero images.
-3. **a11y baseline drift.** Skip-link, landmark order, heading levels, ARIA live regions on the amount picker — these are easy to get wrong differently in each of 10 copies. Owning them in the shell once is the only sustainable posture.
+**Ambient motion**: any animation that fires without user input (hero gradients, SVG morphs, scroll-driven reveals).
+
+- The shell owns the gate. Every archetype declares `motion.ambient: "none" | "reduced-ok" | "requires-pause-control"`.
+- `"none"` (default): no `@keyframes` / `transition`, period. CSS asserts this via a Stylelint rule on the archetype CSS file.
+- `"reduced-ok"`: a low-amplitude motion that is safe under `prefers-reduced-motion: no-preference` and **MUST** be no-op under `prefers-reduced-motion: reduce`. The shell injects a `data-motion="reduced"` attribute that the archetype CSS uses to gate its `@keyframes`.
+- `"requires-pause-control"`: motion longer than 5 s or louder than `reduced-ok`. The shell **renders a visible "Pause animation" toggle** in the top-right of the hero card. The pause state persists in `localStorage` and re-applies across donor sessions. Currently rejected for the donor-conversion path — no archetype in this Epic uses this value; it exists in the type only to force future proposals through review.
+
+**Easter-egg motion**: user-triggered animations (confetti on Konami code, glitch on hover-and-hold, etc.).
+
+- Owned by the shared `useEasterEgg(predicate, callback)` hook. The hook short-circuits to no-op when **any** of: `prefers-reduced-motion: reduce`, `prefers-reduced-data: reduce`, `navigator.connection?.saveData === true`. The hook is the only authorised path; archetypes can't bypass it.
+- Easter-egg side-effects are **visual-only**. No `aria-live` announcement, no focus shift, no DOM injection into the form region, no modification of any element's accessible name during the animation. Egg containers must be `aria-hidden="true"` and appended outside `<main>`.
+- The hook MUST NOT log, persist, or POST the listener input (keystrokes, click coordinates) — only the boolean trigger result is observed by the callback. Donor input on a public page is a GDPR-adjacent risk and the hook is the choke point.
+- Easter eggs are not discoverable by keyboard for non-keyboard triggers (hover-and-hold, triple-click). This is **not** a WCAG violation: per the teardown, easter eggs are donor-irrelevant decorative artefacts; they carry no information a keyboard user is being denied.
 
 ### How the hybrid composes with [Epic #286](https://github.com/purposestack/givernance/issues/286) branding
 
@@ -78,37 +111,48 @@ The shell sets `style={{ "--brand-primary": colorPrimary, "--brand-on-primary": 
 ### Bundle-size budget
 
 - Shell + form: ~120 KB gzipped (unchanged from today).
-- Each archetype's slot bundle: **target ≤ 8 KB gzipped, hard ceiling 15 KB.** Anything over 15 KB triggers a review — likely a sign the archetype is trying to do too much.
+- Each archetype's slot bundle: **target ≤ 8 KB gzipped, hard ceiling 12 KB.** Anything over 12 KB triggers a review — almost always a sign that the archetype is reaching for a motion library it shouldn't.
 - A donor on `foundation` ships shell + foundation slots. Total: ~125–128 KB gzipped, a ~5 KB regression vs. today, which we accept as the cost of the seam.
-- Lazy-loaded via dynamic `import()` keyed on `publicPageStyle` from the API response.
+- The motion-heavy archetypes (`calm-wellness`, `cosmic-gradient`) are the Lighthouse-budget canaries — they sit closest to the 12 KB ceiling and worst-case ~80 ms async-chunk RTT on cold load. They're the first to trip the Revisit-if clause below.
+- Lazy-loaded via the closed `ARCHETYPES` registry (see § Decision) keyed on `publicPageStyle` from the API response.
+
+**Forbidden in archetype slots** (enforced via Biome `noRestrictedImports` on `packages/web/src/archetypes/**` — see ADR-013 for the boundary pattern):
+
+- `framer-motion`, `motion`, `motion/react` (~14–18 KB gz minimum — busts the budget in one line).
+- `gsap`, `@gsap/*` (similar size, plus a license tax).
+- `lottie-web`, `lottie-react`, `@lottiefiles/*` (huge runtime, raster decode cost).
+- Any general-purpose particle / WebGL library.
+
+**Permitted**: CSS `@keyframes` + `transition`, raw SVG with `<animate>` / `<animateTransform>`, hand-rolled `requestAnimationFrame` loops bounded by `motion.ambient` policy. Hand-rolled is fine; library-shaped motion is not.
 
 ### Visual-regression and a11y testing
 
 Each archetype's slot components get:
 
 - **Playwright screenshot test** — desktop + mobile breakpoints, in both en + fr locales.
+- **Playwright reduced-motion screenshot** — `emulateMedia({ reducedMotion: 'reduce' })` asserts no `@keyframes` or `animation` style applies to hero/progress elements (catches ambient-motion drift past the slot contract).
 - **Lighthouse CI** — mobile Performance ≥ 90, Accessibility ≥ 95.
 - **axe-core integration test** — zero violations.
+- **Bundle-size assertion** — the archetype's lazy-chunk gzipped size, asserted ≤ 12 KB (hard ceiling, see § Bundle-size budget). Fails CI on regression.
 
 The shell already has these tests today. Adding an archetype adds rows to the test matrix, not new infrastructure.
 
-### Easter eggs
-
-Easter eggs are owned by the archetype's `motion` spec — they're not allowed to reach into the shell. The shell exposes a tiny `useEasterEgg(predicate, callback)` hook that wires up the keyboard / click listeners and **always** short-circuits to no-op when `window.matchMedia('(prefers-reduced-motion: reduce)').matches`. Archetypes can't bypass this — the hook is the only authorised path.
-
 ### Feature flag
 
-Per `docs/18-feature-flags.md`, the whole archetype system ships behind `donation.public_page_styles`, default off. With the flag off, the shell ignores `publicPageStyle` entirely and renders today's hardcoded layout — i.e. the existing tenants see no change. The flag flips to "on" per tenant once the org has visited the picker once. (See [Epic #362](https://github.com/purposestack/givernance/issues/362) for the rollout plan.)
+Per `docs/18-feature-flags.md`, the whole archetype system ships behind `donation.public_page_styles`, default off. With the flag off, the shell ignores `publicPageStyle` entirely and renders today's hardcoded layout — i.e. existing tenants see no change. **The flag check guards the `ARCHETYPES` registry import itself, not just the call** — so an off-state donor's bundle excludes every archetype chunk from the chunk graph, not just from the runtime execution path.
 
 ### Rejected alternatives
 
-| Alternative | Rejected because |
-|---|---|
-| **Tailwind utility-only theming** (no slot components — every archetype is a different set of Tailwind classes on the same shell). | The three archetypes above need DOM structural changes, not utility swaps. Picked this for the colour/typography axis (`tokens`), rejected for the structure axis. |
-| **CSS-in-JS runtime theming (Stitches, Vanilla Extract).** | Adds a runtime dependency on the donor-facing critical path. The shell uses plain CSS variables + Tailwind v4 `@theme`. |
-| **Per-archetype Next.js segment** (`/p/[id]/foundation/page.tsx`, `/p/[id]/activist/page.tsx`). | Forces the URL to leak the archetype, which makes the picker change a redirect rather than a re-render — bad for the donor and bad for SEO. |
-| **Server-side switch with hard-coded `if (style === "foundation") return …`** in one big page component. | Doesn't ship; the file grows past comprehension as archetypes are added. |
-| **CMS-driven schema** (each archetype is a JSON schema, slots are positions). | Re-invents [Epic #362](https://github.com/purposestack/givernance/issues/362)'s explicit out-of-scope ("no WYSIWYG editor"). |
+| # | Alternative | Rejected because |
+|---|---|---|
+| 1 | **Pure-CSS / Tailwind utility presets** (option 1 from Epic — every archetype is a different set of utilities on the same DOM tree). | Five of the ten archetypes (`foundation`, `activist`, `civic-modern`, `retro-print`, partial `cosmic-gradient`) could ship CSS-only. The other five force structural divergence — `editorial-story` (post-scroll reveal), `emergency-appeal` (counter-as-hero), `minimal-checkout` (hero removed), `cosmic-gradient` (post-scroll reveal), `calm-wellness` (different progress placement). Forcing CSS-only on those five means either degrading the archetypes (CSS variants of today's page = same project as today, defeats the Epic) or smuggling structure via `flex order` which breaks tab order and screen-reader landmark navigation. Adopting the slot model uniformly across all ten keeps one mental model. |
+| 2 | **Full per-archetype pages** (option 2 from Epic — `/p/[id]/foundation/page.tsx`, …). | Three problems: (a) extracting a shared `<DonationCore>` is feasible but recreates the slot contract by accident, with the URL-leakage tax of route segments on top — picker change becomes a 308 redirect rather than a re-render, bad for SEO and donor experience; (b) **a11y baseline drift** — landmark/heading/skip-link/ARIA-live-region scaffolding has to be re-implemented 10 times and *will* drift; (c) [Epic #286](https://github.com/purposestack/givernance/issues/286) Phase 2's per-campaign hero image needs to land in one place, not ten. |
+| 3 | **Server-components-only archetypes** (each archetype is a pure-RSC variant of the shell that imports the shared `<PublicDonationForm>` client island). | Genuinely close to the hybrid in shape — kills the dynamic-import chunk overhead — but loses the lazy-load benefit: every archetype's JSX ships in the server bundle even for tenants on `foundation`, so the server roundtrip carries the same bytes as the largest archetype. The client-side hybrid wins on the donor's bytes-on-the-wire, which is the conversion-critical metric. Re-evaluate if mobile JS-parse cost ever dominates over network in our telemetry. |
+| 4 | **`shadcn`-style copy-paste archetypes** (each archetype scaffolded *into* the tenant-agnostic codebase rather than dynamically loaded). | Same DX as the hybrid (one folder per archetype) without the runtime registry. Rejected because we explicitly want central control over the catalogue (curated, not customer-modifiable per the Epic's scope statement) and lazy-load. |
+| 5 | **MDX-driven / JSON-schema archetypes** (each archetype is content, not code). | Re-invents [Epic #362](https://github.com/purposestack/givernance/issues/362)'s explicit out-of-scope ("no WYSIWYG editor"). |
+| 6 | **Template-literal dynamic `import()`** (`import(\`@/archetypes/${stylePreset}/index.ts\`)`). | Webpack/Turbopack expand this to "anything under `@/archetypes/`" at build time. The moment any code path lets `stylePreset` carry a value other than an enum-validated `ArchetypeKey`, the prefix becomes attacker-controllable. The closed `Record<ArchetypeKey, () => Promise<…>>` map (see § Decision) is the structural fix: unknown values fail the type check before reaching the loader. |
+| 7 | **Per-route CSS-in-JS theming** (Stitches, Vanilla Extract). | Adds a runtime dependency on the donor-facing critical path. The shell uses plain CSS variables + Tailwind v4 `@theme`. |
+| 8 | **Server-side switch with hard-coded `if (style === "foundation") return …`** in one big page component. | Defeats lazy-loading (all 10 archetypes' JSX ships in one server module the bundler can't split) and the file grows past comprehension as archetypes are added. |
 
 ### Consequences
 
@@ -120,12 +164,13 @@ Per `docs/18-feature-flags.md`, the whole archetype system ships behind `donatio
 - A future A/B test framework can pick `publicPageStyle` per cohort without re-architecture.
 
 **Con:**
-- The "slot contract" needs to be documented and stable — changing it is a breaking change across 10 implementations.
-- Code splitting per archetype adds one async chunk per page load; the chunk is cached aggressively but the first donor visit per archetype pays a sub-50 ms request.
-- Designers have to think about three slots, not "the whole page" — slight cognitive overhead vs. option 2.
+- The slot contract (Hero / Progress / AmountPicker / Footer + `layout` enum + `motion` spec + `tokens`) needs to be documented and stable — changing it is a breaking change across 10 implementations.
+- Code splitting per archetype adds one async chunk per page load; the chunk is cached aggressively but the first donor visit per archetype pays a 50–80 ms request, worst on the motion-heavy archetypes (`calm-wellness`, `cosmic-gradient`).
+- Designers have to think about four slots + a layout enum, not "the whole page" — slight cognitive overhead vs. option 2.
 
 ### Revisit if
 
 - We accumulate more than ~3 archetype features that need to reach below the slot interface (e.g. archetype-specific data fetching, archetype-specific Stripe flows). At that point, "shared shell + slots" is no longer earning its keep and we should re-evaluate moving to option 2 with a shared `<DonationCore>` component.
-- Lighthouse Performance on mobile dips below 88 on any archetype despite a 15 KB slot budget. That's the signal that the lazy-load orchestration itself is the cost, and we should consider in-bundle all 10 with tree-shakable design tokens.
+- Lighthouse Performance on mobile dips below 88 on any archetype despite the 12 KB slot ceiling. That's the signal that the lazy-load orchestration itself is the cost; in-bundle all 10 with tree-shakable design tokens becomes worth re-evaluating. The motion archetypes (`calm-wellness`, `cosmic-gradient`) are the canaries.
 - We ever ship the WYSIWYG editor (currently OUT of scope). At that point the JSON-schema alternative becomes worth revisiting and the slot interface should accommodate user-provided slot data, not just designer-built components.
+- An archetype proposal needs a 5th slot. The proposal must amend the Slot Inventory table and ship the slot-interface change in its own PR before the archetype lands — *not* extend the slot type inline with the archetype.

--- a/docs/design/donations/public-foundation.html
+++ b/docs/design/donations/public-foundation.html
@@ -1,4 +1,10 @@
 <!DOCTYPE html>
+<!--
+  NOTE for implementers: the real page renders `<html lang={await getLocale()}>`
+  via next-intl server-side. `lang="en"` here is mockup-only so it renders
+  standalone for design review; the slot contract requires locale-driven
+  `<html lang>` in production.
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -58,6 +64,32 @@
 
     *, *::before, *::after { box-sizing: border-box; }
 
+    /* ── WCAG 2.4.11 focus-not-obscured + 2.4.7 focus-visible ───────── */
+    :focus-visible {
+      outline: 2px solid var(--brand-primary);
+      outline-offset: 2px;
+      border-radius: 8px;
+    }
+    /* Reset UA default outlines that compete with our :focus-visible
+       rule (notably on `<button>` hover-then-focus paths in Safari). */
+    :focus:not(:focus-visible) { outline: none; }
+
+    /* ── WCAG 2.3.3 — reduced-motion guard ──────────────────────────── */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+
+    /* SR-only utility */
+    .sr-only {
+      position: absolute; width: 1px; height: 1px;
+      padding: 0; margin: -1px; overflow: hidden;
+      clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+    }
+
     body {
       margin: 0;
       font-family: var(--font-body);
@@ -95,12 +127,12 @@
       background: var(--surface-muted); border-radius: 999px; padding: 4px;
       font-size: 12px;
     }
-    .lang-switch button {
-      border: 0; background: transparent; padding: 4px 12px;
-      border-radius: 999px; color: var(--ink-secondary); cursor: pointer;
-      font-weight: 500;
+    .lang-switch a {
+      padding: 4px 12px;
+      border-radius: 999px; color: var(--ink-secondary);
+      font-weight: 500; text-decoration: none;
     }
-    .lang-switch button.active {
+    .lang-switch a[aria-current="page"] {
       background: var(--surface-elevated); color: var(--ink-primary);
       box-shadow: 0 1px 2px rgba(0,0,0,0.06);
     }
@@ -160,7 +192,12 @@
       line-height: 1.05;
       letter-spacing: -0.02em;
       margin: 24px 0 0;
-      max-width: 22ch;
+      /* 28ch (not 22ch) — FR translations of the same headline are
+         ~30% longer and the tighter cap forced awkward wraps. Slot
+         contract: archetypes targeting EU markets MUST use a
+         locale-tolerant max-width. */
+      max-width: 28ch;
+      text-wrap: balance;
     }
     .hero p.lede {
       margin: 18px 0 0;
@@ -195,6 +232,10 @@
       font-size: 2.1rem; font-weight: 600;
       margin: 8px 0 14px;
       color: var(--ink-primary);
+      /* tabular-nums keeps the counter from jittering when the
+         live campaign total ticks. Required across every archetype
+         (slot contract — see ADR-030 § Decision). */
+      font-variant-numeric: tabular-nums lining-nums;
     }
     .progress-amount .goal {
       font-family: var(--font-body);
@@ -297,8 +338,17 @@
     .amount-grid {
       display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px;
       margin-bottom: 10px;
+      border: 0; padding: 0;
+    }
+    .amount-chip-label {
+      position: relative; display: block; margin: 0;
+    }
+    .amount-grid input[type="radio"] {
+      position: absolute; opacity: 0; pointer-events: none;
+      width: 1px; height: 1px;
     }
     .amount-chip {
+      display: flex; flex-direction: column; justify-content: center;
       padding: 14px 8px; border-radius: var(--radius-control);
       border: 1.5px solid var(--border-subtle);
       background: var(--surface-elevated);
@@ -307,14 +357,19 @@
       color: var(--ink-primary);
       cursor: pointer; text-align: center;
       transition: border-color 0.15s, background 0.15s, transform 0.06s;
+      font-variant-numeric: tabular-nums lining-nums;
     }
-    .amount-chip:hover { border-color: var(--brand-primary); }
-    .amount-chip:active { transform: scale(0.98); }
-    .amount-chip.selected {
+    .amount-grid input[type="radio"]:focus-visible + .amount-chip {
+      outline: 2px solid var(--brand-primary);
+      outline-offset: 2px;
+    }
+    .amount-grid input[type="radio"]:checked + .amount-chip {
       border-color: var(--brand-primary);
       background: rgba(12, 100, 67, 0.06);
       color: var(--brand-primary-deep);
     }
+    .amount-chip:hover { border-color: var(--brand-primary); }
+    .amount-chip:active { transform: scale(0.98); }
     .amount-chip small {
       display: block; margin-top: 4px;
       font-family: var(--font-body); font-weight: 500;
@@ -329,6 +384,7 @@
       font-family: var(--font-display); font-size: 1.1rem; font-weight: 600;
       color: var(--ink-primary);
       background: var(--surface-elevated);
+      font-variant-numeric: tabular-nums lining-nums;
     }
     .amount-write::placeholder { color: var(--ink-tertiary); font-weight: 500; }
     .amount-write:focus {
@@ -401,13 +457,13 @@
 <body>
   <a class="skip-link" href="#donate">Skip to donation form</a>
 
-  <div class="topbar">
+  <header class="topbar">
     <span class="badge">● Secure giving</span>
-    <div class="lang-switch" role="tablist" aria-label="Language">
-      <button class="active" role="tab" aria-selected="true">EN</button>
-      <button role="tab" aria-selected="false">FR</button>
-    </div>
-  </div>
+    <nav class="lang-switch" aria-label="Language">
+      <a href="?lang=en" aria-current="page" lang="en">EN</a>
+      <a href="?lang=fr" hreflang="fr" lang="fr">FR</a>
+    </nav>
+  </header>
 
   <main>
     <!-- ───── Hero slot ───── -->
@@ -415,11 +471,11 @@
       <div class="hero">
         <span class="org-pill">
           <span class="logo-tile" aria-hidden="true">M</span>
-          <span>Maison des Solidarités</span>
+          <span lang="fr">Maison des Solidarités</span>
         </span>
         <h1 id="campaign-title">Winter shelter campaign 2026 — help us keep 240 beds open.</h1>
-        <p class="lede">Every winter the Maison des Solidarités opens 240 emergency-shelter beds across Lyon and Saint-Étienne. This year we need €58,000 to keep them running through March.</p>
-        <p class="mission">"To welcome, accompany, and rebuild a path forward — without conditions, regardless of paperwork."</p>
+        <p class="lede">Every winter <span lang="fr">Maison des Solidarités</span> opens 240 emergency-shelter beds across Lyon and Saint-Étienne. This year we need <span class="amount">€58&#8239;000</span> to keep them running through March.</p>
+        <p class="mission" lang="fr">«&#8239;Accueillir, accompagner, reconstruire un chemin — sans condition, sans papiers.&#8239;»</p>
       </div>
 
       <div class="progress" aria-label="Campaign progress">
@@ -428,15 +484,22 @@
           <span>★ 142 supporters</span>
         </div>
         <p class="progress-amount">
-          €37,420 <span class="goal">of €58,000 goal</span>
+          €37&#8239;420 <span class="goal">of €58&#8239;000 goal</span>
         </p>
-        <div class="progress-bar" role="progressbar" aria-valuenow="64" aria-valuemin="0" aria-valuemax="100" aria-label="64 percent funded">
+        <div
+          class="progress-bar"
+          role="progressbar"
+          aria-valuenow="64"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuetext="64 percent funded — 37,420 of 58,000 euros raised"
+        >
           <span style="width: 64%;"></span>
         </div>
         <div class="progress-meta">
           <span><strong>64 %</strong> funded</span>
           <span><strong>17 days</strong> remaining</span>
-          <span><strong>Tax-receipt eligible</strong> (Loi Coluche, FR)</span>
+          <span><strong>Tax-receipt eligible</strong> (<span lang="fr">Loi Coluche</span>, FR)</span>
         </div>
       </div>
 
@@ -457,30 +520,69 @@
     </section>
 
     <!-- ───── Donation form (shell-owned) + AmountPicker slot ───── -->
-    <aside class="form-card" id="donate" aria-label="Donation form">
-      <h2>Give to the winter shelter</h2>
+    <!--
+      Real form is `<form>` with action=POST; the mockup uses <section>
+      to demonstrate landmark semantics (an <aside> would be skipped
+      by screen-reader landmark navigation, hiding the conversion-
+      critical surface — fixed per PR #386 review).
+    -->
+    <section class="form-card" id="donate" aria-labelledby="donate-heading">
+      <h2 id="donate-heading" tabindex="-1">Give to the winter shelter</h2>
       <p class="subhead">Your gift opens beds tonight.</p>
 
       <div class="freq-toggle" role="tablist" aria-label="Donation frequency">
-        <button class="active" role="tab" aria-selected="true">One-time</button>
-        <button role="tab" aria-selected="false">Monthly</button>
+        <button class="active" role="tab" aria-selected="true" type="button">One-time</button>
+        <button role="tab" aria-selected="false" type="button">Monthly</button>
       </div>
 
       <div class="label-row">
-        <label for="amount">Amount</label>
-        <span class="help">€ EUR</span>
+        <span id="amount-label">Amount</span>
+        <span class="help" aria-hidden="true">€ EUR</span>
       </div>
 
-      <div class="amount-grid" role="radiogroup" aria-label="Suggested amounts">
-        <button class="amount-chip" type="button">€25<small>One night, one bed</small></button>
-        <button class="amount-chip selected" type="button" aria-pressed="true">€50<small>Bed + meal</small></button>
-        <button class="amount-chip" type="button">€100<small>A week's groceries</small></button>
-        <button class="amount-chip" type="button">€250<small>Casework support</small></button>
-        <button class="amount-chip" type="button">€500<small>Sponsor a family</small></button>
-        <button class="amount-chip" type="button">€1 000<small>Anonymous matching</small></button>
-      </div>
+      <!--
+        Real <input type="radio"> with visually-hidden inputs lets the
+        chips be a true single-tab-stop radio group with native arrow-
+        key navigation; `:checked + .amount-chip` carries the visual
+        state. ARIA-radiogroup-on-buttons (the prior mockup) was wrong
+        semantics — radio means one tab stop + arrow keys, buttons
+        carrying `aria-pressed` is a toggle pattern.
+      -->
+      <fieldset class="amount-grid" aria-labelledby="amount-label">
+        <legend class="sr-only">Suggested amounts</legend>
+        <label class="amount-chip-label">
+          <input type="radio" name="amount" value="25">
+          <span class="amount-chip">€25<small>One night, one bed</small></span>
+        </label>
+        <label class="amount-chip-label">
+          <input type="radio" name="amount" value="50" checked>
+          <span class="amount-chip">€50<small>Bed + meal</small></span>
+        </label>
+        <label class="amount-chip-label">
+          <input type="radio" name="amount" value="100">
+          <span class="amount-chip">€100<small>A week&apos;s groceries</small></span>
+        </label>
+        <label class="amount-chip-label">
+          <input type="radio" name="amount" value="250">
+          <span class="amount-chip">€250<small>Casework support</small></span>
+        </label>
+        <label class="amount-chip-label">
+          <input type="radio" name="amount" value="500">
+          <span class="amount-chip">€500<small>Sponsor a family</small></span>
+        </label>
+        <label class="amount-chip-label">
+          <input type="radio" name="amount" value="1000">
+          <span class="amount-chip">€1&#8239;000<small>Anonymous matching</small></span>
+        </label>
+      </fieldset>
 
-      <input class="amount-write" type="number" min="1" placeholder="Or write your own amount" aria-label="Custom amount in euros">
+      <input
+        class="amount-write"
+        type="number"
+        min="1"
+        placeholder="Or write your own amount"
+        aria-label="Custom amount in euros"
+      >
 
       <div class="donor-fields">
         <input type="email" placeholder="Email" aria-label="Email" autocomplete="email">
@@ -494,12 +596,12 @@
       <p class="reassurance">
         <strong>Stripe-secured.</strong> No card data ever touches our servers. 100 % of your gift reaches the campaign — Givernance charges no commission to donors.
       </p>
-    </aside>
+    </section>
   </main>
 
   <footer>
     <div class="sig">
-      Maison des Solidarités is a French association under the 1901 law, registered in Lyon under SIRET 803 410 922 00018, recognised of general interest (Article 200 CGI).
+      <span lang="fr">Maison des Solidarités</span> is a French association under the 1901 law, registered in Lyon under SIRET 803&#8239;410&#8239;922&#8239;00018, recognised of general interest (<span lang="fr">Article 200 CGI</span>).
     </div>
     <div class="by-givernance">
       Powered by <a href="#">Givernance</a> · Hosted in the EU · GDPR-native

--- a/docs/design/donations/public-foundation.html
+++ b/docs/design/donations/public-foundation.html
@@ -1,0 +1,509 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Public donation page — Foundation archetype · Givernance</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400..700;1,8..60,400..600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    /*
+     * Reference mockup for the FOUNDATION archetype (Epic #362, spike).
+     *
+     * This is the *institutional default* — the closest match to today's
+     * live page (`packages/web/src/app/(public)/p/[id]/page.tsx`). Picking it
+     * as the spike commitment lets us validate the hybrid shell + slots
+     * architecture (ADR-030) against a layout we already know works in
+     * production.
+     *
+     * What this mockup proves:
+     *   - the shell owns the form + skip-link + branding logo block
+     *   - the archetype's "Hero", "AmountPicker", and "Footer" slots
+     *     consume CSS custom properties for brand colour (Epic #286)
+     *   - typography is the archetype's primary identity lever
+     *     (Source Serif display + Inter body for Foundation)
+     *   - the page is two-column desktop, single-column mobile, with
+     *     the donation form sticking to the right rail
+     *
+     * No JS — this is a static visual spec.
+     */
+
+    :root {
+      /* These values are injected at runtime by the shell from
+         `PublishedCampaignPublicPage.colorPrimary` (Epic #286). For the
+         mockup we hard-code Givernance brand green. */
+      --brand-primary: #0c6443;
+      --brand-primary-deep: #064027;
+      --brand-on-primary: #f4faf6;
+
+      /* Foundation archetype's typography contract */
+      --font-display: 'Source Serif 4', Georgia, serif;
+      --font-body: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+
+      /* Foundation surface tokens */
+      --surface: #fdfcf9;
+      --surface-elevated: #ffffff;
+      --surface-muted: #f4f1ea;
+      --ink-primary: #1a1d1c;
+      --ink-secondary: #5e605e;
+      --ink-tertiary: #8a8c89;
+      --border-subtle: #e8e4db;
+
+      --radius-card: 24px;
+      --radius-control: 14px;
+      --shadow-card: 0 1px 2px rgba(13, 24, 19, 0.04), 0 8px 24px rgba(13, 24, 19, 0.06);
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: var(--font-body);
+      color: var(--ink-primary);
+      background: var(--surface);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      line-height: 1.5;
+    }
+
+    /* ── Skip link (shell-owned a11y scaffolding) ───────────────────── */
+    .skip-link {
+      position: absolute; left: -9999px; top: -9999px;
+      background: var(--ink-primary); color: var(--surface);
+      padding: 12px 16px; border-radius: 8px; z-index: 100;
+      font-weight: 600; text-decoration: none;
+    }
+    .skip-link:focus { left: 16px; top: 16px; }
+
+    /* ── Top bar (shell-owned) ──────────────────────────────────────── */
+    .topbar {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 28px 32px 0;
+      display: flex; justify-content: space-between; align-items: center;
+    }
+    .badge {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 6px 12px; border-radius: 999px;
+      background: rgba(12, 100, 67, 0.08); color: var(--brand-primary-deep);
+      font-size: 12px; font-weight: 600; letter-spacing: 0.04em;
+    }
+    .lang-switch {
+      display: inline-flex; gap: 4px;
+      background: var(--surface-muted); border-radius: 999px; padding: 4px;
+      font-size: 12px;
+    }
+    .lang-switch button {
+      border: 0; background: transparent; padding: 4px 12px;
+      border-radius: 999px; color: var(--ink-secondary); cursor: pointer;
+      font-weight: 500;
+    }
+    .lang-switch button.active {
+      background: var(--surface-elevated); color: var(--ink-primary);
+      box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+    }
+
+    /* ── Main grid ──────────────────────────────────────────────────── */
+    main {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 28px 32px 64px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.15fr) minmax(340px, 440px);
+      gap: 36px;
+      align-items: start;
+    }
+    @media (max-width: 960px) {
+      main { grid-template-columns: 1fr; padding: 16px 16px 32px; gap: 20px; }
+      .topbar { padding: 16px 16px 0; }
+    }
+
+    /* ── Hero slot (archetype-owned) ─────────────────────────────────── */
+    .hero-card {
+      background: var(--surface-elevated);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-card);
+      box-shadow: var(--shadow-card);
+      overflow: hidden;
+    }
+    .hero {
+      position: relative;
+      padding: 40px 44px 36px;
+      background:
+        radial-gradient(circle at 85% 12%, rgba(255,255,255,0.18), transparent 45%),
+        linear-gradient(135deg, var(--brand-primary) 0%, var(--brand-primary-deep) 100%);
+      color: var(--brand-on-primary);
+    }
+    @media (max-width: 720px) { .hero { padding: 28px 24px 24px; } }
+    .org-pill {
+      display: inline-flex; align-items: center; gap: 8px;
+      background: rgba(255,255,255,0.14);
+      backdrop-filter: blur(6px);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: 999px; padding: 6px 14px;
+      font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase;
+      font-weight: 500;
+    }
+    .org-pill .logo-tile {
+      width: 22px; height: 22px; border-radius: 6px;
+      background: var(--surface-elevated); color: var(--brand-primary-deep);
+      display: inline-flex; align-items: center; justify-content: center;
+      font-family: var(--font-display); font-weight: 700; font-size: 14px;
+      letter-spacing: 0;
+    }
+    .hero h1 {
+      font-family: var(--font-display);
+      font-weight: 600;
+      font-size: clamp(2rem, 4.5vw, 3.25rem);
+      line-height: 1.05;
+      letter-spacing: -0.02em;
+      margin: 24px 0 0;
+      max-width: 22ch;
+    }
+    .hero p.lede {
+      margin: 18px 0 0;
+      font-size: 1.05rem;
+      line-height: 1.6;
+      max-width: 52ch;
+      opacity: 0.9;
+    }
+    .hero p.mission {
+      margin: 14px 0 0;
+      font-family: var(--font-display);
+      font-style: italic;
+      font-size: 0.95rem;
+      line-height: 1.55;
+      opacity: 0.78;
+      max-width: 52ch;
+    }
+
+    /* Progress + counts strip (archetype-owned) */
+    .progress {
+      padding: 28px 44px 30px;
+      border-top: 1px solid var(--border-subtle);
+    }
+    @media (max-width: 720px) { .progress { padding: 22px 24px 24px; } }
+    .progress-head {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase;
+      color: var(--ink-tertiary); font-weight: 600;
+    }
+    .progress-amount {
+      font-family: var(--font-display);
+      font-size: 2.1rem; font-weight: 600;
+      margin: 8px 0 14px;
+      color: var(--ink-primary);
+    }
+    .progress-amount .goal {
+      font-family: var(--font-body);
+      font-size: 0.95rem; font-weight: 400;
+      color: var(--ink-tertiary);
+      margin-left: 4px;
+    }
+    .progress-bar {
+      height: 10px; background: var(--surface-muted);
+      border-radius: 999px; overflow: hidden;
+    }
+    .progress-bar > span {
+      display: block; height: 100%;
+      background: linear-gradient(90deg, var(--brand-primary), var(--brand-primary-deep));
+      border-radius: 999px;
+      transition: width 0.6s ease;
+    }
+    .progress-meta {
+      margin-top: 14px;
+      font-size: 13px; color: var(--ink-secondary);
+      display: flex; gap: 18px; flex-wrap: wrap;
+    }
+    .progress-meta strong { color: var(--ink-primary); font-weight: 600; }
+
+    /* Trust strip — Foundation's institutional credibility band */
+    .trust {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 0;
+      border-top: 1px solid var(--border-subtle);
+      background: var(--surface-muted);
+    }
+    @media (max-width: 540px) { .trust { grid-template-columns: 1fr; } }
+    .trust div {
+      padding: 22px 28px;
+      border-right: 1px solid var(--border-subtle);
+    }
+    .trust div:last-child { border-right: 0; }
+    @media (max-width: 540px) {
+      .trust div { border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+      .trust div:last-child { border-bottom: 0; }
+    }
+    .trust dt {
+      font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase;
+      color: var(--ink-tertiary); font-weight: 600;
+    }
+    .trust dd {
+      margin: 6px 0 0;
+      font-family: var(--font-display); font-weight: 500;
+      font-size: 1.1rem; color: var(--ink-primary);
+    }
+
+    /* ── Donation form slot (shell-owned — same across archetypes) ──── */
+    .form-card {
+      background: var(--surface-elevated);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-card);
+      box-shadow: var(--shadow-card);
+      padding: 28px 28px 24px;
+      position: sticky; top: 24px;
+    }
+    @media (max-width: 960px) { .form-card { position: static; } }
+    .form-card h2 {
+      font-family: var(--font-display);
+      font-weight: 600; font-size: 1.4rem;
+      margin: 0 0 4px;
+      letter-spacing: -0.01em;
+    }
+    .form-card .subhead {
+      color: var(--ink-secondary); font-size: 14px; margin: 0 0 22px;
+    }
+
+    .freq-toggle {
+      display: grid; grid-template-columns: 1fr 1fr;
+      background: var(--surface-muted); border-radius: var(--radius-control);
+      padding: 4px; gap: 4px; margin-bottom: 20px;
+    }
+    .freq-toggle button {
+      background: transparent; border: 0;
+      padding: 10px 12px; border-radius: 10px;
+      font-weight: 600; font-size: 13px; cursor: pointer;
+      color: var(--ink-secondary);
+    }
+    .freq-toggle button.active {
+      background: var(--surface-elevated); color: var(--ink-primary);
+      box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+    }
+
+    /* AmountPicker slot (archetype-owned) — Foundation: inline chips + write-in */
+    .label-row {
+      display: flex; justify-content: space-between; align-items: baseline;
+      margin-bottom: 10px;
+    }
+    .label-row label {
+      font-size: 13px; font-weight: 600; color: var(--ink-primary);
+    }
+    .label-row .help {
+      font-size: 12px; color: var(--ink-tertiary);
+    }
+    .amount-grid {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px;
+      margin-bottom: 10px;
+    }
+    .amount-chip {
+      padding: 14px 8px; border-radius: var(--radius-control);
+      border: 1.5px solid var(--border-subtle);
+      background: var(--surface-elevated);
+      font-family: var(--font-display);
+      font-size: 1.15rem; font-weight: 600;
+      color: var(--ink-primary);
+      cursor: pointer; text-align: center;
+      transition: border-color 0.15s, background 0.15s, transform 0.06s;
+    }
+    .amount-chip:hover { border-color: var(--brand-primary); }
+    .amount-chip:active { transform: scale(0.98); }
+    .amount-chip.selected {
+      border-color: var(--brand-primary);
+      background: rgba(12, 100, 67, 0.06);
+      color: var(--brand-primary-deep);
+    }
+    .amount-chip small {
+      display: block; margin-top: 4px;
+      font-family: var(--font-body); font-weight: 500;
+      font-size: 11px; color: var(--ink-tertiary);
+      letter-spacing: 0.02em;
+    }
+
+    .amount-write {
+      width: 100%; padding: 14px 16px;
+      border: 1.5px solid var(--border-subtle);
+      border-radius: var(--radius-control);
+      font-family: var(--font-display); font-size: 1.1rem; font-weight: 600;
+      color: var(--ink-primary);
+      background: var(--surface-elevated);
+    }
+    .amount-write::placeholder { color: var(--ink-tertiary); font-weight: 500; }
+    .amount-write:focus {
+      outline: none; border-color: var(--brand-primary);
+      box-shadow: 0 0 0 3px rgba(12, 100, 67, 0.12);
+    }
+
+    .donor-fields {
+      margin-top: 22px; display: grid; gap: 12px;
+    }
+    .donor-fields input {
+      width: 100%; padding: 12px 14px;
+      border: 1.5px solid var(--border-subtle);
+      border-radius: 10px;
+      font-family: var(--font-body); font-size: 14px;
+      background: var(--surface-elevated);
+    }
+    .donor-fields input:focus {
+      outline: none; border-color: var(--brand-primary);
+      box-shadow: 0 0 0 3px rgba(12, 100, 67, 0.12);
+    }
+    .donor-fields .field-row {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+    }
+
+    .cta {
+      width: 100%; margin-top: 18px;
+      padding: 16px 20px; border: 0;
+      border-radius: var(--radius-control);
+      background: var(--brand-primary);
+      color: var(--brand-on-primary);
+      font-family: var(--font-body); font-weight: 600; font-size: 15px;
+      cursor: pointer;
+      box-shadow: 0 6px 18px rgba(12, 100, 67, 0.22);
+      transition: transform 0.06s, box-shadow 0.15s;
+    }
+    .cta:hover {
+      box-shadow: 0 8px 24px rgba(12, 100, 67, 0.32);
+    }
+    .cta:active { transform: scale(0.99); }
+
+    .reassurance {
+      margin: 14px 0 0;
+      font-size: 12px; color: var(--ink-tertiary);
+      text-align: center; line-height: 1.5;
+    }
+    .reassurance strong { color: var(--ink-secondary); }
+
+    /* ── Footer slot (archetype-owned — Foundation: institutional sig) ── */
+    footer {
+      margin-top: 36px;
+      padding-top: 26px;
+      border-top: 1px solid var(--border-subtle);
+      color: var(--ink-tertiary);
+      font-size: 12px; line-height: 1.6;
+      display: flex; justify-content: space-between;
+      flex-wrap: wrap; gap: 16px;
+    }
+    footer a { color: var(--ink-secondary); text-decoration: none; }
+    footer a:hover { color: var(--ink-primary); }
+    footer .sig {
+      font-family: var(--font-display); font-style: italic;
+      max-width: 56ch;
+    }
+    footer .by-givernance {
+      font-size: 11px; letter-spacing: 0.04em;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#donate">Skip to donation form</a>
+
+  <div class="topbar">
+    <span class="badge">● Secure giving</span>
+    <div class="lang-switch" role="tablist" aria-label="Language">
+      <button class="active" role="tab" aria-selected="true">EN</button>
+      <button role="tab" aria-selected="false">FR</button>
+    </div>
+  </div>
+
+  <main>
+    <!-- ───── Hero slot ───── -->
+    <section class="hero-card" aria-labelledby="campaign-title">
+      <div class="hero">
+        <span class="org-pill">
+          <span class="logo-tile" aria-hidden="true">M</span>
+          <span>Maison des Solidarités</span>
+        </span>
+        <h1 id="campaign-title">Winter shelter campaign 2026 — help us keep 240 beds open.</h1>
+        <p class="lede">Every winter the Maison des Solidarités opens 240 emergency-shelter beds across Lyon and Saint-Étienne. This year we need €58,000 to keep them running through March.</p>
+        <p class="mission">"To welcome, accompany, and rebuild a path forward — without conditions, regardless of paperwork."</p>
+      </div>
+
+      <div class="progress" aria-label="Campaign progress">
+        <div class="progress-head">
+          <span>Raised so far</span>
+          <span>★ 142 supporters</span>
+        </div>
+        <p class="progress-amount">
+          €37,420 <span class="goal">of €58,000 goal</span>
+        </p>
+        <div class="progress-bar" role="progressbar" aria-valuenow="64" aria-valuemin="0" aria-valuemax="100" aria-label="64 percent funded">
+          <span style="width: 64%;"></span>
+        </div>
+        <div class="progress-meta">
+          <span><strong>64 %</strong> funded</span>
+          <span><strong>17 days</strong> remaining</span>
+          <span><strong>Tax-receipt eligible</strong> (Loi Coluche, FR)</span>
+        </div>
+      </div>
+
+      <dl class="trust" aria-label="Operational transparency">
+        <div>
+          <dt>Programmes</dt>
+          <dd>82 % of gifts</dd>
+        </div>
+        <div>
+          <dt>Support &amp; admin</dt>
+          <dd>11 %</dd>
+        </div>
+        <div>
+          <dt>Fundraising</dt>
+          <dd>7 %</dd>
+        </div>
+      </dl>
+    </section>
+
+    <!-- ───── Donation form (shell-owned) + AmountPicker slot ───── -->
+    <aside class="form-card" id="donate" aria-label="Donation form">
+      <h2>Give to the winter shelter</h2>
+      <p class="subhead">Your gift opens beds tonight.</p>
+
+      <div class="freq-toggle" role="tablist" aria-label="Donation frequency">
+        <button class="active" role="tab" aria-selected="true">One-time</button>
+        <button role="tab" aria-selected="false">Monthly</button>
+      </div>
+
+      <div class="label-row">
+        <label for="amount">Amount</label>
+        <span class="help">€ EUR</span>
+      </div>
+
+      <div class="amount-grid" role="radiogroup" aria-label="Suggested amounts">
+        <button class="amount-chip" type="button">€25<small>One night, one bed</small></button>
+        <button class="amount-chip selected" type="button" aria-pressed="true">€50<small>Bed + meal</small></button>
+        <button class="amount-chip" type="button">€100<small>A week's groceries</small></button>
+        <button class="amount-chip" type="button">€250<small>Casework support</small></button>
+        <button class="amount-chip" type="button">€500<small>Sponsor a family</small></button>
+        <button class="amount-chip" type="button">€1 000<small>Anonymous matching</small></button>
+      </div>
+
+      <input class="amount-write" type="number" min="1" placeholder="Or write your own amount" aria-label="Custom amount in euros">
+
+      <div class="donor-fields">
+        <input type="email" placeholder="Email" aria-label="Email" autocomplete="email">
+        <div class="field-row">
+          <input type="text" placeholder="First name" aria-label="First name" autocomplete="given-name">
+          <input type="text" placeholder="Last name" aria-label="Last name" autocomplete="family-name">
+        </div>
+      </div>
+
+      <button class="cta" type="submit">Give €50 securely</button>
+      <p class="reassurance">
+        <strong>Stripe-secured.</strong> No card data ever touches our servers. 100 % of your gift reaches the campaign — Givernance charges no commission to donors.
+      </p>
+    </aside>
+  </main>
+
+  <footer>
+    <div class="sig">
+      Maison des Solidarités is a French association under the 1901 law, registered in Lyon under SIRET 803 410 922 00018, recognised of general interest (Article 200 CGI).
+    </div>
+    <div class="by-givernance">
+      Powered by <a href="#">Givernance</a> · Hosted in the EU · GDPR-native
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/ideas/public-page-styles-teardown.md
+++ b/docs/ideas/public-page-styles-teardown.md
@@ -1,6 +1,8 @@
 # Public donation page — competitive teardown & archetype shortlist
 
-> Spike artifact for [Epic #362 — Public donation page · multiple style presets](https://github.com/purposestack/givernance/issues/362). Reviewed alongside [ADR-030](../adrs/adr-030-public-page-style-archetypes.md) and the reference mockup `docs/design/donations/public-foundation.html`.
+> Spike artifact for [Epic #362 — Public donation page · multiple style presets](https://github.com/purposestack/givernance/issues/362). Reviewed alongside [ADR-030](../adrs/adr-030-public-page-style-archetypes.md) and the reference mockup [`docs/design/donations/public-foundation.html`](../design/donations/public-foundation.html).
+>
+> **This is a spike artifact, not the canonical domain doc.** The numbered `docs/26-public-page-styles.md` — covering the shipped ERD, permissions matrix, Mermaid user-flow diagram, GDPR posture, and the "how to add a new archetype" guide — lands in PR-5 of [Epic #362](https://github.com/purposestack/givernance/issues/362) alongside the implementation it documents. Future readers should prefer that doc once it exists; this file remains as the research-trail.
 
 ---
 
@@ -57,12 +59,12 @@ We ended up at 10 (the Epic asked for 3–5; the product directive asked for 10 
 | # | Key | Operator-facing label | Voice / posture | Typography | Hero treatment | Amount picker | Best for |
 |---|---|---|---|---|---|---|---|
 | 1 | `foundation` | **Foundation** *(default)* | Institutional, restrained, trustworthy. The "your grandmother's lawyer wrote the headline" archetype. | Serif display + humanist sans body (Source Serif + Inter). | Logo top-left, headline, mission sentence, soft gradient. Today's page. | Inline chips + write-in. | Long-running NPOs, foundations, board-driven orgs. |
-| 2 | `activist` | **Activist** | Urgent, vivid, emotionally direct. Big colour, big type. | Display sans (bold cut) + same sans body. | Oversized headline as the hero. Optional photo behind. Saturated brand colour wash. | Grid of 4 oversized chips, recurring as a second screen. | Climate, social-justice, mobilisation orgs. |
+| 2 | `activist` | **Activist** | Sustained-mobilisation. Urgent voice, but *recurring-first* — the page wants you back every month, not just today. Big colour, big type. | Display sans (bold cut) + same sans body. | Oversized headline as the hero. Optional photo behind. Saturated brand colour wash. | **Recurring chip-grid first**, one-time as a secondary toggle. Distinguishes from `emergency-appeal` (one-time, counter-led). | Climate, social-justice, sustained-campaign mobilisation orgs (Alternatiba, Sea Shepherd FR). |
 | 3 | `editorial-story` | **Editorial Story** | Long-form, photo-essay, beneficiary-driven. The "magazine feature" archetype. | Editorial serif (Spectral) + humanist sans body. | Full-bleed photo, byline-style attribution, drop cap on the description. | Sits below the story; reveals after scroll. | Humanitarian orgs with strong photography (MSF, Oxfam-adjacent). |
 | 4 | `minimal-checkout` | **Minimal Checkout** | Stripe-Payment-Link-grade. No pitch — the donor already trusts you. | Single sans throughout (Inter). | No hero. Logo small in the corner, headline as a label. | The page **is** the amount picker. | Repeat-donor campaigns, member-only appeals. |
-| 5 | `emergency-appeal` | **Emergency Appeal** | Urgent, counter-led, action-now. The GoFundMe disaster-page archetype. | Bold sans display + condensed mono for the counter. | Counter is the hero. Date stamp, time-since-launch line, optional banner. | Below the counter, single column. | Disasters, time-bound appeals, matching-day campaigns. |
+| 5 | `emergency-appeal` | **Emergency Appeal** | Urgent, counter-led, **one-time-first** — the page exists for *now*. The GoFundMe disaster-page archetype. | Bold sans display + condensed mono for the counter. | Counter is the hero. Date stamp, time-since-launch line, optional banner. | One-time front-and-centre; recurring is a tiny secondary affordance. Distinguishes from `activist` (recurring-mobilisation). | Disasters, time-bound appeals, matching-day campaigns. |
 | 6 | `neo-brutalist` | **Neo-Brutalist** | Confident, type-driven, deliberate visual roughness. Black borders, hard shadows, mono numerals. | All-mono throughout (JetBrains Mono) with one display serif accent. | Concrete-block grid, oversized chevrons, manual misalignments. | Square chips, hard borders, hover-on-shift. | Arts orgs, design-collective NPOs, indie civic-tech. |
-| 7 | `calm-wellness` | **Calm Wellness** | Soft, hopeful, breath-paced. Pastel washes, gentle motion. | Display sans with rounded terminals (Quicksand) + the same family for body. | Animated soft gradient (low-amplitude SVG morphing). Headline in lowercase. | Pill chips, generous whitespace, animated focus state. | Mental-health, mindfulness, ecology-meditation orgs. |
+| 7 | `calm-wellness` | **Calm Wellness** | Soft, hopeful, breath-paced. Pastel washes, gentle motion. | Display sans with rounded terminals (Quicksand) for headline only; humanist sans (Inter) for body — Quicksand body has known readability issues below 16 px which clashes with this archetype's older / SR-user audience. | Animated soft gradient (low-amplitude SVG morphing). Headline in lowercase. | Pill chips, generous whitespace, animated focus state. | Mental-health, mindfulness, ecology-meditation orgs. |
 | 8 | `civic-modern` | **Civic Modern** | Public-sector adjacent. French-administration neutral. Strong transparency framing. | Geometric sans (IBM Plex Sans) throughout, with mono for figures. | Two-column: headline + a transparency-stat block ("82 % programmes, 11 % support, 7 % fundraising"). | Inline chips + recurring + an explicit "where does it go?" expander. | French-NPO sector, civic-tech, public-partnership NPOs. |
 | 9 | `retro-print` | **Retro Print** | Riso-printed-poster energy. Off-register colour, paper grain, vintage feel. | Slab serif display + a thin humanist for body. | Two-colour duotone treatment of the logo. Subtle paper-grain background. | Stamped-postcard chips. | Vintage-feeling orgs: heritage, local museums, alumni associations. |
 | 10 | `cosmic-gradient` | **Cosmic Gradient** | Optimistic, ambitious, future-facing. Big animated gradient mesh, large display type. | Display sans (Geist) + humanist sans body. | Animated CSS gradient mesh as the hero background; headline floats. | Glassmorphism chips on the gradient. | Climate-tech, space, future-of-X NPOs, tech-adjacent orgs. |
@@ -86,17 +88,17 @@ Per the product directive, a subset of archetypes carry a hidden interaction the
 | `calm-wellness` | Click the headline 5 times | Falling-leaves / falling-snow animation (season-dependent in the user's locale). |
 | `neo-brutalist` | Hover and hold any chip for 2 s | RGB-channel glitch on the headline for 600 ms. |
 | `retro-print` | Triple-click the logo | The page flickers and the duotone briefly mis-registers, like a Riso paper-jam. |
-| `cosmic-gradient` | Click the counter | A particle burst spawns from the click point and drifts upward. |
+| `cosmic-gradient` | Click the gradient hero | A particle burst spawns from the click point and drifts upward through the gradient mesh. |
 | `emergency-appeal` | (no egg — emergency campaigns should never have a "fun" moment) | — |
 | `foundation`, `editorial-story`, `minimal-checkout`, `civic-modern` | (no egg — preserves credibility) | — |
 
-All easter eggs are pure-frontend, respect `prefers-reduced-motion` (they no-op when the user has asked for less motion), and are seed-able for screenshot tests so they don't cause flake.
+All easter eggs are pure-frontend, ride the shared `useEasterEgg` hook (ADR-030 § Motion policy) which short-circuits to no-op on `prefers-reduced-motion`, `prefers-reduced-data`, or `navigator.connection.saveData`; they're `aria-hidden`, never announce, never shift focus, and never log donor input. Seed-able for screenshot tests so they don't cause flake.
 
 ---
 
 ## 3. Mockup commitment
 
-Per the Epic's spike acceptance criteria, this PR ships the **first** archetype's HTML mockup — `Foundation` — at `docs/design/donations/public-foundation.html`. It is the closest to the existing live page so we can validate the chosen architecture doesn't break what's already shipped. The other 9 mockups land in [Phase 4 (PR-4)](../../README.md#phases) along with their implementation.
+Per the Epic's spike acceptance criteria, this PR ships the **first** archetype's HTML mockup — `Foundation` — at [`docs/design/donations/public-foundation.html`](../design/donations/public-foundation.html). It is the closest to the existing live page so we can validate the chosen architecture doesn't break what's already shipped. The other 9 mockups land in Phase 4 of [Epic #362](https://github.com/purposestack/givernance/issues/362) along with their implementation.
 
 ---
 

--- a/docs/ideas/public-page-styles-teardown.md
+++ b/docs/ideas/public-page-styles-teardown.md
@@ -1,0 +1,120 @@
+# Public donation page — competitive teardown & archetype shortlist
+
+> Spike artifact for [Epic #362 — Public donation page · multiple style presets](https://github.com/purposestack/givernance/issues/362). Reviewed alongside [ADR-030](../adrs/adr-030-public-page-style-archetypes.md) and the reference mockup `docs/design/donations/public-foundation.html`.
+
+---
+
+## 0. Why this exists — at a glance
+
+The Givernance public donation page today is one fixed layout. Two NPOs running campaigns on Givernance get visually-identical donor surfaces: same hero proportions, same amount-picker grid, same typography rhythm, same footer order. [Epic #286](https://github.com/purposestack/givernance/issues/286) swaps the logo and the primary colour — useful, but a donor scrolling between an environmental foundation and a grassroots activist appeal still feels they're on "the Givernance platform."
+
+This document is the **research half** of the spike — competitive survey + the 10 archetypes we plan to ship — so a non-engineer (operator, designer, prospect) can read it and understand which page-personality belongs to which NPO and *why*. The **architecture half** lives in [ADR-030](../adrs/adr-030-public-page-style-archetypes.md).
+
+The user can pick from 10 distinct visual archetypes. Branding tokens ([Epic #286](https://github.com/purposestack/givernance/issues/286)) compose on top — same archetype, different primary colour, different logo, different hero crop. **The archetype controls structure, typography, illustration motif, and motion; the brand controls colour and identity.** A clean split keeps the operator's mental model simple: "what voice?" vs. "what brand?"
+
+---
+
+## 1. Competitive teardown — what we surveyed and why each one mattered
+
+We looked at the patterns rather than the brands. The interesting questions for a curated preset library are:
+
+- **What is the dominant element above the fold?** A photograph, a quote, a number, a form, a logo?
+- **How does the page treat the *amount*?** Big-number-first, gridded chips, slider, write-in, recurring-first?
+- **What's the page's emotional posture?** Restrained, urgent, hopeful, joyful, civic, intimate?
+- **How does it scale on mobile?** Stacks gracefully, hides the hero, switches to a sticky CTA?
+- **Where does social proof sit?** Donor list, counter, testimonials, none?
+
+### 1.1 Surveyed surfaces
+
+| Platform | What we noticed | Useful for |
+|---|---|---|
+| **Stripe Payment Links** | Single column, no hero. Amount picker is *the* surface. Typography is restrained (Stripe's "Sohne"-feel sans). Mobile-first by construction. | The "Minimal Checkout" archetype — when a donor already trusts the org and you don't need a pitch. |
+| **Donorbox** | Embeddable widget, conservative. Amount chips + recurring toggle as twin first-class controls. Conservative photography. | The "Foundation" archetype — institutional default, doesn't fight the host site. |
+| **Givebutter** | Storytelling-first. Hero photo, supporter feed, live donation ticker, friendly tone. | The "Activist" archetype — when emotional energy matters. |
+| **JustGiving** | Long-form scroll. Heavy on testimonial photography and beneficiary stories. | The "Editorial Story" archetype — beneficiary-driven pitches. |
+| **GoFundMe** | Hero photo + giant counter. Strong colour saturation. The counter *is* the hero. | The "Emergency Appeal" archetype — disasters, urgent fundraisers. |
+| **HelloAsso** (EU/FR) | Civic, neutral colour palette, French-administration-adjacent. Strong on transparency / receipt copy. | The "Civic Modern" archetype — French NPOs adjacent to public-sector partners. |
+| **WWF / Médecins Sans Frontières landing pages** | Editorial typography, large photo essays, restrained palette dominated by one brand colour. | Reference for the photo-driven archetypes. |
+| **joinritmo.com** (referenced by product) | Big editorial type, soft pastel washes, animated gradient hero, single dominant CTA. | The "Calm Wellness" archetype — for mental-health, ecology, mindfulness-adjacent orgs. |
+| **awwwards.com / dribbble modern-website** | Currently fashionable: brutalist mono type, deliberate misalignments, oversized numerals, hyper-saturated gradients, scroll-driven motion. | The "Neo-Brutalist" and "Cosmic Gradient" archetypes — younger / arts-adjacent orgs comfortable taking visual risks. |
+
+### 1.2 Cross-cutting observations
+
+1. **Amount picker dominates conversion.** Every platform we looked at gives the donation amount more visual real estate than the campaign description. A theme that buries the amount loses the donor. → Every archetype must surface 3–5 preset amounts and a write-in within the first viewport.
+2. **The recurring toggle is contested real estate.** Donorbox and Givebutter give it twin-pill prominence next to one-time. JustGiving hides it inside a secondary screen. Stripe Payment Links require it to be configured by the operator and never expose it to the donor. → We expose it for every archetype but two (`Minimal Checkout` and `Foundation Default`) place it inline; others (`Activist`, `Emergency Appeal`) make it a deliberate second step so the urgency framing isn't undermined.
+3. **Mobile is not "desktop, smaller."** GoFundMe's mobile experience is essentially a different page — the photo is cropped tight, the counter is the entire hero, and the form sticks to the bottom. → Each archetype gets a designed mobile breakpoint, not a CSS shrink.
+4. **Photography is the most expensive variable.** Archetypes that depend on a single dominant photograph (`Editorial Story`, `Emergency Appeal`) fall apart when the NPO doesn't have one. → Photo-dependent archetypes degrade gracefully to a CSS-art "scene" when no hero image is configured. This is one of the reasons we did NOT make this Epic also ship per-campaign hero images — that's [Epic #286](https://github.com/purposestack/givernance/issues/286)'s territory, and we want to ship the picker before the photo pipeline.
+5. **Typography is the cheapest differentiator.** Swapping a serif display face for a mono display, or pairing a humanist sans with a heavy slab, transforms the page far more than colour does. → Each archetype's typography pairing is its **identity contract** — bigger lever than the colour palette.
+
+---
+
+## 2. The 10 archetypes — shortlist
+
+We ended up at 10 (the Epic asked for 3–5; the product directive asked for 10 — and the headroom is justified because each archetype lives in a different emotional quadrant, not a different colour palette). Each archetype below has a one-paragraph **brief** that an operator can read in the style picker to know whether it's right for them.
+
+> Naming is deliberate. The picker labels each archetype by **what the NPO is doing**, not by Givernance-internal codename — operators don't want to pick `archetype_3b`, they want to pick "I run an emergency appeal."
+
+| # | Key | Operator-facing label | Voice / posture | Typography | Hero treatment | Amount picker | Best for |
+|---|---|---|---|---|---|---|---|
+| 1 | `foundation` | **Foundation** *(default)* | Institutional, restrained, trustworthy. The "your grandmother's lawyer wrote the headline" archetype. | Serif display + humanist sans body (Source Serif + Inter). | Logo top-left, headline, mission sentence, soft gradient. Today's page. | Inline chips + write-in. | Long-running NPOs, foundations, board-driven orgs. |
+| 2 | `activist` | **Activist** | Urgent, vivid, emotionally direct. Big colour, big type. | Display sans (bold cut) + same sans body. | Oversized headline as the hero. Optional photo behind. Saturated brand colour wash. | Grid of 4 oversized chips, recurring as a second screen. | Climate, social-justice, mobilisation orgs. |
+| 3 | `editorial-story` | **Editorial Story** | Long-form, photo-essay, beneficiary-driven. The "magazine feature" archetype. | Editorial serif (Spectral) + humanist sans body. | Full-bleed photo, byline-style attribution, drop cap on the description. | Sits below the story; reveals after scroll. | Humanitarian orgs with strong photography (MSF, Oxfam-adjacent). |
+| 4 | `minimal-checkout` | **Minimal Checkout** | Stripe-Payment-Link-grade. No pitch — the donor already trusts you. | Single sans throughout (Inter). | No hero. Logo small in the corner, headline as a label. | The page **is** the amount picker. | Repeat-donor campaigns, member-only appeals. |
+| 5 | `emergency-appeal` | **Emergency Appeal** | Urgent, counter-led, action-now. The GoFundMe disaster-page archetype. | Bold sans display + condensed mono for the counter. | Counter is the hero. Date stamp, time-since-launch line, optional banner. | Below the counter, single column. | Disasters, time-bound appeals, matching-day campaigns. |
+| 6 | `neo-brutalist` | **Neo-Brutalist** | Confident, type-driven, deliberate visual roughness. Black borders, hard shadows, mono numerals. | All-mono throughout (JetBrains Mono) with one display serif accent. | Concrete-block grid, oversized chevrons, manual misalignments. | Square chips, hard borders, hover-on-shift. | Arts orgs, design-collective NPOs, indie civic-tech. |
+| 7 | `calm-wellness` | **Calm Wellness** | Soft, hopeful, breath-paced. Pastel washes, gentle motion. | Display sans with rounded terminals (Quicksand) + the same family for body. | Animated soft gradient (low-amplitude SVG morphing). Headline in lowercase. | Pill chips, generous whitespace, animated focus state. | Mental-health, mindfulness, ecology-meditation orgs. |
+| 8 | `civic-modern` | **Civic Modern** | Public-sector adjacent. French-administration neutral. Strong transparency framing. | Geometric sans (IBM Plex Sans) throughout, with mono for figures. | Two-column: headline + a transparency-stat block ("82 % programmes, 11 % support, 7 % fundraising"). | Inline chips + recurring + an explicit "where does it go?" expander. | French-NPO sector, civic-tech, public-partnership NPOs. |
+| 9 | `retro-print` | **Retro Print** | Riso-printed-poster energy. Off-register colour, paper grain, vintage feel. | Slab serif display + a thin humanist for body. | Two-colour duotone treatment of the logo. Subtle paper-grain background. | Stamped-postcard chips. | Vintage-feeling orgs: heritage, local museums, alumni associations. |
+| 10 | `cosmic-gradient` | **Cosmic Gradient** | Optimistic, ambitious, future-facing. Big animated gradient mesh, large display type. | Display sans (Geist) + humanist sans body. | Animated CSS gradient mesh as the hero background; headline floats. | Glassmorphism chips on the gradient. | Climate-tech, space, future-of-X NPOs, tech-adjacent orgs. |
+
+### 2.1 Why ten, not five
+
+A 5-archetype set covers the obvious axes: institutional / urgent / story / minimal / civic. The remaining 5 (`Neo-Brutalist`, `Calm Wellness`, `Retro Print`, `Cosmic Gradient`, and the Activist/Foundation split) are deliberate **personality** archetypes for NPOs whose donor base doesn't respond to corporate restraint. We expect them to be picked by maybe 25 % of tenants combined — but for those tenants they are the difference between "this feels like our website" and "this feels like a generic donation widget."
+
+We considered going further (12, 15) and stopped at 10 because:
+- Beyond ~10 the picker stops being a curated catalogue and becomes a marketplace, and the picker UX collapses (preview thumbnails in a 4×3 grid is still scannable; a 5×3 grid isn't).
+- Each new archetype has a long maintenance tail: visual-regression tests, a11y audit, mobile pass, mockup file, Lighthouse pass. Beyond 10 the doubling of test surface stops paying back.
+- The 10 we picked already span all four corners of the *(restrained ↔ expressive)* × *(institutional ↔ grassroots)* matrix. Adding more would mostly be variations on a corner already covered.
+
+### 2.2 Easter eggs
+
+Per the product directive, a subset of archetypes carry a hidden interaction the operator can discover (or be told about by their CSM). Easter eggs are **never** visible by default, never affect the donor's experience, and never carry behaviour the operator cares about beyond "make the team smile." We commit to one per archetype where the visual identity supports it, and intentionally leave the institutional / civic / minimal archetypes egg-less so they remain credibly restrained.
+
+| Archetype | Easter egg trigger | What happens |
+|---|---|---|
+| `activist` | Konami code (↑↑↓↓←→←→ B A) | Confetti rain in the brand colour for 4 s. |
+| `calm-wellness` | Click the headline 5 times | Falling-leaves / falling-snow animation (season-dependent in the user's locale). |
+| `neo-brutalist` | Hover and hold any chip for 2 s | RGB-channel glitch on the headline for 600 ms. |
+| `retro-print` | Triple-click the logo | The page flickers and the duotone briefly mis-registers, like a Riso paper-jam. |
+| `cosmic-gradient` | Click the counter | A particle burst spawns from the click point and drifts upward. |
+| `emergency-appeal` | (no egg — emergency campaigns should never have a "fun" moment) | — |
+| `foundation`, `editorial-story`, `minimal-checkout`, `civic-modern` | (no egg — preserves credibility) | — |
+
+All easter eggs are pure-frontend, respect `prefers-reduced-motion` (they no-op when the user has asked for less motion), and are seed-able for screenshot tests so they don't cause flake.
+
+---
+
+## 3. Mockup commitment
+
+Per the Epic's spike acceptance criteria, this PR ships the **first** archetype's HTML mockup — `Foundation` — at `docs/design/donations/public-foundation.html`. It is the closest to the existing live page so we can validate the chosen architecture doesn't break what's already shipped. The other 9 mockups land in [Phase 4 (PR-4)](../../README.md#phases) along with their implementation.
+
+---
+
+## 4. What's explicitly out of scope here
+
+- **A WYSIWYG editor / drag-and-drop builder.** Forever out of scope for this Epic; covered by the explicit scope-statement in the Epic itself.
+- **Per-section style mixing.** The picker is "pick one archetype," not "compose your own."
+- **Donor-uploaded photography or video.** Photos belong to the operator's branding ([Epic #286](https://github.com/purposestack/givernance/issues/286)).
+- **A/B testing.** The operator picks one archetype; we don't ship a multi-variant runner.
+- **AI-generated style suggestions** ("pick an archetype based on your mission"). Tempting; deferred until we have shipped data on which archetypes correlate with which donor outcomes.
+
+---
+
+## 5. References
+
+- [Epic #362](https://github.com/purposestack/givernance/issues/362) — this work
+- [Epic #286](https://github.com/purposestack/givernance/issues/286) — organisation branding (logo, primary colour) — composes with archetypes
+- [Issue #39](https://github.com/purposestack/givernance/issues/39) / [PR #197](https://github.com/purposestack/givernance/pull/197) — the existing public donation page
+- [`docs/11-design-identity.md`](../11-design-identity.md) — design-token system the archetypes must respect
+- [`docs/24-branding-assets.md`](../24-branding-assets.md) — branding stack archetypes compose with
+- [ADR-030](../adrs/adr-030-public-page-style-archetypes.md) — architecture decision for archetypes (hybrid shell + slot components)

--- a/packages/api/migrations/0053_donation_public_page_styles_flag.sql
+++ b/packages/api/migrations/0053_donation_public_page_styles_flag.sql
@@ -37,10 +37,7 @@
 --   * `public = TRUE` — the settings layout + the campaign editor
 --     SSR-fetch `/v1/feature-flags` to decide whether to render the
 --     "Page style" picker. A private value here would unconditionally
---     hide the entry and defeat the Epic. The flag name is intentionally
---     descriptive (`donation.public_page_styles`) so the public-
---     projection caveat from `docs/18-feature-flags.md` §0 doesn't
---     tease an unannounced surprise.
+--     hide the entry and defeat the Epic.
 --
 -- Idempotent — `ON CONFLICT (key) DO NOTHING` so a redeploy preserves
 -- any super-admin-toggled value. Migrations are immutable once

--- a/packages/api/migrations/0053_donation_public_page_styles_flag.sql
+++ b/packages/api/migrations/0053_donation_public_page_styles_flag.sql
@@ -1,0 +1,68 @@
+-- Migration: 0053_donation_public_page_styles_flag (Epic #362, spike PR)
+--
+-- Seeds the `donation.public_page_styles` feature flag. This is the
+-- gate for the public donation page style-archetype system —
+-- 10 distinct visual archetypes (Foundation, Activist, Editorial Story,
+-- Minimal Checkout, Emergency Appeal, Neo-Brutalist, Calm Wellness,
+-- Civic Modern, Retro Print, Cosmic Gradient) the operator can pick
+-- from for `/p/[id]`.
+--
+-- See:
+--   - `packages/shared/src/constants/feature-flags.ts` — code-side
+--     `FEATURE_FLAG_REGISTRY` entry (`DONATION_PUBLIC_PAGE_STYLES`).
+--     The parity integration test in
+--     `packages/api/src/tests/integration/feature-flags.test.ts`
+--     asserts label + description + scope + tenant_override_allowed +
+--     public match between this row and the registry. Drift fails CI.
+--   - `docs/adrs/adr-030-public-page-style-archetypes.md` — hybrid
+--     shell + slot architecture.
+--   - `docs/ideas/public-page-styles-teardown.md` — competitive
+--     teardown + archetype shortlist.
+--
+-- Posture:
+--   * `enabled = FALSE` — every tenant ships with the flag off, so
+--     the donor-facing `/p/[id]` page renders today's hardcoded layout
+--     until super-admin flips the per-tenant override on. No big-bang
+--     visual change for existing tenants.
+--   * `scope = 'tenant'` — every NPO is independent; one tenant on
+--     `cosmic-gradient` doesn't force every other tenant to be too.
+--     This is the same posture as `communication.bulk_email` (post-
+--     migration 0052) — the kill-switch is per-tenant rather than
+--     platform-wide.
+--   * `tenant_override_allowed = FALSE` for the initial rollout —
+--     super-admin retains the gate until the picker UX is proven
+--     in production. Flips to TRUE in a follow-up once org-admins can
+--     self-serve safely (no policy reason to keep them out beyond
+--     "let's see how the picker lands first").
+--   * `public = TRUE` — the settings layout + the campaign editor
+--     SSR-fetch `/v1/feature-flags` to decide whether to render the
+--     "Page style" picker. A private value here would unconditionally
+--     hide the entry and defeat the Epic. The flag name is intentionally
+--     descriptive (`donation.public_page_styles`) so the public-
+--     projection caveat from `docs/18-feature-flags.md` §0 doesn't
+--     tease an unannounced surprise.
+--
+-- Idempotent — `ON CONFLICT (key) DO NOTHING` so a redeploy preserves
+-- any super-admin-toggled value. Migrations are immutable once
+-- applied (per `feedback_never_modify_applied_migrations`); a future
+-- adjustment to label/description goes in a NEW migration.
+
+INSERT INTO feature_flags (
+  key,
+  enabled,
+  label,
+  description,
+  scope,
+  tenant_override_allowed,
+  public
+)
+VALUES (
+  'donation.public_page_styles',
+  FALSE,
+  'Visual style picker for the public donation page',
+  'Lets your organisation pick from several visual styles for the public donation page that donors see — from a restrained institutional layout to bold activist designs. Off by default: existing campaigns keep their current look until you choose a different style from the Settings menu. Givernance staff turn this on for your organisation after a brief walk-through of the picker.',
+  'tenant',
+  FALSE,
+  TRUE
+)
+ON CONFLICT (key) DO NOTHING;

--- a/packages/api/migrations/0054_public_page_style_columns.sql
+++ b/packages/api/migrations/0054_public_page_style_columns.sql
@@ -1,61 +1,22 @@
 -- Migration: 0054_public_page_style_columns (Epic #362, Phase 1)
 --
--- Adds two columns that together implement the picker semantics:
+-- Two columns + a Postgres enum. Resolution at read time is:
+--     campaigns.public_page_style ?? tenants.default_public_page_style ?? 'foundation'
 --
---   1. `tenants.default_public_page_style` — org-level default the
---      campaign editor inherits from on first publish. Nullable: NULL
---      means "fall back to the platform-wide hardcoded default
---      (Foundation)". `org_admin` writes it from /settings (PR-3).
+-- Both columns nullable, no backfill, no DEFAULT. Rationale: NULL
+-- distinguishes "operator hasn't picked" from "operator picked
+-- Foundation" — the picker shows the inheritance breadcrumb on the
+-- former. A `NOT NULL DEFAULT 'foundation'` would defeat the soft
+-- rollout by silently stamping every legacy campaign.
 --
---   2. `campaigns.public_page_style` — per-campaign override. Nullable:
---      NULL means "inherit from the tenant default". Campaign owners
---      write it from the campaign editor (PR-3). This is the value the
---      donor-facing API actually reads after the three-layer resolution:
---          campaign override ?? tenant default ?? "foundation"
---
--- Both columns use a Postgres enum (`public_page_style`) whose values
--- are kept in lockstep with `PUBLIC_PAGE_STYLE_KEYS` in
--- `packages/shared/src/constants/public-page-styles.ts`. The integration
--- test in `packages/api/src/tests/integration/public-page-styles.test.ts`
--- asserts the enum and the const tuple match — drift fails CI. Same
--- pattern as `campaignTypeEnum` / `campaignStatusEnum` (migration 0003).
---
--- Why nullable + tenant inheritance rather than `NOT NULL DEFAULT
--- 'foundation'`:
---   * `NOT NULL DEFAULT 'foundation'` permanently stamps every existing
---     campaign with "Foundation". That defeats the soft rollout — the
---     operator never "picks" a style, the DB picks one for them, and
---     the picker's "no choice made yet" affordance no longer renders.
---   * `NULL` cleanly distinguishes "operator hasn't decided" from
---     "operator decided on Foundation," which the picker UI needs in
---     order to show the inherits-from-tenant breadcrumb on a campaign
---     that's never been explicitly styled.
---
--- This migration ships even when the `donation.public_page_styles`
--- feature flag is OFF for every tenant — the column existing on the
--- table is structural and per `docs/18-feature-flags.md` § 5 the
--- evaluator gates *reads*, not column existence. The write path
--- (PR-3 and the PUT /v1/campaigns/:id/public-page route in this PR)
--- gates on `requireFlag(...)` as the FIRST preHandler so a scanner
--- with the flag off gets a 404 without enumerating roles.
---
--- Idempotent — `IF NOT EXISTS` on the enum and `ADD COLUMN IF NOT
--- EXISTS` for both columns. No backfill: every existing row picks up
--- NULL (the inheritance default).
---
--- RLS: the columns inherit the existing per-table RLS posture.
--- `campaigns` is tenant-scoped (FORCE ROW LEVEL SECURITY,
--- `org_id = app_current_organization_id()`); `tenants` is owner-only
--- and the `default_public_page_style` write path runs under the
--- `givernance_app` role through the existing PATCH /v1/tenant
--- machinery, which already enforces the org-admin RBAC guard.
+-- Idempotent. Enum kept in lockstep with `PUBLIC_PAGE_STYLE_KEYS` in
+-- `packages/shared/src/constants/public-page-styles.ts`; the
+-- integration test asserts parity. Flag-gating lives on the routes
+-- (`donation.public_page_styles`), not the schema.
 
 -- ─── 1. The enum ────────────────────────────────────────────────────────────
---
--- Order matches `PUBLIC_PAGE_STYLE_KEYS` in the shared constants file
--- (Foundation first as the institutional default, then in voice-
--- quadrant order per the picker UX). Don't sort alphabetically — the
--- order is operator-facing.
+-- Order matches PUBLIC_PAGE_STYLE_KEYS — operator-facing picker tile
+-- order. Don't sort alphabetically.
 
 DO $$
 BEGIN
@@ -91,9 +52,5 @@ ALTER TABLE campaigns
 COMMENT ON COLUMN campaigns.public_page_style IS
   'Epic #362 — per-campaign visual archetype override. NULL = inherit tenant default (or ''foundation'' if that''s also NULL).';
 
--- No index on either column — neither is a high-cardinality filter
--- column (10 enum values, even distribution at most), and the read
--- path joins on the primary keys / FK indices that already exist.
--- The `/v1/public/campaigns/:id/page` query already filters on
--- `campaign_id` (primary-key) before reading the style column, so the
--- column is just a payload byte on an already-tight scan.
+-- No index on either column — low cardinality, read path already
+-- filters on primary keys before reading the style.

--- a/packages/api/migrations/0054_public_page_style_columns.sql
+++ b/packages/api/migrations/0054_public_page_style_columns.sql
@@ -1,0 +1,99 @@
+-- Migration: 0054_public_page_style_columns (Epic #362, Phase 1)
+--
+-- Adds two columns that together implement the picker semantics:
+--
+--   1. `tenants.default_public_page_style` — org-level default the
+--      campaign editor inherits from on first publish. Nullable: NULL
+--      means "fall back to the platform-wide hardcoded default
+--      (Foundation)". `org_admin` writes it from /settings (PR-3).
+--
+--   2. `campaigns.public_page_style` — per-campaign override. Nullable:
+--      NULL means "inherit from the tenant default". Campaign owners
+--      write it from the campaign editor (PR-3). This is the value the
+--      donor-facing API actually reads after the three-layer resolution:
+--          campaign override ?? tenant default ?? "foundation"
+--
+-- Both columns use a Postgres enum (`public_page_style`) whose values
+-- are kept in lockstep with `PUBLIC_PAGE_STYLE_KEYS` in
+-- `packages/shared/src/constants/public-page-styles.ts`. The integration
+-- test in `packages/api/src/tests/integration/public-page-styles.test.ts`
+-- asserts the enum and the const tuple match — drift fails CI. Same
+-- pattern as `campaignTypeEnum` / `campaignStatusEnum` (migration 0003).
+--
+-- Why nullable + tenant inheritance rather than `NOT NULL DEFAULT
+-- 'foundation'`:
+--   * `NOT NULL DEFAULT 'foundation'` permanently stamps every existing
+--     campaign with "Foundation". That defeats the soft rollout — the
+--     operator never "picks" a style, the DB picks one for them, and
+--     the picker's "no choice made yet" affordance no longer renders.
+--   * `NULL` cleanly distinguishes "operator hasn't decided" from
+--     "operator decided on Foundation," which the picker UI needs in
+--     order to show the inherits-from-tenant breadcrumb on a campaign
+--     that's never been explicitly styled.
+--
+-- This migration ships even when the `donation.public_page_styles`
+-- feature flag is OFF for every tenant — the column existing on the
+-- table is structural and per `docs/18-feature-flags.md` § 5 the
+-- evaluator gates *reads*, not column existence. The write path
+-- (PR-3 and the PUT /v1/campaigns/:id/public-page route in this PR)
+-- gates on `requireFlag(...)` as the FIRST preHandler so a scanner
+-- with the flag off gets a 404 without enumerating roles.
+--
+-- Idempotent — `IF NOT EXISTS` on the enum and `ADD COLUMN IF NOT
+-- EXISTS` for both columns. No backfill: every existing row picks up
+-- NULL (the inheritance default).
+--
+-- RLS: the columns inherit the existing per-table RLS posture.
+-- `campaigns` is tenant-scoped (FORCE ROW LEVEL SECURITY,
+-- `org_id = app_current_organization_id()`); `tenants` is owner-only
+-- and the `default_public_page_style` write path runs under the
+-- `givernance_app` role through the existing PATCH /v1/tenant
+-- machinery, which already enforces the org-admin RBAC guard.
+
+-- ─── 1. The enum ────────────────────────────────────────────────────────────
+--
+-- Order matches `PUBLIC_PAGE_STYLE_KEYS` in the shared constants file
+-- (Foundation first as the institutional default, then in voice-
+-- quadrant order per the picker UX). Don't sort alphabetically — the
+-- order is operator-facing.
+
+DO $$
+BEGIN
+  CREATE TYPE public_page_style AS ENUM (
+    'foundation',
+    'activist',
+    'editorial-story',
+    'minimal-checkout',
+    'emergency-appeal',
+    'neo-brutalist',
+    'calm-wellness',
+    'civic-modern',
+    'retro-print',
+    'cosmic-gradient'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ─── 2. Column on `tenants` — org-level default ─────────────────────────────
+
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS default_public_page_style public_page_style;
+
+COMMENT ON COLUMN tenants.default_public_page_style IS
+  'Epic #362 — org-level default visual archetype for new campaigns. NULL = inherit hardcoded ''foundation''.';
+
+-- ─── 3. Column on `campaigns` — per-campaign override ───────────────────────
+
+ALTER TABLE campaigns
+  ADD COLUMN IF NOT EXISTS public_page_style public_page_style;
+
+COMMENT ON COLUMN campaigns.public_page_style IS
+  'Epic #362 — per-campaign visual archetype override. NULL = inherit tenant default (or ''foundation'' if that''s also NULL).';
+
+-- No index on either column — neither is a high-cardinality filter
+-- column (10 enum values, even distribution at most), and the read
+-- path joins on the primary keys / FK indices that already exist.
+-- The `/v1/public/campaigns/:id/page` query already filters on
+-- `campaign_id` (primary-key) before reading the style column, so the
+-- column is just a payload byte on an already-tight scan.

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1778070000000,
       "tag": "0053_donation_public_page_styles_flag",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1778080000000,
+      "tag": "0054_public_page_style_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1778060000000,
       "tag": "0052_bulk_email_tenant_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1778070000000,
+      "tag": "0053_donation_public_page_styles_flag",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/modules/public/routes.ts
+++ b/packages/api/src/modules/public/routes.ts
@@ -1,7 +1,11 @@
 /** Public donation routes — unauthenticated endpoints for embeddable donation pages */
 
 import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
-import { CampaignPublicPageSchema, PublicPageStyleSchema } from "@givernance/shared/validators";
+import {
+  CampaignPublicPageSchema,
+  PublicPageStyleSchema,
+  TenantStyleDefaultSchema,
+} from "@givernance/shared/validators";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { requireFlag } from "../../lib/flags/flag-guard.js";
@@ -384,14 +388,13 @@ export async function publicDonationRoutes(app: FastifyInstance) {
         publicPageStyle?: string | null;
       };
 
-      // Field-level flag gate (Epic #362). Reject the PUT if the
-      // operator sent `publicPageStyle` while the flag is off for this
-      // tenant — *not* with a silent drop, because that would mask a
-      // misconfigured client and leave the UI claiming "saved" while
-      // the value never landed. 400 with a clear reason is the
-      // honest answer; the picker UI never sends the field in the
-      // first place because its `requireFlag` SSR-fetch hides the
-      // picker entirely (see PR-3).
+      // Field-level flag gate (Epic #362). Silent-drop is rejected —
+      // it would let a misconfigured client see "saved" while the
+      // value never landed. The reply carries the `field` discriminator
+      // so the picker UI can map the rejection back to the input
+      // (precedent: bank-accounts/routes.ts), and never leaks the
+      // literal flag key to the operator-facing string (PR-2 review,
+      // security #1 + API contract I2).
       if (body.publicPageStyle !== undefined) {
         const flagsService = request.flagService;
         const enabled = await flagsService.isEnabled(
@@ -404,8 +407,9 @@ export async function publicDonationRoutes(app: FastifyInstance) {
             .send(
               problemDetail(
                 400,
-                "Style picker not enabled",
-                "The visual style picker is not enabled for this organisation. Contact Givernance staff to enable `donation.public_page_styles`.",
+                "Validation Error",
+                "The visual style picker is not available for your organisation.",
+                { field: "publicPageStyle", reason: "feature_not_available" },
               ),
             );
         }
@@ -432,33 +436,24 @@ export async function publicDonationRoutes(app: FastifyInstance) {
   );
 
   /**
-   * GET /v1/tenant/style-default — the org-level default archetype
-   * (Epic #362, picker UX).
+   * GET /v1/org/style-default — the org-level default archetype
+   * (Epic #362).
    *
-   * Returns the raw `tenants.default_public_page_style` value:
-   *   - one of the curated archetype keys, OR
-   *   - `null` when the operator hasn't picked one (picker UX renders
-   *     "inherits from Givernance default" in that case).
+   * URL convention matches `/v1/org/feature-flags` (Epic #365):
+   * caller-scoped, singular `org`, self-service. `/v1/tenants/:orgId/…`
+   * is reserved for platform-admin or tenant-id-scoped routes.
    *
-   * `requireFlag` is the FIRST preHandler so a tenant with the flag
-   * off gets a 404 without enumerating the org-admin guard underneath
-   * — defence-in-depth + scanner-resistant per `docs/18-feature-flags.md`.
-   *
-   * RBAC: `org_admin`. Campaign-owner role added in PR-3 when the
-   * per-campaign editor needs read access.
+   * `requireFlag` is the FIRST preHandler — anti-disclosure 404 when
+   * the flag is off (`docs/18-feature-flags.md`).
    */
   app.get(
-    "/tenant/style-default",
+    "/org/style-default",
     {
       preHandler: [requireFlag(FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES), requireOrgAdmin],
       schema: {
-        tags: ["Tenant Settings"],
+        tags: ["Org Settings"],
         response: {
-          200: DataResponse(
-            Type.Object({
-              defaultPublicPageStyle: Type.Union([PublicPageStyleSchema, Type.Null()]),
-            }),
-          ),
+          200: DataResponse(TenantStyleDefaultSchema),
           ...ErrorResponses,
         },
       },
@@ -474,33 +469,22 @@ export async function publicDonationRoutes(app: FastifyInstance) {
   );
 
   /**
-   * PATCH /v1/tenant/style-default — set the org-level default
-   * archetype (Epic #362). Same flag gate as the GET; same RBAC
-   * (`org_admin` only).
+   * PATCH /v1/org/style-default — set the org-level default archetype
+   * (Epic #362). Same flag gate as the GET; same RBAC (`org_admin`).
    *
-   * The body is tri-state via the explicit `null` / archetype-key
-   * union: a missing field is rejected by the validator. Per-campaign
-   * overrides are unchanged by this write — the resolution at read
-   * time picks the campaign override first, then this default, then
-   * the hardcoded `foundation`. Invalidates the public-page cache
-   * for every campaign owned by this tenant so donors see the new
-   * style on the next pageload.
+   * Tri-state via `{ defaultPublicPageStyle: null | <key> }`. Bulk-
+   * invalidates every cached public-page entry for this tenant so
+   * donors see the new style on the next pageload.
    */
   app.patch(
-    "/tenant/style-default",
+    "/org/style-default",
     {
       preHandler: [requireFlag(FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES), requireOrgAdmin],
       schema: {
-        tags: ["Tenant Settings"],
-        body: Type.Object({
-          defaultPublicPageStyle: Type.Union([PublicPageStyleSchema, Type.Null()]),
-        }),
+        tags: ["Org Settings"],
+        body: TenantStyleDefaultSchema,
         response: {
-          200: DataResponse(
-            Type.Object({
-              defaultPublicPageStyle: Type.Union([PublicPageStyleSchema, Type.Null()]),
-            }),
-          ),
+          200: DataResponse(TenantStyleDefaultSchema),
           ...ErrorResponses,
         },
       },

--- a/packages/api/src/modules/public/routes.ts
+++ b/packages/api/src/modules/public/routes.ts
@@ -1,8 +1,10 @@
 /** Public donation routes — unauthenticated endpoints for embeddable donation pages */
 
-import { CampaignPublicPageSchema } from "@givernance/shared/validators";
+import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
+import { CampaignPublicPageSchema, PublicPageStyleSchema } from "@givernance/shared/validators";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
+import { requireFlag } from "../../lib/flags/flag-guard.js";
 import { requireOrgAdmin } from "../../lib/guards.js";
 import {
   DataResponse,
@@ -15,7 +17,9 @@ import {
   createDonationIntent,
   getAdminPublicPage,
   getPublicPage,
+  getTenantDefaultPublicPageStyle,
   resolveCampaignQrCode,
+  setTenantDefaultPublicPageStyle,
   upsertPublicPage,
 } from "./service.js";
 
@@ -91,6 +95,18 @@ const PublicPageResponse = Type.Object({
    * public page. Boolean only — never the internal bank_account_id.
    */
   hasSwissQrBill: Type.Boolean(),
+  /**
+   * Epic #362 — donor-facing archetype after the three-layer
+   * resolution (campaign override → tenant default → platform
+   * default). `null` when the `donation.public_page_styles` feature
+   * flag is OFF for this campaign's tenant; the donor-page shell
+   * falls back to today's hardcoded layout in that case, so existing
+   * tenants see no change until super-admin flips the flag on. The
+   * value, when non-null, is always one of `PUBLIC_PAGE_STYLE_KEYS`
+   * — defence-in-depth filter in the service strips any stale DB
+   * value that survived a removed-archetype migration.
+   */
+  publicPageStyle: Type.Union([PublicPageStyleSchema, Type.Null()]),
 });
 
 const DonateBody = Type.Object({
@@ -138,6 +154,15 @@ const PublicPageAdminResponse = Type.Object({
   description: Type.Union([Type.String(), Type.Null()]),
   colorPrimary: Type.Union([Type.String(), Type.Null()]),
   goalAmountCents: Type.Union([Type.Integer(), Type.Null()]),
+  /**
+   * Per-campaign archetype override (Epic #362). `null` means
+   * "inherit the tenant default (or the platform default if that's
+   * also null)". The admin response always carries the raw column
+   * value — the picker UX renders the inheritance breadcrumb when
+   * this is `null`. The donor-facing endpoint resolves the three-
+   * layer fallback before responding.
+   */
+  publicPageStyle: Type.Union([PublicPageStyleSchema, Type.Null()]),
   createdAt: Type.String({ format: "date-time" }),
   updatedAt: Type.String({ format: "date-time" }),
 });
@@ -351,14 +376,145 @@ export async function publicDonationRoutes(app: FastifyInstance) {
         colorPrimary?: string | null;
         goalAmountCents?: number | null;
         status?: "draft" | "published";
+        // Epic #362 — per-campaign archetype override. The full route
+        // isn't behind `requireFlag` because the existing PUT predates
+        // the Epic and shipping with the flag off must keep colour /
+        // title / goal edits working. The style field is gated by a
+        // field-level check below — flag off + style in body → 400.
+        publicPageStyle?: string | null;
       };
 
-      const page = await upsertPublicPage(orgId, id, body);
+      // Field-level flag gate (Epic #362). Reject the PUT if the
+      // operator sent `publicPageStyle` while the flag is off for this
+      // tenant — *not* with a silent drop, because that would mask a
+      // misconfigured client and leave the UI claiming "saved" while
+      // the value never landed. 400 with a clear reason is the
+      // honest answer; the picker UI never sends the field in the
+      // first place because its `requireFlag` SSR-fetch hides the
+      // picker entirely (see PR-3).
+      if (body.publicPageStyle !== undefined) {
+        const flagsService = request.flagService;
+        const enabled = await flagsService.isEnabled(
+          FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES,
+          { orgId },
+        );
+        if (!enabled) {
+          return reply
+            .status(400)
+            .send(
+              problemDetail(
+                400,
+                "Style picker not enabled",
+                "The visual style picker is not enabled for this organisation. Contact Givernance staff to enable `donation.public_page_styles`.",
+              ),
+            );
+        }
+      }
+
+      // Cast tightens the `string | null | undefined` from the wire
+      // to the validator-checked `PublicPageStyleKey | null | undefined`
+      // because the request body has already been validated against
+      // `CampaignPublicPageSchema` (PublicPageStyleSchema union) by
+      // Fastify's preHandler ahead of this handler.
+      const page = await upsertPublicPage(orgId, id, {
+        ...body,
+        publicPageStyle: body.publicPageStyle as
+          | import("@givernance/shared/constants").PublicPageStyleKey
+          | null
+          | undefined,
+      });
       if (!page) {
         return reply.status(404).send(problemDetail(404, "Not Found", "Campaign not found"));
       }
 
       return { data: page };
+    },
+  );
+
+  /**
+   * GET /v1/tenant/style-default — the org-level default archetype
+   * (Epic #362, picker UX).
+   *
+   * Returns the raw `tenants.default_public_page_style` value:
+   *   - one of the curated archetype keys, OR
+   *   - `null` when the operator hasn't picked one (picker UX renders
+   *     "inherits from Givernance default" in that case).
+   *
+   * `requireFlag` is the FIRST preHandler so a tenant with the flag
+   * off gets a 404 without enumerating the org-admin guard underneath
+   * — defence-in-depth + scanner-resistant per `docs/18-feature-flags.md`.
+   *
+   * RBAC: `org_admin`. Campaign-owner role added in PR-3 when the
+   * per-campaign editor needs read access.
+   */
+  app.get(
+    "/tenant/style-default",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES), requireOrgAdmin],
+      schema: {
+        tags: ["Tenant Settings"],
+        response: {
+          200: DataResponse(
+            Type.Object({
+              defaultPublicPageStyle: Type.Union([PublicPageStyleSchema, Type.Null()]),
+            }),
+          ),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const value = await getTenantDefaultPublicPageStyle(orgId);
+      return { data: { defaultPublicPageStyle: value } };
+    },
+  );
+
+  /**
+   * PATCH /v1/tenant/style-default — set the org-level default
+   * archetype (Epic #362). Same flag gate as the GET; same RBAC
+   * (`org_admin` only).
+   *
+   * The body is tri-state via the explicit `null` / archetype-key
+   * union: a missing field is rejected by the validator. Per-campaign
+   * overrides are unchanged by this write — the resolution at read
+   * time picks the campaign override first, then this default, then
+   * the hardcoded `foundation`. Invalidates the public-page cache
+   * for every campaign owned by this tenant so donors see the new
+   * style on the next pageload.
+   */
+  app.patch(
+    "/tenant/style-default",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES), requireOrgAdmin],
+      schema: {
+        tags: ["Tenant Settings"],
+        body: Type.Object({
+          defaultPublicPageStyle: Type.Union([PublicPageStyleSchema, Type.Null()]),
+        }),
+        response: {
+          200: DataResponse(
+            Type.Object({
+              defaultPublicPageStyle: Type.Union([PublicPageStyleSchema, Type.Null()]),
+            }),
+          ),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const body = request.body as {
+        defaultPublicPageStyle: import("@givernance/shared/constants").PublicPageStyleKey | null;
+      };
+      const value = await setTenantDefaultPublicPageStyle(orgId, body.defaultPublicPageStyle);
+      return { data: { defaultPublicPageStyle: value } };
     },
   );
 }

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -128,34 +128,65 @@ export async function getPublicPage(campaignId: string) {
     return null;
   }
 
-  // Cache hit — return the snapshot. We cache the full payload (config +
-  // aggregates) since the donate flow is the only consumer and 30s
-  // staleness on either piece is acceptable. `null` is cached as the
-  // string "404" to distinguish "we know there's no page" from a cache
-  // miss; saves DB hits on a scraper hammering unknown campaign ids.
+  // Cache hit — return the snapshot. The cached payload carries the
+  // *raw* per-campaign + per-tenant style columns (not the flag-
+  // resolved `publicPageStyle`); flag evaluation and the three-layer
+  // fallback resolution happen below, AFTER the cache read. This is
+  // the load-bearing fix for the flag-flip residual: a super-admin
+  // flipping `donation.public_page_styles` mid-cache window is picked
+  // up on the very next read instead of being shadowed by a stale
+  // cache entry for up to 30 s (PR-2 multi-agent review, security #4
+  // + backend I4). The flag service has its own Redis → PG cache so
+  // the extra check is sub-millisecond in steady state.
   const cacheKey = `${PUBLIC_PAGE_CACHE_PREFIX}${campaignId}`;
   const cached = await redis.get(cacheKey);
   if (cached === "404") return null;
+
+  let raw: Awaited<ReturnType<typeof loadPublicPage>> = null;
   if (cached !== null) {
     try {
-      return JSON.parse(cached) as Awaited<ReturnType<typeof loadPublicPage>>;
+      raw = JSON.parse(cached) as Awaited<ReturnType<typeof loadPublicPage>>;
     } catch {
       // Bad JSON — fall through to a fresh fetch + overwrite.
+      raw = null;
     }
   }
-
-  const fresh = await loadPublicPage(campaignId);
-  if (fresh === null) {
-    await redis.set(cacheKey, "404", "EX", PUBLIC_PAGE_CACHE_TTL_SECONDS);
-  } else {
-    await redis.set(cacheKey, JSON.stringify(fresh), "EX", PUBLIC_PAGE_CACHE_TTL_SECONDS);
+  if (raw === null) {
+    raw = await loadPublicPage(campaignId);
+    if (raw === null) {
+      await redis.set(cacheKey, "404", "EX", PUBLIC_PAGE_CACHE_TTL_SECONDS);
+      return null;
+    }
+    await redis.set(cacheKey, JSON.stringify(raw), "EX", PUBLIC_PAGE_CACHE_TTL_SECONDS);
   }
-  return fresh;
+
+  // Resolve the donor-facing `publicPageStyle` outside the cached
+  // payload — flagService.isEnabled is Redis-cached so this is a
+  // sub-millisecond hop. With the flag off the field is null and the
+  // donor-page shell falls back to today's hardcoded layout. With
+  // the flag on, the three-layer fallback (campaign override → tenant
+  // default → "foundation") runs against the cached raw columns.
+  const styleEnabled = await flagService.isEnabled(FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES, {
+    orgId: raw.orgIdForStyleResolution,
+  });
+  const {
+    orgIdForStyleResolution: _,
+    campaignPublicPageStyle,
+    tenantDefaultPublicPageStyle,
+    ...rest
+  } = raw;
+  return {
+    ...rest,
+    publicPageStyle: styleEnabled
+      ? resolvePublicPageStyle(campaignPublicPageStyle, tenantDefaultPublicPageStyle)
+      : null,
+  };
 }
 
 async function loadPublicPage(campaignId: string) {
-  // Find the page without RLS to get the orgId.
-  // campaign_public_pages does not enforce RLS for reads.
+  // campaign_public_pages does not enforce RLS for reads — we
+  // resolve `orgId` first, then enter `withTenantContext` for the
+  // joins on tables that DO enforce RLS.
   const [basicPage] = await db
     .select({ orgId: campaignPublicPages.orgId })
     .from(campaignPublicPages)
@@ -169,13 +200,6 @@ async function loadPublicPage(campaignId: string) {
   if (!basicPage) {
     return null;
   }
-
-  // Resolve the donor's archetype out-of-line so the per-tenant flag
-  // check (Epic #362) doesn't add a column to the cache payload. The
-  // public-page cache key (`PUBLIC_PAGE_CACHE_PREFIX`) doesn't include
-  // the flag state, so we evaluate the flag AFTER the cache read to
-  // avoid a 30 s window of stale flag posture leaking to donors.
-  const styleResolved = await resolveDonorFacingStyle(basicPage.orgId);
 
   // Query with tenant context to allow joining with campaigns (which has strict RLS)
   return withTenantContext(basicPage.orgId, async (tx) => {
@@ -262,55 +286,24 @@ async function loadPublicPage(campaignId: string) {
       .from(donations)
       .where(and(eq(donations.campaignId, campaignId), eq(donations.status, "cleared")));
 
-    // Strip the internal `logoVariants` + raw `bankAccountId` + the two
-    // raw style columns from the returned shape. The public response
-    // only ships:
-    //   - the resolved logo URL (never the raw S3 variant manifest),
-    //   - a boolean `hasSwissQrBill` flag (never the internal bank-
-    //     account id),
-    //   - the resolved `publicPageStyle` derived from the three-layer
-    //     fallback, ONLY when the `donation.public_page_styles` flag is
-    //     on for this tenant. With the flag off, the field is omitted so
-    //     the donor-facing shell falls back to today's hardcoded layout.
-    const {
-      logoVariants: _logoVariants,
-      bankAccountId: _ba,
-      campaignPublicPageStyle,
-      tenantDefaultPublicPageStyle,
-      ...rest
-    } = page;
+    // Strip the internal `logoVariants` + raw `bankAccountId` from
+    // the cached shape. The two raw style columns survive into the
+    // cache untouched — `getPublicPage` resolves them against the
+    // current flag state at the read boundary, so a flag flip is
+    // visible to donors on the next request rather than after the
+    // 30 s cache TTL.
+    const { logoVariants: _logoVariants, bankAccountId: _ba, ...rest } = page;
     return {
       ...rest,
       raisedCents: stats?.raisedCents ?? 0,
       donorCount: stats?.donorCount ?? 0,
       organisationLogoUrl,
       hasSwissQrBill: page.bankAccountId !== null,
-      publicPageStyle: styleResolved.enabled
-        ? resolvePublicPageStyle(campaignPublicPageStyle, tenantDefaultPublicPageStyle)
-        : null,
+      // `getPublicPage` needs this to evaluate the per-tenant flag at
+      // the boundary; stripped from the donor-facing response there.
+      orgIdForStyleResolution: basicPage.orgId,
     };
   });
-}
-
-/**
- * Evaluate the `donation.public_page_styles` flag for the tenant that
- * owns this campaign (Epic #362). Returns a small struct rather than a
- * raw boolean so the call-site documents intent ("on or off") cleanly.
- *
- * Read directly from `flagService` rather than going through
- * `request.flagService` because this code path is reached from both:
- *   - the Fastify route (where `request.flagService` would be
- *     available), AND
- *   - the cache miss inside `getPublicPage` (no request context).
- *
- * The flag service caches Redis → PG, so the additional check is a
- * sub-millisecond hop in steady state.
- */
-async function resolveDonorFacingStyle(orgId: string): Promise<{ enabled: boolean }> {
-  const enabled = await flagService.isEnabled(FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES, {
-    orgId,
-  });
-  return { enabled };
 }
 
 /** Fetch the current public page configuration by campaign ID (admin) */
@@ -381,7 +374,7 @@ export async function createDonationIntent(
   if (!publicPage) return null;
 
   return withTenantContext(publicPage.orgId, async (tx) => {
-    // Look up the campaign to find the default currency (requires RLS context)
+    // Requires RLS context — campaigns is FORCE ROW LEVEL SECURITY.
     const [campaign] = await tx
       .select({
         id: campaigns.id,
@@ -393,7 +386,6 @@ export async function createDonationIntent(
 
     if (!campaign) return null;
 
-    // Look up the tenant's Stripe account
     const [tenant] = await tx
       .select({ id: tenants.id, stripeAccountId: tenants.stripeAccountId })
       .from(tenants)
@@ -536,7 +528,6 @@ export async function upsertPublicPage(
   }
 
   return withTenantContext(orgId, async (tx) => {
-    // Verify campaign belongs to this org
     const [campaign] = await tx
       .select({ id: campaigns.id })
       .from(campaigns)
@@ -565,7 +556,6 @@ export async function upsertPublicPage(
       await redis.del(`${PUBLIC_PAGE_CACHE_PREFIX}${campaignId}`);
     }
 
-    // Check for existing page
     const [existing] = await tx
       .select({ id: campaignPublicPages.id })
       .from(campaignPublicPages)
@@ -679,10 +669,17 @@ export async function setTenantDefaultPublicPageStyle(
 
 /**
  * Best-effort cache invalidation for every cached public-page entry
- * belonging to `orgId`. Read the campaign list (RLS-scoped) and DEL
- * the matching keys. Not transactional with the DB write — a donor
- * who lands during the ~50 ms gap sees the previous style for one
- * page-load, which is acceptable for a settings change.
+ * belonging to `orgId`. Read the campaign list (RLS-scoped, indexed
+ * on `org_id`), then issue a single variadic `redis.del(...keys)` —
+ * ioredis pipelines it as one variadic DEL which Redis processes in
+ * O(N) but in a single round-trip, so even a tenant with thousands
+ * of campaigns clears in sub-10 ms on a LAN. Not transactional with
+ * the DB write — a donor who lands during the ~50 ms gap sees the
+ * previous style for one page-load, which is acceptable for a
+ * settings change. Since PR-2's review, flag flips don't go through
+ * here at all: the donor-facing flag-resolution moved out of the
+ * cached payload (see `getPublicPage`), so a flag toggle is picked
+ * up on the very next request regardless of cache state.
  */
 async function invalidateTenantPublicPageCache(orgId: string): Promise<void> {
   const rows = await withTenantContext(orgId, async (tx) =>

--- a/packages/api/src/modules/public/service.ts
+++ b/packages/api/src/modules/public/service.ts
@@ -1,6 +1,12 @@
 /** Public donations service — unauthenticated campaign page lookups and Stripe intent creation */
 
 import {
+  DEFAULT_PUBLIC_PAGE_STYLE,
+  FEATURE_FLAG_KEYS,
+  isPublicPageStyleKey,
+  type PublicPageStyleKey,
+} from "@givernance/shared/constants";
+import {
   type BrandingAssetVariants,
   campaignPublicPages,
   campaignQrCodes,
@@ -11,10 +17,31 @@ import {
 } from "@givernance/shared/schema";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { db, systemDb, withTenantContext } from "../../lib/db.js";
+import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import { brandingPublicUrl } from "../../lib/s3.js";
 import { isUuid } from "../../lib/schemas.js";
 import { getStripe } from "../payments/service.js";
+
+/**
+ * Three-layer resolution of the donor-facing archetype (Epic #362).
+ *
+ *   campaign-level override ?? tenant-level default ?? "foundation"
+ *
+ * `isPublicPageStyleKey` defends against a stale DB value surviving a
+ * removed-archetype migration (defence-in-depth — the validator already
+ * rejects unknown values on write, but a soft-deleted archetype could
+ * leave a dangling row). An unrecognised value falls all the way back
+ * to the platform default rather than 404-ing the donor's page.
+ */
+function resolvePublicPageStyle(
+  campaignStyle: string | null | undefined,
+  tenantDefault: string | null | undefined,
+): PublicPageStyleKey {
+  if (isPublicPageStyleKey(campaignStyle)) return campaignStyle;
+  if (isPublicPageStyleKey(tenantDefault)) return tenantDefault;
+  return DEFAULT_PUBLIC_PAGE_STYLE;
+}
 
 /**
  * 30s Redis cache for the public-page payload (issue #193 review,
@@ -143,6 +170,13 @@ async function loadPublicPage(campaignId: string) {
     return null;
   }
 
+  // Resolve the donor's archetype out-of-line so the per-tenant flag
+  // check (Epic #362) doesn't add a column to the cache payload. The
+  // public-page cache key (`PUBLIC_PAGE_CACHE_PREFIX`) doesn't include
+  // the flag state, so we evaluate the flag AFTER the cache read to
+  // avoid a 30 s window of stale flag posture leaking to donors.
+  const styleResolved = await resolveDonorFacingStyle(basicPage.orgId);
+
   // Query with tenant context to allow joining with campaigns (which has strict RLS)
   return withTenantContext(basicPage.orgId, async (tx) => {
     const [page] = await tx
@@ -154,6 +188,13 @@ async function loadPublicPage(campaignId: string) {
         colorPrimary: campaignPublicPages.colorPrimary,
         goalAmountCents: campaignPublicPages.goalAmountCents,
         defaultCurrency: campaigns.defaultCurrency,
+        /**
+         * Per-campaign style override + tenant default (Epic #362).
+         * Both are nullable on the schema; the three-layer resolution
+         * happens in `resolveDonorFacingStyle` after the join.
+         */
+        campaignPublicPageStyle: campaigns.publicPageStyle,
+        tenantDefaultPublicPageStyle: tenants.defaultPublicPageStyle,
         // Connect direct-charge requires the browser SDK to bind to the
         // connected account — exposed on this public endpoint so the donor
         // page can both (a) initialise Stripe.js and (b) handle 3DS
@@ -221,19 +262,55 @@ async function loadPublicPage(campaignId: string) {
       .from(donations)
       .where(and(eq(donations.campaignId, campaignId), eq(donations.status, "cleared")));
 
-    // Strip the internal `logoVariants` + raw `bankAccountId` from the
-    // returned shape. The public response only ships the resolved logo
-    // URL (never the raw S3 variant manifest) and a boolean
-    // `hasSwissQrBill` flag (never the internal bank-account id).
-    const { logoVariants: _logoVariants, bankAccountId: _ba, ...rest } = page;
+    // Strip the internal `logoVariants` + raw `bankAccountId` + the two
+    // raw style columns from the returned shape. The public response
+    // only ships:
+    //   - the resolved logo URL (never the raw S3 variant manifest),
+    //   - a boolean `hasSwissQrBill` flag (never the internal bank-
+    //     account id),
+    //   - the resolved `publicPageStyle` derived from the three-layer
+    //     fallback, ONLY when the `donation.public_page_styles` flag is
+    //     on for this tenant. With the flag off, the field is omitted so
+    //     the donor-facing shell falls back to today's hardcoded layout.
+    const {
+      logoVariants: _logoVariants,
+      bankAccountId: _ba,
+      campaignPublicPageStyle,
+      tenantDefaultPublicPageStyle,
+      ...rest
+    } = page;
     return {
       ...rest,
       raisedCents: stats?.raisedCents ?? 0,
       donorCount: stats?.donorCount ?? 0,
       organisationLogoUrl,
       hasSwissQrBill: page.bankAccountId !== null,
+      publicPageStyle: styleResolved.enabled
+        ? resolvePublicPageStyle(campaignPublicPageStyle, tenantDefaultPublicPageStyle)
+        : null,
     };
   });
+}
+
+/**
+ * Evaluate the `donation.public_page_styles` flag for the tenant that
+ * owns this campaign (Epic #362). Returns a small struct rather than a
+ * raw boolean so the call-site documents intent ("on or off") cleanly.
+ *
+ * Read directly from `flagService` rather than going through
+ * `request.flagService` because this code path is reached from both:
+ *   - the Fastify route (where `request.flagService` would be
+ *     available), AND
+ *   - the cache miss inside `getPublicPage` (no request context).
+ *
+ * The flag service caches Redis → PG, so the additional check is a
+ * sub-millisecond hop in steady state.
+ */
+async function resolveDonorFacingStyle(orgId: string): Promise<{ enabled: boolean }> {
+  const enabled = await flagService.isEnabled(FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES, {
+    orgId,
+  });
+  return { enabled };
 }
 
 /** Fetch the current public page configuration by campaign ID (admin) */
@@ -244,7 +321,13 @@ export async function getAdminPublicPage(orgId: string, campaignId: string) {
 
   return withTenantContext(orgId, async (tx) => {
     const [campaign] = await tx
-      .select({ id: campaigns.id })
+      .select({
+        id: campaigns.id,
+        // Per-campaign archetype override (Epic #362). The admin view
+        // sees the raw value (NULL = "inherits from tenant"); the
+        // donor-facing endpoint resolves the three-layer fallback.
+        publicPageStyle: campaigns.publicPageStyle,
+      })
       .from(campaigns)
       .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
 
@@ -255,7 +338,13 @@ export async function getAdminPublicPage(orgId: string, campaignId: string) {
       .from(campaignPublicPages)
       .where(eq(campaignPublicPages.campaignId, campaignId));
 
-    return page ?? null;
+    if (!page) return null;
+
+    // Merge the campaign-level style override into the admin response
+    // so the editor can render it in the picker without a second
+    // round-trip. Distinct from the donor-facing endpoint, which
+    // resolves the three-layer fallback before responding.
+    return { ...page, publicPageStyle: campaign.publicPageStyle ?? null };
   });
 }
 
@@ -427,6 +516,19 @@ export async function upsertPublicPage(
     colorPrimary?: string | null;
     goalAmountCents?: number | null;
     status?: "draft" | "published";
+    /**
+     * Per-campaign archetype override (Epic #362). Tri-state:
+     *   - `undefined` → leave the column untouched (the PUT only sent
+     *     the public-page fields and didn't intend to clobber style).
+     *   - `null` → explicitly clear the override, inherit from tenant.
+     *   - one of `PUBLIC_PAGE_STYLE_KEYS` → set the override.
+     *
+     * The validator (`CampaignPublicPageSchema`) rejects any other
+     * value before it reaches this service. The route adds the
+     * `requireFlag(DONATION_PUBLIC_PAGE_STYLES)` preHandler so a
+     * caller with the flag off gets 404 before the body is parsed.
+     */
+    publicPageStyle?: PublicPageStyleKey | null;
   },
 ) {
   if (!isUuid(campaignId)) {
@@ -442,12 +544,34 @@ export async function upsertPublicPage(
 
     if (!campaign) return null;
 
+    // Per-campaign style lives on `campaigns`, not on
+    // `campaign_public_pages`, because the operator can pick a style
+    // before publishing (and continue editing the draft after). Update
+    // the campaign row only when the caller actually sent the field
+    // — `undefined` means "leave untouched"; `null` means "clear
+    // override, inherit from tenant default."
+    if (body.publicPageStyle !== undefined) {
+      await tx
+        .update(campaigns)
+        .set({
+          publicPageStyle: body.publicPageStyle,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
+
+      // Bust the public-page Redis cache so the donor view picks up
+      // the new style on the next pageload (same 30 s window as colour
+      // / goal / description edits — see `PUBLIC_PAGE_CACHE_TTL_SECONDS`).
+      await redis.del(`${PUBLIC_PAGE_CACHE_PREFIX}${campaignId}`);
+    }
+
     // Check for existing page
     const [existing] = await tx
       .select({ id: campaignPublicPages.id })
       .from(campaignPublicPages)
       .where(eq(campaignPublicPages.campaignId, campaignId));
 
+    let saved: typeof campaignPublicPages.$inferSelect | undefined;
     if (existing) {
       const [updated] = await tx
         .update(campaignPublicPages)
@@ -461,23 +585,110 @@ export async function upsertPublicPage(
         })
         .where(eq(campaignPublicPages.id, existing.id))
         .returning();
-
-      return updated;
+      saved = updated;
+    } else {
+      const [created] = await tx
+        .insert(campaignPublicPages)
+        .values({
+          orgId,
+          campaignId,
+          title: body.title,
+          description: body.description ?? null,
+          colorPrimary: body.colorPrimary ?? null,
+          goalAmountCents: body.goalAmountCents ?? null,
+          status: body.status ?? "draft",
+        })
+        .returning();
+      saved = created;
     }
 
-    const [created] = await tx
-      .insert(campaignPublicPages)
-      .values({
-        orgId,
-        campaignId,
-        title: body.title,
-        description: body.description ?? null,
-        colorPrimary: body.colorPrimary ?? null,
-        goalAmountCents: body.goalAmountCents ?? null,
-        status: body.status ?? "draft",
-      })
-      .returning();
+    // Drizzle's `.returning()` is typed as `T[]`; `[updated]` could be
+    // undefined if the UPDATE matched zero rows (concurrent DELETE
+    // beats this transaction). RLS already guarantees the row exists
+    // under the tenant context, so this is a true should-never-happen.
+    if (!saved) {
+      throw new Error(`Upsert returned no row for campaign ${campaignId} — RLS / row mismatch`);
+    }
 
-    return created;
+    // Re-read the campaign-side style so the admin response is in
+    // sync with what was just written (the caller may have explicitly
+    // set it to null; the editor needs that value back to render).
+    const [campaignAfter] = await tx
+      .select({ publicPageStyle: campaigns.publicPageStyle })
+      .from(campaigns)
+      .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
+
+    return { ...saved, publicPageStyle: campaignAfter?.publicPageStyle ?? null };
   });
+}
+
+/**
+ * Fetch the tenant's org-level default archetype (Epic #362, PR-3
+ * picker UX). Routed under `/v1/tenant/style-default` so the picker
+ * doesn't have to know about the broader tenant settings endpoint
+ * (which exists but is a denser PATCH payload).
+ *
+ * Returns `null` for tenants that haven't picked a default yet —
+ * the picker UI surfaces "inherits from Givernance default" in that
+ * case rather than implicitly stamping `foundation` on a fresh tenant.
+ */
+export async function getTenantDefaultPublicPageStyle(
+  orgId: string,
+): Promise<PublicPageStyleKey | null> {
+  return withTenantContext(orgId, async (tx) => {
+    const [row] = await tx
+      .select({ defaultPublicPageStyle: tenants.defaultPublicPageStyle })
+      .from(tenants)
+      .where(eq(tenants.id, orgId));
+    const value = row?.defaultPublicPageStyle ?? null;
+    // Defence-in-depth: the validator rejects unknown values on
+    // write, but a soft-deleted archetype could leave a dangling
+    // value. Strip anything not in the current registry so the
+    // picker doesn't render a deprecated chip.
+    return isPublicPageStyleKey(value) ? value : null;
+  });
+}
+
+/**
+ * Update the tenant's org-level default archetype (Epic #362). Same
+ * tri-state contract as the campaign override: `null` clears it,
+ * a key sets it, omitting the field is rejected by the validator.
+ */
+export async function setTenantDefaultPublicPageStyle(
+  orgId: string,
+  value: PublicPageStyleKey | null,
+): Promise<PublicPageStyleKey | null> {
+  await withTenantContext(orgId, async (tx) => {
+    await tx
+      .update(tenants)
+      .set({ defaultPublicPageStyle: value, updatedAt: new Date() })
+      .where(eq(tenants.id, orgId));
+  });
+
+  // Bust every public-page cache entry for this tenant's campaigns —
+  // changing the org-level default shifts the resolved style for
+  // every campaign that didn't have its own override. Scan via the
+  // existing prefix; the cache is small (30 s TTL) so the SCAN cost
+  // is bounded even on a tenant with hundreds of campaigns. Doing
+  // this here keeps the cache contract local to the service layer
+  // rather than leaking it into the route handler.
+  await invalidateTenantPublicPageCache(orgId);
+
+  return value;
+}
+
+/**
+ * Best-effort cache invalidation for every cached public-page entry
+ * belonging to `orgId`. Read the campaign list (RLS-scoped) and DEL
+ * the matching keys. Not transactional with the DB write — a donor
+ * who lands during the ~50 ms gap sees the previous style for one
+ * page-load, which is acceptable for a settings change.
+ */
+async function invalidateTenantPublicPageCache(orgId: string): Promise<void> {
+  const rows = await withTenantContext(orgId, async (tx) =>
+    tx.select({ id: campaigns.id }).from(campaigns).where(eq(campaigns.orgId, orgId)),
+  );
+  if (rows.length === 0) return;
+  const keys = rows.map((row) => `${PUBLIC_PAGE_CACHE_PREFIX}${row.id}`);
+  await redis.del(...keys);
 }

--- a/packages/api/src/tests/integration/feature-flags.test.ts
+++ b/packages/api/src/tests/integration/feature-flags.test.ts
@@ -384,15 +384,33 @@ describe("Feature flag CHECK against DB drift between schema + seed", () => {
   // two halves of the same source-of-truth. Editing one and forgetting
   // the other leaves the Back Office UI with a label/description that
   // doesn't match a fresh-DB seed. This test catches the drift in CI.
-  it("FEATURE_FLAG_REGISTRY matches the seeded DB rows (label + description + key parity)", async () => {
+  it("FEATURE_FLAG_REGISTRY matches the seeded DB rows (label + description + scope + tenant_override_allowed + public parity)", async () => {
+    // PR #386 Plat-IMPORTANT (Epic #362 spike review): the prior parity
+    // assertion only covered label + description, leaving scope /
+    // tenant_override_allowed / public uncovered. Migration headers
+    // (0051, 0053, …) and `docs/18-feature-flags.md` § 0 promise CI
+    // catches drift on those three columns — extending the assertion
+    // closes the gap so the next flag we add doesn't quietly ship with
+    // the wrong scope or public-projection bit.
     for (const entry of FEATURE_FLAG_REGISTRY) {
       const [dbRow] = await db
-        .select({ label: featureFlags.label, description: featureFlags.description })
+        .select({
+          label: featureFlags.label,
+          description: featureFlags.description,
+          scope: featureFlags.scope,
+          tenantOverrideAllowed: featureFlags.tenantOverrideAllowed,
+          public: featureFlags.public,
+        })
         .from(featureFlags)
         .where(eq(featureFlags.key, entry.key));
       expect(dbRow, `Missing seed row for ${entry.key}`).toBeDefined();
       expect(dbRow?.label, `Label drift for ${entry.key}`).toBe(entry.label);
       expect(dbRow?.description, `Description drift for ${entry.key}`).toBe(entry.description);
+      expect(dbRow?.scope, `Scope drift for ${entry.key}`).toBe(entry.scope);
+      expect(dbRow?.tenantOverrideAllowed, `tenantOverrideAllowed drift for ${entry.key}`).toBe(
+        entry.tenantOverrideAllowed,
+      );
+      expect(dbRow?.public, `public-projection drift for ${entry.key}`).toBe(entry.public);
     }
   });
 

--- a/packages/api/src/tests/integration/public-page-styles.test.ts
+++ b/packages/api/src/tests/integration/public-page-styles.test.ts
@@ -23,7 +23,7 @@
  *      gate is field-level (`publicPageStyle in body && flag off → 400`).
  *      Non-style PUT bodies are unaffected.
  *
- *   4. **Tenant default routes** — `GET / PATCH /v1/tenant/style-default`
+ *   4. **Tenant default routes** — `GET / PATCH /v1/org/style-default`
  *      are gated by `requireFlag(...)` as their FIRST preHandler. With
  *      the flag off both return 404 (anti-disclosure). With the flag on,
  *      they obey the existing `requireOrgAdmin` posture (404 for
@@ -48,7 +48,14 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { db } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { createServer } from "../../server.js";
-import { authHeader, ensureTestTenants, ORG_A, signToken } from "../helpers/auth.js";
+import {
+  authHeader,
+  ensureTestTenants,
+  ORG_A,
+  ORG_B,
+  signToken,
+  signTokenB,
+} from "../helpers/auth.js";
 
 let app: FastifyInstance;
 
@@ -70,6 +77,7 @@ afterAll(async () => {
   await db.execute(sql`DELETE FROM campaign_public_pages WHERE org_id = ${ORG_A}`);
   await db.execute(sql`DELETE FROM campaigns WHERE org_id = ${ORG_A} AND name LIKE 'Style Test%'`);
   await db.execute(sql`UPDATE tenants SET default_public_page_style = NULL WHERE id = ${ORG_A}`);
+  await db.execute(sql`UPDATE tenants SET default_public_page_style = NULL WHERE id = ${ORG_B}`);
   // Leave the flag in its seeded state so subsequent suites see a
   // deterministic starting point.
   await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
@@ -78,9 +86,12 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  // Each test starts with the flag OFF and tenant-default cleared.
+  // Each test starts with the flag OFF and BOTH tenants' defaults
+  // cleared. Includes org-B so the cross-tenant defence test
+  // observes a clean precondition.
   await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
   await db.execute(sql`UPDATE tenants SET default_public_page_style = NULL WHERE id = ${ORG_A}`);
+  await db.execute(sql`UPDATE tenants SET default_public_page_style = NULL WHERE id = ${ORG_B}`);
   await flagService.invalidate();
 });
 
@@ -219,9 +230,24 @@ describe("PUT /v1/campaigns/:id/public-page — publicPageStyle field gate", () 
       },
     });
     expect(res.statusCode).toBe(400);
-    const body = res.json<{ type: string; title: string; status: number; detail: string }>();
+    // PR-2 review: assert on the `field` discriminator (RFC 9457
+    // extension, precedent in bank-accounts/routes.ts) rather than the
+    // user-facing title copy — copy can change without breaking the
+    // contract this test locks in. Also: the response MUST NOT leak
+    // the literal flag key in any operator-facing string.
+    const body = res.json<{
+      type: string;
+      title: string;
+      status: number;
+      detail: string;
+      field?: string;
+      reason?: string;
+    }>();
     expect(body.status).toBe(400);
-    expect(body.title).toContain("Style picker not enabled");
+    expect(body.field).toBe("publicPageStyle");
+    expect(body.reason).toBe("feature_not_available");
+    expect(body.detail).not.toContain("donation.public_page_styles");
+    expect(body.title).not.toContain("donation.public_page_styles");
   });
 
   it("accepts publicPageStyle when the flag is ON; persists it on the campaign row", async () => {
@@ -335,12 +361,12 @@ describe("PUT /v1/campaigns/:id/public-page — publicPageStyle field gate", () 
 
 // ─── 4. Tenant default routes ────────────────────────────────────────
 
-describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", () => {
+describe("GET / PATCH /v1/org/style-default — flag-gated, org-admin-only", () => {
   it("GET returns 404 when the flag is OFF (anti-disclosure)", async () => {
     const token = signToken(app);
     const res = await app.inject({
       method: "GET",
-      url: "/v1/tenant/style-default",
+      url: "/v1/org/style-default",
       headers: authHeader(token),
     });
     expect(res.statusCode).toBe(404);
@@ -350,7 +376,7 @@ describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", 
     const token = signToken(app);
     const res = await app.inject({
       method: "PATCH",
-      url: "/v1/tenant/style-default",
+      url: "/v1/org/style-default",
       headers: authHeader(token),
       payload: { defaultPublicPageStyle: "activist" },
     });
@@ -365,7 +391,7 @@ describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", 
     const token = signToken(app);
     const res = await app.inject({
       method: "GET",
-      url: "/v1/tenant/style-default",
+      url: "/v1/org/style-default",
       headers: authHeader(token),
     });
     expect(res.statusCode).toBe(200);
@@ -378,7 +404,7 @@ describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", 
     const token = signToken(app);
     const res = await app.inject({
       method: "GET",
-      url: "/v1/tenant/style-default",
+      url: "/v1/org/style-default",
       headers: authHeader(token),
     });
     expect(res.statusCode).toBe(200);
@@ -391,7 +417,7 @@ describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", 
     const token = signToken(app);
     const res = await app.inject({
       method: "PATCH",
-      url: "/v1/tenant/style-default",
+      url: "/v1/org/style-default",
       headers: authHeader(token),
       payload: { defaultPublicPageStyle: "cosmic-gradient" },
     });
@@ -402,7 +428,7 @@ describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", 
     // Round-trip via GET.
     const getRes = await app.inject({
       method: "GET",
-      url: "/v1/tenant/style-default",
+      url: "/v1/org/style-default",
       headers: authHeader(token),
     });
     const getBody = getRes.json<{ data: { defaultPublicPageStyle: string | null } }>();
@@ -417,7 +443,7 @@ describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", 
     const token = signToken(app);
     const res = await app.inject({
       method: "PATCH",
-      url: "/v1/tenant/style-default",
+      url: "/v1/org/style-default",
       headers: authHeader(token),
       payload: { defaultPublicPageStyle: null },
     });
@@ -431,7 +457,7 @@ describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", 
     const token = signToken(app);
     const res = await app.inject({
       method: "PATCH",
-      url: "/v1/tenant/style-default",
+      url: "/v1/org/style-default",
       headers: authHeader(token),
       payload: { defaultPublicPageStyle: "definitely-not-a-style" },
     });
@@ -443,7 +469,7 @@ describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", 
     const token = signToken(app, { role: "user" });
     const res = await app.inject({
       method: "PATCH",
-      url: "/v1/tenant/style-default",
+      url: "/v1/org/style-default",
       headers: authHeader(token),
       payload: { defaultPublicPageStyle: "minimal-checkout" },
     });
@@ -453,5 +479,84 @@ describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", 
     // anti-disclosure 404 only applies when the *route itself* should
     // appear not to exist (flag off).
     expect(res.statusCode).toBe(403);
+  });
+});
+
+// ─── 5. Closed-set contract assertions ───────────────────────────────
+
+describe("Response contract — publicPageStyle values are closed set", () => {
+  it("returned values are always one of PUBLIC_PAGE_STYLE_KEYS (or null)", async () => {
+    const campaign = await createCampaign("Style Test Closed Set");
+    await publishPage(campaign.id);
+    await db.execute(
+      sql`UPDATE campaigns SET public_page_style = 'cosmic-gradient' WHERE id = ${campaign.id}`,
+    );
+    await flipFlagOn();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/public/campaigns/${campaign.id}/page`,
+    });
+    const body = res.json<{ data: { publicPageStyle: string | null } }>();
+    // A regression that emitted (e.g.) "cosmic-gradient-v2" would
+    // satisfy every per-case `toBe(...)` test if the DB carried it.
+    // This pins the wire shape to the curated registry.
+    expect(body.data.publicPageStyle).not.toBeNull();
+    expect(PUBLIC_PAGE_STYLE_KEYS as readonly string[]).toContain(
+      body.data.publicPageStyle as string,
+    );
+  });
+});
+
+// ─── 6. Cross-tenant defence ─────────────────────────────────────────
+
+describe("Cross-tenant defence — org A cannot mutate org B's tenant default", () => {
+  it("org-A's PATCH carries org-A's JWT orgId; org-B's tenants row is untouched", async () => {
+    // Even though `tenants` is owner-only at the SQL grant level
+    // (mig 0005 grants UPDATE to `givernance_app` on every table),
+    // the route's `request.auth.orgId` is the JWT-derived value and
+    // the service-layer `WHERE id = orgId` predicate scopes the
+    // UPDATE to that tenant. This test pins the invariant: org-A
+    // cannot reach org-B's row even when the JWT orgId IS org-A.
+    // A future refactor that drops the predicate would surface here.
+    await flipFlagOn();
+
+    // Pre-state: org-B has its own default.
+    await db.execute(
+      sql`UPDATE tenants SET default_public_page_style = 'editorial-story' WHERE id = ${ORG_B}`,
+    );
+
+    // Org-A operator PATCHes their own default.
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/org/style-default",
+      headers: authHeader(tokenA),
+      payload: { defaultPublicPageStyle: "minimal-checkout" },
+    });
+    expect(res.statusCode).toBe(200);
+
+    // Org-B's value MUST be unchanged.
+    const orgBResult = await db.execute<{ default_public_page_style: string | null }>(
+      sql`SELECT default_public_page_style FROM tenants WHERE id = ${ORG_B}`,
+    );
+    expect(orgBResult.rows[0]?.default_public_page_style).toBe("editorial-story");
+
+    // Org-A's value MUST be the new one.
+    const orgAResult = await db.execute<{ default_public_page_style: string | null }>(
+      sql`SELECT default_public_page_style FROM tenants WHERE id = ${ORG_A}`,
+    );
+    expect(orgAResult.rows[0]?.default_public_page_style).toBe("minimal-checkout");
+
+    // And org-B's own GET sees their unchanged value through the API.
+    const tokenB = signTokenB(app);
+    const getRes = await app.inject({
+      method: "GET",
+      url: "/v1/org/style-default",
+      headers: authHeader(tokenB),
+    });
+    expect(getRes.statusCode).toBe(200);
+    const getBody = getRes.json<{ data: { defaultPublicPageStyle: string | null } }>();
+    expect(getBody.data.defaultPublicPageStyle).toBe("editorial-story");
   });
 });

--- a/packages/api/src/tests/integration/public-page-styles.test.ts
+++ b/packages/api/src/tests/integration/public-page-styles.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Public donation page style-archetype integration tests (Epic #362, PR-2).
+ *
+ * Five surfaces covered:
+ *
+ *   1. **Enum / registry parity** — the Postgres enum (migration 0054)
+ *      and the const-tuple `PUBLIC_PAGE_STYLE_KEYS` in
+ *      `@givernance/shared/constants` are two halves of the same source
+ *      of truth. A test asserts the live enum equals the registry; drift
+ *      fails CI.
+ *
+ *   2. **Public endpoint flag-gating** — `GET /v1/public/campaigns/:id/page`
+ *      returns `publicPageStyle: null` when the
+ *      `donation.public_page_styles` flag is OFF for the campaign's
+ *      tenant. With the flag ON it returns the three-layer-resolved value.
+ *      The pattern is "field-level gate," not "404 the route," because
+ *      the public endpoint existed before this Epic and must keep
+ *      serving the page for tenants who haven't opted in.
+ *
+ *   3. **Admin PUT field-level gate** — the existing
+ *      `PUT /v1/campaigns/:id/public-page` route stays open for legacy
+ *      fields (title / colour / goal) even when the flag is off; the
+ *      gate is field-level (`publicPageStyle in body && flag off → 400`).
+ *      Non-style PUT bodies are unaffected.
+ *
+ *   4. **Tenant default routes** — `GET / PATCH /v1/tenant/style-default`
+ *      are gated by `requireFlag(...)` as their FIRST preHandler. With
+ *      the flag off both return 404 (anti-disclosure). With the flag on,
+ *      they obey the existing `requireOrgAdmin` posture (404 for
+ *      non-admins by the same anti-disclosure pattern in this codebase,
+ *      since the platform follows it for the rest of the admin surface).
+ *
+ *   5. **Validation** — unknown style keys are rejected at the
+ *      validator layer (400) before reaching the service; `null` is
+ *      accepted as the explicit-clear value; omitted is no-op on PUT.
+ *
+ * Lifecycle: tests flip the flag on/off via direct DB write +
+ * `flagService.invalidate()` (matches the bulk-email feature-flag
+ * test pattern). Every test resets the flag to its seeded OFF state
+ * in `afterEach` so the parity guarantee holds for the next suite.
+ */
+
+import { FEATURE_FLAG_KEYS, PUBLIC_PAGE_STYLE_KEYS } from "@givernance/shared/constants";
+import { featureFlags } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { flagService } from "../../lib/flags/flag-service.js";
+import { createServer } from "../../server.js";
+import { authHeader, ensureTestTenants, ORG_A, signToken } from "../helpers/auth.js";
+
+let app: FastifyInstance;
+
+const FLAG_KEY = FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES;
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+  // Ensure tenant A has a Stripe account so the public-page query
+  // hits the tenants join successfully (the unit-of-test here is the
+  // style field, not Stripe wiring).
+  await db.execute(
+    sql`UPDATE tenants SET stripe_account_id = 'acct_test_org_a' WHERE id = ${ORG_A}`,
+  );
+});
+
+afterAll(async () => {
+  await db.execute(sql`DELETE FROM campaign_public_pages WHERE org_id = ${ORG_A}`);
+  await db.execute(sql`DELETE FROM campaigns WHERE org_id = ${ORG_A} AND name LIKE 'Style Test%'`);
+  await db.execute(sql`UPDATE tenants SET default_public_page_style = NULL WHERE id = ${ORG_A}`);
+  // Leave the flag in its seeded state so subsequent suites see a
+  // deterministic starting point.
+  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+  await app.close();
+});
+
+beforeEach(async () => {
+  // Each test starts with the flag OFF and tenant-default cleared.
+  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
+  await db.execute(sql`UPDATE tenants SET default_public_page_style = NULL WHERE id = ${ORG_A}`);
+  await flagService.invalidate();
+});
+
+afterEach(async () => {
+  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+});
+
+async function flipFlagOn() {
+  await db.update(featureFlags).set({ enabled: true }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+}
+
+async function createCampaign(name: string): Promise<{ id: string }> {
+  const token = signToken(app);
+  const res = await app.inject({
+    method: "POST",
+    url: "/v1/campaigns",
+    headers: authHeader(token),
+    payload: { name, type: "digital" },
+  });
+  return res.json<{ data: { id: string } }>().data;
+}
+
+async function publishPage(campaignId: string, body: Record<string, unknown> = {}): Promise<void> {
+  const token = signToken(app);
+  await app.inject({
+    method: "PUT",
+    url: `/v1/campaigns/${campaignId}/public-page`,
+    headers: authHeader(token),
+    payload: { title: "Style Test", status: "published", ...body },
+  });
+}
+
+// ─── 1. Enum / registry parity ───────────────────────────────────────
+
+describe("Public-page style enum + registry parity", () => {
+  it("PUBLIC_PAGE_STYLE_KEYS matches the Postgres enum values (migration 0054)", async () => {
+    const result = await db.execute<{ enum_value: string }>(sql`
+      SELECT unnest(enum_range(NULL::public_page_style))::text AS enum_value
+    `);
+    const dbValues = result.rows.map((r) => r.enum_value).sort();
+    const codeValues = [...PUBLIC_PAGE_STYLE_KEYS].sort();
+    expect(
+      dbValues,
+      "Postgres public_page_style enum drifted from PUBLIC_PAGE_STYLE_KEYS — add a NEW migration (not a modification of 0054) to align",
+    ).toEqual(codeValues);
+  });
+});
+
+// ─── 2. Public endpoint flag-gating ──────────────────────────────────
+
+describe("GET /v1/public/campaigns/:id/page — publicPageStyle field", () => {
+  it("returns publicPageStyle: null when the flag is OFF", async () => {
+    const campaign = await createCampaign("Style Test FlagOff");
+    await publishPage(campaign.id);
+    // Direct DB set so the persistence is independent of any flag
+    // gate that may incidentally swallow the value.
+    await db.execute(
+      sql`UPDATE campaigns SET public_page_style = 'activist' WHERE id = ${campaign.id}`,
+    );
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/public/campaigns/${campaign.id}/page`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { publicPageStyle: string | null } }>();
+    expect(body.data.publicPageStyle).toBeNull();
+  });
+
+  it("returns the resolved publicPageStyle when the flag is ON", async () => {
+    const campaign = await createCampaign("Style Test FlagOn Campaign");
+    await publishPage(campaign.id);
+    await db.execute(
+      sql`UPDATE campaigns SET public_page_style = 'activist' WHERE id = ${campaign.id}`,
+    );
+    await flipFlagOn();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/public/campaigns/${campaign.id}/page`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { publicPageStyle: string | null } }>();
+    expect(body.data.publicPageStyle).toBe("activist");
+  });
+
+  it("falls back to the tenant default when no campaign override is set", async () => {
+    const campaign = await createCampaign("Style Test Tenant Default");
+    await publishPage(campaign.id);
+    await db.execute(
+      sql`UPDATE tenants SET default_public_page_style = 'civic-modern' WHERE id = ${ORG_A}`,
+    );
+    await flipFlagOn();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/public/campaigns/${campaign.id}/page`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { publicPageStyle: string | null } }>();
+    expect(body.data.publicPageStyle).toBe("civic-modern");
+  });
+
+  it("falls back to 'foundation' when neither campaign nor tenant has a value", async () => {
+    const campaign = await createCampaign("Style Test Hardcoded Default");
+    await publishPage(campaign.id);
+    await flipFlagOn();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/public/campaigns/${campaign.id}/page`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { publicPageStyle: string | null } }>();
+    expect(body.data.publicPageStyle).toBe("foundation");
+  });
+});
+
+// ─── 3. Admin PUT field-level gate ───────────────────────────────────
+
+describe("PUT /v1/campaigns/:id/public-page — publicPageStyle field gate", () => {
+  it("rejects publicPageStyle in body when the flag is OFF (400, not silent)", async () => {
+    const campaign = await createCampaign("Style Test PUT FlagOff");
+    const token = signToken(app);
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: {
+        title: "X",
+        status: "draft",
+        publicPageStyle: "activist",
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ type: string; title: string; status: number; detail: string }>();
+    expect(body.status).toBe(400);
+    expect(body.title).toContain("Style picker not enabled");
+  });
+
+  it("accepts publicPageStyle when the flag is ON; persists it on the campaign row", async () => {
+    const campaign = await createCampaign("Style Test PUT FlagOn");
+    const token = signToken(app);
+    await flipFlagOn();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: {
+        title: "Activist Campaign",
+        status: "published",
+        publicPageStyle: "activist",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { publicPageStyle: string | null } }>();
+    expect(body.data.publicPageStyle).toBe("activist");
+
+    // Round-trip: the donor-facing endpoint should now emit the value.
+    const publicRes = await app.inject({
+      method: "GET",
+      url: `/v1/public/campaigns/${campaign.id}/page`,
+    });
+    const publicBody = publicRes.json<{ data: { publicPageStyle: string | null } }>();
+    expect(publicBody.data.publicPageStyle).toBe("activist");
+  });
+
+  it("explicit null clears the per-campaign override (inherit from tenant)", async () => {
+    const campaign = await createCampaign("Style Test PUT Null");
+    const token = signToken(app);
+    await flipFlagOn();
+    // First set it to a value.
+    await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: { title: "X", status: "draft", publicPageStyle: "neo-brutalist" },
+    });
+    // Then clear it explicitly.
+    const res = await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: { title: "X", status: "draft", publicPageStyle: null },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { publicPageStyle: string | null } }>();
+    expect(body.data.publicPageStyle).toBeNull();
+  });
+
+  it("omitting publicPageStyle leaves the existing value untouched", async () => {
+    const campaign = await createCampaign("Style Test PUT Untouched");
+    const token = signToken(app);
+    await flipFlagOn();
+    await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: { title: "X", status: "draft", publicPageStyle: "calm-wellness" },
+    });
+    // Second PUT without publicPageStyle in body.
+    const res = await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: { title: "Y", status: "draft" },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { publicPageStyle: string | null } }>();
+    expect(body.data.publicPageStyle).toBe("calm-wellness");
+  });
+
+  it("rejects an unknown style key at the validator layer (400)", async () => {
+    const campaign = await createCampaign("Style Test PUT Bad Key");
+    const token = signToken(app);
+    await flipFlagOn();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: { title: "X", status: "draft", publicPageStyle: "not-a-real-style" },
+    });
+    // Fastify TypeBox schema validation kicks in before the route
+    // handler runs; the resulting 400 carries the validation error
+    // shape, not the route-level problem-detail.
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("legacy PUT (no publicPageStyle) keeps working with the flag OFF", async () => {
+    const campaign = await createCampaign("Style Test PUT Legacy");
+    const token = signToken(app);
+    // Flag stays OFF (default state).
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/v1/campaigns/${campaign.id}/public-page`,
+      headers: authHeader(token),
+      payload: { title: "Legacy", status: "draft" },
+    });
+    expect(res.statusCode).toBe(200);
+    // No regression: the existing fields round-trip normally.
+    const body = res.json<{ data: { title: string; publicPageStyle: string | null } }>();
+    expect(body.data.title).toBe("Legacy");
+    expect(body.data.publicPageStyle).toBeNull();
+  });
+});
+
+// ─── 4. Tenant default routes ────────────────────────────────────────
+
+describe("GET / PATCH /v1/tenant/style-default — flag-gated, org-admin-only", () => {
+  it("GET returns 404 when the flag is OFF (anti-disclosure)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/tenant/style-default",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("PATCH returns 404 when the flag is OFF (anti-disclosure)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/tenant/style-default",
+      headers: authHeader(token),
+      payload: { defaultPublicPageStyle: "activist" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("GET returns the current value when the flag is ON", async () => {
+    await flipFlagOn();
+    await db.execute(
+      sql`UPDATE tenants SET default_public_page_style = 'retro-print' WHERE id = ${ORG_A}`,
+    );
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/tenant/style-default",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { defaultPublicPageStyle: string | null } }>();
+    expect(body.data.defaultPublicPageStyle).toBe("retro-print");
+  });
+
+  it("GET returns null when the tenant hasn't picked a default", async () => {
+    await flipFlagOn();
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/tenant/style-default",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { defaultPublicPageStyle: string | null } }>();
+    expect(body.data.defaultPublicPageStyle).toBeNull();
+  });
+
+  it("PATCH sets the tenant default to a valid key", async () => {
+    await flipFlagOn();
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/tenant/style-default",
+      headers: authHeader(token),
+      payload: { defaultPublicPageStyle: "cosmic-gradient" },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { defaultPublicPageStyle: string | null } }>();
+    expect(body.data.defaultPublicPageStyle).toBe("cosmic-gradient");
+
+    // Round-trip via GET.
+    const getRes = await app.inject({
+      method: "GET",
+      url: "/v1/tenant/style-default",
+      headers: authHeader(token),
+    });
+    const getBody = getRes.json<{ data: { defaultPublicPageStyle: string | null } }>();
+    expect(getBody.data.defaultPublicPageStyle).toBe("cosmic-gradient");
+  });
+
+  it("PATCH null clears the tenant default", async () => {
+    await flipFlagOn();
+    await db.execute(
+      sql`UPDATE tenants SET default_public_page_style = 'editorial-story' WHERE id = ${ORG_A}`,
+    );
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/tenant/style-default",
+      headers: authHeader(token),
+      payload: { defaultPublicPageStyle: null },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { defaultPublicPageStyle: string | null } }>();
+    expect(body.data.defaultPublicPageStyle).toBeNull();
+  });
+
+  it("PATCH rejects an unknown style key at the validator layer", async () => {
+    await flipFlagOn();
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/tenant/style-default",
+      headers: authHeader(token),
+      payload: { defaultPublicPageStyle: "definitely-not-a-style" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("PATCH returns 403 for a non-org-admin user when flag is ON", async () => {
+    await flipFlagOn();
+    const token = signToken(app, { role: "user" });
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/tenant/style-default",
+      headers: authHeader(token),
+      payload: { defaultPublicPageStyle: "minimal-checkout" },
+    });
+    // `requireOrgAdmin` is the second preHandler — it 403s for `user`
+    // role. We deliberately don't 404 here because the flag IS on:
+    // the route exists, but this caller doesn't have permission. The
+    // anti-disclosure 404 only applies when the *route itself* should
+    // appear not to exist (flag off).
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/packages/shared/src/constants/feature-flags.ts
+++ b/packages/shared/src/constants/feature-flags.ts
@@ -61,6 +61,53 @@ export const FEATURE_FLAG_KEYS = {
   COMMUNICATION_BULK_EMAIL: "communication.bulk_email",
 
   /**
+   * Gates the public donation page style-archetype system (Epic #362).
+   *
+   * The Epic adds 10 visual archetypes the operator can pick from for
+   * the public donation page (`/p/[id]`) — `Foundation`, `Activist`,
+   * `Editorial Story`, `Minimal Checkout`, `Emergency Appeal`,
+   * `Neo-Brutalist`, `Calm Wellness`, `Civic Modern`, `Retro Print`,
+   * `Cosmic Gradient`. With the flag OFF the public page renders
+   * today's hardcoded layout — i.e. existing tenants see exactly what
+   * they see today, until they explicitly opt in via the picker.
+   *
+   * `scope='tenant'`: every NPO is independent; one tenant on
+   * `cosmic-gradient` shouldn't force every other tenant to be too.
+   *
+   * `tenant_override_allowed=false` for the initial rollout: super-
+   * admin flips the gate per tenant after a brief CSM walk-through.
+   * Flips to `true` in a follow-up once the picker UX is proven and
+   * org-admins can self-serve safely (no policy reason to keep them
+   * out beyond "let's see how the picker lands").
+   *
+   * `public=true`: SSR-fetch in the settings layout + the campaign
+   * editor decides whether to render the "Page style" picker; a
+   * private value would unconditionally hide the entry and defeat
+   * the Epic. The flag *name itself* (`donation.public_page_styles`)
+   * is intentionally descriptive — no tease of an unannounced
+   * surprise.
+   *
+   * Surfaces gated by this key:
+   *   - API: GET / PATCH on `publicPageStyle` field of campaigns and
+   *     tenants (Phase 1, PR-2). Routes return 404 not 403 when the
+   *     flag is off, so a scanner can't enumerate the feature.
+   *   - API: `publicPageStyle` field on `/v1/public/campaigns/:id/page`
+   *     response is omitted when the flag is off for the tenant; the
+   *     frontend shell falls back to the hardcoded "Foundation-ish"
+   *     layout in that case.
+   *   - Web: org-level picker on `/settings` (Phase 2, PR-3).
+   *   - Web: per-campaign picker on the campaign editor (Phase 2,
+   *     PR-3).
+   *   - Web: every archetype's lazy-loaded slot bundle is excluded
+   *     from the chunk graph when the flag is off — the shell
+   *     short-circuits before the dynamic `import()` (ADR-030).
+   *
+   * Emergency rollback: see `docs/runbooks/feature-flag-rollback.md`
+   * if the Back Office is unavailable.
+   */
+  DONATION_PUBLIC_PAGE_STYLES: "donation.public_page_styles",
+
+  /**
    * Gates the Feature flags Phase 2 work itself (Epic #365 / PR #366).
    *
    * Even flag-administration tooling gets a flag — the new tenant-
@@ -145,6 +192,16 @@ export const FEATURE_FLAG_REGISTRY: ReadonlyArray<{
     label: "Bulk emails to constituents",
     description:
       "Lets operators send one email to several constituents at once from the Constituents page. Off by default — Givernance staff will turn it on for your organisation once your email-deliverability setup is verified so messages don't land in donors' spam folders.",
+    scope: "tenant",
+    tenantOverrideAllowed: false,
+    public: true,
+  },
+  {
+    key: FEATURE_FLAG_KEYS.DONATION_PUBLIC_PAGE_STYLES,
+    defaultEnabled: false,
+    label: "Visual style picker for the public donation page",
+    description:
+      "Lets your organisation pick from several visual styles for the public donation page that donors see — from a restrained institutional layout to bold activist designs. Off by default: existing campaigns keep their current look until you choose a different style from the Settings menu. Givernance staff turn this on for your organisation after a brief walk-through of the picker.",
     scope: "tenant",
     tenantOverrideAllowed: false,
     public: true,

--- a/packages/shared/src/constants/feature-flags.ts
+++ b/packages/shared/src/constants/feature-flags.ts
@@ -83,9 +83,7 @@ export const FEATURE_FLAG_KEYS = {
    * `public=true`: SSR-fetch in the settings layout + the campaign
    * editor decides whether to render the "Page style" picker; a
    * private value would unconditionally hide the entry and defeat
-   * the Epic. The flag *name itself* (`donation.public_page_styles`)
-   * is intentionally descriptive — no tease of an unannounced
-   * surprise.
+   * the Epic.
    *
    * Surfaces gated by this key:
    *   - API: GET / PATCH on `publicPageStyle` field of campaigns and

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -23,5 +23,13 @@ export { assertSafeOrgAttributes, SAFE_ORG_ATTRIBUTES } from "./keycloak-org-att
 export { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "./password";
 export { isPersonalEmailDomain, PERSONAL_EMAIL_DOMAINS } from "./personal-email-domains";
 export { PINO_REDACT_PATHS } from "./pino-redact";
+export {
+  DEFAULT_PUBLIC_PAGE_STYLE,
+  isPublicPageStyleKey,
+  PUBLIC_PAGE_STYLE_KEYS,
+  PUBLIC_PAGE_STYLE_REGISTRY,
+  type PublicPageStyleDescriptor,
+  type PublicPageStyleKey,
+} from "./public-page-styles";
 export { isReservedSlug, RESERVED_SLUGS } from "./reserved-slugs";
 export { DOMAIN_PATTERN, validateTenantDomain } from "./tenant-domain";

--- a/packages/shared/src/constants/public-page-styles.ts
+++ b/packages/shared/src/constants/public-page-styles.ts
@@ -1,0 +1,168 @@
+/**
+ * Public donation page archetype registry (Epic #362).
+ *
+ * Single source of truth for the set of visual archetypes the operator can
+ * pick from for `/p/[id]`. Two surfaces care about these values:
+ *
+ *   - **Backend** (`packages/api`): the Postgres enum
+ *     `public_page_style` (migration 0054) is kept in lockstep with this
+ *     array, so adding or removing an archetype is a one-place change in
+ *     code that any new migration mirrors.
+ *   - **Frontend** (`packages/web`): the closed `ARCHETYPES` registry
+ *     (ADR-030, § Decision) is keyed by these identifiers. The lazy
+ *     dynamic import resolves through that registry, so an unknown value
+ *     fails the type check before reaching the loader — there is no
+ *     attacker-controllable template-literal `import()` anywhere.
+ *
+ * Ordering: the literal order of `PUBLIC_PAGE_STYLE_KEYS` is the order the
+ * picker UI surfaces them (`Foundation` first as the institutional
+ * default, then in voice-quadrant order). Don't sort alphabetically.
+ *
+ * Naming: dotted-namespace-free, kebab-case, archetype-keyed (NOT
+ * domain-keyed). Each key is the operator-facing identifier used in the
+ * style picker UI; it never carries a `donation.` prefix because the
+ * column lives on `campaigns` / `tenants` and the context is already
+ * scoped. The closest analog is `campaign_type` enum values
+ * (`nominative_postal`, `door_drop`, …) — same dialect.
+ *
+ * The picker shows the operator-facing **label** (from
+ * `PUBLIC_PAGE_STYLE_REGISTRY` below), never the bare key.
+ */
+
+/**
+ * Every archetype identifier as a const-tuple literal so the type system
+ * keeps it closed: `PublicPageStyleKey` is the discriminated-union type
+ * the backend validator + the frontend `ARCHETYPES` map both consume.
+ */
+export const PUBLIC_PAGE_STYLE_KEYS = [
+  "foundation",
+  "activist",
+  "editorial-story",
+  "minimal-checkout",
+  "emergency-appeal",
+  "neo-brutalist",
+  "calm-wellness",
+  "civic-modern",
+  "retro-print",
+  "cosmic-gradient",
+] as const;
+
+export type PublicPageStyleKey = (typeof PUBLIC_PAGE_STYLE_KEYS)[number];
+
+/**
+ * The hardcoded default when neither the campaign nor the tenant has
+ * explicitly picked a style. `Foundation` matches the layout that
+ * shipped before Epic #362, so every existing campaign keeps its
+ * current look until the operator opts in.
+ *
+ * Used as the resolution fallback in the API service: `campaign style
+ * ?? tenant default ?? DEFAULT_PUBLIC_PAGE_STYLE`.
+ */
+export const DEFAULT_PUBLIC_PAGE_STYLE: PublicPageStyleKey = "foundation";
+
+/**
+ * Operator-facing copy + brief-line for each archetype. Powers the
+ * picker UI's grid cards and the campaign-editor selector. Voice +
+ * typography hints kept brief — the long-form archetype briefs live
+ * in `docs/ideas/public-page-styles-teardown.md` (and the future
+ * `docs/26-public-page-styles.md`).
+ *
+ * Text-field convention (mirrors `FEATURE_FLAG_REGISTRY` in
+ * `feature-flags.ts`):
+ *   - `label` and `tagline` are operator-facing, plain language,
+ *     no jargon, no issue numbers. Read by non-technical
+ *     fundraising managers.
+ *   - Engineering notes (slot constraints, motion policy, bundle
+ *     considerations) live in the per-archetype README under
+ *     `packages/web/src/archetypes/<key>/README.md` — invisible to
+ *     operators, visible to engineers.
+ */
+export interface PublicPageStyleDescriptor {
+  key: PublicPageStyleKey;
+  /** Short noun phrase shown on the picker tile (≤ 24 chars). */
+  label: string;
+  /** Single-sentence brief shown under the label (≤ 120 chars). */
+  tagline: string;
+  /**
+   * Voice / posture word for grouping in the picker UX. Used by the
+   * picker to render mini-section headers ("Institutional",
+   * "Expressive", "Editorial", "Civic"). Keep the set small.
+   */
+  voice: "institutional" | "expressive" | "editorial" | "minimal" | "civic";
+}
+
+export const PUBLIC_PAGE_STYLE_REGISTRY: ReadonlyArray<PublicPageStyleDescriptor> = [
+  {
+    key: "foundation",
+    label: "Foundation",
+    tagline: "Restrained institutional look. Donor reads the headline first, the brand second.",
+    voice: "institutional",
+  },
+  {
+    key: "activist",
+    label: "Activist",
+    tagline: "Sustained mobilisation. Recurring-first. Big colour, big type, big ask.",
+    voice: "expressive",
+  },
+  {
+    key: "editorial-story",
+    label: "Editorial Story",
+    tagline: "Long-form photo essay. The donation form reveals after the story.",
+    voice: "editorial",
+  },
+  {
+    key: "minimal-checkout",
+    label: "Minimal Checkout",
+    tagline: "Stripe-Payment-Link grade. No pitch — the donor already trusts you.",
+    voice: "minimal",
+  },
+  {
+    key: "emergency-appeal",
+    label: "Emergency Appeal",
+    tagline: "Counter-led, one-time-first. For disasters and time-bound appeals.",
+    voice: "expressive",
+  },
+  {
+    key: "neo-brutalist",
+    label: "Neo-Brutalist",
+    tagline: "Mono type, hard borders, deliberate roughness. For arts and indie civic orgs.",
+    voice: "expressive",
+  },
+  {
+    key: "calm-wellness",
+    label: "Calm Wellness",
+    tagline: "Soft pastel washes, breath-paced. For mental-health and mindfulness orgs.",
+    voice: "expressive",
+  },
+  {
+    key: "civic-modern",
+    label: "Civic Modern",
+    tagline: "Public-sector neutral. Transparency stats foregrounded.",
+    voice: "civic",
+  },
+  {
+    key: "retro-print",
+    label: "Retro Print",
+    tagline: "Riso-printed energy, two-colour duotone. For heritage and alumni orgs.",
+    voice: "editorial",
+  },
+  {
+    key: "cosmic-gradient",
+    label: "Cosmic Gradient",
+    tagline: "Animated mesh, optimistic, future-facing. For climate-tech and arts orgs.",
+    voice: "expressive",
+  },
+];
+
+/**
+ * Runtime predicate: `true` when the input is one of the curated archetype
+ * keys. The validator wraps this for the request body; the API service
+ * wraps it for the read-path fallback when a stale DB value somehow
+ * survives a removed-archetype migration. Defence-in-depth — every read
+ * path that returns `publicPageStyle` to a donor MUST verify the value
+ * is currently in the registry, because a deprecated archetype removed
+ * from the frontend bundle would 404 the donor's page otherwise.
+ */
+export function isPublicPageStyleKey(value: unknown): value is PublicPageStyleKey {
+  return typeof value === "string" && (PUBLIC_PAGE_STYLE_KEYS as readonly string[]).includes(value);
+}

--- a/packages/shared/src/constants/public-page-styles.ts
+++ b/packages/shared/src/constants/public-page-styles.ts
@@ -1,32 +1,17 @@
 /**
  * Public donation page archetype registry (Epic #362).
  *
- * Single source of truth for the set of visual archetypes the operator can
- * pick from for `/p/[id]`. Two surfaces care about these values:
+ * Single source of truth for the set of visual archetypes — kept in
+ * lockstep with the Postgres enum (migration 0054) and the frontend
+ * `ARCHETYPES` closed map (ADR-030 § Decision). The integration parity
+ * test asserts both halves match.
  *
- *   - **Backend** (`packages/api`): the Postgres enum
- *     `public_page_style` (migration 0054) is kept in lockstep with this
- *     array, so adding or removing an archetype is a one-place change in
- *     code that any new migration mirrors.
- *   - **Frontend** (`packages/web`): the closed `ARCHETYPES` registry
- *     (ADR-030, § Decision) is keyed by these identifiers. The lazy
- *     dynamic import resolves through that registry, so an unknown value
- *     fails the type check before reaching the loader — there is no
- *     attacker-controllable template-literal `import()` anywhere.
+ * **Ordering** is operator-facing — picker tile order. `Foundation`
+ * first as the institutional default; remaining keys grouped by voice
+ * quadrant. Don't sort alphabetically.
  *
- * Ordering: the literal order of `PUBLIC_PAGE_STYLE_KEYS` is the order the
- * picker UI surfaces them (`Foundation` first as the institutional
- * default, then in voice-quadrant order). Don't sort alphabetically.
- *
- * Naming: dotted-namespace-free, kebab-case, archetype-keyed (NOT
- * domain-keyed). Each key is the operator-facing identifier used in the
- * style picker UI; it never carries a `donation.` prefix because the
- * column lives on `campaigns` / `tenants` and the context is already
- * scoped. The closest analog is `campaign_type` enum values
- * (`nominative_postal`, `door_drop`, …) — same dialect.
- *
- * The picker shows the operator-facing **label** (from
- * `PUBLIC_PAGE_STYLE_REGISTRY` below), never the bare key.
+ * **Naming** is bare kebab-case, no `donation.` prefix — the column
+ * lives on `campaigns` / `tenants` and the context is already scoped.
  */
 
 /**
@@ -61,21 +46,10 @@ export type PublicPageStyleKey = (typeof PUBLIC_PAGE_STYLE_KEYS)[number];
 export const DEFAULT_PUBLIC_PAGE_STYLE: PublicPageStyleKey = "foundation";
 
 /**
- * Operator-facing copy + brief-line for each archetype. Powers the
- * picker UI's grid cards and the campaign-editor selector. Voice +
- * typography hints kept brief — the long-form archetype briefs live
- * in `docs/ideas/public-page-styles-teardown.md` (and the future
- * `docs/26-public-page-styles.md`).
- *
- * Text-field convention (mirrors `FEATURE_FLAG_REGISTRY` in
- * `feature-flags.ts`):
- *   - `label` and `tagline` are operator-facing, plain language,
- *     no jargon, no issue numbers. Read by non-technical
- *     fundraising managers.
- *   - Engineering notes (slot constraints, motion policy, bundle
- *     considerations) live in the per-archetype README under
- *     `packages/web/src/archetypes/<key>/README.md` — invisible to
- *     operators, visible to engineers.
+ * Operator-facing copy for each archetype. `label` + `tagline` are
+ * read by non-technical fundraising managers in the picker — plain
+ * language, no jargon, no issue numbers. Engineering notes live in
+ * the per-archetype README under `packages/web/src/archetypes/<key>/`.
  */
 export interface PublicPageStyleDescriptor {
   key: PublicPageStyleKey;

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -40,6 +40,20 @@ export type CampaignStatus = (typeof CAMPAIGN_STATUS_VALUES)[number];
 
 export const campaignStatusEnum = pgEnum("campaign_status", [...CAMPAIGN_STATUS_VALUES]);
 
+/**
+ * Public donation page visual archetypes (Epic #362, migration 0054).
+ *
+ * Re-exported from the operator-facing source of truth in
+ * `@givernance/shared/constants` (`PUBLIC_PAGE_STYLE_KEYS`). Keep the
+ * two in lockstep — adding an archetype is a one-place change in the
+ * constants file; this schema and the migration mirror it. The
+ * integration parity test in
+ * `packages/api/src/tests/integration/public-page-styles.test.ts`
+ * fails CI on drift.
+ */
+import { PUBLIC_PAGE_STYLE_KEYS } from "../constants/public-page-styles";
+export const publicPageStyleEnum = pgEnum("public_page_style", [...PUBLIC_PAGE_STYLE_KEYS]);
+
 export const campaignDocumentStatusEnum = pgEnum("campaign_document_status", [
   "pending",
   "generated",
@@ -194,6 +208,24 @@ export const tenants = pgTable(
      * UI surfaces fall back to the Givernance default + org name.
      */
     logoAssetId: uuid("logo_asset_id"),
+    /**
+     * Default public donation page archetype for this org (Epic #362).
+     * NULL = "inherit the hardcoded platform default (`foundation`)".
+     * `org_admin` writes this from /settings; the campaign editor
+     * inherits from it on first publish unless the campaign owner
+     * explicitly overrides via `campaigns.public_page_style`. The
+     * three-layer resolution at read time is:
+     *
+     *   campaigns.public_page_style       (per-campaign override)
+     *   ?? tenants.default_public_page_style (org-level default)
+     *   ?? "foundation"                     (platform default)
+     *
+     * The donor-facing API only returns a non-null value when the
+     * `donation.public_page_styles` flag is on for this tenant; with
+     * the flag off, the shell falls back to today's hardcoded layout
+     * regardless of what's stored here.
+     */
+    defaultPublicPageStyle: publicPageStyleEnum("default_public_page_style"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -1011,6 +1043,16 @@ export const campaigns = pgTable(
      * `bankAccountId IS NULL`.
      */
     qrReferenceMode: campaignQrReferenceModeEnum("qr_reference_mode").notNull().default("auto"),
+    /**
+     * Per-campaign override of the public-page archetype (Epic #362).
+     * NULL = "inherit `tenants.default_public_page_style`, falling
+     * back to ''foundation'' if that's also NULL." Donor-facing API
+     * only emits this through to the public response when the
+     * `donation.public_page_styles` feature flag is on for the
+     * owning tenant; with the flag off, the field is omitted and
+     * the donor page falls back to today's hardcoded layout.
+     */
+    publicPageStyle: publicPageStyleEnum("public_page_style"),
     operationalCostCents: bigint("operational_cost_cents", { mode: "number" }),
     platformFeesCents: bigint("platform_fees_cents", { mode: "number" }).notNull().default(0),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -2,6 +2,7 @@
 
 import { type Static, type TSchema, Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
+import { PUBLIC_PAGE_STYLE_KEYS } from "../constants/public-page-styles";
 import { isReservedSlug } from "../constants/reserved-slugs";
 
 export {
@@ -253,6 +254,19 @@ export const CAMPAIGN_PUBLIC_PAGE_COLOR_VALUES = [
 
 export type CampaignPublicPageColor = (typeof CAMPAIGN_PUBLIC_PAGE_COLOR_VALUES)[number];
 
+/**
+ * Closed union of public-page archetype identifiers (Epic #362).
+ * Kept in lockstep with `PUBLIC_PAGE_STYLE_KEYS` in
+ * `@givernance/shared/constants` — the single source of truth — so
+ * the validator, the Drizzle enum, the Postgres enum (migration 0054),
+ * and the frontend `ARCHETYPES` map all share the same alphabet. Any
+ * value outside this union is rejected by the request validator before
+ * reaching the service layer.
+ */
+export const PublicPageStyleSchema = Type.Union(
+  PUBLIC_PAGE_STYLE_KEYS.map((value) => Type.Literal(value)),
+);
+
 /** Schema for creating or updating a campaign public page */
 export const CampaignPublicPageSchema = Type.Object({
   title: Type.String({ minLength: 1, maxLength: 255 }),
@@ -265,6 +279,17 @@ export const CampaignPublicPageSchema = Type.Object({
   ),
   goalAmountCents: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
   status: Type.Optional(Type.Union([Type.Literal("draft"), Type.Literal("published")])),
+  /**
+   * Per-campaign archetype override (Epic #362). `null` clears the
+   * override and falls back to the tenant default (or the platform
+   * default). Omitting the field in a PUT body leaves the prior value
+   * untouched — distinct from `null`, which explicitly clears it.
+   *
+   * Behind the `donation.public_page_styles` feature flag: the route
+   * gates on `requireFlag(...)` as its FIRST preHandler, so with the
+   * flag off the PUT returns 404 and the field can't be set.
+   */
+  publicPageStyle: Type.Optional(Type.Union([PublicPageStyleSchema, Type.Null()])),
 });
 
 /** Schema for list query parameters */
@@ -283,6 +308,7 @@ export type DonationAllocation = Static<typeof DonationAllocationSchema>;
 export type CampaignCreate = Static<typeof CampaignCreateSchema>;
 export type CampaignUpdate = Static<typeof CampaignUpdateSchema>;
 export type CampaignPublicPage = Static<typeof CampaignPublicPageSchema>;
+export type PublicPageStyle = Static<typeof PublicPageStyleSchema>;
 export type PaginationQuery = Static<typeof PaginationQuerySchema>;
 
 /** Validate, coerce, and apply defaults — throws on failure */

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -255,17 +255,27 @@ export const CAMPAIGN_PUBLIC_PAGE_COLOR_VALUES = [
 export type CampaignPublicPageColor = (typeof CAMPAIGN_PUBLIC_PAGE_COLOR_VALUES)[number];
 
 /**
- * Closed union of public-page archetype identifiers (Epic #362).
+ * Closed enum of public-page archetype identifiers (Epic #362).
  * Kept in lockstep with `PUBLIC_PAGE_STYLE_KEYS` in
  * `@givernance/shared/constants` — the single source of truth — so
  * the validator, the Drizzle enum, the Postgres enum (migration 0054),
  * and the frontend `ARCHETYPES` map all share the same alphabet. Any
- * value outside this union is rejected by the request validator before
+ * value outside this set is rejected by the request validator before
  * reaching the service layer.
+ *
+ * `Type.Unsafe<PublicPageStyleKey>({ type: "string", enum: […] })`:
+ * emits a canonical JSON-Schema `enum:` keyword (OpenAPI 3.1 consumers
+ * render this as a single enum dropdown rather than 10 separate
+ * single-value string types — PR-2 review, API contract N2) while
+ * keeping the inferred `Static<>` type narrowed to the literal union
+ * — `Type.String({ enum })` widens to `string`, which would defeat
+ * compile-time exhaustiveness in the service layer.
  */
-export const PublicPageStyleSchema = Type.Union(
-  PUBLIC_PAGE_STYLE_KEYS.map((value) => Type.Literal(value)),
-);
+export const PublicPageStyleSchema = Type.Unsafe<(typeof PUBLIC_PAGE_STYLE_KEYS)[number]>({
+  type: "string",
+  enum: [...PUBLIC_PAGE_STYLE_KEYS],
+  $id: "PublicPageStyle",
+});
 
 /** Schema for creating or updating a campaign public page */
 export const CampaignPublicPageSchema = Type.Object({
@@ -309,6 +319,17 @@ export type CampaignCreate = Static<typeof CampaignCreateSchema>;
 export type CampaignUpdate = Static<typeof CampaignUpdateSchema>;
 export type CampaignPublicPage = Static<typeof CampaignPublicPageSchema>;
 export type PublicPageStyle = Static<typeof PublicPageStyleSchema>;
+
+/**
+ * Body + response shape for `GET / PATCH /v1/org/style-default`
+ * (Epic #362). Single-field schema today; lives next to
+ * `PublicPageStyleSchema` so the picker UI gets one named schema in
+ * the OpenAPI emit rather than three anonymous inline objects.
+ */
+export const TenantStyleDefaultSchema = Type.Object({
+  defaultPublicPageStyle: Type.Union([PublicPageStyleSchema, Type.Null()]),
+});
+export type TenantStyleDefault = Static<typeof TenantStyleDefaultSchema>;
 export type PaginationQuery = Static<typeof PaginationQuerySchema>;
 
 /** Validate, coerce, and apply defaults — throws on failure */


### PR DESCRIPTION
## Summary

Phase 1 (Foundation) of [Epic #362](https://github.com/purposestack/givernance/issues/362). Adds the database columns, the shared theme registry, and the backend API the picker UI (PR-3) and the archetype implementations (PR-4) build on top of. Behind `donation.public_page_styles` — every existing tenant keeps today's hardcoded layout until super-admin flips the per-tenant override on.

**Stacking note**: PR-1 (#386, spike) is cherry-picked at the base of this branch so PR-2 typechecks independently against `main`. When #386 merges first, `git pull --rebase` deduplicates the cherry-picked commits cleanly.

## What ships

### Shared theme registry — `@givernance/shared/constants`
- New `public-page-styles.ts` exports `PUBLIC_PAGE_STYLE_KEYS` (10 archetypes, picker order), `PUBLIC_PAGE_STYLE_REGISTRY` (label + tagline + voice quadrant per entry), `DEFAULT_PUBLIC_PAGE_STYLE`, and `isPublicPageStyleKey`.

### Schema migration 0054
- New Postgres enum `public_page_style` (10 values) — parity-tested against `PUBLIC_PAGE_STYLE_KEYS`.
- `tenants.default_public_page_style` (nullable) — org-level default.
- `campaigns.public_page_style` (nullable) — per-campaign override.
- Three-layer read-time resolution: `campaign override ?? tenant default ?? "foundation"`.
- No backfill — every existing row stays `NULL` (picker shows "no choice made yet" rather than implicitly stamping `foundation`).

### Backend API
| Surface | Behaviour | Flag posture |
|---|---|---|
| `GET /v1/public/campaigns/:id/page` | Includes resolved `publicPageStyle` field | Field-level: `null` when flag off; resolved key when on |
| `PUT /v1/campaigns/:id/public-page` | Accepts `publicPageStyle` body field, tri-state (`undefined` / `null` / key) | Field-level: 400 when flag off + field in body. Legacy fields unaffected |
| `GET /v1/campaigns/:id/public-page` (admin) | Response shape adds `publicPageStyle` | Always returned (admin context; field is `null` when not set) |
| `GET /v1/tenant/style-default` | **NEW** | `requireFlag(...)` as FIRST preHandler → 404 when off |
| `PATCH /v1/tenant/style-default` | **NEW** | Same gate. Bulk-invalidates per-tenant public-page cache on write |

### Tests (19 new, full suite 883/883)
- **Enum / registry parity** — Postgres enum equals `PUBLIC_PAGE_STYLE_KEYS`. Drift fails CI.
- **Public endpoint flag-gating** — 4 cases (flag-off null, campaign override, tenant default, hardcoded fallback).
- **Admin PUT field-level gate** — 6 cases (flag-off 400, persist + round-trip, explicit null clears, omitted leaves untouched, unknown key 400, legacy PUT unaffected).
- **Tenant default routes** — 7 cases (404 flag-off GET/PATCH, value, null-unset, set, clear, unknown 400, non-admin 403).

## Pre-push gate (per CLAUDE.md DEV PROCESS)
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @givernance/api test -- public-page-styles` — 19/19 pass
- [x] Full suite — 883/883 pass
- [x] `pnpm biome check .` — clean

## Manual acceptance

### Flag-off (every existing tenant — no behaviour change)
- [ ] Visit `/p/[campaignId]` for a tenant with the flag off → renders today's layout exactly
- [ ] `GET /v1/public/campaigns/:id/page` returns `publicPageStyle: null`
- [ ] `PUT /v1/campaigns/:id/public-page` with `publicPageStyle` in body → 400 with clear "Style picker not enabled" message
- [ ] `GET /v1/tenant/style-default` → 404
- [ ] `PATCH /v1/tenant/style-default` → 404

### Flag-on (Givernance staff enables via Back Office)
- [ ] Set `tenants.default_public_page_style = 'activist'` → `/p/[id]` returns `publicPageStyle: "activist"` after cache TTL
- [ ] Set `campaigns.public_page_style = 'cosmic-gradient'` → overrides the tenant default
- [ ] Clear both → resolves to `"foundation"`
- [ ] Set unknown value via direct SQL → service strips it (defence-in-depth) and falls back to `"foundation"`

### Schema
- [ ] `psql -c "SELECT unnest(enum_range(NULL::public_page_style))::text"` — returns 10 values in picker order
- [ ] `\d tenants` shows `default_public_page_style public_page_style`
- [ ] `\d campaigns` shows `public_page_style public_page_style`

## What's deferred

- **Picker UI** (org-level + per-campaign) → PR-3
- **The 10 archetype implementations** (HTML mockups + React + easter eggs) → PR-4
- **`docs/26-public-page-styles.md`** (ERD + permissions matrix + user-flow diagram + cross-links) → PR-5
- **Lighthouse + visual-regression** infra extension → ships with PR-4 alongside the archetype slot bundles

## Related

close #362 (will resolve after PR-3, PR-4, PR-5 ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)