### PR TITLE
feat(notifications): in-app notification centre — GLO-004 (Epic #363)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── 24-branding-assets.md       — Organisation branding (Epic #286): logo upload, sharp variants, bucket topology, Keycloak sync, PDF embedding
 │   ├── 25-swiss-qr-bill.md         — Swiss QR-bill (BVR) generation + camt.053 reconciliation (Epic #318): bank accounts, per-letter QRR/SCOR, ISO 20022 ingestion
 │   ├── 26-public-page-styles.md    — Public donation page archetype catalogue (Epic #362): 10 archetypes, schema, three-layer resolution, picker UX, easter-egg policy
-│   ├── adrs/                       — Individual ADR files (incl. ADR-023 bucket topology, ADR-024 image pipeline, ADR-025 PDF code boundary, ADR-027 Swiss QR-bill, ADR-028 camt.053 ingestion, ADR-029 Keycloak session revocation, ADR-030 public-page archetype slots — hybrid shell + slot components per Epic #362)
+│   ├── 27-notifications.md         — In-app notification centre (Epic #363, GLO-004): bell + side panel + per-user preferences + SSE delivery + opt-in email digest + outbox-fanout producer
+│   ├── adrs/                       — Individual ADR files (incl. ADR-023 bucket topology, ADR-024 image pipeline, ADR-025 PDF code boundary, ADR-027 Swiss QR-bill, ADR-028 camt.053 ingestion, ADR-029 Keycloak session revocation, ADR-030 public-page archetype slots — hybrid shell + slot components per Epic #362, ADR-031 notification delivery + outbox fanout — SSE with polling fallback per Epic #363)
 │   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283; launch-prod.md for the production-environment launch — issue #344); each file is plan + live journal + post-mortem. Also: bulk-email-stalled-job.md (recurring SRE triage flow for issue #326's Stalled / Partial bulk-email recovery), feature-flag-rollback.md (emergency psql + redis-cli flip when the Back Office page is unavailable), and keycloak-backchannel-logout-cutover.md (per-env override of `backchannel.logout.url` after each realm sync — issue #76)
 │   ├── dev/
 │   │   └── staging-secrets-setup.md — Reference for fork developers + the prod-launch runbook: every GH-Environment secret the deploy needs, how to generate it, how to rotate it (#343)
@@ -74,7 +75,8 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── branding-upload-flow.mmd — Logo upload → process → activate → donor render (companion to docs/24)
 │   ├── swiss-qr-bill-flow.mmd — Swiss QR-bill issuance: operator → donor → bank (companion to docs/25)
 │   ├── camt053-reconciliation-flow.mmd — camt.053 import + match algorithm (companion to docs/25)
-│   └── public-page-styles-flow.mmd — Operator picks archetype → donor sees archetype (Epic #362, companion to docs/26)
+│   ├── public-page-styles-flow.mmd — Operator picks archetype → donor sees archetype (Epic #362, companion to docs/26)
+│   └── notifications-flow.mmd     — Outbox event → worker fanout → SSE delivery → panel + email digest (Epic #363, companion to docs/27)
 └── .claude/agents/        — 12 specialized Claude agents
 ```
 

--- a/diagrams/notifications-flow.mmd
+++ b/diagrams/notifications-flow.mmd
@@ -1,0 +1,69 @@
+---
+title: In-app notification centre — end-to-end flow (Epic #363)
+---
+sequenceDiagram
+  autonumber
+  actor User as Operator / org admin
+  participant API as Fastify API
+  participant DB as Postgres (RLS)
+  participant Relay as Outbox relay
+  participant Worker as BullMQ worker
+  participant Digest as Daily digest job
+  participant SMTP as Email sender
+  participant Bell as Topbar bell
+  participant Panel as Notifications panel
+
+  Note over User,DB: 1. Producer side — same tx as the business mutation
+  User->>API: POST /v1/donations (or invite / postal-export / bulk-email)
+  API->>DB: INSERT donation + INSERT outbox_events (same tx)
+  API-->>User: 201 Created
+
+  Note over Relay,Worker: 2. Outbox → BullMQ enqueue
+  Relay->>DB: SELECT pending outbox_events FOR UPDATE SKIP LOCKED
+  Relay->>Worker: enqueue job (givernance_events queue)
+
+  Note over Worker,DB: 3. Notification fanout — runs alongside existing routing
+  Worker->>Worker: fanoutNotifications(event)
+  Worker->>Worker: isFlagEnabled(communication.notifications_center)?
+  alt flag off
+    Worker-->>Worker: silently skip — log debug
+  else flag on
+    Worker->>DB: SELECT users WHERE org_id = tenant<br/>AND role = 'org_admin' (or specific user)
+    Worker->>DB: SELECT notification_preferences<br/>(skip users with in_app=false)
+    Worker->>DB: INSERT notifications (one row per recipient)
+  end
+  Worker->>Worker: routeDomainEvent → existing receipt / postal / branding job
+
+  Note over Bell,API: 4. Delivery — SSE primary, polling fallback
+  Bell->>API: EventSource GET /v1/notifications/stream<br/>Cookie: session
+  API->>API: requireFlag(...) + requireAuth(...)
+  API-->>Bell: event: ready
+  loop polling generator
+    API->>DB: SELECT FROM notifications WHERE created_at > cursor
+    DB-->>API: new rows (if any)
+    API-->>Bell: event: notification\nid: <ISO>\ndata: <json>
+  end
+  Bell-->>Bell: re-render badge + prepend row in panel
+
+  Note over Bell,API: 5. Polling fallback when SSE errors
+  alt SSE error / EventSource unavailable
+    Bell->>API: GET /v1/notifications/unread-count (every 30s, focused tab only)
+    API-->>Bell: { data: { unread: N } }
+  end
+
+  Note over User,API: 6. User actions on the panel
+  User->>Panel: click row (link)
+  Panel->>API: PATCH /v1/notifications/:id/read
+  API->>DB: UPDATE read_at = NOW() WHERE id = ? AND user_id = ?
+  User->>Panel: click "Mark all read"
+  Panel->>API: POST /v1/notifications/read-all
+  User->>Panel: click "Dismiss"
+  Panel->>API: DELETE /v1/notifications/:id
+  API->>DB: UPDATE deleted_at = NOW() (soft-delete)
+
+  Note over Digest,SMTP: 7. Email digest — daily at 09:00 UTC, opt-in
+  Digest->>Digest: isFlagEnabled(...)? (else exit)
+  loop each tenant
+    Digest->>DB: SELECT unread notifications<br/>WHERE EXISTS preferences.email_digest=TRUE<br/>AND created_at > since
+    Digest->>SMTP: send one batched email per recipient
+  end

--- a/docs/27-notifications.md
+++ b/docs/27-notifications.md
@@ -1,0 +1,248 @@
+# 27 — In-app Notification Centre (GLO-004)
+
+> Related: [`docs/14-screen-inventory.md`](14-screen-inventory.md) GLO-004, [`docs/17-log-management.md`](17-log-management.md), [`docs/18-feature-flags.md`](18-feature-flags.md), [`docs/adrs/adr-031-notifications-delivery-and-fanout.md`](adrs/adr-031-notifications-delivery-and-fanout.md), [`diagrams/notifications-flow.mmd`](../diagrams/notifications-flow.mmd), [Epic #363](https://github.com/purposestack/givernance/issues/363).
+>
+> Migration that ships the schema: [`packages/api/migrations/0055_notifications_center.sql`](../packages/api/migrations/0055_notifications_center.sql).
+> Feature flag: `communication.notifications_center` (default off, scope `tenant`).
+
+## 0. Why this exists — at a glance
+
+Givernance's async surface area is growing — postal exports (Epic #274), branding pipelines (Epic #286), Swiss QR-bill bank reconciliation (Epic #318), bulk emails (Epic #326). Each of these produces work the operator initiated and now wants to know about: "did the export finish?", "did the donation come through?", "did the invitee actually accept?". The audit log already records these events but is tenant-wide and admin-only. **There is no per-user, per-event signal anywhere in the product today.**
+
+This Epic ships the missing surface: a topbar bell with an unread badge, a side panel listing recent events filtered by category, per-user preferences for which alerts to receive and on which channel (in-app / email digest), and real-time delivery via SSE with a polling fallback.
+
+The architecture leans on infrastructure already proven in production: the transactional outbox + BullMQ worker (Epic #274, #286, #326), the feature-flag scaffolding (Epic #326, #365), and the RLS / soft-delete patterns (ADR-021). Adding this surface is a fan-out at the worker, a single Fastify module, a topbar component, and a settings sub-page — no new infrastructure, no new tools.
+
+A future `docs/27` revision will fold AI aggregation ("3 similar grant-deadline alerts grouped"), push notifications, and SMS into the same model; those are explicitly out of scope for this Epic and live in [§ 7](#7-out-of-scope).
+
+## 1. End-to-end user flow
+
+The shipped MVP covers six notification types — one per "thing an operator initiated that runs async":
+
+| Type | Producer event | Recipients | Visual | Default in-app | Default email digest |
+|---|---|---|---|---|---|
+| `donation.received` | `donation.created` | every `org_admin` of the tenant | donation (green) | on | off |
+| `invitation.created` | `invitation.created` | every `org_admin` of the tenant | team (indigo) | on | off |
+| `invitation.resent` | `invitation.resent` | every `org_admin` of the tenant | team (indigo) | off | off |
+| `branding.logo_synced` | `branding.activate_logo` | every `org_admin` of the tenant | system (sky) | on | off |
+| `postal_export.queued` | `campaign.postal_export_requested` | requester (fallback: org_admins) | system (sky) | on | off |
+| `bulk_email.queued` | `communication.bulk_email_requested` | requester (fallback: org_admins) | team (indigo) | on | off |
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Operator as Org admin
+  participant API as Fastify API
+  participant DB as Postgres (RLS)
+  participant Relay as Outbox relay
+  participant Worker as BullMQ worker
+  participant Bell as Topbar bell
+  participant Panel as Notifications panel
+
+  Operator->>API: POST /v1/donations (creates donation)
+  API->>DB: INSERT donation + outbox_events (same tx)
+  API-->>Operator: 201 Created
+  Relay->>DB: SELECT pending outbox_events FOR UPDATE SKIP LOCKED
+  Relay->>Worker: enqueue { type: "donation.created", payload }
+  Worker->>Worker: fanoutNotifications(event)
+  Worker->>Worker: flag check: communication.notifications_center?
+  alt flag off
+    Worker-->>Worker: skip — log debug
+  else flag on
+    Worker->>DB: SELECT users WHERE role='org_admin'<br/>+ honour notification_preferences (in_app)
+    Worker->>DB: INSERT notifications (one per recipient)
+  end
+  Worker->>Worker: routeDomainEvent → existing receipt PDF job
+  Bell->>API: EventSource /v1/notifications/stream
+  API->>DB: SELECT new rows WHERE created_at > cursor (polling loop)
+  API-->>Bell: event: notification (SSE frame)
+  Bell->>Panel: re-render badge + new row at the top
+  Operator->>Panel: clicks row → /donations/<id>
+  Panel->>API: PATCH /v1/notifications/:id/read
+  API->>DB: UPDATE read_at = NOW()
+```
+
+### Off-state behaviour (flag off)
+
+- Topbar has no bell icon at all (off-state QA per `feedback_feature_flag_first`).
+- `/v1/notifications*` + `/v1/notification-preferences*` routes return 404 (anti-disclosure — same posture as `/v1/constituents/bulk-email`).
+- `/profile/notifications` returns 404 (the page itself re-checks the flag SSR).
+- Outbox-fanout worker silently no-ops on every event.
+- Email-digest BullMQ tick reads the flag, sees off, returns.
+
+## 2. Architecture overview
+
+```mermaid
+flowchart LR
+  subgraph "API (Fastify 5)"
+    A1[POST /v1/donations]
+    A2[GET /v1/notifications]
+    A3[GET /v1/notifications/stream]
+    A4[PATCH /v1/notification-preferences/:type]
+  end
+
+  subgraph "Worker (BullMQ)"
+    W1[processDomainEvent]
+    W2[fanoutNotifications]
+    W3[Daily digest tick]
+  end
+
+  subgraph "Postgres (RLS app role)"
+    DB1[(outbox_events)]
+    DB2[(notifications)]
+    DB3[(notification_preferences)]
+  end
+
+  subgraph "Web (Next.js)"
+    UI1[Topbar bell]
+    UI2[Notifications panel]
+    UI3[/profile/notifications/]
+  end
+
+  A1 -->|tx| DB1
+  DB1 -->|relay → BullMQ| W1
+  W1 --> W2
+  W2 -->|withWorkerContext| DB2
+  W3 -->|read each tenant + send digest| DB2
+  UI1 -->|SSE| A3
+  UI1 -->|polling fallback| A2
+  UI2 --> A2
+  UI3 --> A4
+  A2 -->|withTenantContext| DB2
+  A4 --> DB3
+```
+
+### Code boundaries
+
+| Concern | Package | File(s) |
+|---|---|---|
+| Schema (Drizzle) | `packages/shared/src/schema/notifications.ts` | `notifications`, `notification_preferences` |
+| Type registry | `packages/shared/src/constants/notifications.ts` | `NOTIFICATION_TYPE_VALUES`, `NOTIFICATION_TYPE_REGISTRY` |
+| Feature flag | `packages/shared/src/constants/feature-flags.ts` | `COMMUNICATION_NOTIFICATIONS_CENTER` |
+| Migration | `packages/api/migrations/0055_notifications_center.sql` | seed + table + RLS |
+| Fanout producer | `packages/worker/src/processors/notifications-fanout.ts` | `fanoutNotifications`, `planFanout` |
+| Worker wiring | `packages/worker/src/worker.ts` | `processDomainEvent` calls fanout first |
+| Email digest job | `packages/worker/src/processors/notifications-email-digest.ts` | `processNotificationsEmailDigest` |
+| API routes | `packages/api/src/modules/notifications/routes.ts` | REST + SSE |
+| API service | `packages/api/src/modules/notifications/service.ts` | list + cursor + RLS reads |
+| Web service | `packages/web/src/services/NotificationsService.ts` | API client wrapper |
+| Web live hook | `packages/web/src/components/notifications/use-notifications-live.ts` | SSE + polling fallback |
+| Topbar bell | `packages/web/src/components/notifications/notifications-bell.tsx` | trigger + badge |
+| Panel | `packages/web/src/components/notifications/notifications-panel.tsx` | filter chips + rows |
+| Preferences page | `packages/web/src/app/(app)/profile/notifications/page.tsx` | SSR + form |
+| Preferences form | `packages/web/src/components/notifications/notification-preferences-form.tsx` | optimistic checkboxes |
+
+## 3. Data model
+
+```mermaid
+erDiagram
+  TENANTS ||--o{ NOTIFICATIONS : "scopes"
+  USERS ||--o{ NOTIFICATIONS : "is recipient"
+  TENANTS ||--o{ NOTIFICATION_PREFERENCES : "scopes"
+  USERS ||--o{ NOTIFICATION_PREFERENCES : "owns"
+  OUTBOX_EVENTS ||..o{ NOTIFICATIONS : "fans out (via worker)"
+
+  NOTIFICATIONS {
+    uuid id PK
+    uuid org_id FK
+    uuid user_id FK
+    varchar(64) type
+    varchar(128) title_key
+    varchar(128) body_key
+    jsonb params
+    text link_url
+    timestamptz read_at
+    timestamptz archived_at
+    timestamptz deleted_at
+    timestamptz created_at
+  }
+
+  NOTIFICATION_PREFERENCES {
+    uuid id PK
+    uuid org_id FK
+    uuid user_id FK
+    varchar(64) type
+    boolean in_app
+    boolean email_digest
+    timestamptz created_at
+    timestamptz updated_at
+  }
+```
+
+### Field rationale
+
+- **`type` is `varchar(64)`** with a CHECK constraint on shape (`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$`), NOT a Postgres enum. Adding a new type is a code change + producer wiring, never a migration.
+- **`(title_key, body_key, params)` instead of frozen `text`** — i18n resolution at READ time. A French recipient sees French regardless of the worker's session locale.
+- **`link_url` is a relative path** (CHECK `link_url LIKE '/%'`). Frontend prepends `APP_URL`. Absolute URLs would break for tenants on custom subdomains (Epic #279 follow-up).
+- **`deleted_at` (soft-delete)** per `feedback_soft_delete_universal` — a panel "delete" sets the column; the row stays for audit + GDPR DSR replay.
+- **Partial index `(user_id) WHERE read_at IS NULL AND deleted_at IS NULL`** keeps the bell badge query O(log N) on a noisy tenant.
+
+### Recipient resolution
+
+The worker's `planFanout(event)` resolves recipients per the table in [§ 1](#1-end-to-end-user-flow). For "specific user" rules (postal export, bulk email), the payload carries `requestedBy` — if absent (older events, super-admin actions), the rule falls back to "all org_admins". A user with `notification_preferences.in_app = false` for the type is silently dropped at write time so the worker doesn't pile rows onto an opted-out user.
+
+## 4. Permissions matrix
+
+| Endpoint | Method | Flag | Guard | Notes |
+|---|---|---|---|---|
+| `/v1/notifications` | GET | `communication.notifications_center` | `requireAuth` | Lists caller's own rows. RLS isolates tenant; service filters `user_id = currentUserId`. |
+| `/v1/notifications/unread-count` | GET | `communication.notifications_center` | `requireAuth` | Caller-scoped count. |
+| `/v1/notifications/:id/read` | PATCH | `communication.notifications_center` | `requireAuth` | Caller-scoped — 404 if not owned. Idempotent. |
+| `/v1/notifications/read-all` | POST | `communication.notifications_center` | `requireAuth` | Idempotent — returns count of rows touched. |
+| `/v1/notifications/:id` | DELETE | `communication.notifications_center` | `requireAuth` | Soft-delete (sets `deleted_at`). |
+| `/v1/notifications/stream` | GET | `communication.notifications_center` | `requireAuth` | SSE. Heartbeat every 25 s. Resumes from `Last-Event-ID`. |
+| `/v1/notification-preferences` | GET | `communication.notifications_center` | `requireAuth` | Returns the closed set (every registered type), defaults merged in. |
+| `/v1/notification-preferences/:type` | PATCH | `communication.notifications_center` | `requireAuth` | Upsert (idempotent). Body `{ inApp, emailDigest }`. |
+| `/profile/notifications` | GET | `communication.notifications_center` | requireAuth (SSR) | 404 if flag off. |
+
+Flag gate runs FIRST per the canonical `[requireFlag, requireRole]` pattern from `docs/18-feature-flags.md` § 6.1 — a scanner can't enumerate gated routes by their auth requirement.
+
+## 5. GDPR posture
+
+The notification surface is per-user data; GDPR Articles 5, 15, 17 apply.
+
+- **PII in the row body**: NEVER. `params` carries opaque identifiers (donation id, campaign id, invitation id) and non-sensitive counters (`amountCents`, `currency`). Donor names / emails are dereferenced client-side via `link_url`. A constituent deleted via GDPR DSR (Epic #21 / ADR-021) does NOT leave their name frozen in the panel — the link target itself filters on `deleted_at IS NULL`.
+- **Soft-delete**: a panel "Dismiss" sets `deleted_at`; the row stays for the audit chain. A future GDPR DSR purge step (out of scope for this Epic — tracked under ADR-021 cleanup) hard-deletes notifications whose `user_id` matches the erased account.
+- **User-rights export** (Art. 15): the existing `/v1/users/me` GDPR-snapshot export adds `notifications` + `notification_preferences` to its payload in a follow-up — tracked alongside ADR-021's universal export schema.
+- **User-rights erasure** (Art. 17): on user purge the FK `users.id → notifications.user_id` is `ON DELETE SET NULL`, so historical rows are orphaned (kept for tenant audit) but no longer attribute to an identified person. `notification_preferences.user_id → users.id` is `ON DELETE CASCADE` since the preferences are personal-only and don't carry audit value once the user is gone.
+- **Cross-tenant isolation**: RLS keys `notifications.org_id` to `app.current_organization_id` (FORCE ROW LEVEL SECURITY). The worker writes under `withWorkerContext(tenantId)`; the API reads under `withTenantContext(orgId)`. A cross-tenant SELECT returns zero rows even with a hand-crafted SQL injection — the partial unique on the GUC is the durable boundary.
+- **Audit log**: every PATCH / POST / DELETE on `/v1/notifications*` is auto-recorded by the existing `plugins/audit.ts` plugin (impersonation context propagates per `project_impersonation_two_modes` — both the impersonator and the impersonated user land in the audit row).
+
+## 6. Implementation phases
+
+The Epic ships in one PR:
+
+1. **Step 0 — feature flag**: register `communication.notifications_center` in the shared registry; seed via migration. Every new route + worker job pickup + web surface gates on it.
+2. **Phase 1 — schema + outbox subscriber + REST API**: migration 0055 creates the two tables + RLS + indices. Worker's `fanoutNotifications` runs alongside `routeDomainEvent` for every outbox event. API exposes list / unread-count / mark-read / mark-all-read / soft-delete.
+3. **Phase 2 — topbar bell + panel**: `NotificationsBell` mounts when the SSR-resolved flag is on; `NotificationsPanel` matches the GLO-004 mockup (filter chips, accent bars, mark-all-read, click-through). Polling fallback at 30 s.
+4. **Phase 3 — preferences page**: `/profile/notifications` (every authenticated role; not `/settings/*` which is org-admin only). Optimistic upsert.
+5. **Phase 4 — SSE delivery**: `/v1/notifications/stream` (`text/event-stream`). EventSource client swaps polling for SSE; falls back automatically on error. `Last-Event-ID` resume.
+6. **Phase 5 — email digest (opt-in)**: BullMQ recurring job at 09:00 UTC daily. Reads each tenant's opted-in users + their unread rows since the cursor, sends one digest per recipient via `defaultEmailSender`. Templates are minimal text/HTML — per-user locale + per-tenant DKIM are explicit follow-ups (see § 7).
+7. **Phase 6 — docs**: this doc + ADR-031 + flow diagram + CLAUDE.md file-tree update.
+
+## 7. Out of scope
+
+The Epic explicitly does NOT ship:
+
+- **Push notifications (mobile / browser Web Push)** — opt-in re-engagement is non-trivial; deferred.
+- **SMS notifications** — `ff.sms_notifications` placeholder exists in `docs/04-business-capabilities.md`; not in this Epic.
+- **AI aggregation** ("3 similar grant-deadline alerts grouped") — listed as future enhancement in GLO-004 spec.
+- **Cross-org notifications for super-admins** — Back Office is the cross-org surface; the panel is tenant-scoped.
+- **Per-tenant DKIM / sending domain for the email digest** — depends on Epic #279.
+- **Per-user locale resolution for the email digest body** — current digest renders English. Follow-up wires the same i18n keys the panel uses.
+- **HTML templating with the tenant logo in the email digest** — same dependency on Epic #279 / tenant branding propagation to email.
+- **`LISTEN/NOTIFY` for the SSE generator's internal loop** — current polling at 5 s is acceptable for the shipped MVP; ADR-031 § Revisit if calls out the migration trigger.
+- **Re-routing notifications when a user is offboarded** — handled by tenant-offboarding flow, not this Epic.
+- **Archive management UI** — the column exists; surfacing it is a small follow-up.
+
+## 8. Acceptance — per Epic #363
+
+- [x] `communication.notifications_center` flag registered + seeded; every new route protected with `requireFlag(...)` as the first preHandler; every dependent UI surface and worker job pickup gated; off-state QA done.
+- [x] Spike ADR merged ([`docs/adrs/adr-031`](adrs/adr-031-notifications-delivery-and-fanout.md)).
+- [x] `notifications` table + RLS shipped, with passing isolation tests.
+- [x] At least 5 event producers wired (donation, invitation × 2, branding activation, postal export, bulk email).
+- [x] Topbar bell + panel match the mockup.
+- [x] Preferences page live.
+- [x] SSE delivery shipped + polling fallback in place.
+- [x] `docs/27-notifications.md` + ERD + permissions matrix + GDPR section (this file).
+- [x] CLAUDE.md updated.

--- a/docs/27-notifications.md
+++ b/docs/27-notifications.md
@@ -181,6 +181,17 @@ erDiagram
 
 The worker's `planFanout(event)` resolves recipients per the table in [§ 1](#1-end-to-end-user-flow). For "specific user" rules (postal export, bulk email), the payload carries `requestedBy` — if absent (older events, super-admin actions), the rule falls back to "all org_admins". A user with `notification_preferences.in_app = false` for the type is silently dropped at write time so the worker doesn't pile rows onto an opted-out user.
 
+### Identifier discipline (`users.id` vs `keycloak_id`)
+
+Every column on `notifications` / `notification_preferences` that points at a person is `user_id uuid REFERENCES users(id)` — the application's row UUID, NOT the Keycloak `sub`. Real seeds (and the impersonation playground tenant) keep `users.id ≠ users.keycloak_id`, so confusing the two is silent: queries return zero rows, fanout writes zero recipients, and the bell never lights up.
+
+Two consequences for any code that touches the notification graph:
+
+1. **Routes filter by `request.auth.userRowId`, not `request.auth.userId`.** The auth plugin resolves the row UUID alongside the active-row check (ADR-021) and surfaces it as `userRowId`. The route returns 401 when it's null — super-admins (no `users` row) and DB-blip fail-opens both surface that way.
+2. **Outbox payloads that the fanout reads as a recipient (e.g. `requestedBy` for `campaign.postal_export_requested`, `communication.bulk_email_requested`) carry the resolved row UUID, not the JWT subject.** Audit attribution for "who requested this" is captured separately by the audit plugin from `request.auth.userId` — payload `requestedBy` is fanout-targeting only.
+
+The same discipline applies to other FK columns pointing at `users.id` across the schema (`tenant_flag_overrides.set_by`, `bulk_email_jobs.requested_by`, `campaign_postal_exports.requested_by`, …): write the row UUID, never the JWT `sub`.
+
 ## 4. Permissions matrix
 
 | Endpoint | Method | Flag | Guard | Notes |

--- a/docs/adrs/adr-031-notifications-delivery-and-fanout.md
+++ b/docs/adrs/adr-031-notifications-delivery-and-fanout.md
@@ -1,0 +1,111 @@
+## ADR-031: In-app notification centre — delivery mechanism + event-source fanout
+
+**Status**: Proposed (Epic #363, 2026-05-16)
+**Related**: ADR-011 (4-layer frontend), ADR-012 (shadcn/ui + design tokens), ADR-013 (frontend type boundary), ADR-021 (soft-delete universal), ADR-022 (platform admins disjoint), `docs/14-screen-inventory.md` GLO-004, `docs/17-log-management.md`, `docs/18-feature-flags.md`, `docs/27-notifications.md`
+
+### Context
+
+[Epic #363](https://github.com/purposestack/givernance/issues/363) ships the in-app notification centre specified by GLO-004 in `docs/14-screen-inventory.md`: bell icon in the topbar, side panel with filter chips, per-user preferences, and real-time delivery. Today the codebase has the producer side (outbox events for donations, invitations, branding activation, postal exports, bulk emails) but no consumer surface for end users — campaign imports finish without an in-app signal, grant deadlines pass silently, donations arrive without alerting anyone.
+
+Three architectural decisions need a commit before the implementation can land:
+
+1. **Delivery mechanism** — how does a fresh notification reach the donor / operator browser?
+   - SSE (`text/event-stream`) — simple, unidirectional, behind any HTTP proxy.
+   - WebSocket — bidirectional, adds infra (sticky sessions, custom proxy config on Kamal + Scaleway LB).
+   - Polling only — cheapest to ship, worst UX.
+2. **Event source** — who produces a notification row?
+   - (a) Producer-side double-write: every domain mutation in the API service ALSO writes a notification row in the same transaction.
+   - (b) Consumer-side fanout: a worker subscribes to the outbox and writes notification rows downstream of every event it cares about.
+   - (c) Hybrid.
+3. **Data model** — frozen string body vs. `(title_key, body_key, params)` i18n tuple; tenant-scoped vs. recipient-scoped; soft-delete vs. hard-delete.
+
+Decisions must be justified against:
+
+- **Cost of a brand-new tenant** that hasn't yet flipped the feature on — must be zero (no idle SSE connections, no orphan worker queues).
+- **Per-tenant locale** — a French org_admin sees French notifications even when the worker that wrote the row was processing an English-session request.
+- **GDPR posture** — notification rows must not freeze constituent PII in their body. A constituent deleted via GDPR DSR must not leave their name in the panel.
+- **Existing infrastructure** — the codebase already has BullMQ + outbox + RLS + feature-flag scaffolding. The Epic should *lean on* these, not duplicate them.
+
+### Decision
+
+#### 1. Delivery mechanism: **SSE with polling fallback**
+
+`GET /v1/notifications/stream` (`text/event-stream`) is the primary transport. The frontend hook (`useNotificationsLive`) opens an `EventSource` with `withCredentials: true` so the session cookie rides along; the server sends an initial `event: ready` ping followed by `event: notification` frames as new rows arrive. Heartbeat comment frames (`: heartbeat\n\n`) every 25 s keep idle proxies from closing the connection.
+
+Reconnect is handled by the browser's native `EventSource` retry logic. The server reads the `Last-Event-ID` header on reconnect — we set it to the most-recently-delivered row's `created_at` ISO so reconnect resumes from the exact position without replaying older rows.
+
+**Polling fallback** activates in three cases:
+- `EventSource` is unavailable (jsdom test environments, very old browsers).
+- The SSE connection emits an `error` event (proxy rejecting `text/event-stream`, CSP block, network blip beyond the browser's retry).
+- The flag-gate or another upstream layer 404s the route.
+
+The fallback hits `GET /v1/notifications/unread-count` every 30 s when the tab is focused (no work when backgrounded). Polling and SSE coexist safely — the panel dedupes rows by id, so an overlap window doesn't show duplicates.
+
+**Why not WebSocket**: the notification surface is fundamentally one-way (server → client). WebSocket would require sticky sessions across Kamal's load balancer + Scaleway's LB, a separate protocol handshake, and a custom Fastify plugin. SSE is one Fastify route, plain HTTP, no infra changes.
+
+**Why not polling-only**: a 30 s round-trip on an active operator session feels stale ("did the donation come through?" → wait, refresh). SSE is the right primary; polling is the safety net.
+
+#### 2. Event source: **consumer-side fanout (option b)** via the existing outbox subscriber
+
+The worker's `processDomainEvent` (`packages/worker/src/worker.ts`) already runs on every outbox row. The Epic adds **one new step at the top of that handler**: a feature-flag-gated `fanoutNotifications(event)` call that translates the event into one or more notification rows.
+
+`planFanout(event)` is a pure function that returns a list of `(notificationType, recipientFilter, titleKey, bodyKey, params, linkUrl)` entries. The worker:
+1. Reads the flag (`isFlagEnabled(COMMUNICATION_NOTIFICATIONS_CENTER)`). Short-circuits with zero DB work if off.
+2. For each entry, resolves recipients (`all_org_admins` or `specific_user`).
+3. Honours `notification_preferences.in_app = false` at write time — opted-out users never get a row.
+4. Inserts inside `withWorkerContext(tenantId)` so RLS isolates the tenant.
+5. Logs and continues on any failure — fanout is best-effort UX, never blocks the existing routing decision (donation → receipt PDF, branding → activation, etc.).
+
+**Why not producer-side double-write**: the producer (the API service handling `POST /v1/donations`) doesn't know who the recipients are. "Notify every org_admin of the tenant" requires a `SELECT … FROM users WHERE org_id = ? AND role = 'org_admin'` — fine to run server-side, but the same query duplicates everywhere. Centralising it in the worker keeps the producer code clean and lets us add recipient rules (per-user opt-in / opt-out, role-based routing) without touching every service.
+
+**Why not "subscribe to the audit log" instead of the outbox**: the audit log is request-scoped (synchronous, inside the route's transaction) and admin-facing — it doesn't propagate to BullMQ. The outbox is already the source of truth for "things happened that downstream consumers might care about." Adding a second consumer (notifications) alongside the existing first (receipts, postal exports, branding activation) is the obvious place.
+
+**Why a soft-fail, not a retry**: if the notification row write fails, retrying the whole outbox event would also retry the receipt PDF generation, the postal-export ZIP, etc. — non-idempotent side-effects that we'd rather not run twice for the sake of a UX row. A future Phase moves fanout to a dedicated retry-bearing queue if real-world flake demands it.
+
+#### 3. Data model
+
+`notifications` is **recipient-scoped** (`user_id`), not just tenant-scoped. Every read filters `notifications.user_id = currentUserId`; a tenant member can never see another member's notifications even within the same tenant. The DB constraint is enforced at the service layer, not via a second RLS policy — Postgres RLS keys on a single GUC, and `app.current_user_id` would be a second GUC to wire through the API + worker. The user filter is cheap (indexed) and the service code is a stable boundary.
+
+**i18n via `(title_key, body_key, params)`** instead of a frozen `text` body. The web panel resolves keys against the consumer's locale via `next-intl`; the email digest does the same. Two consequences:
+- A French org_admin sees French even when the donation creator was on an English session.
+- `params` is a `jsonb` map of opaque identifiers + non-sensitive counters (e.g. `{donationId, amountCents, currency}`). Donor names / emails are NEVER in `params` — the panel dereferences them via the `link_url` page, which itself goes through tenant RLS. GDPR DSR-deleted constituents do NOT leave names frozen in the panel.
+
+**Soft-delete universal** (per `feedback_soft_delete_universal` / ADR-021): a panel "delete" sets `deleted_at`; the row stays for audit + GDPR DSR replay. Every read filters `deleted_at IS NULL`.
+
+**`type` is `varchar(64)`** with a CHECK constraint on shape (`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$`), NOT a Postgres enum. Adding a new type ("campaign_postal_export_completed") is a code change in `NOTIFICATION_TYPE_VALUES` + producer wiring — never a migration. The shared registry (`packages/shared/src/constants/notifications.ts`) is the source of truth.
+
+### Consequences
+
+**Pro**:
+- Zero infra delta: SSE is a single Fastify route, fanout sits alongside existing outbox routing, no new BullMQ queue beyond the daily digest.
+- Adding a notification type is a 3-line code change (registry + producer wiring), no migration.
+- Per-tenant locale flows automatically.
+- Soft-delete keeps audit + DSR replay trivial.
+- A tenant with the flag off is indistinguishable from one before the Epic shipped — no idle connections, no orphan rows, no UI flash.
+
+**Con**:
+- SSE through Cloudflare requires `X-Accel-Buffering: no` to disable proxy buffering — already set in the route, but a future proxy swap needs the same hint.
+- Consumer-side fanout means the recipient set is resolved at fanout time. If an org_admin role is granted between the donation event and the fanout (unusual, but possible), they don't get the notification. The audit log still records the grant; this is acceptable for a UX surface.
+- `LISTEN/NOTIFY` would be cheaper than polling for the SSE generator's internal loop. We poll every 5 s instead — a known follow-up (see § Revisit if).
+- The email digest renders an English-only body in this Epic. Per-user locale resolution there is a small but explicit follow-up.
+
+### Rejected alternatives
+
+| # | Alternative | Rejected because |
+|---|---|---|
+| 1 | WebSocket transport | Adds sticky sessions, custom Kamal/LB config, separate protocol handshake. SSE covers the unidirectional use case at one route's cost. |
+| 2 | Polling only | A 30 s round-trip on an active operator session feels stale. SSE is the right primary, polling is the safety net. |
+| 3 | Producer-side double-write | Duplicates recipient resolution across every domain service; future role-based routing changes would touch every call site. |
+| 4 | Subscribe to `audit_logs` instead of outbox | Audit log is request-scoped + admin-facing; doesn't propagate to BullMQ. Outbox is the existing async-event boundary. |
+| 5 | Hard-delete on panel "Dismiss" | Conflicts with ADR-021 universal soft-delete + breaks GDPR DSR replay (audit must be able to enumerate every notification a user has ever seen). |
+| 6 | Frozen `text` body, no i18n keys | French user can't see French unless the producer was on a French session. Doesn't compose with per-user locale (ADR-011 / issue #153). |
+| 7 | Postgres enum for `type` | Every new notification type requires `ALTER TYPE` migration. `varchar` + CHECK constraint + shared registry gives the same type-safety without the migration cost. |
+| 8 | Cross-org notifications for super-admins | Out of scope per Epic § 4. Super-admins use the Back Office for cross-org visibility; the panel is a tenant-scoped UX. |
+| 9 | A dedicated BullMQ queue for fanout (retried, DLQ-backed) | Premature given the soft-fail posture. Today's fanout runs inline in `processDomainEvent`; a future Phase splits it out if real-world flake demands retries. |
+
+### Revisit if
+
+- Polling SSE generator becomes a measurable PG cost (the 5 s `WHERE created_at > $cursor` polling loop is per-stream — at >500 concurrent streams per replica it adds up).
+- A tenant requests an email-only mode (no in-app surface). The current model assumes `in_app = false` is the suppression knob; an explicit "email only, no row written at all" would need a second flag.
+- WebSocket needs justified by a new bidirectional flow (e.g. operator-to-operator chat) — at that point we'd reuse the WebSocket boundary for notifications too.
+- The notification volume per tenant exceeds the daily digest's "scan all unread since cursor" pattern (>10 k rows per user per day). At that scale the digest job needs to switch to a cursor-paginated batch rather than a single-tenant SELECT.

--- a/packages/api/migrations/0055_notifications_center.sql
+++ b/packages/api/migrations/0055_notifications_center.sql
@@ -85,6 +85,17 @@ CREATE TABLE IF NOT EXISTS notifications (
   id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
   -- Tenant boundary — RLS policy keys on this column.
   org_id       UUID         NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  -- Originating outbox event id. Natural idempotency key — the
+  -- (outbox_event_id, user_id, type) unique constraint below means
+  -- an outbox redelivery (relay retry, worker crash mid-fanout) does
+  -- NOT produce a second row for the same recipient. The fanout
+  -- worker passes the event id from BullMQ's job.data; same defence
+  -- pattern as bulk-email's `bulk-email-${outboxId}` jobId
+  -- (`packages/worker/src/worker.ts:198`). FK omitted by design — the
+  -- outbox row is `completed` once relayed and may be GC'd by a
+  -- future retention sweep, but the notification's audit trail keys
+  -- on the id string itself.
+  outbox_event_id UUID      NOT NULL,
   -- Recipient. SET NULL on user purge so a GDPR-erased account doesn't
   -- FK-block historical notifications. The orphaned rows are then
   -- garbage-collected by the universal soft-delete sweep (out of scope
@@ -122,8 +133,26 @@ CREATE TABLE IF NOT EXISTS notifications (
 
   CONSTRAINT notifications_type_chk
     CHECK (type ~ '^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$'),
+  -- `link_url` must be a relative path. The `LIKE '/%'` part rejects
+  -- absolute URLs (`https://evil…`) but a single-slash CHECK alone
+  -- accepts `//evil.example/path` — browsers resolve protocol-
+  -- relative URLs against the page's scheme, so `${APP_URL}//evil…`
+  -- would navigate to the attacker's host. Tighten with
+  -- `NOT LIKE '//%' AND NOT LIKE '/\\%'` so neither protocol-relative
+  -- nor Windows-style alternate roots can slip through. Reviewed by
+  -- the Security + Data architect agents (PR #393 cross-confirmed).
   CONSTRAINT notifications_link_url_chk
-    CHECK (link_url IS NULL OR link_url LIKE '/%')
+    CHECK (
+      link_url IS NULL
+      OR (
+        link_url LIKE '/%'
+        AND link_url NOT LIKE '//%'
+        AND link_url NOT LIKE '/\%' ESCAPE '\'
+      )
+    ),
+  -- Natural idempotency key — see `outbox_event_id` column comment.
+  CONSTRAINT notifications_outbox_recipient_type_unique
+    UNIQUE (outbox_event_id, user_id, type)
 );
 
 -- Per-user, time-ordered listing (panel + email digest).
@@ -132,10 +161,14 @@ CREATE INDEX IF NOT EXISTS notifications_user_created_idx
   WHERE deleted_at IS NULL;
 
 -- Bell-badge unread-count query — narrow partial index so the count
--- doesn't scan archived/read rows on a noisy tenant.
+-- doesn't scan archived/read rows on a noisy tenant. Predicate
+-- mirrors `getUnreadCount` in `notifications/service.ts` exactly
+-- (`read_at IS NULL AND deleted_at IS NULL AND archived_at IS NULL`)
+-- so the planner can use an index-only scan rather than residual-
+-- filtering archived rows out at heap time.
 CREATE INDEX IF NOT EXISTS notifications_user_unread_idx
   ON notifications (user_id)
-  WHERE read_at IS NULL AND deleted_at IS NULL;
+  WHERE read_at IS NULL AND deleted_at IS NULL AND archived_at IS NULL;
 
 -- Tenant-level admin / debug queries (Back Office "view all rows for
 -- tenant X"). Filters by org_id then orders by created_at.

--- a/packages/api/migrations/0055_notifications_center.sql
+++ b/packages/api/migrations/0055_notifications_center.sql
@@ -1,0 +1,192 @@
+-- Migration: 0055_notifications_center (Epic #363, single PR)
+--
+-- In-app notification centre (GLO-004). One PR delivers schema +
+-- producer + API + UI + preferences + SSE + email digest scaffolding,
+-- all gated behind `communication.notifications_center` (default OFF).
+--
+-- This migration ships:
+--   1. The `communication.notifications_center` feature-flag seed row.
+--   2. `notifications` — one row per (recipient, event). Tenant-scoped,
+--      RLS-isolated, soft-delete universal.
+--   3. `notification_preferences` — per (user, type) channel matrix
+--      (in-app on/off, email-digest on/off). Tenant-scoped, RLS.
+--
+-- Design notes (full rationale in `docs/adrs/adr-031-notifications.md`
+-- and `docs/27-notifications.md`):
+--
+--   * Recipient resolution happens in the worker, NOT in the producer.
+--     The same outbox event (e.g. `donation.created`) may fan out to
+--     multiple recipients (every org_admin of the tenant), and the
+--     producer doesn't know who they are. The worker subscribes to
+--     outbox events via `processDomainEvent` (existing infra — Epic
+--     #274/#286/#326) and inserts N notification rows per event inside
+--     `withWorkerContext`. RLS isolates the writes to the originating
+--     tenant.
+--
+--   * `type` is `varchar(64)`, NOT a Postgres enum. Adding a new
+--     notification type ("campaign_postal_export_completed") is a code
+--     change in `NOTIFICATION_TYPE_VALUES` + a producer wiring, never a
+--     migration. The CHECK constraint pins the allowed prefixes so a
+--     buggy producer can't insert `null` / empty / oversized strings.
+--
+--   * `title_key` + `body_key` + `params jsonb` instead of frozen
+--     `text`. A French org_admin sees French even when the producer
+--     ran in an English worker — the i18n interpolation happens at the
+--     READ boundary (web panel, email digest), not at write time. This
+--     matches the per-tenant locale model already in `users.locale`.
+--
+--   * `link_url` is a relative path (e.g. `/donations/<uuid>`) — the
+--     frontend prepends `APP_URL`. Storing absolute URLs would break
+--     when a tenant moves to a custom subdomain (Epic #279 follow-up).
+--
+--   * Soft-delete is universal per `feedback_soft_delete_universal` —
+--     a notification a user "deletes" from the panel is kept in the DB
+--     with `deleted_at = NOW()` so the audit chain stays queryable. The
+--     RLS policy + every read query filters `deleted_at IS NULL`.
+--
+--   * Index on `(user_id, read_at) WHERE read_at IS NULL AND
+--     deleted_at IS NULL` keeps the bell-badge query
+--     (`SELECT COUNT(*)`) O(log N) even on a busy tenant. Per-user
+--     ordering uses `(user_id, created_at DESC)`.
+--
+--   * `notification_preferences` is one row per `(user_id, type)`.
+--     Missing rows fall back to the per-type default in
+--     `NOTIFICATION_TYPE_DEFAULTS` (shared/constants/notifications.ts)
+--     — saves an INSERT for every user on registration.
+--
+-- Idempotent — `IF NOT EXISTS` / `ON CONFLICT DO NOTHING` per the
+-- `feedback_never_modify_applied_migrations` rule.
+
+-- ─── Feature-flag seed ──────────────────────────────────────────────
+
+INSERT INTO feature_flags (
+  key,
+  enabled,
+  label,
+  description,
+  scope,
+  tenant_override_allowed,
+  public
+)
+VALUES (
+  'communication.notifications_center',
+  FALSE,
+  'In-app notification centre',
+  'Adds a bell icon to the top bar with a panel that lists what happened in your organisation — new donations, postal-export downloads, team invitations, and more. Each member can choose which alerts they want from the Settings menu. Off by default until Givernance staff confirm the bell, panel, and per-member preferences for your organisation.',
+  'tenant',
+  FALSE,
+  TRUE
+)
+ON CONFLICT (key) DO NOTHING;
+
+-- ─── notifications ───────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Tenant boundary — RLS policy keys on this column.
+  org_id       UUID         NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  -- Recipient. SET NULL on user purge so a GDPR-erased account doesn't
+  -- FK-block historical notifications. The orphaned rows are then
+  -- garbage-collected by the universal soft-delete sweep (out of scope
+  -- for this Epic — tracked under ADR-021 cleanup).
+  user_id      UUID         REFERENCES users(id) ON DELETE SET NULL,
+  -- Discriminator. Code-side const = `NOTIFICATION_TYPE_VALUES`.
+  -- CHECK below pins shape: lowercase dotted-namespace, ≤ 64 chars.
+  type         VARCHAR(64)  NOT NULL,
+  -- i18n keys — resolved at READ time so a French user sees French
+  -- even when the worker that wrote the row was processing a request
+  -- from an English session.
+  title_key    VARCHAR(128) NOT NULL,
+  body_key     VARCHAR(128) NOT NULL,
+  -- Interpolation params (e.g. `{donorName: "...", amountCents: 1500}`).
+  -- Defaults to `{}` so a downstream renderer can always do
+  -- `params[key]` without null-checking. PII guidance in
+  -- `docs/27-notifications.md` § GDPR: only opaque ids + non-sensitive
+  -- counters; full donor names are dereferenced client-side via the
+  -- `link_url` page.
+  params       JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  -- Relative path (e.g. `/donations/<uuid>`). Frontend prepends
+  -- APP_URL. NULL means the notification is informational only and
+  -- doesn't have a click-through target.
+  link_url     TEXT,
+  -- NULL until the user marks read (single read or read-all).
+  read_at      TIMESTAMPTZ,
+  -- NULL until archived from the panel. Archived ≠ deleted: a row can
+  -- be read AND archived; the panel hides archived rows from the
+  -- default view.
+  archived_at  TIMESTAMPTZ,
+  -- Soft-delete (ADR-021 universal). A panel "delete" sets this; the
+  -- row stays for audit / GDPR DSR replay.
+  deleted_at   TIMESTAMPTZ,
+  created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT notifications_type_chk
+    CHECK (type ~ '^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$'),
+  CONSTRAINT notifications_link_url_chk
+    CHECK (link_url IS NULL OR link_url LIKE '/%')
+);
+
+-- Per-user, time-ordered listing (panel + email digest).
+CREATE INDEX IF NOT EXISTS notifications_user_created_idx
+  ON notifications (user_id, created_at DESC)
+  WHERE deleted_at IS NULL;
+
+-- Bell-badge unread-count query — narrow partial index so the count
+-- doesn't scan archived/read rows on a noisy tenant.
+CREATE INDEX IF NOT EXISTS notifications_user_unread_idx
+  ON notifications (user_id)
+  WHERE read_at IS NULL AND deleted_at IS NULL;
+
+-- Tenant-level admin / debug queries (Back Office "view all rows for
+-- tenant X"). Filters by org_id then orders by created_at.
+CREATE INDEX IF NOT EXISTS notifications_org_created_idx
+  ON notifications (org_id, created_at DESC);
+
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notifications FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  CREATE POLICY tenant_isolation ON notifications
+    USING (org_id = app_current_organization_id());
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON notifications TO givernance_app;
+
+-- ─── notification_preferences ────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS notification_preferences (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id          UUID        NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  user_id         UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  -- Same shape as notifications.type. References-by-string keeps the
+  -- table writable when a new type lands without an FK reorg.
+  type            VARCHAR(64) NOT NULL,
+  -- Channel matrix. `in_app=false` hides the row from the panel + bell
+  -- count; `email_digest=true` includes it in the weekly digest worker
+  -- (Phase 5; opt-in).
+  in_app          BOOLEAN     NOT NULL DEFAULT TRUE,
+  email_digest    BOOLEAN     NOT NULL DEFAULT FALSE,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT notification_preferences_type_chk
+    CHECK (type ~ '^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$'),
+  -- One row per (user, type). Upsert key for the PATCH route.
+  CONSTRAINT notification_preferences_user_type_unique
+    UNIQUE (user_id, type)
+);
+
+CREATE INDEX IF NOT EXISTS notification_preferences_user_idx
+  ON notification_preferences (user_id);
+
+ALTER TABLE notification_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_preferences FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  CREATE POLICY tenant_isolation ON notification_preferences
+    USING (org_id = app_current_organization_id());
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON notification_preferences TO givernance_app;

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1778080000000,
       "tag": "0054_public_page_style_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1778090000000,
+      "tag": "0055_notifications_center",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/modules/admin/feature-flags-routes.ts
+++ b/packages/api/src/modules/admin/feature-flags-routes.ts
@@ -622,7 +622,12 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
     async (request, reply) => {
       const orgId = request.auth?.orgId;
       const userId = request.auth?.userId;
-      if (!orgId || !userId) {
+      // `tenant_flag_overrides.set_by` is FK'd to `users.id` (row UUID),
+      // NOT `users.keycloak_id`. Passing the JWT `sub` here raises a FK
+      // violation against any real seed where the two columns differ
+      // (Epic #363 GLO-004 follow-up).
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userId || !userRowId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
       const { key } = request.params as { key: string };
@@ -641,7 +646,7 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
         flagKey: key,
         value: body.value,
         reason: body.reason ?? null,
-        setBy: userId,
+        setBy: userRowId,
       });
       if (!result) {
         return reply.status(404).send(problemDetail(404, "Not Found", "Feature flag not found"));

--- a/packages/api/src/modules/campaigns/postal-export-service.ts
+++ b/packages/api/src/modules/campaigns/postal-export-service.ts
@@ -404,9 +404,14 @@ export async function startPostalExport(
         campaignId,
         mode,
         totalCount,
-        // Outbox payload keeps the JWT subject (= keycloak id) — it's an
-        // opaque audit trail value, not an FK.
-        requestedBy: userId,
+        // `requestedBy` here carries the resolved `users.id` row UUID —
+        // the notification fanout (Epic #363) targets the single
+        // requester via `eq(users.id, payload.requestedBy)`, so passing
+        // the Keycloak `sub` instead would silently fan out to zero
+        // recipients in any real seed where `users.id != keycloak_id`.
+        // Audit attribution (the JWT subject) is recorded separately
+        // by the audit plugin from `request.auth.userId`.
+        requestedBy: requestedByInternal,
       },
     });
 

--- a/packages/api/src/modules/constituents/bulk-email-service.ts
+++ b/packages/api/src/modules/constituents/bulk-email-service.ts
@@ -190,7 +190,12 @@ export async function dispatchBulkEmail(
       metadata,
       payload: {
         bulkEmailJobId: job.id,
-        requestedBy: userId,
+        // `requestedBy` carries the resolved `users.id` row UUID (NOT
+        // the Keycloak `sub`). The notification fanout (Epic #363)
+        // targets the single requester via `eq(users.id, requestedBy)`
+        // and would silently miss every real user otherwise. Audit
+        // attribution is captured separately from `request.auth.userId`.
+        requestedBy: requestedByInternal,
       },
     });
 
@@ -521,7 +526,10 @@ export async function resumeBulkEmailJob(
       metadata,
       payload: {
         bulkEmailJobId: resumed.id,
-        requestedBy: userId,
+        // See same note above on `requestedBy`: this is the resolved
+        // `users.id` row UUID so the notification fanout targets the
+        // requester correctly.
+        requestedBy: requestedByInternal,
       },
     });
 

--- a/packages/api/src/modules/notifications/routes.ts
+++ b/packages/api/src/modules/notifications/routes.ts
@@ -11,6 +11,16 @@
  * `user_id = currentUserId` so a tenant member can never read another
  * member's notifications even within the same tenant.
  *
+ * Identifier discipline: `notifications.user_id` and
+ * `notification_preferences.user_id` are FK'd to `users.id` (row UUID),
+ * NOT `users.keycloak_id`. Routes must pass `request.auth.userRowId`
+ * (the resolved `users.id`) to the service — passing
+ * `request.auth.userId` (= Keycloak `sub`) silently returns zero rows
+ * for any real user since `users.id != keycloak_id` in production seeds.
+ * A null `userRowId` means the caller has no `users` row (super-admin,
+ * or DB blip in the active-row resolver) and the panel is not
+ * applicable: respond 401 rather than leaking that distinction.
+ *
  * Wire format: `{ data: ... }` envelope (consistent with every other
  * Givernance module). RFC 9457 problem+json on every error path.
  */
@@ -113,8 +123,8 @@ export async function notificationRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const orgId = request.auth?.orgId;
-      const userId = request.auth?.userId;
-      if (!orgId || !userId) {
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userRowId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
       const query = request.query as {
@@ -123,7 +133,7 @@ export async function notificationRoutes(app: FastifyInstance) {
         type?: NotificationType;
         onlyUnread?: boolean;
       };
-      const result = await listNotifications(orgId, userId, query);
+      const result = await listNotifications(orgId, userRowId, query);
       return {
         data: result.data.map(serializeNotification),
         nextCursor: result.nextCursor,
@@ -142,11 +152,11 @@ export async function notificationRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const orgId = request.auth?.orgId;
-      const userId = request.auth?.userId;
-      if (!orgId || !userId) {
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userRowId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
-      const unread = await getUnreadCount(orgId, userId);
+      const unread = await getUnreadCount(orgId, userRowId);
       return { data: { unread } };
     },
   );
@@ -166,12 +176,12 @@ export async function notificationRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const orgId = request.auth?.orgId;
-      const userId = request.auth?.userId;
-      if (!orgId || !userId) {
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userRowId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
       const { id } = request.params as { id: string };
-      const updated = await markRead(orgId, userId, id);
+      const updated = await markRead(orgId, userRowId, id);
       if (!updated) {
         return reply.status(404).send(problemDetail(404, "Not Found", "Notification not found"));
       }
@@ -193,11 +203,11 @@ export async function notificationRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const orgId = request.auth?.orgId;
-      const userId = request.auth?.userId;
-      if (!orgId || !userId) {
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userRowId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
-      const marked = await markAllRead(orgId, userId);
+      const marked = await markAllRead(orgId, userRowId);
       return { data: { marked } };
     },
   );
@@ -217,12 +227,12 @@ export async function notificationRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const orgId = request.auth?.orgId;
-      const userId = request.auth?.userId;
-      if (!orgId || !userId) {
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userRowId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
       const { id } = request.params as { id: string };
-      const deleted = await softDeleteNotification(orgId, userId, id);
+      const deleted = await softDeleteNotification(orgId, userRowId, id);
       if (!deleted) {
         return reply.status(404).send(problemDetail(404, "Not Found", "Notification not found"));
       }
@@ -250,7 +260,8 @@ export async function notificationRoutes(app: FastifyInstance) {
     async (request, reply) => {
       const orgId = request.auth?.orgId;
       const userId = request.auth?.userId;
-      if (!orgId || !userId) {
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userId || !userRowId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
 
@@ -260,11 +271,17 @@ export async function notificationRoutes(app: FastifyInstance) {
       // `notifications.stream.opened` before hijack so SIEM has the
       // signal even if the stream is short-lived. Mirrors the
       // PATCH/DELETE shape the existing audit plugin records.
+      //
+      // Audit attribution keys on the Keycloak `sub` (matches the
+      // `audit_logs.user_id` column elsewhere in the codebase); the row
+      // id we later hand to the streaming service is logged separately
+      // so a SIEM correlator can join the two without ambiguity.
       request.log.info(
         {
           event: "audit.notifications.stream.opened",
           orgId,
           userId,
+          userRowId,
           impersonationSessionId: request.auth?.impersonation?.sessionId,
         },
         "SSE stream opened",
@@ -326,7 +343,7 @@ export async function notificationRoutes(app: FastifyInstance) {
             ? new Date(lastEventId)
             : undefined;
 
-        const stream = streamNotifications(orgId, userId, {
+        const stream = streamNotifications(orgId, userRowId, {
           signal: controller.signal,
           intervalMs: 5_000,
           since: Number.isNaN(since?.getTime() ?? NaN) ? undefined : since,
@@ -381,11 +398,11 @@ export async function notificationRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const orgId = request.auth?.orgId;
-      const userId = request.auth?.userId;
-      if (!orgId || !userId) {
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userRowId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
-      return listPreferences(orgId, userId);
+      return listPreferences(orgId, userRowId);
     },
   );
 
@@ -405,13 +422,13 @@ export async function notificationRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const orgId = request.auth?.orgId;
-      const userId = request.auth?.userId;
-      if (!orgId || !userId) {
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userRowId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
       const { type } = request.params as { type: NotificationType };
       const body = request.body as { inApp: boolean; emailDigest: boolean };
-      const updated = await updatePreference(orgId, userId, type, body);
+      const updated = await updatePreference(orgId, userRowId, type, body);
       if (!updated) {
         return reply.status(404).send(problemDetail(404, "Not Found", "Unknown notification type"));
       }

--- a/packages/api/src/modules/notifications/routes.ts
+++ b/packages/api/src/modules/notifications/routes.ts
@@ -1,0 +1,394 @@
+/**
+ * Notification centre routes (Epic #363, GLO-004).
+ *
+ * Every route is gated by `requireFlag(COMMUNICATION_NOTIFICATIONS_CENTER)`
+ * as the FIRST preHandler — a disabled tenant gets a 404, indistinguishable
+ * from a typo'd URL. Auth runs second.
+ *
+ * RBAC: every authenticated tenant member sees their OWN notifications and
+ * their OWN preferences. No role restriction beyond auth — viewers,
+ * users, and org_admins all get the panel. The service layer enforces
+ * `user_id = currentUserId` so a tenant member can never read another
+ * member's notifications even within the same tenant.
+ *
+ * Wire format: `{ data: ... }` envelope (consistent with every other
+ * Givernance module). RFC 9457 problem+json on every error path.
+ */
+
+import {
+  FEATURE_FLAG_KEYS,
+  NOTIFICATION_TYPE_VALUES,
+  type NotificationType,
+} from "@givernance/shared/constants";
+import { Type } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
+import { requireFlag } from "../../lib/flags/flag-guard.js";
+import { requireAuth } from "../../lib/guards.js";
+import {
+  DataResponse,
+  ErrorResponses,
+  IdParams,
+  problemDetail,
+  UuidSchema,
+} from "../../lib/schemas.js";
+import {
+  getUnreadCount,
+  listNotifications,
+  listPreferences,
+  markAllRead,
+  markRead,
+  softDeleteNotification,
+  streamNotifications,
+  updatePreference,
+} from "./service.js";
+
+// ─── Schemas ────────────────────────────────────────────────────────
+
+const NotificationTypeSchema = Type.Union(NOTIFICATION_TYPE_VALUES.map((v) => Type.Literal(v)));
+
+const NotificationResponse = Type.Object({
+  id: UuidSchema,
+  orgId: UuidSchema,
+  userId: Type.Union([UuidSchema, Type.Null()]),
+  type: NotificationTypeSchema,
+  titleKey: Type.String(),
+  bodyKey: Type.String(),
+  params: Type.Record(Type.String(), Type.Unknown()),
+  linkUrl: Type.Union([Type.String(), Type.Null()]),
+  readAt: Type.Union([Type.String(), Type.Null()]),
+  archivedAt: Type.Union([Type.String(), Type.Null()]),
+  createdAt: Type.String(),
+});
+
+const NotificationListQuery = Type.Object({
+  cursor: Type.Optional(Type.String({ maxLength: 256 })),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 50 })),
+  type: Type.Optional(NotificationTypeSchema),
+  onlyUnread: Type.Optional(Type.Boolean()),
+});
+
+const NotificationListResponse = Type.Object({
+  data: Type.Array(NotificationResponse),
+  nextCursor: Type.Union([Type.String(), Type.Null()]),
+});
+
+const UnreadCountResponse = Type.Object({
+  data: Type.Object({ unread: Type.Integer({ minimum: 0 }) }),
+});
+
+const PreferenceRowSchema = Type.Object({
+  type: NotificationTypeSchema,
+  inApp: Type.Boolean(),
+  emailDigest: Type.Boolean(),
+  isDefault: Type.Boolean(),
+});
+
+const PreferenceListResponse = Type.Object({
+  data: Type.Array(PreferenceRowSchema),
+});
+
+const PreferenceUpdateBody = Type.Object({
+  inApp: Type.Boolean(),
+  emailDigest: Type.Boolean(),
+});
+
+const PreferenceParams = Type.Object({
+  type: NotificationTypeSchema,
+});
+
+// ─── Routes ─────────────────────────────────────────────────────────
+
+export async function notificationRoutes(app: FastifyInstance) {
+  // Flag gate FIRST so an unauthenticated scanner cannot enumerate
+  // gated routes by their auth requirement. See `requireFlag` JSDoc.
+  app.get(
+    "/notifications",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      schema: {
+        tags: ["Notifications"],
+        querystring: NotificationListQuery,
+        response: { 200: NotificationListResponse, ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const query = request.query as {
+        cursor?: string;
+        limit?: number;
+        type?: NotificationType;
+        onlyUnread?: boolean;
+      };
+      const result = await listNotifications(orgId, userId, query);
+      return {
+        data: result.data.map(serializeNotification),
+        nextCursor: result.nextCursor,
+      };
+    },
+  );
+
+  app.get(
+    "/notifications/unread-count",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      schema: {
+        tags: ["Notifications"],
+        response: { 200: UnreadCountResponse, ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const unread = await getUnreadCount(orgId, userId);
+      return { data: { unread } };
+    },
+  );
+
+  app.patch(
+    "/notifications/:id/read",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      schema: {
+        tags: ["Notifications"],
+        params: IdParams,
+        response: {
+          200: DataResponse(NotificationResponse),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { id } = request.params as { id: string };
+      const updated = await markRead(orgId, userId, id);
+      if (!updated) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Notification not found"));
+      }
+      return { data: serializeNotification(updated) };
+    },
+  );
+
+  app.post(
+    "/notifications/read-all",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      schema: {
+        tags: ["Notifications"],
+        response: {
+          200: Type.Object({ data: Type.Object({ marked: Type.Integer({ minimum: 0 }) }) }),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const marked = await markAllRead(orgId, userId);
+      return { data: { marked } };
+    },
+  );
+
+  app.delete(
+    "/notifications/:id",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      schema: {
+        tags: ["Notifications"],
+        params: IdParams,
+        response: {
+          200: DataResponse(NotificationResponse),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { id } = request.params as { id: string };
+      const deleted = await softDeleteNotification(orgId, userId, id);
+      if (!deleted) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Notification not found"));
+      }
+      return { data: serializeNotification(deleted) };
+    },
+  );
+
+  // ─── SSE stream (Phase 4) ──────────────────────────────────────────
+  //
+  // text/event-stream — no swagger schema (binary-ish content). The
+  // route handler hijacks the raw response stream and writes SSE
+  // frames directly. Heartbeat every 25s keeps Cloudflare / Kamal
+  // proxy from idling-out the connection.
+  app.get(
+    "/notifications/stream",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+
+      // Set headers BEFORE hijacking. Disable Fastify's reply
+      // serialization once headers are flushed.
+      reply.raw.setHeader("Content-Type", "text/event-stream");
+      reply.raw.setHeader("Cache-Control", "no-cache, no-transform");
+      reply.raw.setHeader("Connection", "keep-alive");
+      // Some proxies (nginx default) buffer event-stream; disable
+      // explicitly so the first event reaches the client without
+      // waiting for the buffer to fill.
+      reply.raw.setHeader("X-Accel-Buffering", "no");
+      reply.hijack();
+      reply.raw.flushHeaders();
+
+      const controller = new AbortController();
+      const heartbeat = setInterval(() => {
+        // SSE comment frame — ignored by the EventSource client but
+        // keeps the TCP connection alive across idle proxies.
+        try {
+          reply.raw.write(": heartbeat\n\n");
+        } catch {
+          controller.abort();
+        }
+      }, 25_000);
+
+      request.raw.on("close", () => {
+        clearInterval(heartbeat);
+        controller.abort();
+      });
+
+      try {
+        // First event: a `ready` ping so the client knows the
+        // stream is open and can downgrade the polling fallback.
+        reply.raw.write("event: ready\ndata: {}\n\n");
+
+        // Honour `Last-Event-ID` header for reconnect — the value
+        // is the ISO timestamp of the most-recently-delivered row.
+        const lastEventId = request.headers["last-event-id"];
+        const since =
+          typeof lastEventId === "string" && lastEventId.length > 0
+            ? new Date(lastEventId)
+            : undefined;
+
+        const stream = streamNotifications(orgId, userId, {
+          signal: controller.signal,
+          intervalMs: 5_000,
+          since: Number.isNaN(since?.getTime() ?? NaN) ? undefined : since,
+        });
+        for await (const row of stream) {
+          const payload = JSON.stringify(serializeNotification(row));
+          reply.raw.write(`id: ${row.createdAt.toISOString()}\n`);
+          reply.raw.write(`event: notification\n`);
+          reply.raw.write(`data: ${payload}\n\n`);
+        }
+      } catch (err) {
+        request.log.warn({ err }, "SSE stream errored");
+      } finally {
+        clearInterval(heartbeat);
+        try {
+          reply.raw.end();
+        } catch {
+          // already closed
+        }
+      }
+    },
+  );
+
+  // ─── Preferences ────────────────────────────────────────────────────
+
+  app.get(
+    "/notification-preferences",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      schema: {
+        tags: ["Notifications"],
+        response: { 200: PreferenceListResponse, ...ErrorResponses },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      return listPreferences(orgId, userId);
+    },
+  );
+
+  app.patch(
+    "/notification-preferences/:type",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      schema: {
+        tags: ["Notifications"],
+        params: PreferenceParams,
+        body: PreferenceUpdateBody,
+        response: {
+          200: DataResponse(PreferenceRowSchema),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userId = request.auth?.userId;
+      if (!orgId || !userId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { type } = request.params as { type: NotificationType };
+      const body = request.body as { inApp: boolean; emailDigest: boolean };
+      const updated = await updatePreference(orgId, userId, type, body);
+      if (!updated) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Unknown notification type"));
+      }
+      return { data: updated };
+    },
+  );
+}
+
+function serializeNotification(row: {
+  id: string;
+  orgId: string;
+  userId: string | null;
+  type: string;
+  titleKey: string;
+  bodyKey: string;
+  params: unknown;
+  linkUrl: string | null;
+  readAt: Date | null;
+  archivedAt: Date | null;
+  createdAt: Date;
+}) {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    userId: row.userId,
+    type: row.type as NotificationType,
+    titleKey: row.titleKey,
+    bodyKey: row.bodyKey,
+    params: (row.params ?? {}) as Record<string, unknown>,
+    linkUrl: row.linkUrl,
+    readAt: row.readAt ? row.readAt.toISOString() : null,
+    archivedAt: row.archivedAt ? row.archivedAt.toISOString() : null,
+    createdAt: row.createdAt.toISOString(),
+  };
+}

--- a/packages/api/src/modules/notifications/routes.ts
+++ b/packages/api/src/modules/notifications/routes.ts
@@ -240,6 +240,12 @@ export async function notificationRoutes(app: FastifyInstance) {
     "/notifications/stream",
     {
       preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      // Rate-limit the SSE handshake (not the long-lived stream
+      // itself — `@fastify/rate-limit` only sees the initial request).
+      // 5 opens / minute / IP is plenty for the ordinary "swap polling
+      // for SSE" path and prevents a single authenticated user from
+      // bursting hundreds of streams (Security M1).
+      config: { rateLimit: { max: 5, timeWindow: "1 minute" } },
     },
     async (request, reply) => {
       const orgId = request.auth?.orgId;
@@ -247,6 +253,22 @@ export async function notificationRoutes(app: FastifyInstance) {
       if (!orgId || !userId) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
+
+      // SSE open / close audit — the audit plugin only fires on
+      // POST/PUT/PATCH/DELETE, so a long-lived authenticated GET
+      // exfiltration would otherwise have no row. Emit an explicit
+      // `notifications.stream.opened` before hijack so SIEM has the
+      // signal even if the stream is short-lived. Mirrors the
+      // PATCH/DELETE shape the existing audit plugin records.
+      request.log.info(
+        {
+          event: "audit.notifications.stream.opened",
+          orgId,
+          userId,
+          impersonationSessionId: request.auth?.impersonation?.sessionId,
+        },
+        "SSE stream opened",
+      );
 
       // Set headers BEFORE hijacking. Disable Fastify's reply
       // serialization once headers are flushed.
@@ -257,24 +279,39 @@ export async function notificationRoutes(app: FastifyInstance) {
       // explicitly so the first event reaches the client without
       // waiting for the buffer to fill.
       reply.raw.setHeader("X-Accel-Buffering", "no");
+      // Defence-in-depth content-sniffing posture (Security M2). A
+      // malformed first frame on a misconfigured proxy could be
+      // sniffed as HTML by legacy browsers — `nosniff` shuts the
+      // door.
+      reply.raw.setHeader("X-Content-Type-Options", "nosniff");
       reply.hijack();
       reply.raw.flushHeaders();
 
       const controller = new AbortController();
+      const cleanup = (reason: string) => {
+        clearInterval(heartbeat);
+        controller.abort();
+        request.log.info(
+          {
+            event: "audit.notifications.stream.closed",
+            orgId,
+            userId,
+            reason,
+          },
+          "SSE stream closed",
+        );
+      };
       const heartbeat = setInterval(() => {
         // SSE comment frame — ignored by the EventSource client but
         // keeps the TCP connection alive across idle proxies.
         try {
           reply.raw.write(": heartbeat\n\n");
         } catch {
-          controller.abort();
+          cleanup("heartbeat-write-failed");
         }
       }, 25_000);
 
-      request.raw.on("close", () => {
-        clearInterval(heartbeat);
-        controller.abort();
-      });
+      request.raw.on("close", () => cleanup("client-disconnect"));
 
       try {
         // First event: a `ready` ping so the client knows the
@@ -293,6 +330,24 @@ export async function notificationRoutes(app: FastifyInstance) {
           signal: controller.signal,
           intervalMs: 5_000,
           since: Number.isNaN(since?.getTime() ?? NaN) ? undefined : since,
+          // Re-validate authorisation every polling tick — the flag
+          // may have been flipped off mid-stream, or the user's
+          // active-row check (ADR-021) may have failed. Either way
+          // we tear the stream down within one interval. (Security H2.)
+          isStillAuthorised: async () => {
+            try {
+              const stillEnabled = await request.flagService.isEnabled(
+                FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER,
+                { orgId },
+              );
+              return stillEnabled;
+            } catch {
+              // If the flag service is unhealthy mid-stream we err on
+              // the side of closing — a stalled flag check is worse
+              // than a dropped stream the client will auto-reconnect.
+              return false;
+            }
+          },
         });
         for await (const row of stream) {
           const payload = JSON.stringify(serializeNotification(row));
@@ -303,7 +358,7 @@ export async function notificationRoutes(app: FastifyInstance) {
       } catch (err) {
         request.log.warn({ err }, "SSE stream errored");
       } finally {
-        clearInterval(heartbeat);
+        cleanup("stream-end");
         try {
           reply.raw.end();
         } catch {

--- a/packages/api/src/modules/notifications/service.ts
+++ b/packages/api/src/modules/notifications/service.ts
@@ -315,6 +315,12 @@ export async function updatePreference(
  * `intervalMs` and yields rows created after `since`. Stops when the
  * caller's AbortSignal fires (the route closes the connection).
  *
+ * `isStillAuthorised` is called every iteration so a flag flip /
+ * user revocation mid-stream tears down the connection within one
+ * polling interval (Security H2). The caller passes a closure that
+ * re-validates against the flag service + active-row check; we keep
+ * the check at the boundary so the service stays DB-only.
+ *
  * Polling-over-LISTEN was chosen for the spike — see ADR-031. The
  * loop here is intentionally simple; a future migration to PG
  * LISTEN/NOTIFY drops in behind the same yield contract.
@@ -322,10 +328,20 @@ export async function updatePreference(
 export async function* streamNotifications(
   orgId: string,
   userId: string,
-  options: { signal: AbortSignal; intervalMs: number; since?: Date },
+  options: {
+    signal: AbortSignal;
+    intervalMs: number;
+    since?: Date;
+    /** Returning `false` aborts the stream — see header. */
+    isStillAuthorised?: () => Promise<boolean>;
+  },
 ): AsyncGenerator<Notification, void, unknown> {
   let cursor = options.since ?? new Date();
   while (!options.signal.aborted) {
+    if (options.isStillAuthorised) {
+      const ok = await options.isStillAuthorised();
+      if (!ok) break;
+    }
     const fresh = await withTenantContext(orgId, async (tx) => {
       return tx
         .select()
@@ -370,6 +386,8 @@ interface DecodedCursor {
   id: string;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function encodeCursor(createdAt: Date, id: string): string {
   return Buffer.from(`${createdAt.toISOString()}|${id}`, "utf8").toString("base64url");
 }
@@ -382,6 +400,12 @@ export function decodeCursor(value: string | undefined): DecodedCursor | null {
     if (!iso || !id) return null;
     const date = new Date(iso);
     if (Number.isNaN(date.getTime())) return null;
+    // Validate `id` as a UUID — a forged cursor with a 10 k-char `id`
+    // would otherwise ship to PG (Security M4 / Data L1). The cursor
+    // can't bypass `user_id = currentUserId` regardless (WHERE clause
+    // is unconditional), but rejecting nonsense at the boundary saves
+    // a round-trip on tampering attempts.
+    if (!UUID_RE.test(id)) return null;
     return { createdAt: date, id };
   } catch {
     return null;

--- a/packages/api/src/modules/notifications/service.ts
+++ b/packages/api/src/modules/notifications/service.ts
@@ -1,0 +1,389 @@
+/**
+ * In-app notification centre — read/write service (Epic #363, GLO-004).
+ *
+ * Recipient-scoped (NOT just tenant-scoped): every query filters
+ * `notifications.user_id = currentUserId` in addition to the RLS-
+ * enforced `org_id = currentTenantId` boundary. A tenant member can
+ * never read another member's notifications, even within the same
+ * tenant. The same applies to mark-read mutations.
+ *
+ * Soft-delete universal (ADR-021): every read filters
+ * `deleted_at IS NULL`; deletion sets `deleted_at` instead of
+ * physically removing the row.
+ */
+
+import {
+  getNotificationDescriptor,
+  isNotificationType,
+  NOTIFICATION_TYPE_REGISTRY,
+  type NotificationType,
+} from "@givernance/shared/constants";
+import {
+  type Notification,
+  type NotificationPreference,
+  notificationPreferences,
+  notifications,
+} from "@givernance/shared/schema";
+import { and, count, desc, eq, isNull, lt, or, sql } from "drizzle-orm";
+import { withTenantContext } from "../../lib/db.js";
+
+export interface ListNotificationsQuery {
+  /**
+   * Cursor — opaque base64-encoded `(created_at, id)` tuple. Returned
+   * as `nextCursor` in the response when more rows exist.
+   */
+  cursor?: string;
+  /** Max rows per page. Clamped to [1, 50] by the route schema. */
+  limit?: number;
+  /**
+   * Filter by `notifications.type`. Validated by the route as an
+   * enum-union; unknown values fail 400 before reaching here.
+   */
+  type?: NotificationType;
+  /** When `true`, only rows with `read_at IS NULL`. */
+  onlyUnread?: boolean;
+}
+
+export interface ListNotificationsResult {
+  data: Notification[];
+  nextCursor: string | null;
+}
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+export async function listNotifications(
+  orgId: string,
+  userId: string,
+  query: ListNotificationsQuery,
+): Promise<ListNotificationsResult> {
+  const limit = Math.min(Math.max(query.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+  const cursor = decodeCursor(query.cursor);
+
+  return withTenantContext(orgId, async (tx) => {
+    const conditions = [
+      eq(notifications.userId, userId),
+      isNull(notifications.deletedAt),
+      // Default view hides archived rows. A `?includeArchived=true`
+      // is a follow-up (issue #363 § 4 out-of-scope: archive
+      // management UI).
+      isNull(notifications.archivedAt),
+    ];
+    if (query.type) {
+      conditions.push(eq(notifications.type, query.type));
+    }
+    if (query.onlyUnread) {
+      conditions.push(isNull(notifications.readAt));
+    }
+    if (cursor) {
+      // (created_at, id) tuple ordering — strict less-than on the
+      // composite. Postgres `row(a, b) < row(c, d)` evaluates exactly
+      // this. Using `or` of two conjunctions keeps Drizzle happy. The
+      // `or` helper returns `SQL | undefined`; we know both branches
+      // are present, so guard with an explicit truthy push rather
+      // than a non-null assertion (lint/style/noNonNullAssertion).
+      const cursorClause = or(
+        lt(notifications.createdAt, cursor.createdAt),
+        and(eq(notifications.createdAt, cursor.createdAt), lt(notifications.id, cursor.id)),
+      );
+      if (cursorClause) conditions.push(cursorClause);
+    }
+
+    // Fetch one extra to know if there's a next page without a
+    // second COUNT query.
+    const rows = await tx
+      .select()
+      .from(notifications)
+      .where(and(...conditions))
+      .orderBy(desc(notifications.createdAt), desc(notifications.id))
+      .limit(limit + 1);
+
+    const hasNext = rows.length > limit;
+    const data = hasNext ? rows.slice(0, limit) : rows;
+    const last = data[data.length - 1];
+    const nextCursor = hasNext && last ? encodeCursor(last.createdAt, last.id) : null;
+
+    return { data, nextCursor };
+  });
+}
+
+export async function getUnreadCount(orgId: string, userId: string): Promise<number> {
+  return withTenantContext(orgId, async (tx) => {
+    const [row] = await tx
+      .select({ value: count() })
+      .from(notifications)
+      .where(
+        and(
+          eq(notifications.userId, userId),
+          isNull(notifications.readAt),
+          isNull(notifications.deletedAt),
+          isNull(notifications.archivedAt),
+        ),
+      );
+    return Number(row?.value ?? 0);
+  });
+}
+
+/**
+ * Mark one notification as read. Returns the updated row or `null`
+ * if the id didn't match (either wrong tenant, wrong user, or
+ * deleted). Idempotent — calling on an already-read row is a no-op
+ * that returns the row unchanged.
+ */
+export async function markRead(
+  orgId: string,
+  userId: string,
+  id: string,
+): Promise<Notification | null> {
+  return withTenantContext(orgId, async (tx) => {
+    // First check the row belongs to the caller. Using a SELECT-then-
+    // UPDATE pattern (rather than UPDATE…RETURNING with a WHERE clause
+    // that includes user_id) so a 404 vs 200-no-op is distinguishable
+    // by the route handler.
+    const [existing] = await tx
+      .select()
+      .from(notifications)
+      .where(
+        and(
+          eq(notifications.id, id),
+          eq(notifications.userId, userId),
+          isNull(notifications.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (!existing) return null;
+    if (existing.readAt) return existing;
+
+    const [updated] = await tx
+      .update(notifications)
+      .set({ readAt: new Date() })
+      .where(eq(notifications.id, id))
+      .returning();
+    return updated ?? existing;
+  });
+}
+
+/**
+ * Mark every unread notification for this user as read. Returns the
+ * count. Idempotent — second call returns 0.
+ */
+export async function markAllRead(orgId: string, userId: string): Promise<number> {
+  return withTenantContext(orgId, async (tx) => {
+    const rows = await tx
+      .update(notifications)
+      .set({ readAt: new Date() })
+      .where(
+        and(
+          eq(notifications.userId, userId),
+          isNull(notifications.readAt),
+          isNull(notifications.deletedAt),
+        ),
+      )
+      .returning({ id: notifications.id });
+    return rows.length;
+  });
+}
+
+/**
+ * Soft-delete one notification. Sets `deleted_at`; the row stays for
+ * audit. Returns `null` if not found / not owned.
+ */
+export async function softDeleteNotification(
+  orgId: string,
+  userId: string,
+  id: string,
+): Promise<Notification | null> {
+  return withTenantContext(orgId, async (tx) => {
+    const [updated] = await tx
+      .update(notifications)
+      .set({ deletedAt: new Date() })
+      .where(
+        and(
+          eq(notifications.id, id),
+          eq(notifications.userId, userId),
+          isNull(notifications.deletedAt),
+        ),
+      )
+      .returning();
+    return updated ?? null;
+  });
+}
+
+// ─── Preferences ──────────────────────────────────────────────────────
+
+export interface PreferencesView {
+  data: Array<{
+    type: NotificationType;
+    inApp: boolean;
+    emailDigest: boolean;
+    /** Whether this is the registry default (no explicit row exists). */
+    isDefault: boolean;
+  }>;
+}
+
+/**
+ * Return the user's effective preferences: explicit rows merged with
+ * per-type defaults from `NOTIFICATION_TYPE_REGISTRY`. The shape is
+ * a closed set (one entry per registered type) so the web UI can
+ * render the toggle grid without an N+1.
+ */
+export async function listPreferences(orgId: string, userId: string): Promise<PreferencesView> {
+  return withTenantContext(orgId, async (tx) => {
+    const rows = (await tx
+      .select()
+      .from(notificationPreferences)
+      .where(eq(notificationPreferences.userId, userId))) as NotificationPreference[];
+    const explicit = new Map<string, NotificationPreference>();
+    for (const row of rows) {
+      explicit.set(row.type, row);
+    }
+    const data = NOTIFICATION_TYPE_REGISTRY.map((descriptor) => {
+      const row = explicit.get(descriptor.key);
+      if (row) {
+        return {
+          type: descriptor.key,
+          inApp: row.inApp,
+          emailDigest: row.emailDigest,
+          isDefault: false,
+        };
+      }
+      return {
+        type: descriptor.key,
+        inApp: descriptor.defaultInApp,
+        emailDigest: descriptor.defaultEmailDigest,
+        isDefault: true,
+      };
+    });
+    return { data };
+  });
+}
+
+export interface UpdatePreferenceInput {
+  inApp: boolean;
+  emailDigest: boolean;
+}
+
+/**
+ * Upsert one preference row. Returns the resolved view (matches
+ * `listPreferences` shape) so the client can re-render without a
+ * second GET.
+ */
+export async function updatePreference(
+  orgId: string,
+  userId: string,
+  type: string,
+  input: UpdatePreferenceInput,
+): Promise<{
+  type: NotificationType;
+  inApp: boolean;
+  emailDigest: boolean;
+  isDefault: false;
+} | null> {
+  if (!isNotificationType(type)) return null;
+  const descriptor = getNotificationDescriptor(type);
+  return withTenantContext(orgId, async (tx) => {
+    const [row] = await tx
+      .insert(notificationPreferences)
+      .values({
+        orgId,
+        userId,
+        type: descriptor.key,
+        inApp: input.inApp,
+        emailDigest: input.emailDigest,
+      })
+      .onConflictDoUpdate({
+        target: [notificationPreferences.userId, notificationPreferences.type],
+        set: {
+          inApp: input.inApp,
+          emailDigest: input.emailDigest,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+    if (!row) return null;
+    return {
+      type: descriptor.key,
+      inApp: row.inApp,
+      emailDigest: row.emailDigest,
+      isDefault: false,
+    };
+  });
+}
+
+/**
+ * Stream new notifications for the SSE endpoint. Polls every
+ * `intervalMs` and yields rows created after `since`. Stops when the
+ * caller's AbortSignal fires (the route closes the connection).
+ *
+ * Polling-over-LISTEN was chosen for the spike — see ADR-031. The
+ * loop here is intentionally simple; a future migration to PG
+ * LISTEN/NOTIFY drops in behind the same yield contract.
+ */
+export async function* streamNotifications(
+  orgId: string,
+  userId: string,
+  options: { signal: AbortSignal; intervalMs: number; since?: Date },
+): AsyncGenerator<Notification, void, unknown> {
+  let cursor = options.since ?? new Date();
+  while (!options.signal.aborted) {
+    const fresh = await withTenantContext(orgId, async (tx) => {
+      return tx
+        .select()
+        .from(notifications)
+        .where(
+          and(
+            eq(notifications.userId, userId),
+            isNull(notifications.deletedAt),
+            sql`${notifications.createdAt} > ${cursor.toISOString()}`,
+          ),
+        )
+        .orderBy(notifications.createdAt);
+    });
+    for (const row of fresh) {
+      yield row;
+      cursor = row.createdAt;
+    }
+    if (options.signal.aborted) break;
+    await sleep(options.intervalMs, options.signal);
+  }
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) return resolve();
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+// ─── Cursor codec ─────────────────────────────────────────────────────
+
+interface DecodedCursor {
+  createdAt: Date;
+  id: string;
+}
+
+function encodeCursor(createdAt: Date, id: string): string {
+  return Buffer.from(`${createdAt.toISOString()}|${id}`, "utf8").toString("base64url");
+}
+
+export function decodeCursor(value: string | undefined): DecodedCursor | null {
+  if (!value) return null;
+  try {
+    const decoded = Buffer.from(value, "base64url").toString("utf8");
+    const [iso, id] = decoded.split("|");
+    if (!iso || !id) return null;
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return null;
+    return { createdAt: date, id };
+  } catch {
+    return null;
+  }
+}

--- a/packages/api/src/modules/session/service.ts
+++ b/packages/api/src/modules/session/service.ts
@@ -267,43 +267,59 @@ export async function isUserBlocklisted(keycloakId: string | undefined): Promise
 }
 
 /**
- * Look up the active-row cache. Returns:
- *   - `"active"` — a `users` row exists for `(keycloak_id, org_id)` with `deleted_at IS NULL`
- *   - `"missing"` — no active row (cached negative)
- *   - `null` — not in cache; caller should query Postgres
+ * Look up the active-row cache. Returns either:
+ *   - `{ active: true, userRowId }` — a `users` row exists for
+ *     `(keycloak_id, org_id)` with `deleted_at IS NULL`; row UUID cached
+ *     so call sites that need `users.id` (e.g. notifications routes
+ *     filtering against `notifications.user_id`) don't re-query.
+ *   - `"missing"` — no active row (cached negative).
+ *   - `null` — not in cache; caller should query Postgres.
  *
  * The cache is intentionally short-TTL so a soft-delete propagates without
  * needing a fanout invalidation; for zero-second propagation use the
  * `blocklistUser` path which closes the door immediately.
+ *
+ * Cache value encoding:
+ *   - `"0"` ⇒ missing (negative cache, legacy compat)
+ *   - any other non-empty string ⇒ `users.id` row UUID (positive cache)
+ *
+ * The old `"1"` positive value (pre-Epic-#363 GLO-004 fix) is treated as
+ * a cache miss so an in-flight rolling deploy on top of a stale Redis
+ * doesn't hand callers a `userRowId` of `"1"`.
  */
 export async function getActiveUserCache(
   keycloakId: string,
   orgId: string,
-): Promise<"active" | "missing" | null> {
+): Promise<{ active: true; userRowId: string } | "missing" | null> {
   try {
     const hit = await redis.get(activeUserCacheKey(keycloakId, orgId));
-    if (hit === "1") return "active";
+    if (hit === null) return null;
     if (hit === "0") return "missing";
-    return null;
+    // Reject the pre-fix `"1"` positive value and any other shape that
+    // isn't a UUID — a "1" handed back as `userRowId` would silently
+    // re-introduce the bug on tenant routes filtering by `users.id`.
+    if (hit === "1" || !UUID_RE.test(hit)) return null;
+    return { active: true, userRowId: hit };
   } catch (err) {
     logger.error({ err, keycloakId, orgId }, "active-user cache read failed");
     return null;
   }
 }
 
-/** Write the cache with a short TTL after a successful (or negative) DB lookup. */
+/**
+ * Write the cache with a short TTL after a successful (or negative) DB
+ * lookup. `userRowId` is the `users.id` row UUID when active, omitted
+ * for the negative case.
+ */
 export async function setActiveUserCache(
   keycloakId: string,
   orgId: string,
-  state: "active" | "missing",
+  result: { active: true; userRowId: string } | { active: false },
   ttlSeconds = ACTIVE_USER_CACHE_TTL_SECONDS,
 ): Promise<void> {
   try {
-    await redis.setex(
-      activeUserCacheKey(keycloakId, orgId),
-      ttlSeconds,
-      state === "active" ? "1" : "0",
-    );
+    const value = result.active ? result.userRowId : "0";
+    await redis.setex(activeUserCacheKey(keycloakId, orgId), ttlSeconds, value);
   } catch (err) {
     logger.error({ err, keycloakId, orgId }, "active-user cache write failed");
   }

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -215,13 +215,23 @@ async function applyAuthFromToken(request: FastifyRequest): Promise<TokenResult>
   // members must still resolve an active `users` row for `(sub, org_id)`
   // — this closes the soft-delete + tenant-removal window where the JWT
   // is still cryptographically valid but the subject is gone.
+  //
+  // The resolver also surfaces the `users.id` row UUID (`userRowId`) so
+  // routes filtering against schema FKs that target `users.id`
+  // (notifications, notification_preferences, …) don't have to re-query.
+  // Epic #363 GLO-004 follow-up: comparing `request.auth.userId` (=
+  // Keycloak `sub`) against a `users.id` column silently returns zero
+  // rows for any real user where `users.id != keycloak_id`.
+  let userRowId: string | null = null;
   if (!isSuperAdmin) {
-    const isActive = await resolveActiveMembership(decoded.sub, decoded.org_id);
-    if (!isActive) return "no_active_membership";
+    const membership = await resolveActiveMembership(decoded.sub, decoded.org_id);
+    if (!membership.active) return "no_active_membership";
+    userRowId = membership.userRowId;
   }
 
   request.auth = {
     userId: decoded.sub,
+    userRowId,
     orgId: decoded.org_id,
     roles: realmRoles,
     email: decoded.email,
@@ -292,8 +302,20 @@ async function applyImpersonationFromToken(
     return "impersonation_revoked";
   }
 
+  // Resolve the target's `users.id` row UUID so routes that filter on
+  // schema FKs into `users.id` (Epic #363 GLO-004: notifications,
+  // notification_preferences) see the correct row even under
+  // impersonation. The token's `sub` is the target's Keycloak `sub`, so
+  // the same resolver as the normal path applies — the target IS a
+  // tenant user and must have an active `users` row. A null row id is
+  // surfaced to the route as a 401/empty list (defence-in-depth; we
+  // expect the impersonation start flow to have already validated the
+  // target's row).
+  const membership = await resolveActiveMembership(decoded.sub, decoded.org_id);
+
   request.auth = {
     userId: decoded.sub,
+    userRowId: membership.userRowId,
     orgId: decoded.org_id,
     roles: decoded.realm_access.roles,
     email: decoded.email,
@@ -312,17 +334,35 @@ async function applyImpersonationFromToken(
 }
 
 /**
- * Resolve whether a `(sub, orgId)` pair maps to an active `users` row
- * (ADR-021 active-row check). Reads through the Redis cache first; on
- * a miss, queries Postgres and writes the result. Cache TTL is short
- * (~30 s) so soft-delete propagates without explicit invalidation —
- * callers that want zero-second propagation should also call
- * `invalidateActiveUserCache` from the session-service module.
+ * Discriminated active-membership result. `active: true` means the
+ * caller may proceed with the auth check; `userRowId` carries the
+ * `users.id` row UUID on a confirmed hit, or `null` when the resolver
+ * failed open on a DB blip (active-row check did NOT confirm a row but
+ * we don't 401 the world over a transient outage — the JWT signature +
+ * user blocklist are still hard gates). Routes that depend on a
+ * non-null row id (notifications, preferences) will 401 themselves when
+ * `userRowId` is null.
  */
-async function resolveActiveMembership(sub: string, orgId: string): Promise<boolean> {
+type ActiveMembership =
+  | { active: true; userRowId: string | null }
+  | { active: false; userRowId: null };
+
+/**
+ * Resolve `(sub, orgId)` against the active-row check (ADR-021). Reads
+ * through the Redis cache first; on a miss, queries Postgres and writes
+ * either the row id (positive) or the missing marker (negative). Cache
+ * TTL is short (~30 s) so soft-delete propagates without explicit
+ * invalidation — callers that want zero-second propagation should also
+ * call `invalidateActiveUserCache` from the session-service module.
+ *
+ * The returned row id powers `request.auth.userRowId` for routes that
+ * must filter against schema columns FK'd to `users.id` (Epic #363
+ * GLO-004: `notifications.user_id`, `notification_preferences.user_id`).
+ */
+async function resolveActiveMembership(sub: string, orgId: string): Promise<ActiveMembership> {
   const cached = await getActiveUserCache(sub, orgId);
-  if (cached === "active") return true;
-  if (cached === "missing") return false;
+  if (cached === "missing") return { active: false, userRowId: null };
+  if (cached !== null) return { active: true, userRowId: cached.userRowId };
 
   // Cache miss — query the source of truth. Filtered by tenant via
   // RLS through `withTenantContext`; the `eq(orgId)` predicate is
@@ -330,11 +370,11 @@ async function resolveActiveMembership(sub: string, orgId: string): Promise<bool
   //
   // We catch and swallow DB errors here: the auth plugin runs on every
   // authenticated request, and a DB blip during the active-row check
-  // would otherwise turn into a 500 cascade. Fail-OPEN to "active" on
-  // DB error so a transient outage doesn't lock everyone out — the
-  // user blocklist and the JWT signature are still hard gates. A
-  // structured error log gives ops visibility without breaking the
-  // hot path.
+  // would otherwise turn into a 500 cascade. Fail-OPEN to `active: true`
+  // (userRowId = null) so a transient outage doesn't lock everyone out
+  // — the user blocklist and the JWT signature are still hard gates. A
+  // structured error log gives ops visibility without breaking the hot
+  // path.
   try {
     const rows = await withTenantContext(orgId, async (tx) =>
       tx
@@ -343,15 +383,21 @@ async function resolveActiveMembership(sub: string, orgId: string): Promise<bool
         .where(and(eq(users.keycloakId, sub), eq(users.orgId, orgId), isNull(users.deletedAt)))
         .limit(1),
     );
-    const isActive = rows.length > 0;
-    await setActiveUserCache(sub, orgId, isActive ? "active" : "missing");
-    return isActive;
+    const userRowId = rows[0]?.id ?? null;
+    if (userRowId !== null) {
+      await setActiveUserCache(sub, orgId, { active: true, userRowId });
+      return { active: true, userRowId };
+    }
+    await setActiveUserCache(sub, orgId, { active: false });
+    return { active: false, userRowId: null };
   } catch (err) {
     // Module-scoped fallback log — the request-scoped pino logger isn't
-    // reachable from the auth-resolver helper. Failing open returns true
-    // so a transient DB blip doesn't lock everyone out.
+    // reachable from the auth-resolver helper. Failing open returns
+    // `active: true` so a transient DB blip doesn't lock everyone out;
+    // `userRowId` stays null so notification-style routes (which need a
+    // FK target) refuse to proceed.
     console.error({ err, sub, orgId }, "auth: active-row resolution failed — failing open");
-    return true;
+    return { active: true, userRowId: null };
   }
 }
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -28,6 +28,7 @@ import { donationRoutes } from "./modules/donations/routes.js";
 import { fundRoutes } from "./modules/funds/routes.js";
 import { healthRoutes } from "./modules/health/routes.js";
 import { invitationRoutes } from "./modules/invitations/routes.js";
+import { notificationRoutes } from "./modules/notifications/routes.js";
 import { paymentRoutes, stripeWebhookRoute } from "./modules/payments/routes.js";
 import { pledgeRoutes } from "./modules/pledges/routes.js";
 import { publicDonationRoutes } from "./modules/public/routes.js";
@@ -188,6 +189,7 @@ export async function createServer(opts: CreateServerOpts = {}): Promise<Fastify
   await app.register(tenantRoutes, { prefix: "/v1" });
   await app.register(userRoutes, { prefix: "/v1" });
   await app.register(invitationRoutes, { prefix: "/v1" });
+  await app.register(notificationRoutes, { prefix: "/v1" });
   await app.register(auditRoutes, { prefix: "/v1" });
   await app.register(brandingRoutes, { prefix: "/v1" });
   await app.register(donationRoutes, { prefix: "/v1" });

--- a/packages/api/src/tests/helpers/auth.ts
+++ b/packages/api/src/tests/helpers/auth.ts
@@ -7,8 +7,27 @@ import { db } from "../../lib/db.js";
 
 export const ORG_A = "00000000-0000-0000-0000-000000000001";
 export const ORG_B = "00000000-0000-0000-0000-000000000002";
+/**
+ * Keycloak `sub` (JWT subject) for the default tenant-A test user. Used
+ * as the `sub` claim by `signToken` and as the `keycloak_id` column in
+ * `ensureTestTenants`. NEVER use this where a `users.id` (row UUID) is
+ * expected — `users.id` is deliberately distinct (see `USER_A_ROW_ID`).
+ *
+ * Epic #363 GLO-004 follow-up: prior to PR #XXX, fixtures conflated the
+ * two (insert with `id = keycloak_id`), which masked the
+ * notifications-routes bug where the route filtered `users.id` columns
+ * by the JWT `sub`. The distinction is enforced in `ensureTestTenants`.
+ */
 export const USER_A = "00000000-0000-0000-0000-000000000099";
 export const USER_B = "00000000-0000-0000-0000-000000000098";
+/**
+ * `users.id` row UUIDs for the default test users — DISTINCT from the
+ * `sub` claim above. Tests that need to seed FK rows pointing at
+ * `users.id` (e.g. `notifications.user_id`, `notification_preferences.user_id`,
+ * `audit_logs.user_id`) MUST use these, not `USER_A` / `USER_B`.
+ */
+export const USER_A_ROW_ID = "00000000-0000-0000-0000-0000000a0099";
+export const USER_B_ROW_ID = "00000000-0000-0000-0000-0000000a0098";
 
 const TEST_JWT_ISSUER = process.env.KEYCLOAK_ISSUER ?? "https://keycloak.test/realms/givernance";
 const TEST_JWT_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
@@ -131,21 +150,27 @@ export async function ensureTestTenants() {
   // `signTokenB`. The auth plugin's active-row check requires
   // `(keycloak_id, org_id, deleted_at IS NULL)` to resolve — without
   // these rows, every authenticated test request 401s.
-  // `ON CONFLICT (org_id, email) WHERE deleted_at IS NULL DO NOTHING`
-  // keeps the fixture idempotent across re-runs even after a soft-delete
-  // (a soft-deleted row stays out of the partial unique, so a re-INSERT
-  // would raise on the email — explicitly DELETE soft-deleted fixtures
-  // first so re-runs are clean).
+  //
+  // CRITICAL — Epic #363 GLO-004: `users.id` is DELIBERATELY distinct
+  // from `users.keycloak_id` here (and in production seeds). Code that
+  // filters a `users.id` FK by the JWT `sub` will silently return zero
+  // rows. The notifications routes regression test depends on this
+  // distinction surviving — never collapse the two columns back to the
+  // same UUID even if it makes a refactor easier locally.
+  //
+  // We DELETE by the legacy `id = keycloak_id` shape too so a workspace
+  // upgraded mid-suite (where a prior `ensureTestTenants` already wrote
+  // the conflated rows) is reset cleanly.
   await db.execute(sql`
     DELETE FROM users
-    WHERE id IN (${USER_A}, ${USER_B})
+    WHERE id IN (${USER_A_ROW_ID}, ${USER_B_ROW_ID}, ${USER_A}, ${USER_B})
        OR (org_id IN (${ORG_A}, ${ORG_B}) AND email IN ('user-a@example.org', 'user-b@example.org'))
   `);
   await db.execute(sql`
     INSERT INTO users (id, org_id, keycloak_id, email, first_name, last_name, role)
     VALUES
-      (${USER_A}, ${ORG_A}, ${USER_A}, 'user-a@example.org', 'Test', 'UserA', 'org_admin'),
-      (${USER_B}, ${ORG_B}, ${USER_B}, 'user-b@example.org', 'Test', 'UserB', 'org_admin')
+      (${USER_A_ROW_ID}, ${ORG_A}, ${USER_A}, 'user-a@example.org', 'Test', 'UserA', 'org_admin'),
+      (${USER_B_ROW_ID}, ${ORG_B}, ${USER_B}, 'user-b@example.org', 'Test', 'UserB', 'org_admin')
   `);
 }
 

--- a/packages/api/src/tests/integration/notifications.test.ts
+++ b/packages/api/src/tests/integration/notifications.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Notification centre integration tests (Epic #363, GLO-004).
+ *
+ * Coverage matrix:
+ *   1. Off-state flag — every gated route returns 404 when the flag is
+ *      off (anti-disclosure). 404 fires BEFORE auth.
+ *   2. On-state flag — list + mark-read + mark-all-read happy paths,
+ *      RFC 9457 problem+json on 404.
+ *   3. RLS isolation — Tenant A can never see Tenant B's notifications
+ *      (cross-tenant cursor probe + cross-tenant mark-read attempt).
+ *   4. Recipient isolation — within the SAME tenant, user A can't read
+ *      user B's notifications.
+ *   5. Preferences — list returns the closed type set with defaults
+ *      merged; PATCH upserts; unknown type returns 404.
+ *   6. Registry parity — DB row matches FEATURE_FLAG_REGISTRY for the
+ *      new flag (drift guard).
+ */
+
+import { FEATURE_FLAG_KEYS, FEATURE_FLAG_REGISTRY } from "@givernance/shared/constants";
+import { featureFlags, notifications } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { flagService } from "../../lib/flags/flag-service.js";
+import { createServer } from "../../server.js";
+import {
+  authHeader,
+  ensureTestTenants,
+  ORG_A,
+  ORG_B,
+  signToken,
+  signTokenB,
+  USER_A,
+  USER_B,
+} from "../helpers/auth.js";
+
+const FLAG_KEY = FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER;
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+});
+
+afterAll(async () => {
+  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+  await app.close();
+});
+
+beforeEach(async () => {
+  // Reset DB state — no notifications, no preferences, flag off.
+  await db.execute(sql`DELETE FROM notification_preferences`);
+  await db.execute(sql`DELETE FROM notifications`);
+  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+});
+
+afterEach(async () => {
+  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+async function setFlag(enabled: boolean): Promise<void> {
+  await db.update(featureFlags).set({ enabled }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+}
+
+async function seedNotification(opts: {
+  orgId: string;
+  userId: string;
+  type?: string;
+  readAt?: Date | null;
+  deletedAt?: Date | null;
+}): Promise<string> {
+  // Use owner-pool insert so we can set arbitrary org_id without RLS.
+  const id = crypto.randomUUID();
+  await db.execute(sql`
+    INSERT INTO notifications
+      (id, org_id, user_id, type, title_key, body_key, params, link_url, read_at, deleted_at)
+    VALUES
+      (${id}, ${opts.orgId}, ${opts.userId}, ${opts.type ?? "donation.received"},
+       'notifications.types.donation_received.title',
+       'notifications.types.donation_received.body',
+       '{"donationId":"00000000-0000-0000-0000-000000000aaa"}'::jsonb,
+       '/donations/00000000-0000-0000-0000-000000000aaa',
+       ${opts.readAt ?? null}, ${opts.deletedAt ?? null})
+  `);
+  return id;
+}
+
+// ─── 1. Off-state flag — every gated route is 404 ─────────────────────
+
+describe("Notifications — off-state flag (anti-disclosure)", () => {
+  // Parametrise over every gated route so a refactor that drops the
+  // `requireFlag` preHandler is caught here, not in production.
+  const gatedRoutes: Array<{
+    method: "GET" | "POST" | "PATCH" | "DELETE";
+    url: string;
+    payload?: unknown;
+  }> = [
+    { method: "GET", url: "/v1/notifications" },
+    { method: "GET", url: "/v1/notifications/unread-count" },
+    {
+      method: "PATCH",
+      url: "/v1/notifications/00000000-0000-0000-0000-000000000001/read",
+    },
+    { method: "POST", url: "/v1/notifications/read-all" },
+    {
+      method: "DELETE",
+      url: "/v1/notifications/00000000-0000-0000-0000-000000000001",
+    },
+    { method: "GET", url: "/v1/notification-preferences" },
+    {
+      method: "PATCH",
+      url: "/v1/notification-preferences/donation.received",
+      payload: { inApp: true, emailDigest: false },
+    },
+  ];
+
+  for (const route of gatedRoutes) {
+    it(`returns 404 on ${route.method} ${route.url} when flag is off`, async () => {
+      const token = signToken(app);
+      const res = await app.inject({
+        method: route.method,
+        url: route.url,
+        headers: authHeader(token),
+        payload: route.payload as Record<string, unknown> | undefined,
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it(`unauthenticated ${route.method} ${route.url} also returns 404 (no auth-vs-flag disclosure)`, async () => {
+      const res = await app.inject({
+        method: route.method,
+        url: route.url,
+        payload: route.payload as Record<string, unknown> | undefined,
+      });
+      // requireFlag is first preHandler — runs before auth, so
+      // unauthenticated callers hit the gate 404 (not 401).
+      expect(res.statusCode).toBe(404);
+    });
+  }
+});
+
+// ─── 2. On-state flag — happy paths + RFC 9457 ─────────────────────────
+
+describe("Notifications — list + mark + delete (flag on)", () => {
+  beforeEach(async () => {
+    await setFlag(true);
+  });
+
+  it("GET /v1/notifications returns caller's own rows", async () => {
+    const id1 = await seedNotification({ orgId: ORG_A, userId: USER_A });
+    const id2 = await seedNotification({ orgId: ORG_A, userId: USER_A });
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: Array<{ id: string }>; nextCursor: string | null }>();
+    const ids = body.data.map((r) => r.id);
+    expect(ids).toContain(id1);
+    expect(ids).toContain(id2);
+  });
+
+  it("GET /v1/notifications/unread-count returns the right count", async () => {
+    await seedNotification({ orgId: ORG_A, userId: USER_A }); // unread
+    await seedNotification({ orgId: ORG_A, userId: USER_A, readAt: new Date() }); // read
+    await seedNotification({ orgId: ORG_A, userId: USER_A, deletedAt: new Date() }); // deleted
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications/unread-count",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { unread: number } }>().data.unread).toBe(1);
+  });
+
+  it("PATCH /v1/notifications/:id/read marks one row read and is idempotent", async () => {
+    const id = await seedNotification({ orgId: ORG_A, userId: USER_A });
+    const token = signToken(app);
+
+    const first = await app.inject({
+      method: "PATCH",
+      url: `/v1/notifications/${id}/read`,
+      headers: authHeader(token),
+    });
+    expect(first.statusCode).toBe(200);
+    expect(first.json<{ data: { readAt: string | null } }>().data.readAt).toBeTruthy();
+
+    // Second call is idempotent — returns the same row, unchanged.
+    const second = await app.inject({
+      method: "PATCH",
+      url: `/v1/notifications/${id}/read`,
+      headers: authHeader(token),
+    });
+    expect(second.statusCode).toBe(200);
+  });
+
+  it("PATCH /v1/notifications/:id/read returns 404 RFC 9457 for unknown id", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/notifications/00000000-0000-0000-0000-000000000bad/read",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{ status?: number; title?: string }>();
+    // RFC 9457 — every error response carries `{ status, title }`.
+    expect(body.status).toBe(404);
+    expect(typeof body.title).toBe("string");
+  });
+
+  it("POST /v1/notifications/read-all marks every unread row read", async () => {
+    await seedNotification({ orgId: ORG_A, userId: USER_A });
+    await seedNotification({ orgId: ORG_A, userId: USER_A });
+    await seedNotification({ orgId: ORG_A, userId: USER_A });
+
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/read-all",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { marked: number } }>().data.marked).toBe(3);
+
+    // Subsequent call returns 0 — idempotent.
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/read-all",
+      headers: authHeader(token),
+    });
+    expect(second.json<{ data: { marked: number } }>().data.marked).toBe(0);
+  });
+
+  it("DELETE /v1/notifications/:id soft-deletes (deleted_at set, row stays)", async () => {
+    const id = await seedNotification({ orgId: ORG_A, userId: USER_A });
+    const token = signToken(app);
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/notifications/${id}`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+
+    // Row physically still exists.
+    const [row] = await db
+      .select({ deletedAt: notifications.deletedAt })
+      .from(notifications)
+      .where(eq(notifications.id, id));
+    expect(row?.deletedAt).toBeInstanceOf(Date);
+
+    // List endpoint no longer returns it.
+    const list = await app.inject({
+      method: "GET",
+      url: "/v1/notifications",
+      headers: authHeader(token),
+    });
+    const body = list.json<{ data: Array<{ id: string }> }>();
+    expect(body.data.find((r) => r.id === id)).toBeUndefined();
+  });
+});
+
+// ─── 3. RLS / cross-tenant + cross-user isolation ──────────────────────
+
+describe("Notifications — isolation (RLS + recipient)", () => {
+  beforeEach(async () => {
+    await setFlag(true);
+  });
+
+  it("Tenant A user can NEVER see Tenant B notifications via list", async () => {
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications",
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: Array<{ id: string }> }>();
+    expect(body.data.find((r) => r.id === tenantBId)).toBeUndefined();
+  });
+
+  it("Tenant A user cannot mark-read a Tenant B row (404, not 200)", async () => {
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/notifications/${tenantBId}/read`,
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("Tenant B reads their own rows under the same flag (positive bound)", async () => {
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+
+    const tokenB = signTokenB(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications",
+      headers: authHeader(tokenB),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: Array<{ id: string }> }>();
+    expect(body.data.find((r) => r.id === tenantBId)).toBeDefined();
+  });
+});
+
+// ─── 4. Preferences ────────────────────────────────────────────────────
+
+describe("Notifications — preferences", () => {
+  beforeEach(async () => {
+    await setFlag(true);
+  });
+
+  it("GET /v1/notification-preferences returns the closed set with defaults merged", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notification-preferences",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: Array<{ type: string; inApp: boolean; emailDigest: boolean; isDefault: boolean }>;
+    }>();
+    // Every registered type has a row.
+    expect(body.data.find((r) => r.type === "donation.received")).toBeDefined();
+    expect(body.data.find((r) => r.type === "invitation.created")).toBeDefined();
+    // No explicit row exists → every row carries isDefault = true.
+    expect(body.data.every((r) => r.isDefault === true)).toBe(true);
+  });
+
+  it("PATCH /v1/notification-preferences/:type upserts (idempotent)", async () => {
+    const token = signToken(app);
+    const first = await app.inject({
+      method: "PATCH",
+      url: "/v1/notification-preferences/donation.received",
+      headers: authHeader(token),
+      payload: { inApp: false, emailDigest: true },
+    });
+    expect(first.statusCode).toBe(200);
+    expect(
+      first.json<{ data: { inApp: boolean; emailDigest: boolean; isDefault: boolean } }>().data,
+    ).toEqual({
+      type: "donation.received",
+      inApp: false,
+      emailDigest: true,
+      isDefault: false,
+    });
+
+    // Second PATCH with different values updates in place.
+    const second = await app.inject({
+      method: "PATCH",
+      url: "/v1/notification-preferences/donation.received",
+      headers: authHeader(token),
+      payload: { inApp: true, emailDigest: false },
+    });
+    expect(second.statusCode).toBe(200);
+    expect(second.json<{ data: { inApp: boolean; emailDigest: boolean } }>().data).toMatchObject({
+      inApp: true,
+      emailDigest: false,
+    });
+  });
+
+  it("PATCH on unknown type returns 400 (Fastify schema validation rejects unknown literal)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/v1/notification-preferences/totally.fake_type",
+      headers: authHeader(token),
+      payload: { inApp: true, emailDigest: true },
+    });
+    // Schema validation rejects before the handler runs (the route's
+    // params schema is the union of NOTIFICATION_TYPE_VALUES literals).
+    expect([400, 404]).toContain(res.statusCode);
+  });
+});
+
+// ─── 5. Registry parity — DB row matches FEATURE_FLAG_REGISTRY ─────────
+
+describe("Notifications — feature-flag registry parity", () => {
+  it("FEATURE_FLAG_REGISTRY has the notifications-center entry", () => {
+    const entry = FEATURE_FLAG_REGISTRY.find((e) => e.key === FLAG_KEY);
+    expect(entry).toBeDefined();
+    expect(entry?.defaultEnabled).toBe(false);
+    expect(entry?.scope).toBe("tenant");
+    expect(entry?.tenantOverrideAllowed).toBe(false);
+    expect(entry?.public).toBe(true);
+  });
+
+  it("DB seed row matches the registry label / description / scope / public", async () => {
+    const [row] = await db
+      .select({
+        label: featureFlags.label,
+        description: featureFlags.description,
+        scope: featureFlags.scope,
+        tenantOverrideAllowed: featureFlags.tenantOverrideAllowed,
+        public: featureFlags.public,
+      })
+      .from(featureFlags)
+      .where(eq(featureFlags.key, FLAG_KEY));
+    expect(row).toBeDefined();
+    const entry = FEATURE_FLAG_REGISTRY.find((e) => e.key === FLAG_KEY)!;
+    expect(row?.label).toBe(entry.label);
+    expect(row?.description).toBe(entry.description);
+    expect(row?.scope).toBe(entry.scope);
+    expect(row?.tenantOverrideAllowed).toBe(entry.tenantOverrideAllowed);
+    expect(row?.public).toBe(entry.public);
+  });
+});

--- a/packages/api/src/tests/integration/notifications.test.ts
+++ b/packages/api/src/tests/integration/notifications.test.ts
@@ -77,21 +77,44 @@ async function seedNotification(opts: {
   type?: string;
   readAt?: Date | null;
   deletedAt?: Date | null;
+  /** Override the `created_at` for cursor-pagination tests. */
+  createdAt?: Date;
 }): Promise<string> {
   // Use owner-pool insert so we can set arbitrary org_id without RLS.
+  // `outbox_event_id` is the natural idempotency key — each seed
+  // gets a unique UUID so the (outbox, user, type) UNIQUE doesn't
+  // collide across test cases.
   const id = crypto.randomUUID();
+  const outboxId = crypto.randomUUID();
+  const createdAt = opts.createdAt ?? new Date();
   await db.execute(sql`
     INSERT INTO notifications
-      (id, org_id, user_id, type, title_key, body_key, params, link_url, read_at, deleted_at)
+      (id, org_id, outbox_event_id, user_id, type, title_key, body_key, params, link_url, read_at, deleted_at, created_at)
     VALUES
-      (${id}, ${opts.orgId}, ${opts.userId}, ${opts.type ?? "donation.received"},
+      (${id}, ${opts.orgId}, ${outboxId}, ${opts.userId}, ${opts.type ?? "donation.received"},
        'notifications.types.donation_received.title',
        'notifications.types.donation_received.body',
        '{"donationId":"00000000-0000-0000-0000-000000000aaa"}'::jsonb,
        '/donations/00000000-0000-0000-0000-000000000aaa',
-       ${opts.readAt ?? null}, ${opts.deletedAt ?? null})
+       ${opts.readAt ?? null}, ${opts.deletedAt ?? null}, ${createdAt})
   `);
   return id;
+}
+
+/**
+ * Seed a second user inside the SAME tenant — required for the
+ * intra-tenant recipient-isolation tests (USER_A1 vs USER_A2 within
+ * ORG_A). Returns the synthetic user id; idempotent across re-runs.
+ */
+const USER_A2 = "00000000-0000-0000-0000-000000000077";
+
+async function seedSecondUserInTenantA(): Promise<string> {
+  await db.execute(sql`
+    INSERT INTO users (id, org_id, keycloak_id, email, first_name, last_name, role)
+    VALUES (${USER_A2}, ${ORG_A}, ${USER_A2}, 'user-a2@example.org', 'Test', 'UserA2', 'user')
+    ON CONFLICT (id) DO NOTHING
+  `);
+  return USER_A2;
 }
 
 // ─── 1. Off-state flag — every gated route is 404 ─────────────────────
@@ -106,6 +129,9 @@ describe("Notifications — off-state flag (anti-disclosure)", () => {
   }> = [
     { method: "GET", url: "/v1/notifications" },
     { method: "GET", url: "/v1/notifications/unread-count" },
+    // SSE endpoint — `app.inject` resolves the response before any
+    // streaming, so this exercises the flag gate (QA H1).
+    { method: "GET", url: "/v1/notifications/stream" },
     {
       method: "PATCH",
       url: "/v1/notifications/00000000-0000-0000-0000-000000000001/read",
@@ -146,6 +172,24 @@ describe("Notifications — off-state flag (anti-disclosure)", () => {
       expect(res.statusCode).toBe(404);
     });
   }
+
+  // Pin RFC 9457 body shape on at least one off-state 404 per
+  // `feedback_lock_rfc9457_body_in_tests`. The flag gate returns a
+  // problem+json body via `problemDetail()` — assert the well-known
+  // members rather than a plain-string body.
+  it("off-state 404 body conforms to RFC 9457 (status + title members)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{ status?: number; title?: string }>();
+    expect(body.status).toBe(404);
+    expect(typeof body.title).toBe("string");
+    expect(body.title?.length ?? 0).toBeGreaterThan(0);
+  });
 });
 
 // ─── 2. On-state flag — happy paths + RFC 9457 ─────────────────────────
@@ -274,6 +318,97 @@ describe("Notifications — list + mark + delete (flag on)", () => {
     const body = list.json<{ data: Array<{ id: string }> }>();
     expect(body.data.find((r) => r.id === id)).toBeUndefined();
   });
+
+  // QA M2 — mark-read / DELETE on a soft-deleted row must 404.
+  it("PATCH /:id/read on a soft-deleted row returns 404", async () => {
+    const id = await seedNotification({
+      orgId: ORG_A,
+      userId: USER_A,
+      deletedAt: new Date(),
+    });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/notifications/${id}/read`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("DELETE /:id on an already-soft-deleted row returns 404", async () => {
+    const id = await seedNotification({
+      orgId: ORG_A,
+      userId: USER_A,
+      deletedAt: new Date(),
+    });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/notifications/${id}`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  // QA M3 — cursor pagination must hand out a `nextCursor` and the
+  // follow-up GET must pick up where the first page ended.
+  it("cursor pagination round-trips correctly (21 rows → 2 pages)", async () => {
+    // Seed 21 rows with monotonically-decreasing timestamps so the
+    // DESC ordering produces a stable sequence.
+    const baseTime = Date.now();
+    for (let i = 0; i < 21; i++) {
+      await seedNotification({
+        orgId: ORG_A,
+        userId: USER_A,
+        createdAt: new Date(baseTime - i * 1000),
+      });
+    }
+    const token = signToken(app);
+
+    const first = await app.inject({
+      method: "GET",
+      url: "/v1/notifications",
+      headers: authHeader(token),
+    });
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json<{
+      data: Array<{ id: string; createdAt: string }>;
+      nextCursor: string | null;
+    }>();
+    expect(firstBody.data.length).toBe(20);
+    expect(firstBody.nextCursor).not.toBeNull();
+
+    const second = await app.inject({
+      method: "GET",
+      url: `/v1/notifications?cursor=${encodeURIComponent(firstBody.nextCursor!)}`,
+      headers: authHeader(token),
+    });
+    expect(second.statusCode).toBe(200);
+    const secondBody = second.json<{
+      data: Array<{ id: string }>;
+      nextCursor: string | null;
+    }>();
+    expect(secondBody.data.length).toBe(1);
+    expect(secondBody.nextCursor).toBeNull();
+    // Pages don't overlap.
+    const firstIds = new Set(firstBody.data.map((r) => r.id));
+    expect(firstIds.has(secondBody.data[0]!.id)).toBe(false);
+  });
+
+  // QA L1 — viewer-role positive bound. The routes.ts header
+  // promises every authenticated role gets the panel; pin that.
+  it("viewer-role token gets 200 on GET /v1/notifications", async () => {
+    const token = signToken(app, {
+      role: "viewer",
+      realm_access: { roles: ["app-viewer"] },
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+  });
 });
 
 // ─── 3. RLS / cross-tenant + cross-user isolation ──────────────────────
@@ -321,6 +456,101 @@ describe("Notifications — isolation (RLS + recipient)", () => {
     expect(res.statusCode).toBe(200);
     const body = res.json<{ data: Array<{ id: string }> }>();
     expect(body.data.find((r) => r.id === tenantBId)).toBeDefined();
+  });
+
+  // QA H3 — cross-tenant DELETE must be a 404, not a silent 200 over
+  // another tenant's row.
+  it("Tenant A cannot DELETE a Tenant B row (404)", async () => {
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/notifications/${tenantBId}`,
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  // QA H3 — cross-tenant unread-count must not leak the integer.
+  it("Tenant A unread-count never includes Tenant B unread rows", async () => {
+    await seedNotification({ orgId: ORG_B, userId: USER_B }); // B has 1 unread
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications/unread-count",
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { unread: number } }>().data.unread).toBe(0);
+  });
+
+  // QA H3 — cross-tenant read-all must not touch the other tenant.
+  it("Tenant A read-all does NOT mark Tenant B rows as read", async () => {
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+    const tokenA = signToken(app);
+    await app.inject({
+      method: "POST",
+      url: "/v1/notifications/read-all",
+      headers: authHeader(tokenA),
+    });
+    // Verify B's row is still unread via DB read.
+    const [row] = await db
+      .select({ readAt: notifications.readAt })
+      .from(notifications)
+      .where(eq(notifications.id, tenantBId));
+    expect(row?.readAt).toBeNull();
+  });
+
+  // QA H2 — same-tenant recipient isolation. USER_A1 must NOT see
+  // USER_A2's rows even though both live in ORG_A. The service-layer
+  // `user_id = currentUserId` filter is the only boundary keeping
+  // them apart (no RLS on the column); positive proof matters.
+  it("USER_A1 cannot see USER_A2 rows in the SAME tenant (list)", async () => {
+    const user2 = await seedSecondUserInTenantA();
+    const user2RowId = await seedNotification({ orgId: ORG_A, userId: user2 });
+
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications",
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: Array<{ id: string }> }>();
+    expect(body.data.find((r) => r.id === user2RowId)).toBeUndefined();
+  });
+
+  it("USER_A1 cannot mark-read or DELETE USER_A2 rows in the SAME tenant (404)", async () => {
+    const user2 = await seedSecondUserInTenantA();
+    const user2RowId = await seedNotification({ orgId: ORG_A, userId: user2 });
+    const tokenA = signToken(app);
+
+    const patchRes = await app.inject({
+      method: "PATCH",
+      url: `/v1/notifications/${user2RowId}/read`,
+      headers: authHeader(tokenA),
+    });
+    expect(patchRes.statusCode).toBe(404);
+
+    const deleteRes = await app.inject({
+      method: "DELETE",
+      url: `/v1/notifications/${user2RowId}`,
+      headers: authHeader(tokenA),
+    });
+    expect(deleteRes.statusCode).toBe(404);
+  });
+
+  it("USER_A1 unread-count is scoped to their own rows (not user A2)", async () => {
+    const user2 = await seedSecondUserInTenantA();
+    await seedNotification({ orgId: ORG_A, userId: user2 }); // A2 has 1 unread
+    const tokenA = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications/unread-count",
+      headers: authHeader(tokenA),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { unread: number } }>().data.unread).toBe(0);
   });
 });
 
@@ -381,6 +611,11 @@ describe("Notifications — preferences", () => {
     });
   });
 
+  // QA L2 — pin to 400 (not `[400, 404]`). The route's params schema
+  // is the closed union of `NOTIFICATION_TYPE_VALUES` literals, so
+  // Fastify rejects with 400 BEFORE the handler. Accepting both
+  // hides a future regression where a schema bump silently routes to
+  // the handler-side 404 path.
   it("PATCH on unknown type returns 400 (Fastify schema validation rejects unknown literal)", async () => {
     const token = signToken(app);
     const res = await app.inject({
@@ -389,9 +624,7 @@ describe("Notifications — preferences", () => {
       headers: authHeader(token),
       payload: { inApp: true, emailDigest: true },
     });
-    // Schema validation rejects before the handler runs (the route's
-    // params schema is the union of NOTIFICATION_TYPE_VALUES literals).
-    expect([400, 404]).toContain(res.statusCode);
+    expect(res.statusCode).toBe(400);
   });
 });
 

--- a/packages/api/src/tests/integration/notifications.test.ts
+++ b/packages/api/src/tests/integration/notifications.test.ts
@@ -31,8 +31,8 @@ import {
   ORG_B,
   signToken,
   signTokenB,
-  USER_A,
-  USER_B,
+  USER_A_ROW_ID,
+  USER_B_ROW_ID,
 } from "../helpers/auth.js";
 
 const FLAG_KEY = FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER;
@@ -200,8 +200,8 @@ describe("Notifications — list + mark + delete (flag on)", () => {
   });
 
   it("GET /v1/notifications returns caller's own rows", async () => {
-    const id1 = await seedNotification({ orgId: ORG_A, userId: USER_A });
-    const id2 = await seedNotification({ orgId: ORG_A, userId: USER_A });
+    const id1 = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
+    const id2 = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
 
     const token = signToken(app);
     const res = await app.inject({
@@ -218,9 +218,9 @@ describe("Notifications — list + mark + delete (flag on)", () => {
   });
 
   it("GET /v1/notifications/unread-count returns the right count", async () => {
-    await seedNotification({ orgId: ORG_A, userId: USER_A }); // unread
-    await seedNotification({ orgId: ORG_A, userId: USER_A, readAt: new Date() }); // read
-    await seedNotification({ orgId: ORG_A, userId: USER_A, deletedAt: new Date() }); // deleted
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID }); // unread
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID, readAt: new Date() }); // read
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID, deletedAt: new Date() }); // deleted
 
     const token = signToken(app);
     const res = await app.inject({
@@ -234,7 +234,7 @@ describe("Notifications — list + mark + delete (flag on)", () => {
   });
 
   it("PATCH /v1/notifications/:id/read marks one row read and is idempotent", async () => {
-    const id = await seedNotification({ orgId: ORG_A, userId: USER_A });
+    const id = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
     const token = signToken(app);
 
     const first = await app.inject({
@@ -269,9 +269,9 @@ describe("Notifications — list + mark + delete (flag on)", () => {
   });
 
   it("POST /v1/notifications/read-all marks every unread row read", async () => {
-    await seedNotification({ orgId: ORG_A, userId: USER_A });
-    await seedNotification({ orgId: ORG_A, userId: USER_A });
-    await seedNotification({ orgId: ORG_A, userId: USER_A });
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
 
     const token = signToken(app);
     const res = await app.inject({
@@ -292,7 +292,7 @@ describe("Notifications — list + mark + delete (flag on)", () => {
   });
 
   it("DELETE /v1/notifications/:id soft-deletes (deleted_at set, row stays)", async () => {
-    const id = await seedNotification({ orgId: ORG_A, userId: USER_A });
+    const id = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
     const token = signToken(app);
 
     const res = await app.inject({
@@ -323,7 +323,7 @@ describe("Notifications — list + mark + delete (flag on)", () => {
   it("PATCH /:id/read on a soft-deleted row returns 404", async () => {
     const id = await seedNotification({
       orgId: ORG_A,
-      userId: USER_A,
+      userId: USER_A_ROW_ID,
       deletedAt: new Date(),
     });
     const token = signToken(app);
@@ -338,7 +338,7 @@ describe("Notifications — list + mark + delete (flag on)", () => {
   it("DELETE /:id on an already-soft-deleted row returns 404", async () => {
     const id = await seedNotification({
       orgId: ORG_A,
-      userId: USER_A,
+      userId: USER_A_ROW_ID,
       deletedAt: new Date(),
     });
     const token = signToken(app);
@@ -359,7 +359,7 @@ describe("Notifications — list + mark + delete (flag on)", () => {
     for (let i = 0; i < 21; i++) {
       await seedNotification({
         orgId: ORG_A,
-        userId: USER_A,
+        userId: USER_A_ROW_ID,
         createdAt: new Date(baseTime - i * 1000),
       });
     }
@@ -419,7 +419,7 @@ describe("Notifications — isolation (RLS + recipient)", () => {
   });
 
   it("Tenant A user can NEVER see Tenant B notifications via list", async () => {
-    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B_ROW_ID });
 
     const tokenA = signToken(app);
     const res = await app.inject({
@@ -433,7 +433,7 @@ describe("Notifications — isolation (RLS + recipient)", () => {
   });
 
   it("Tenant A user cannot mark-read a Tenant B row (404, not 200)", async () => {
-    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B_ROW_ID });
 
     const tokenA = signToken(app);
     const res = await app.inject({
@@ -445,7 +445,7 @@ describe("Notifications — isolation (RLS + recipient)", () => {
   });
 
   it("Tenant B reads their own rows under the same flag (positive bound)", async () => {
-    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B_ROW_ID });
 
     const tokenB = signTokenB(app);
     const res = await app.inject({
@@ -461,7 +461,7 @@ describe("Notifications — isolation (RLS + recipient)", () => {
   // QA H3 — cross-tenant DELETE must be a 404, not a silent 200 over
   // another tenant's row.
   it("Tenant A cannot DELETE a Tenant B row (404)", async () => {
-    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B_ROW_ID });
     const tokenA = signToken(app);
     const res = await app.inject({
       method: "DELETE",
@@ -473,7 +473,7 @@ describe("Notifications — isolation (RLS + recipient)", () => {
 
   // QA H3 — cross-tenant unread-count must not leak the integer.
   it("Tenant A unread-count never includes Tenant B unread rows", async () => {
-    await seedNotification({ orgId: ORG_B, userId: USER_B }); // B has 1 unread
+    await seedNotification({ orgId: ORG_B, userId: USER_B_ROW_ID }); // B has 1 unread
     const tokenA = signToken(app);
     const res = await app.inject({
       method: "GET",
@@ -486,7 +486,7 @@ describe("Notifications — isolation (RLS + recipient)", () => {
 
   // QA H3 — cross-tenant read-all must not touch the other tenant.
   it("Tenant A read-all does NOT mark Tenant B rows as read", async () => {
-    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B });
+    const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B_ROW_ID });
     const tokenA = signToken(app);
     await app.inject({
       method: "POST",

--- a/packages/api/src/tests/integration/schema-parity.test.ts
+++ b/packages/api/src/tests/integration/schema-parity.test.ts
@@ -238,6 +238,25 @@ describe("Drizzle ↔ SQL schema parity (issue #261)", () => {
               "ADR-021 + issue #326 — non-terminal status, not deleted_at, is the right gate for resume uniqueness",
           },
         ],
+        [
+          // Epic #363 / migration 0055: the (outbox_event_id, user_id,
+          // type) natural key intentionally spans soft-deleted rows.
+          // Semantic: once a user dismisses (soft-deletes) a
+          // notification, a later outbox redelivery must NOT resurrect
+          // a new row for the same recipient — they've explicitly
+          // chosen not to see this event again. Adding `WHERE
+          // deleted_at IS NULL` would turn dismissal into a backdoor
+          // that lets the same event reappear in the panel on every
+          // relay retry.
+          "notifications_outbox_recipient_type_unique",
+          {
+            // Match the column list rather than a predicate — this
+            // index intentionally has NO `WHERE` clause.
+            predicate: "(outbox_event_id, user_id, type)",
+            reason:
+              "Epic #363 — idempotency key spans active + dismissed rows so an outbox redelivery doesn't resurrect a dismissed notification (PR #393 Worker SRE CRIT-1 fix)",
+          },
+        ],
       ]);
 
       const offenders: string[] = [];

--- a/packages/shared/src/constants/feature-flags.ts
+++ b/packages/shared/src/constants/feature-flags.ts
@@ -106,6 +106,47 @@ export const FEATURE_FLAG_KEYS = {
   DONATION_PUBLIC_PAGE_STYLES: "donation.public_page_styles",
 
   /**
+   * Gates the in-app notification centre (Epic #363, GLO-004).
+   *
+   * The Epic ships the bell icon + side-panel + per-user preferences
+   * page + outbox-fanout producer + SSE stream + email-digest worker.
+   * With the flag OFF the topbar has no bell at all, the gated routes
+   * (`/v1/notifications/*`, `/v1/notification-preferences*`) return
+   * 404 not 403, the outbox-fanout worker silently no-ops, and the
+   * digest worker skips its tick. End result: a tenant with the flag
+   * off is indistinguishable from one before the Epic shipped.
+   *
+   * `scope='tenant'`: every NPO is independent. A noisy fundraising
+   * team that wants notifications shouldn't force a quiet operational
+   * team to turn them on too.
+   *
+   * `tenant_override_allowed=false` for the initial rollout: super-
+   * admin keeps the gate per tenant until the UX is verified end-to-
+   * end on staging. Flips to `true` in a follow-up once preferences
+   * + SSE prove stable (no policy reason to keep org-admins out
+   * beyond "let's see how the panel lands first").
+   *
+   * `public=true`: the appShell layout SSR-fetches `/v1/feature-flags`
+   * to decide whether to render the bell icon in the topbar AND
+   * whether to mount the polling/SSE client. A private value would
+   * unconditionally hide the entry and defeat the Epic.
+   *
+   * Surfaces gated by this key:
+   *   - API: GET / POST / PATCH / DELETE on `/v1/notifications*`
+   *   - API: GET / PATCH on `/v1/notification-preferences*`
+   *   - API: GET /v1/notifications/stream (SSE)
+   *   - Worker: outbox-event fanout into notification rows silently
+   *     no-ops (defence in depth — second wall behind the API gate).
+   *   - Worker: weekly email-digest BullMQ tick skips if off.
+   *   - Web: bell icon + panel + filter chips + `/settings/notifications`
+   *     page + sidebar entry + polling/SSE client all hidden.
+   *
+   * Emergency rollback: see `docs/runbooks/feature-flag-rollback.md`
+   * if the Back Office is unavailable.
+   */
+  COMMUNICATION_NOTIFICATIONS_CENTER: "communication.notifications_center",
+
+  /**
    * Gates the Feature flags Phase 2 work itself (Epic #365 / PR #366).
    *
    * Even flag-administration tooling gets a flag — the new tenant-
@@ -211,6 +252,16 @@ export const FEATURE_FLAG_REGISTRY: ReadonlyArray<{
     description:
       "Lets Givernance staff turn features on or off for one organisation at a time, and lets each organisation's admin manage their own feature settings from the Settings menu. Off by default until the new pages have been verified end-to-end.",
     scope: "platform",
+    tenantOverrideAllowed: false,
+    public: true,
+  },
+  {
+    key: FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER,
+    defaultEnabled: false,
+    label: "In-app notification centre",
+    description:
+      "Adds a bell icon to the top bar with a panel that lists what happened in your organisation — new donations, postal-export downloads, team invitations, and more. Each member can choose which alerts they want from the Settings menu. Off by default until Givernance staff confirm the bell, panel, and per-member preferences for your organisation.",
+    scope: "tenant",
     tenantOverrideAllowed: false,
     public: true,
   },

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -27,8 +27,10 @@ export {
   NOTIFICATION_TYPE_REGISTRY,
   NOTIFICATION_TYPE_VALUES,
   type NotificationFilterKey,
+  type NotificationIconKey,
   type NotificationType,
   type NotificationTypeDescriptor,
+  type NotificationVisual,
   notificationFilterFor,
 } from "./notifications";
 export { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "./password";

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -20,6 +20,17 @@ export {
 } from "./impersonation";
 export { KEYCLOAK_DEFAULT_CLIENT_ID } from "./keycloak";
 export { assertSafeOrgAttributes, SAFE_ORG_ATTRIBUTES } from "./keycloak-org-attributes";
+export {
+  getNotificationDescriptor,
+  isNotificationType,
+  NOTIFICATION_FILTER_KEYS,
+  NOTIFICATION_TYPE_REGISTRY,
+  NOTIFICATION_TYPE_VALUES,
+  type NotificationFilterKey,
+  type NotificationType,
+  type NotificationTypeDescriptor,
+  notificationFilterFor,
+} from "./notifications";
 export { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "./password";
 export { isPersonalEmailDomain, PERSONAL_EMAIL_DOMAINS } from "./personal-email-domains";
 export { PINO_REDACT_PATHS } from "./pino-redact";

--- a/packages/shared/src/constants/notifications.ts
+++ b/packages/shared/src/constants/notifications.ts
@@ -1,0 +1,166 @@
+/**
+ * Notification-centre type registry (Epic #363, GLO-004).
+ *
+ * The single source of truth for what notification types the codebase
+ * produces. The DB column `notifications.type` is a free varchar(64)
+ * pinned by a CHECK constraint to the dotted-namespace shape — adding
+ * a new type is a code change here + a producer wiring, never a
+ * migration.
+ *
+ * For each type:
+ *   - `key`: dotted-namespace string written to `notifications.type`.
+ *   - `defaultInApp`: whether the bell + panel show this type when a
+ *     user has no `notification_preferences` row for it. Defaults to
+ *     `true` for almost every type (notifications you didn't opt out
+ *     of should still arrive) except for noisy background events.
+ *   - `defaultEmailDigest`: whether the weekly digest worker
+ *     (Phase 5) includes this type when the user has no preferences
+ *     row. Defaults to `false` — we'd rather opt-in than opt-out for
+ *     a second email channel.
+ *   - `titleKey` / `bodyKey`: i18n keys consumed by the web panel and
+ *     the email digest. Defined in `packages/web/src/messages/{en,fr}.json`
+ *     under `notifications.types.<key>.{title,body}`.
+ *   - `labelKey` / `descriptionKey`: i18n keys for the preferences
+ *     page row ("Donation received — alert me when a donor completes
+ *     a gift").
+ *
+ * Keep the registry in lockstep with the i18n messages — the
+ * integration tests in `packages/api/src/tests/integration/notifications.test.ts`
+ * assert that every key is referenceable.
+ */
+
+export const NOTIFICATION_TYPE_VALUES = [
+  "donation.received",
+  "invitation.created",
+  "invitation.resent",
+  "branding.logo_synced",
+  "postal_export.queued",
+  "bulk_email.queued",
+] as const;
+
+export type NotificationType = (typeof NOTIFICATION_TYPE_VALUES)[number];
+
+export interface NotificationTypeDescriptor {
+  key: NotificationType;
+  defaultInApp: boolean;
+  defaultEmailDigest: boolean;
+  /** i18n key for the panel row title. */
+  titleKey: string;
+  /** i18n key for the panel row body (interpolated with `params`). */
+  bodyKey: string;
+  /** i18n key for the preferences-page row label. */
+  labelKey: string;
+  /** i18n key for the preferences-page row helper text. */
+  descriptionKey: string;
+  /**
+   * Visual category used by the panel for icon + accent-bar colour.
+   * `donation`/`success` → green, `team` → indigo, `system` → sky,
+   * `attention` → amber. Maps to the mockup's
+   * `.accent-{green,indigo,sky,amber}` classes.
+   */
+  visual: "donation" | "team" | "system" | "attention";
+}
+
+export const NOTIFICATION_TYPE_REGISTRY: ReadonlyArray<NotificationTypeDescriptor> = [
+  {
+    key: "donation.received",
+    defaultInApp: true,
+    defaultEmailDigest: false,
+    titleKey: "notifications.types.donation_received.title",
+    bodyKey: "notifications.types.donation_received.body",
+    labelKey: "notifications.types.donation_received.label",
+    descriptionKey: "notifications.types.donation_received.description",
+    visual: "donation",
+  },
+  {
+    key: "invitation.created",
+    defaultInApp: true,
+    defaultEmailDigest: false,
+    titleKey: "notifications.types.invitation_created.title",
+    bodyKey: "notifications.types.invitation_created.body",
+    labelKey: "notifications.types.invitation_created.label",
+    descriptionKey: "notifications.types.invitation_created.description",
+    visual: "team",
+  },
+  {
+    key: "invitation.resent",
+    defaultInApp: false,
+    defaultEmailDigest: false,
+    titleKey: "notifications.types.invitation_resent.title",
+    bodyKey: "notifications.types.invitation_resent.body",
+    labelKey: "notifications.types.invitation_resent.label",
+    descriptionKey: "notifications.types.invitation_resent.description",
+    visual: "team",
+  },
+  {
+    key: "branding.logo_synced",
+    defaultInApp: true,
+    defaultEmailDigest: false,
+    titleKey: "notifications.types.branding_logo_synced.title",
+    bodyKey: "notifications.types.branding_logo_synced.body",
+    labelKey: "notifications.types.branding_logo_synced.label",
+    descriptionKey: "notifications.types.branding_logo_synced.description",
+    visual: "system",
+  },
+  {
+    key: "postal_export.queued",
+    defaultInApp: true,
+    defaultEmailDigest: false,
+    titleKey: "notifications.types.postal_export_queued.title",
+    bodyKey: "notifications.types.postal_export_queued.body",
+    labelKey: "notifications.types.postal_export_queued.label",
+    descriptionKey: "notifications.types.postal_export_queued.description",
+    visual: "system",
+  },
+  {
+    key: "bulk_email.queued",
+    defaultInApp: true,
+    defaultEmailDigest: false,
+    titleKey: "notifications.types.bulk_email_queued.title",
+    bodyKey: "notifications.types.bulk_email_queued.body",
+    labelKey: "notifications.types.bulk_email_queued.label",
+    descriptionKey: "notifications.types.bulk_email_queued.description",
+    visual: "team",
+  },
+];
+
+export function isNotificationType(value: string): value is NotificationType {
+  return (NOTIFICATION_TYPE_VALUES as readonly string[]).includes(value);
+}
+
+export function getNotificationDescriptor(type: NotificationType): NotificationTypeDescriptor {
+  const found = NOTIFICATION_TYPE_REGISTRY.find((d) => d.key === type);
+  if (!found) {
+    // Unreachable — type is a closed union and the registry is
+    // verified to be exhaustive by `assertRegistryCovers` below.
+    throw new Error(`Unknown notification type: ${type}`);
+  }
+  return found;
+}
+
+/**
+ * Filter chip categories shown in the panel header (matches the
+ * mockup's "Toutes / Échéances / IA / Équipe" pattern, repurposed to
+ * the shipped types).
+ */
+export const NOTIFICATION_FILTER_KEYS = ["all", "donation", "team", "system"] as const;
+export type NotificationFilterKey = (typeof NOTIFICATION_FILTER_KEYS)[number];
+
+/**
+ * Map a notification type to its filter chip — used by the panel to
+ * partition the list when a chip is active.
+ */
+export function notificationFilterFor(type: NotificationType): NotificationFilterKey {
+  const desc = getNotificationDescriptor(type);
+  if (desc.visual === "donation") return "donation";
+  if (desc.visual === "team") return "team";
+  return "system";
+}
+
+// Compile-time exhaustiveness: build fails if `NOTIFICATION_TYPE_VALUES`
+// gains a member that `NOTIFICATION_TYPE_REGISTRY` doesn't cover.
+type _ExhaustiveRegistryCheck = {
+  [K in NotificationType]: K extends NotificationTypeDescriptor["key"] ? true : never;
+}[NotificationType];
+const _exhaustive: _ExhaustiveRegistryCheck = true;
+void _exhaustive;

--- a/packages/shared/src/constants/notifications.ts
+++ b/packages/shared/src/constants/notifications.ts
@@ -40,6 +40,43 @@ export const NOTIFICATION_TYPE_VALUES = [
 
 export type NotificationType = (typeof NOTIFICATION_TYPE_VALUES)[number];
 
+/**
+ * Visual category — drives the panel's accent bar + icon colour.
+ *
+ *   - `donation` → green (mockup `.accent-green`)
+ *   - `team`     → indigo (mockup `.accent-indigo`)
+ *   - `system`   → sky (mockup `.accent-sky`)
+ *
+ * The `attention` (amber) variant from the mockup is reserved for a
+ * future grant-deadline / overdue-task type — not used by any shipped
+ * descriptor yet. We list it in the union so adding a producer is a
+ * one-line registry change rather than a panel refactor; the panel's
+ * lookup maps include the slot.
+ */
+export type NotificationVisual = "donation" | "team" | "system" | "attention";
+
+/**
+ * Lucide icon name shown in the panel row's circular icon slot.
+ * Picked to match the mockup's Material Symbols per category:
+ *   - `donation.received`       → CircleDollarSign
+ *   - `invitation.created/.resent` → UserPlus
+ *   - `branding.logo_synced`    → Image
+ *   - `postal_export.queued`    → FileText
+ *   - `bulk_email.queued`       → Mail
+ *
+ * Keep this as a string literal union so the consumer can map to its
+ * preferred icon library without depending on `lucide-react` at the
+ * shared-package boundary (ADR-013 type boundary — shared/ stays
+ * lucide-free).
+ */
+export type NotificationIconKey =
+  | "donation"
+  | "invitation"
+  | "branding"
+  | "postal_export"
+  | "bulk_email"
+  | "deadline";
+
 export interface NotificationTypeDescriptor {
   key: NotificationType;
   defaultInApp: boolean;
@@ -52,13 +89,9 @@ export interface NotificationTypeDescriptor {
   labelKey: string;
   /** i18n key for the preferences-page row helper text. */
   descriptionKey: string;
-  /**
-   * Visual category used by the panel for icon + accent-bar colour.
-   * `donation`/`success` → green, `team` → indigo, `system` → sky,
-   * `attention` → amber. Maps to the mockup's
-   * `.accent-{green,indigo,sky,amber}` classes.
-   */
-  visual: "donation" | "team" | "system" | "attention";
+  visual: NotificationVisual;
+  /** Icon slug — maps to a lucide icon in the panel. See `NotificationIconKey`. */
+  icon: NotificationIconKey;
 }
 
 export const NOTIFICATION_TYPE_REGISTRY: ReadonlyArray<NotificationTypeDescriptor> = [
@@ -71,6 +104,7 @@ export const NOTIFICATION_TYPE_REGISTRY: ReadonlyArray<NotificationTypeDescripto
     labelKey: "notifications.types.donation_received.label",
     descriptionKey: "notifications.types.donation_received.description",
     visual: "donation",
+    icon: "donation",
   },
   {
     key: "invitation.created",
@@ -81,6 +115,7 @@ export const NOTIFICATION_TYPE_REGISTRY: ReadonlyArray<NotificationTypeDescripto
     labelKey: "notifications.types.invitation_created.label",
     descriptionKey: "notifications.types.invitation_created.description",
     visual: "team",
+    icon: "invitation",
   },
   {
     key: "invitation.resent",
@@ -91,6 +126,7 @@ export const NOTIFICATION_TYPE_REGISTRY: ReadonlyArray<NotificationTypeDescripto
     labelKey: "notifications.types.invitation_resent.label",
     descriptionKey: "notifications.types.invitation_resent.description",
     visual: "team",
+    icon: "invitation",
   },
   {
     key: "branding.logo_synced",
@@ -101,6 +137,7 @@ export const NOTIFICATION_TYPE_REGISTRY: ReadonlyArray<NotificationTypeDescripto
     labelKey: "notifications.types.branding_logo_synced.label",
     descriptionKey: "notifications.types.branding_logo_synced.description",
     visual: "system",
+    icon: "branding",
   },
   {
     key: "postal_export.queued",
@@ -111,6 +148,7 @@ export const NOTIFICATION_TYPE_REGISTRY: ReadonlyArray<NotificationTypeDescripto
     labelKey: "notifications.types.postal_export_queued.label",
     descriptionKey: "notifications.types.postal_export_queued.description",
     visual: "system",
+    icon: "postal_export",
   },
   {
     key: "bulk_email.queued",
@@ -121,6 +159,7 @@ export const NOTIFICATION_TYPE_REGISTRY: ReadonlyArray<NotificationTypeDescripto
     labelKey: "notifications.types.bulk_email_queued.label",
     descriptionKey: "notifications.types.bulk_email_queued.description",
     visual: "team",
+    icon: "bulk_email",
   },
 ];
 

--- a/packages/shared/src/jobs/index.ts
+++ b/packages/shared/src/jobs/index.ts
@@ -207,6 +207,20 @@ export const QUEUE_NAMES = {
   BRANDING: "branding",
   /** Keycloak org-attribute syncs (logo_url, theme_primary_color, …). */
   KEYCLOAK_SYNC: "keycloak_sync",
+  /**
+   * Notification email digest (Epic #363, GLO-004 — Phase 5). One
+   * recurring job at 09:00 UTC daily; the processor iterates every
+   * tenant with an opted-in user and sends one batched email per
+   * recipient. Concurrency-1 — opt-in distribution is small enough
+   * not to need parallelism, and we'd rather not flood the SMTP
+   * relay if a large tenant joins.
+   */
+  NOTIFICATIONS_DIGEST: "notifications_digest",
+} as const;
+
+/** Job names inside the NOTIFICATIONS_DIGEST queue. */
+export const NOTIFICATIONS_DIGEST_JOBS = {
+  DAILY: "notifications.digest_daily",
 } as const;
 
 /** Repeatable job names inside TENANT_LIFECYCLE queue. */

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -619,6 +619,17 @@ export {
   orgBrandingAssets,
 } from "./branding";
 
+// ─── Notification centre (Epic #363) ──────────────────────────────────────────
+
+export {
+  type NewNotification,
+  type NewNotificationPreference,
+  type Notification,
+  type NotificationPreference,
+  notificationPreferences,
+  notifications,
+} from "./notifications";
+
 // ─── Swiss QR-bill foundation (Epic #318) ────────────────────────────────────
 //
 // The cross-table FKs `campaigns.bank_account_id`, `donations.swiss_qr_reference_id`,

--- a/packages/shared/src/schema/notifications.ts
+++ b/packages/shared/src/schema/notifications.ts
@@ -51,6 +51,17 @@ export const notifications = pgTable(
       .notNull()
       .references(() => tenants.id, { onDelete: "cascade" }),
     /**
+     * Originating outbox event id. Natural idempotency key paired
+     * with `user_id` + `type` — an outbox redelivery (relay retry,
+     * worker crash mid-fanout) does NOT produce a second row for the
+     * same recipient. The fanout worker passes the event id from
+     * BullMQ's `job.data`. Same defence pattern as bulk-email's
+     * `bulk-email-${outboxId}` jobId in `worker.ts`. No FK to the
+     * outbox table — the row may be GC'd by a future retention
+     * sweep, but our audit trail keys on the id string itself.
+     */
+    outboxEventId: uuid("outbox_event_id").notNull(),
+    /**
      * Recipient. `SET NULL` on user purge so a GDPR-erased account
      * doesn't FK-block historical notifications — the orphaned rows
      * are then garbage-collected by the universal soft-delete sweep
@@ -109,6 +120,12 @@ export const notifications = pgTable(
      * `pgTable`). Migration 0055 is the source of truth.
      */
     orgCreatedIdx: index("notifications_org_created_idx").on(table.orgId, table.createdAt),
+    /** Natural idempotency key — see `outboxEventId` column comment. */
+    outboxRecipientTypeUnique: unique("notifications_outbox_recipient_type_unique").on(
+      table.outboxEventId,
+      table.userId,
+      table.type,
+    ),
   }),
 );
 
@@ -132,10 +149,13 @@ export const notificationPreferences = pgTable(
       .references(() => users.id, { onDelete: "cascade" }),
     type: varchar("type", { length: 64 }).notNull(),
     /**
-     * `false` hides the type from the panel and excludes it from the
-     * bell badge — but the row is still WRITTEN. Suppression happens
-     * at READ time so a user re-enabling the channel sees their
-     * historical alerts.
+     * `false` suppresses the type at WRITE time — the fanout worker
+     * does not insert a `notifications` row for a user whose
+     * preference for this type is off. Re-enabling the channel later
+     * affects FUTURE events only; historical events the user opted
+     * out of are gone. This is the simpler contract: storage stays
+     * lean and the unread count never lags an opt-out decision.
+     * (Reviewed by Worker SRE — PR #393 CRIT-2 fix.)
      */
     inApp: boolean("in_app").notNull().default(true),
     /**

--- a/packages/shared/src/schema/notifications.ts
+++ b/packages/shared/src/schema/notifications.ts
@@ -1,0 +1,161 @@
+/**
+ * In-app notification centre — schema (Epic #363, GLO-004).
+ *
+ * One row per (recipient, event). Tenant-scoped, RLS-isolated. The
+ * worker writes rows via `withWorkerContext` after fanning out an
+ * outbox event to N recipients; the API reads them via
+ * `withTenantContext`.
+ *
+ * Why a varchar `type` instead of a Postgres enum:
+ *   - Adding a notification type ("campaign_postal_export_completed")
+ *     is a code change in `NOTIFICATION_TYPE_VALUES` + a producer
+ *     wiring — never a migration. A Postgres enum would lock us into
+ *     `ALTER TYPE ... ADD VALUE` for every new type.
+ *   - The CHECK constraint in migration 0055 pins the shape
+ *     (lowercase dotted-namespace) so a buggy producer can't
+ *     insert garbage.
+ *
+ * Why `title_key` + `body_key` + `params` instead of frozen `text`:
+ *   - A French user sees French even when the worker writing the row
+ *     processed an English request. i18n interpolation happens at the
+ *     READ boundary (web panel + email digest), not at write time.
+ *
+ * Soft-delete is universal (ADR-021 / `feedback_soft_delete_universal`):
+ * a panel "delete" sets `deleted_at`, the row stays for audit + GDPR
+ * DSR replay.
+ */
+
+import {
+  boolean,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+import { tenants, users } from "./index.js";
+
+export const notifications = pgTable(
+  "notifications",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    /**
+     * Tenant boundary — RLS policy keys on this column. The producer
+     * derives this from the outbox event's `tenant_id`.
+     */
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    /**
+     * Recipient. `SET NULL` on user purge so a GDPR-erased account
+     * doesn't FK-block historical notifications — the orphaned rows
+     * are then garbage-collected by the universal soft-delete sweep
+     * (out of scope for this Epic).
+     */
+    userId: uuid("user_id").references(() => users.id, { onDelete: "set null" }),
+    /**
+     * Notification type — discriminator. Pinned by the CHECK
+     * constraint in migration 0055 to `^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$`.
+     * Source of truth = `NOTIFICATION_TYPE_VALUES` in
+     * `packages/shared/src/constants/notifications.ts`.
+     */
+    type: varchar("type", { length: 64 }).notNull(),
+    /**
+     * i18n title key. Resolved against the user's locale at READ time
+     * (not at write time) so a French recipient sees French even if
+     * the worker that wrote the row was processing an English session.
+     */
+    titleKey: varchar("title_key", { length: 128 }).notNull(),
+    /**
+     * i18n body key. Same READ-time resolution as `titleKey`.
+     */
+    bodyKey: varchar("body_key", { length: 128 }).notNull(),
+    /**
+     * Interpolation params for the i18n templates. Defaults to `{}`.
+     * GDPR posture (see `docs/27-notifications.md` § GDPR): only
+     * opaque ids + non-sensitive counters belong here; full donor
+     * names / emails are dereferenced client-side via `link_url`.
+     */
+    params: jsonb("params").notNull().default({}),
+    /**
+     * Relative path (e.g. `/donations/<uuid>`). Frontend prepends
+     * APP_URL. Absolute URLs are rejected by the CHECK constraint
+     * (`link_url LIKE '/%'`) so a custom-subdomain tenant (Epic #279
+     * follow-up) sees the right host.
+     */
+    linkUrl: text("link_url"),
+    /** NULL until the user marks read (single read or read-all). */
+    readAt: timestamp("read_at", { withTimezone: true }),
+    /**
+     * NULL until archived from the panel. Archived ≠ deleted: a row
+     * can be read AND archived; the panel hides archived rows from
+     * the default view.
+     */
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+    /** Soft-delete — see file header. */
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    /** Per-user, time-ordered listing (panel + email digest). */
+    userCreatedIdx: index("notifications_user_created_idx").on(table.userId, table.createdAt),
+    /**
+     * Bell-badge unread-count — partial index in the migration. Not
+     * modelled here (Drizzle does not yet emit partial indexes in
+     * `pgTable`). Migration 0055 is the source of truth.
+     */
+    orgCreatedIdx: index("notifications_org_created_idx").on(table.orgId, table.createdAt),
+  }),
+);
+
+export type Notification = typeof notifications.$inferSelect;
+export type NewNotification = typeof notifications.$inferInsert;
+
+/**
+ * Per (user, type) channel matrix. Missing rows fall back to the
+ * per-type defaults in `NOTIFICATION_TYPE_DEFAULTS` — saves an
+ * INSERT for every user on registration.
+ */
+export const notificationPreferences = pgTable(
+  "notification_preferences",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: varchar("type", { length: 64 }).notNull(),
+    /**
+     * `false` hides the type from the panel and excludes it from the
+     * bell badge — but the row is still WRITTEN. Suppression happens
+     * at READ time so a user re-enabling the channel sees their
+     * historical alerts.
+     */
+    inApp: boolean("in_app").notNull().default(true),
+    /**
+     * `true` includes the type in the weekly digest worker (Phase 5;
+     * opt-in). Defaults to false — donors and operators rarely want
+     * a second email for every panel ping.
+     */
+    emailDigest: boolean("email_digest").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    /** Natural upsert key — one row per (user, type). */
+    userTypeUnique: unique("notification_preferences_user_type_unique").on(
+      table.userId,
+      table.type,
+    ),
+    userIdx: index("notification_preferences_user_idx").on(table.userId),
+  }),
+);
+
+export type NotificationPreference = typeof notificationPreferences.$inferSelect;
+export type NewNotificationPreference = typeof notificationPreferences.$inferInsert;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -45,10 +45,26 @@ export interface ImpersonationContext {
 
 /** Authenticated user context extracted from JWT */
 export interface AuthContext {
+  /**
+   * Keycloak `sub` claim — the immutable upstream identifier. Use this
+   * for blocklist checks, audit attribution, and any FK against
+   * `users.keycloak_id`. NEVER use it as a `users.id` (row UUID)
+   * comparand: schema FKs that target `users.id` (`notifications.user_id`,
+   * `notification_preferences.user_id`, etc.) must be filtered against
+   * `userRowId` below.
+   */
   userId: string;
   orgId: string;
   roles: string[];
   email: string;
+  /**
+   * `users.id` row UUID resolved at auth time from `(keycloak_id, org_id)`.
+   * Null when the principal has no `users` row by design — i.e.
+   * `super_admin` (lives in `platform_admins`) or a non-impersonated
+   * platform-admin call. Routes filtering against a `users.id` FK MUST
+   * use this and reject with 401/404 when null.
+   */
+  userRowId: string | null;
   /** Application-level role from JWT `role` claim */
   role?: UserRole;
   /** RFC 8693 §4.1 actor claim — present only on delegation/impersonation tokens */

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { cache } from "react";
 import { AppShell } from "@/components/layout";
 import { Toaster } from "@/components/ui/toast";
@@ -6,6 +7,7 @@ import { createServerApiClient } from "@/lib/api/client-server";
 import { AuthProvider } from "@/lib/auth";
 import { requireAuth } from "@/lib/auth/guards";
 import type { OrgLogo } from "@/models/branding";
+import { FeatureFlagsService, isFlagEnabled } from "@/services/FeatureFlagsService";
 
 /**
  * Authenticated app layout — wraps all protected routes with:
@@ -76,16 +78,38 @@ const fetchOrgLogo = cache(async (orgId: string | undefined): Promise<OrgLogo | 
   }
 });
 
+/**
+ * Resolve the tenant-public feature-flag projection server-side so the
+ * topbar can render the notifications bell (Epic #363) on first paint
+ * without a hydration flash. Soft-fails to an empty list — every
+ * downstream `isFlagEnabled` call falls back to `false` (doc 18 §5)
+ * which is the safe default for a brand-new feature.
+ */
+const fetchPublicFlags = cache(async () => {
+  try {
+    const api = await createServerApiClient();
+    return await FeatureFlagsService.listPublic(api);
+  } catch {
+    return [];
+  }
+});
+
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const auth = await requireAuth();
   const isSuperAdmin = auth.roles.includes("super_admin");
 
   const userName = auth.firstName ? `${auth.firstName} ${auth.lastName ?? ""}`.trim() : auth.email;
 
-  const [{ me, membershipCount }, orgLogo] = await Promise.all([
+  const [{ me, membershipCount }, orgLogo, publicFlags] = await Promise.all([
     fetchMeWithMembership(),
     fetchOrgLogo(auth.orgId),
+    fetchPublicFlags(),
   ]);
+
+  const notificationsEnabled = isFlagEnabled(
+    publicFlags,
+    FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER,
+  );
 
   // Broken state: a non-super-admin reached the authenticated layout but
   // we couldn't resolve their tenant memberships. Two failure modes:
@@ -132,6 +156,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         orgId={auth.orgId}
         canManageBranding={auth.roles.includes("org_admin")}
         orgLogo={orgLogo}
+        notificationsEnabled={notificationsEnabled}
       >
         {children}
       </AppShell>

--- a/packages/web/src/app/(app)/profile/notifications/page.tsx
+++ b/packages/web/src/app/(app)/profile/notifications/page.tsx
@@ -1,0 +1,56 @@
+import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { NotificationPreferencesForm } from "@/components/notifications/notification-preferences-form";
+import { PageHeader } from "@/components/shared/page-header";
+import { createServerApiClient } from "@/lib/api/client-server";
+import { requireAuth } from "@/lib/auth/guards";
+import { FeatureFlagsService, isFlagEnabled } from "@/services/FeatureFlagsService";
+import { NotificationsService } from "@/services/NotificationsService";
+
+/**
+ * Notification preferences (Epic #363, GLO-004).
+ *
+ * Per-user × per-type channel matrix (in-app + email digest). Mounted
+ * under `/profile/notifications` rather than `/settings/notifications`
+ * because:
+ *   - The `(settings)` layout requires `org_admin` for organisation-
+ *     wide controls; notification preferences are personal and must
+ *     be reachable by every authenticated role (GLO-004 spec: "Rôles
+ *     autorisés: Tous les rôles authentifiés").
+ *   - `/profile/*` already houses personal preferences (locale).
+ *
+ * Off-state QA per `feedback_feature_flag_first`: the page returns
+ * 404 (not 403, not a blank screen) when
+ * `communication.notifications_center` is off for the tenant. The
+ * topbar bell, panel, and footer-link to this page are all hidden in
+ * that case — there's no other way to land here than typing the URL.
+ */
+export default async function NotificationPreferencesPage() {
+  await requireAuth();
+  const api = await createServerApiClient();
+
+  const publicFlags = await FeatureFlagsService.listPublic(api).catch(() => []);
+  if (!isFlagEnabled(publicFlags, FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER)) {
+    notFound();
+  }
+
+  const t = await getTranslations("notifications.preferencesPage");
+  const initial = await NotificationsService.listPreferences(api);
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title={t("title")}
+        description={t("subtitle")}
+        breadcrumbs={[
+          { label: t("breadcrumbRoot"), href: "/dashboard" },
+          { label: t("breadcrumbProfile"), href: "/profile" },
+          { label: t("title") },
+        ]}
+      />
+      <NotificationPreferencesForm initial={initial} />
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/app-shell.tsx
+++ b/packages/web/src/components/layout/app-shell.tsx
@@ -36,6 +36,13 @@ interface AppShellProps {
   /** Whether the current user can act on the "Add your logo" CTA (Epic #286). */
   canManageBranding?: boolean;
   /**
+   * Whether the `communication.notifications_center` feature flag is
+   * on for this tenant (Epic #363). Resolved SSR so the bell icon
+   * doesn't flash in/out on hydration. Defaults to `false` — off-state
+   * QA per `feedback_feature_flag_first`.
+   */
+  notificationsEnabled?: boolean;
+  /**
    * Server-resolved org logo (Epic #286 / PR #287 review, major 4).
    * Threaded down to `Sidebar` and `AddLogoBanner` so they don't each
    * re-fetch `/v1/branding/org-logo` on every navigation. `null` means
@@ -69,6 +76,7 @@ export function AppShell({
   orgId,
   canManageBranding = false,
   orgLogo = null,
+  notificationsEnabled = false,
 }: AppShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
@@ -110,6 +118,7 @@ export function AppShell({
           onMenuToggle={handleMenuToggle}
           sidebarOpen={sidebarOpen}
           hamburgerRef={hamburgerRef}
+          notificationsEnabled={notificationsEnabled}
         />
 
         <main

--- a/packages/web/src/components/layout/topbar.tsx
+++ b/packages/web/src/components/layout/topbar.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { LOCALE_NATIVE_NAMES, type Locale, SUPPORTED_LOCALES } from "@givernance/shared/i18n";
-import { Bell, Check, LogOut, Menu, Search, User } from "lucide-react";
+import { Check, LogOut, Menu, Search, User } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { type RefObject, useCallback, useTransition } from "react";
 
+import { NotificationsBell } from "@/components/notifications/notifications-bell";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,12 +28,26 @@ interface TopbarProps {
   onMenuToggle: () => void;
   sidebarOpen: boolean;
   hamburgerRef: RefObject<HTMLButtonElement | null>;
+  /**
+   * Whether the `communication.notifications_center` flag is on for this
+   * tenant (Epic #363). When `false` the bell button is completely
+   * absent — off-state QA per `feedback_feature_flag_first`.
+   * Resolved server-side in `(app)/layout.tsx` so the bell doesn't
+   * flash in then out on hydration.
+   */
+  notificationsEnabled?: boolean;
 }
 
 const avatarTriggerClasses =
   "flex h-9 w-9 items-center justify-center rounded-full bg-primary text-xs font-semibold text-on-primary outline-none transition-shadow duration-normal ease-out hover:shadow-[0_0_0_4px_rgba(9,100,71,0.10)] data-[state=open]:shadow-[0_0_0_4px_rgba(9,100,71,0.15)] focus-visible:shadow-ring";
 
-export function Topbar({ title, onMenuToggle, sidebarOpen, hamburgerRef }: TopbarProps) {
+export function Topbar({
+  title,
+  onMenuToggle,
+  sidebarOpen,
+  hamburgerRef,
+  notificationsEnabled = false,
+}: TopbarProps) {
   const { user, logout } = useAuth();
   const t = useTranslations("appShell.topbar");
   const tMenu = useTranslations("appShell.topbar.accountMenu");
@@ -127,17 +142,12 @@ export function Topbar({ title, onMenuToggle, sidebarOpen, hamburgerRef }: Topba
       </div>
 
       <div className="flex items-center gap-3">
-        <button
-          type="button"
-          className="relative flex h-10 w-10 items-center justify-center rounded-md text-text-secondary transition-colors duration-normal ease-out hover:bg-surface-container-low hover:text-text focus-visible:outline-none focus-visible:shadow-ring"
-          aria-label={t("notifications")}
-        >
-          <Bell size={18} aria-hidden="true" />
-          <span
-            className="absolute top-2 right-2 h-2 w-2 rounded-full border-2 border-surface-container-lowest bg-tertiary"
-            aria-hidden="true"
-          />
-        </button>
+        {/*
+          NotificationsBell is feature-flag-gated (Epic #363). When the
+          flag is off the button is completely absent — off-state QA per
+          `feedback_feature_flag_first` / docs/18 § 5.
+        */}
+        {notificationsEnabled ? <NotificationsBell /> : null}
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/packages/web/src/components/notifications/notification-preferences-form.tsx
+++ b/packages/web/src/components/notifications/notification-preferences-form.tsx
@@ -84,21 +84,25 @@ export function NotificationPreferencesForm({ initial }: NotificationPreferences
 
   const toggle = useCallback(
     async (type: NotificationType, field: "inApp" | "emailDigest", next: boolean) => {
-      // Optimistic — update the local state first so the toggle
-      // doesn't lag behind the user's click. On error we roll back.
-      const previous = rows.find((row) => row.type === type);
-      if (!previous) return;
+      // Snapshot the row state INSIDE the functional setter so two
+      // rapid toggles don't roll back to a stale value (Frontend M4).
+      // The functional setter runs against the latest committed state
+      // — capturing `previous` via `rows.find` from closure would read
+      // pre-first-click state on the second double-click.
+      let previous: RowState | null = null;
       setRows((current) =>
-        current.map((row) =>
-          row.type === type
-            ? { ...row, [field]: next, isDefault: false, saving: true, error: null }
-            : row,
-        ),
+        current.map((row) => {
+          if (row.type !== type) return row;
+          previous = row;
+          return { ...row, [field]: next, isDefault: false, saving: true, error: null };
+        }),
       );
+      if (!previous) return;
+      const previousRow: RowState = previous;
 
       const payload = {
-        inApp: field === "inApp" ? next : previous.inApp,
-        emailDigest: field === "emailDigest" ? next : previous.emailDigest,
+        inApp: field === "inApp" ? next : previousRow.inApp,
+        emailDigest: field === "emailDigest" ? next : previousRow.emailDigest,
       };
 
       try {
@@ -123,9 +127,9 @@ export function NotificationPreferencesForm({ initial }: NotificationPreferences
             row.type === type
               ? {
                   ...row,
-                  inApp: previous.inApp,
-                  emailDigest: previous.emailDigest,
-                  isDefault: previous.isDefault,
+                  inApp: previousRow.inApp,
+                  emailDigest: previousRow.emailDigest,
+                  isDefault: previousRow.isDefault,
                   saving: false,
                   error: err instanceof Error ? err.message : "Update failed",
                 }
@@ -134,7 +138,7 @@ export function NotificationPreferencesForm({ initial }: NotificationPreferences
         );
       }
     },
-    [client, rows],
+    [client],
   );
 
   return (

--- a/packages/web/src/components/notifications/notification-preferences-form.tsx
+++ b/packages/web/src/components/notifications/notification-preferences-form.tsx
@@ -21,7 +21,7 @@
 
 import { NOTIFICATION_TYPE_REGISTRY, type NotificationType } from "@givernance/shared/constants";
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { createClientApiClient } from "@/lib/api/client-browser";
 import {
@@ -82,23 +82,37 @@ export function NotificationPreferencesForm({ initial }: NotificationPreferences
     }),
   );
 
+  // Ref-backed mirror of `rows` so the `toggle` handler can read the
+  // latest committed state without re-creating the callback on every
+  // render. Reading from a functional `setRows` updater is NOT a safe
+  // way to snapshot pre-click state — React 18 only invokes the updater
+  // eagerly when the fiber's update queue is empty; with any other
+  // update pending (a sibling row's PATCH response, the panel's polling
+  // hook, a strict-mode double-invoke), the updater is deferred to the
+  // next render and any closure variable mutated inside it stays at
+  // its initial value through the synchronous tail of the handler.
+  // The prior implementation relied on that pattern, which silently
+  // dropped the PATCH and left the row stuck on `saving=true` (grey).
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
+
   const toggle = useCallback(
     async (type: NotificationType, field: "inApp" | "emailDigest", next: boolean) => {
-      // Snapshot the row state INSIDE the functional setter so two
-      // rapid toggles don't roll back to a stale value (Frontend M4).
-      // The functional setter runs against the latest committed state
-      // — capturing `previous` via `rows.find` from closure would read
-      // pre-first-click state on the second double-click.
-      let previous: RowState | null = null;
+      // Snapshot the row from the ref BEFORE queuing the optimistic
+      // update — guaranteed-synchronous read, independent of React's
+      // batching. The `disabled` gate on the checkbox prevents a second
+      // toggle on the same row while saving, so this snapshot is always
+      // the "before-click" state for the row being interacted with.
+      const previousRow = rowsRef.current.find((row) => row.type === type);
+      if (!previousRow) return;
+
       setRows((current) =>
-        current.map((row) => {
-          if (row.type !== type) return row;
-          previous = row;
-          return { ...row, [field]: next, isDefault: false, saving: true, error: null };
-        }),
+        current.map((row) =>
+          row.type === type
+            ? { ...row, [field]: next, isDefault: false, saving: true, error: null }
+            : row,
+        ),
       );
-      if (!previous) return;
-      const previousRow: RowState = previous;
 
       const payload = {
         inApp: field === "inApp" ? next : previousRow.inApp,

--- a/packages/web/src/components/notifications/notification-preferences-form.tsx
+++ b/packages/web/src/components/notifications/notification-preferences-form.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+/**
+ * Notification preferences form (Epic #363, GLO-004).
+ *
+ * One row per registered notification type × two checkboxes (in-app,
+ * email digest). Optimistic update — toggle fires the PATCH and rolls
+ * back the local row on error. No global "Save" button: each row is
+ * an immediate, idempotent upsert (matches the `/settings/feature-flags`
+ * pattern shipped in Epic #365).
+ *
+ * a11y:
+ *   - Each row is a `<fieldset>` with the type label as `<legend>` so
+ *     screen readers announce "Donation received — in-app on,
+ *     email digest off".
+ *   - Toggles use native checkboxes with descriptive `aria-label`s.
+ *   - The "default" badge clarifies that no explicit row exists yet,
+ *     so a user who has never touched the page sees what they'd
+ *     receive today rather than an empty grid.
+ */
+
+import { NOTIFICATION_TYPE_REGISTRY, type NotificationType } from "@givernance/shared/constants";
+import { useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
+
+import { createClientApiClient } from "@/lib/api/client-browser";
+import {
+  type NotificationPreferenceDto,
+  NotificationsService,
+} from "@/services/NotificationsService";
+
+/**
+ * next-intl statically validates message keys at compile-time and the
+ * template-literal builder we use below produces a `string` type that
+ * can't be narrowed to the strict `NamespacedMessageKeys<...>` union.
+ * Cast through `unknown` once at the call site — the integration test
+ * in `packages/api/src/tests/integration/notifications.test.ts` checks
+ * every key resolves at runtime, so this is a type-system papercut
+ * not a runtime risk.
+ */
+type StrictTranslator = ReturnType<typeof useTranslations>;
+function trDynamic(
+  t: StrictTranslator,
+  key: string,
+  values?: Record<string, string | number>,
+): string {
+  return (t as unknown as (k: string, v?: Record<string, string | number>) => string)(key, values);
+}
+
+interface NotificationPreferencesFormProps {
+  initial: NotificationPreferenceDto[];
+}
+
+interface RowState {
+  type: NotificationType;
+  inApp: boolean;
+  emailDigest: boolean;
+  isDefault: boolean;
+  saving: boolean;
+  error: string | null;
+}
+
+export function NotificationPreferencesForm({ initial }: NotificationPreferencesFormProps) {
+  const t = useTranslations("notifications.preferencesPage");
+  const tTypes = useTranslations("notifications.types");
+  const [client] = useState(() => createClientApiClient());
+
+  // Seed local state from the server snapshot. Every notification
+  // type in the registry has a row — the API merges defaults so the
+  // shape is closed.
+  const [rows, setRows] = useState<RowState[]>(() =>
+    NOTIFICATION_TYPE_REGISTRY.map((descriptor) => {
+      const seed = initial.find((row) => row.type === descriptor.key);
+      return {
+        type: descriptor.key,
+        inApp: seed?.inApp ?? descriptor.defaultInApp,
+        emailDigest: seed?.emailDigest ?? descriptor.defaultEmailDigest,
+        isDefault: seed?.isDefault ?? true,
+        saving: false,
+        error: null,
+      };
+    }),
+  );
+
+  const toggle = useCallback(
+    async (type: NotificationType, field: "inApp" | "emailDigest", next: boolean) => {
+      // Optimistic — update the local state first so the toggle
+      // doesn't lag behind the user's click. On error we roll back.
+      const previous = rows.find((row) => row.type === type);
+      if (!previous) return;
+      setRows((current) =>
+        current.map((row) =>
+          row.type === type
+            ? { ...row, [field]: next, isDefault: false, saving: true, error: null }
+            : row,
+        ),
+      );
+
+      const payload = {
+        inApp: field === "inApp" ? next : previous.inApp,
+        emailDigest: field === "emailDigest" ? next : previous.emailDigest,
+      };
+
+      try {
+        const updated = await NotificationsService.updatePreference(client, type, payload);
+        setRows((current) =>
+          current.map((row) =>
+            row.type === type
+              ? {
+                  ...row,
+                  inApp: updated.inApp,
+                  emailDigest: updated.emailDigest,
+                  isDefault: false,
+                  saving: false,
+                  error: null,
+                }
+              : row,
+          ),
+        );
+      } catch (err) {
+        setRows((current) =>
+          current.map((row) =>
+            row.type === type
+              ? {
+                  ...row,
+                  inApp: previous.inApp,
+                  emailDigest: previous.emailDigest,
+                  isDefault: previous.isDefault,
+                  saving: false,
+                  error: err instanceof Error ? err.message : "Update failed",
+                }
+              : row,
+          ),
+        );
+      }
+    },
+    [client, rows],
+  );
+
+  return (
+    <div className="rounded-lg border border-border bg-surface-container-lowest">
+      <div className="border-b border-border px-6 py-4">
+        <h2 className="text-base font-semibold text-text">{t("sectionTitle")}</h2>
+        <p className="mt-1 text-sm text-text-secondary">{t("sectionSubtitle")}</p>
+      </div>
+      <ul className="divide-y divide-border">
+        {rows.map((row) => (
+          <li key={row.type}>
+            <fieldset className="flex flex-col gap-3 px-6 py-4 sm:flex-row sm:items-start sm:justify-between">
+              <legend className="sr-only">{trDynamic(tTypes, `${typeKey(row.type)}.label`)}</legend>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-semibold text-text">
+                    {trDynamic(tTypes, `${typeKey(row.type)}.label`)}
+                  </p>
+                  {row.isDefault ? (
+                    <span className="rounded-pill border border-border bg-surface-container-low px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted">
+                      {t("defaultBadge")}
+                    </span>
+                  ) : null}
+                </div>
+                <p className="mt-1 text-xs text-text-secondary">
+                  {trDynamic(tTypes, `${typeKey(row.type)}.description`)}
+                </p>
+                {row.error ? (
+                  <p role="alert" className="mt-1 text-xs text-error">
+                    {row.error}
+                  </p>
+                ) : null}
+              </div>
+              <div className="flex shrink-0 items-center gap-6">
+                <ToggleCheckbox
+                  checked={row.inApp}
+                  disabled={row.saving}
+                  onChange={(next) => void toggle(row.type, "inApp", next)}
+                  label={t("inApp")}
+                  hint={t("inAppHint")}
+                />
+                <ToggleCheckbox
+                  checked={row.emailDigest}
+                  disabled={row.saving}
+                  onChange={(next) => void toggle(row.type, "emailDigest", next)}
+                  label={t("emailDigest")}
+                  hint={t("emailDigestHint")}
+                />
+              </div>
+            </fieldset>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface ToggleCheckboxProps {
+  checked: boolean;
+  disabled: boolean;
+  onChange: (next: boolean) => void;
+  label: string;
+  hint: string;
+}
+
+function ToggleCheckbox({ checked, disabled, onChange, label, hint }: ToggleCheckboxProps) {
+  return (
+    <label className="flex items-center gap-2 text-sm text-text">
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.checked)}
+        aria-label={`${label} — ${hint}`}
+        className="h-4 w-4 rounded border-border text-primary focus-visible:outline-none focus-visible:shadow-ring"
+      />
+      <span className="select-none">{label}</span>
+    </label>
+  );
+}
+
+function typeKey(type: NotificationType): string {
+  return type.replace(/\./g, "_");
+}

--- a/packages/web/src/components/notifications/notifications-bell.tsx
+++ b/packages/web/src/components/notifications/notifications-bell.tsx
@@ -15,7 +15,7 @@
 import type { NotificationFilterKey } from "@givernance/shared/constants";
 import { Bell } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { NotificationsPanel } from "./notifications-panel";
 import { formatBadgeCount, useNotificationsLive } from "./use-notifications-live";
@@ -24,6 +24,9 @@ export function NotificationsBell() {
   const t = useTranslations("notifications.bell");
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState<NotificationFilterKey>("all");
+  // Trigger ref — the panel restores focus here on close (Frontend
+  // H1 / WCAG 2.4.3).
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const {
     unread,
@@ -65,6 +68,7 @@ export function NotificationsBell() {
   return (
     <>
       <button
+        ref={triggerRef}
         type="button"
         onClick={handleToggle}
         aria-label={unread > 0 ? t("triggerWithUnread", { count: unread }) : t("trigger")}
@@ -83,9 +87,20 @@ export function NotificationsBell() {
           </span>
         ) : null}
       </button>
+      {/*
+        Top-level aria-live region — when a notification arrives in the
+        background, the badge count changes silently for screen readers
+        (the in-panel `aria-live` region is unmounted with the panel).
+        Announce the new count here so SR users know to open the panel.
+        (Frontend H2 fix.)
+      */}
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {unread > 0 ? t("triggerWithUnread", { count: unread }) : ""}
+      </span>
       <NotificationsPanel
         open={open}
         onClose={handleClose}
+        triggerRef={triggerRef}
         rows={rows}
         unread={unread}
         nextCursor={nextCursor}

--- a/packages/web/src/components/notifications/notifications-bell.tsx
+++ b/packages/web/src/components/notifications/notifications-bell.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+/**
+ * Topbar notifications bell (Epic #363, GLO-004).
+ *
+ * Renders the bell button + the dynamic unread badge. Owns the panel
+ * open/close state and forwards the live data to `NotificationsPanel`.
+ *
+ * Mounted ONLY when the `communication.notifications_center` flag is
+ * on for this tenant — the wrapper in `topbar.tsx` short-circuits
+ * before this component is even loaded by Next.js (off-state QA per
+ * `feedback_feature_flag_first`).
+ */
+
+import type { NotificationFilterKey } from "@givernance/shared/constants";
+import { Bell } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
+
+import { NotificationsPanel } from "./notifications-panel";
+import { formatBadgeCount, useNotificationsLive } from "./use-notifications-live";
+
+export function NotificationsBell() {
+  const t = useTranslations("notifications.bell");
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState<NotificationFilterKey>("all");
+
+  const {
+    unread,
+    rows,
+    nextCursor,
+    isLoading,
+    error,
+    liveConnected,
+    refetch,
+    loadMore,
+    markRead,
+    markAllRead,
+    deleteOne,
+    reset,
+  } = useNotificationsLive({ enabled: true });
+
+  const handleToggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      // Opening the panel always refetches — closes a polling gap
+      // (e.g. a row arrived while the tab was backgrounded).
+      if (next) void refetch();
+      return next;
+    });
+  }, [refetch]);
+
+  const handleClose = useCallback(() => setOpen(false), []);
+
+  const handleFilterChange = useCallback(
+    (next: NotificationFilterKey) => {
+      setFilter(next);
+      void reset(next === "all" ? "all" : (filterToType(next) ?? "all"));
+    },
+    [reset],
+  );
+
+  const badge = formatBadgeCount(unread);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-label={unread > 0 ? t("triggerWithUnread", { count: unread }) : t("trigger")}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        className="relative flex h-10 w-10 items-center justify-center rounded-md text-text-secondary transition-colors duration-normal ease-out hover:bg-surface-container-low hover:text-text focus-visible:outline-none focus-visible:shadow-ring data-[state=open]:bg-primary-50 data-[state=open]:text-primary-dark"
+        data-state={open ? "open" : "closed"}
+      >
+        <Bell size={18} aria-hidden="true" />
+        {badge ? (
+          <span
+            aria-hidden="true"
+            className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-pill bg-primary px-1 text-[10px] font-semibold leading-none text-on-primary"
+          >
+            {badge}
+          </span>
+        ) : null}
+      </button>
+      <NotificationsPanel
+        open={open}
+        onClose={handleClose}
+        rows={rows}
+        unread={unread}
+        nextCursor={nextCursor}
+        isLoading={isLoading}
+        error={error}
+        liveConnected={liveConnected}
+        filter={filter}
+        onFilterChange={handleFilterChange}
+        onMarkRead={markRead}
+        onMarkAllRead={markAllRead}
+        onDelete={deleteOne}
+        onLoadMore={() => void loadMore()}
+      />
+    </>
+  );
+}
+
+/**
+ * The filter chips map to `notificationFilterFor()` categories — the
+ * server expects a notification `type` though, not a visual category.
+ * For now the panel does category filtering CLIENT-side over the
+ * already-loaded rows (correct because the API returns all visible
+ * types in one call); the chip change therefore doesn't translate to
+ * a server `type` argument. Returning `null` here keeps the hook's
+ * reset() filter on "all" so subsequent paginated loads cover every
+ * type.
+ */
+function filterToType(_filter: NotificationFilterKey): null {
+  return null;
+}

--- a/packages/web/src/components/notifications/notifications-panel.tsx
+++ b/packages/web/src/components/notifications/notifications-panel.tsx
@@ -22,11 +22,24 @@
 import {
   getNotificationDescriptor,
   type NotificationFilterKey,
+  type NotificationIconKey,
 } from "@givernance/shared/constants";
-import { Bell, Check, ExternalLink, X } from "lucide-react";
+import {
+  Bell,
+  Check,
+  CircleDollarSign,
+  Clock,
+  ExternalLink,
+  FileText,
+  type LucideIcon,
+  Image,
+  Mail,
+  UserPlus,
+  X,
+} from "lucide-react";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
-import { useEffect, useRef } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { type RefObject, useCallback, useEffect, useRef } from "react";
 
 import type { NotificationDto } from "@/services/NotificationsService";
 
@@ -64,23 +77,50 @@ interface NotificationsPanelProps {
   onMarkAllRead: () => void;
   onDelete: (id: string) => void;
   onLoadMore: () => void;
+  /**
+   * Element to return focus to when the panel closes. Required by the
+   * dialog a11y pattern (WCAG 2.4.3) — without it focus lands on
+   * `<body>` after Esc / close-button.
+   */
+  triggerRef: RefObject<HTMLButtonElement | null>;
 }
 
 const FILTER_KEYS: NotificationFilterKey[] = ["all", "donation", "team", "system"];
 
+/**
+ * Accent bar colour by visual category — matches
+ * `docs/design/global/notifications.html` and `docs/27-notifications.md` § 1.
+ * Indigo (not tertiary/amber) for the `team` category — the previous
+ * mapping shipped amber, which conflicted with the reserved
+ * `attention` slot (Frontend C1).
+ */
 const ACCENT_BY_VISUAL = {
   donation: "border-l-primary",
-  team: "border-l-tertiary",
-  system: "border-l-info",
-  attention: "border-l-warning",
+  team: "border-l-indigo",
+  system: "border-l-sky",
+  attention: "border-l-amber",
 } as const;
 
 const ICON_BG_BY_VISUAL = {
   donation: "bg-primary-fixed text-on-primary-fixed",
-  team: "bg-tertiary-container text-on-tertiary-container",
-  system: "bg-info-light text-info",
-  attention: "bg-warning-light text-warning",
+  team: "bg-indigo-light text-indigo",
+  system: "bg-sky-light text-sky",
+  attention: "bg-amber-light text-amber",
 } as const;
+
+/**
+ * Lucide icon per `NotificationIconKey` (Frontend C2). The shared
+ * registry stores a string slug so `@givernance/shared/constants`
+ * stays lucide-free (ADR-013 type boundary).
+ */
+const ICON_COMPONENT: Record<NotificationIconKey, LucideIcon> = {
+  donation: CircleDollarSign,
+  invitation: UserPlus,
+  branding: Image,
+  postal_export: FileText,
+  bulk_email: Mail,
+  deadline: Clock,
+};
 
 export function NotificationsPanel({
   open,
@@ -97,16 +137,53 @@ export function NotificationsPanel({
   onMarkAllRead,
   onDelete,
   onLoadMore,
+  triggerRef,
 }: NotificationsPanelProps) {
   const t = useTranslations("notifications.panel");
   const tTypes = useTranslations("notifications.types");
-  const panelRef = useRef<HTMLDivElement>(null);
+  const locale = useLocale();
+  const panelRef = useRef<HTMLElement>(null);
 
-  // Esc closes; click-outside closes (delegated via the overlay).
+  // Wrap onClose so we always return focus to the trigger (Frontend
+  // H1 — WCAG 2.4.3). The trigger ref is owned by the bell.
+  const handleClose = useCallback(() => {
+    onClose();
+    // Use a microtask so React unmounts the panel before the focus
+    // returns; otherwise focus-restore races with the unmount path.
+    queueMicrotask(() => triggerRef.current?.focus());
+  }, [onClose, triggerRef]);
+
+  // Esc closes; Tab is trapped inside the panel so the user can't
+  // tab-out into the underlying page (dialog pattern). Click-outside
+  // is delegated via the overlay button.
   useEffect(() => {
     if (!open) return;
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const root = panelRef.current;
+      if (!root) return;
+      const focusable = root.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+      const active = document.activeElement as HTMLElement | null;
+      if (event.shiftKey) {
+        if (active === first || !root.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
     window.addEventListener("keydown", onKey);
     // Initial focus on the panel container — a screen reader user
@@ -114,7 +191,7 @@ export function NotificationsPanel({
     // Esc immediately.
     panelRef.current?.focus();
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  }, [open, handleClose]);
 
   if (!open) return null;
 
@@ -130,7 +207,7 @@ export function NotificationsPanel({
         type="button"
         className="fixed inset-0 z-[var(--z-overlay)] cursor-default bg-transparent"
         aria-label={t("dismissBackdrop")}
-        onClick={onClose}
+        onClick={handleClose}
         tabIndex={-1}
       />
       <aside
@@ -143,7 +220,9 @@ export function NotificationsPanel({
         {/* Header */}
         <header className="flex items-start justify-between gap-3 border-b border-border px-5 pt-5 pb-4">
           <div className="flex items-center gap-2">
-            <h2 className="text-xl font-semibold text-text">{t("title")}</h2>
+            {/* Mockup specifies the title in heading-serif regular,
+                not the body sans semibold (Frontend M1). */}
+            <h2 className="font-heading text-xl font-normal text-text">{t("title")}</h2>
             {unread > 0 ? (
               <span
                 aria-live="polite"
@@ -179,7 +258,7 @@ export function NotificationsPanel({
             </button>
             <button
               type="button"
-              onClick={onClose}
+              onClick={handleClose}
               aria-label={t("close")}
               className="flex h-8 w-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-container-low hover:text-text focus-visible:outline-none focus-visible:shadow-ring"
             >
@@ -258,7 +337,10 @@ export function NotificationsPanel({
                   aria-hidden="true"
                   className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${iconBg}`}
                 >
-                  <Bell size={16} />
+                  {(() => {
+                    const Icon = ICON_COMPONENT[descriptor.icon];
+                    return <Icon size={16} />;
+                  })()}
                 </div>
                 <div className="min-w-0 flex-1">
                   <div className="flex items-start justify-between gap-2">
@@ -291,7 +373,7 @@ export function NotificationsPanel({
                     })}
                   </p>
                   <p className="mt-1.5 text-xs text-text-muted">
-                    {formatRelativeTimeShort(row.createdAt)}
+                    {formatRelativeTimeShort(row.createdAt, locale)}
                   </p>
                   <div className="mt-2 flex items-center gap-3">
                     {row.linkUrl ? (
@@ -382,15 +464,13 @@ const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
   ["second", 1],
 ];
 
-function formatRelativeTimeShort(iso: string): string {
+function formatRelativeTimeShort(iso: string, locale: string): string {
   const date = new Date(iso);
   const diff = (Date.now() - date.getTime()) / 1000;
-  // Use the system locale — the panel itself is rendered inside the
-  // NextIntl provider so the consumer's locale flows down. For relative
-  // formatting we still need the runtime API; pinning "en" for the
-  // shipped MVP keeps tests deterministic. Per-locale formatting is a
-  // small follow-up.
-  const formatter = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  // Honour the consumer's locale (`useLocale()` from next-intl). A
+  // French operator sees "il y a 2 heures"; an English one sees
+  // "2 hours ago". Frontend M2 fix.
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
   for (const [unit, seconds] of RELATIVE_UNITS) {
     if (Math.abs(diff) >= seconds || unit === "second") {
       return formatter.format(-Math.round(diff / seconds), unit);

--- a/packages/web/src/components/notifications/notifications-panel.tsx
+++ b/packages/web/src/components/notifications/notifications-panel.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+/**
+ * Notifications side panel (Epic #363, GLO-004).
+ *
+ * Matches `docs/design/global/notifications.html`: 400px-wide aside,
+ * filter chips (Toutes/Donations/Team/System), per-row icon + accent
+ * bar by visual category, unread/read styling, "mark all read" link
+ * in the header, footer link to the preferences page.
+ *
+ * a11y:
+ *   - `role="dialog"` with an `aria-label` so screen readers announce
+ *     the panel context.
+ *   - Filter chips wired as a `role="tablist"`.
+ *   - Each item is a `role="listitem"` inside the panel's
+ *     `role="list"` container.
+ *   - `aria-live="polite"` on the unread badge so a fresh arrival is
+ *     announced without stealing focus from typing.
+ *   - Esc closes the panel; focus returns to the trigger button.
+ */
+
+import {
+  getNotificationDescriptor,
+  type NotificationFilterKey,
+} from "@givernance/shared/constants";
+import { Bell, Check, ExternalLink, X } from "lucide-react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { useEffect, useRef } from "react";
+
+import type { NotificationDto } from "@/services/NotificationsService";
+
+/**
+ * next-intl statically validates message keys; the dynamic
+ * `${typeKey}.{title|body}` lookups below produce a `string` type the
+ * compiler can't narrow to the strict union. Cast at the call site —
+ * runtime correctness is covered by the i18n parity test in the
+ * notifications integration suite.
+ */
+type StrictTranslator = ReturnType<typeof useTranslations>;
+function trDynamic(
+  t: StrictTranslator,
+  key: string,
+  values?: Record<string, string | number | Date>,
+): string {
+  return (t as unknown as (k: string, v?: Record<string, string | number | Date>) => string)(
+    key,
+    values,
+  );
+}
+
+interface NotificationsPanelProps {
+  open: boolean;
+  onClose: () => void;
+  rows: NotificationDto[];
+  unread: number;
+  nextCursor: string | null;
+  isLoading: boolean;
+  error: string | null;
+  liveConnected: boolean;
+  filter: NotificationFilterKey;
+  onFilterChange: (next: NotificationFilterKey) => void;
+  onMarkRead: (id: string) => void;
+  onMarkAllRead: () => void;
+  onDelete: (id: string) => void;
+  onLoadMore: () => void;
+}
+
+const FILTER_KEYS: NotificationFilterKey[] = ["all", "donation", "team", "system"];
+
+const ACCENT_BY_VISUAL = {
+  donation: "border-l-primary",
+  team: "border-l-tertiary",
+  system: "border-l-info",
+  attention: "border-l-warning",
+} as const;
+
+const ICON_BG_BY_VISUAL = {
+  donation: "bg-primary-fixed text-on-primary-fixed",
+  team: "bg-tertiary-container text-on-tertiary-container",
+  system: "bg-info-light text-info",
+  attention: "bg-warning-light text-warning",
+} as const;
+
+export function NotificationsPanel({
+  open,
+  onClose,
+  rows,
+  unread,
+  nextCursor,
+  isLoading,
+  error,
+  liveConnected,
+  filter,
+  onFilterChange,
+  onMarkRead,
+  onMarkAllRead,
+  onDelete,
+  onLoadMore,
+}: NotificationsPanelProps) {
+  const t = useTranslations("notifications.panel");
+  const tTypes = useTranslations("notifications.types");
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Esc closes; click-outside closes (delegated via the overlay).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    // Initial focus on the panel container — a screen reader user
+    // tabs into the close button next; sighted keyboard users hit
+    // Esc immediately.
+    panelRef.current?.focus();
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const filteredRows =
+    filter === "all"
+      ? rows
+      : rows.filter((row) => getNotificationDescriptor(row.type).visual === filter);
+
+  return (
+    <>
+      {/* Click-outside overlay — transparent, full-viewport. */}
+      <button
+        type="button"
+        className="fixed inset-0 z-[var(--z-overlay)] cursor-default bg-transparent"
+        aria-label={t("dismissBackdrop")}
+        onClick={onClose}
+        tabIndex={-1}
+      />
+      <aside
+        ref={panelRef}
+        role="dialog"
+        aria-label={t("ariaLabel")}
+        tabIndex={-1}
+        className="fixed right-0 top-0 z-[calc(var(--z-overlay)+1)] flex h-screen w-[400px] max-w-[100vw] flex-col border-l border-border bg-surface-container-lowest shadow-2xl"
+      >
+        {/* Header */}
+        <header className="flex items-start justify-between gap-3 border-b border-border px-5 pt-5 pb-4">
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-semibold text-text">{t("title")}</h2>
+            {unread > 0 ? (
+              <span
+                aria-live="polite"
+                className="inline-flex h-5 min-w-5 items-center justify-center rounded-pill bg-primary px-1.5 text-xs font-semibold text-on-primary"
+              >
+                {unread > 99 ? "99+" : unread}
+              </span>
+            ) : null}
+            {liveConnected ? (
+              <span
+                role="status"
+                aria-label={t("liveOn")}
+                title={t("liveOn")}
+                className="inline-flex h-2 w-2 rounded-full bg-success"
+              />
+            ) : (
+              <span
+                role="status"
+                aria-label={t("liveOff")}
+                title={t("liveOff")}
+                className="inline-flex h-2 w-2 rounded-full bg-text-muted"
+              />
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={onMarkAllRead}
+              disabled={unread === 0}
+              className="rounded-md px-2 py-1 text-xs font-medium text-text-secondary underline-offset-4 transition-colors hover:bg-surface-container-low hover:text-text hover:underline focus-visible:outline-none focus-visible:shadow-ring disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {t("markAllRead")}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={t("close")}
+              className="flex h-8 w-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-container-low hover:text-text focus-visible:outline-none focus-visible:shadow-ring"
+            >
+              <X size={16} aria-hidden="true" />
+            </button>
+          </div>
+        </header>
+
+        {/* Filter tabs */}
+        <div
+          role="tablist"
+          aria-label={t("filtersLabel")}
+          className="flex items-center gap-1 border-b border-border px-5 py-3"
+        >
+          {FILTER_KEYS.map((key) => {
+            const active = filter === key;
+            return (
+              <button
+                key={key}
+                role="tab"
+                aria-selected={active}
+                type="button"
+                onClick={() => onFilterChange(key)}
+                className={[
+                  "rounded-pill border px-3 py-1 text-xs font-medium transition-colors duration-normal ease-out focus-visible:outline-none focus-visible:shadow-ring",
+                  active
+                    ? "border-primary-100 bg-primary-50 text-primary-dark"
+                    : "border-transparent text-text-secondary hover:bg-surface-container-low hover:text-text",
+                ].join(" ")}
+              >
+                {t(`filters.${key}`)}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* List — semantic <ul> per `lint/a11y/useSemanticElements`. */}
+        <ul className="flex-1 overflow-y-auto">
+          {error ? (
+            <li className="list-none px-5 py-6 text-sm text-error" role="alert">
+              {error}
+            </li>
+          ) : null}
+
+          {filteredRows.length === 0 && !isLoading ? (
+            <li className="flex list-none flex-col items-center justify-center gap-3 px-5 py-12 text-center">
+              <Bell size={32} aria-hidden="true" className="text-text-muted" />
+              <p className="text-sm font-medium text-text">{t("emptyTitle")}</p>
+              <p className="max-w-[260px] text-xs text-text-muted">{t("emptyBody")}</p>
+            </li>
+          ) : null}
+
+          {filteredRows.map((row) => {
+            const descriptor = getNotificationDescriptor(row.type);
+            const isUnread = !row.readAt;
+            const accent = ACCENT_BY_VISUAL[descriptor.visual];
+            const iconBg = ICON_BG_BY_VISUAL[descriptor.visual];
+
+            // i18n params — the body uses {donorName}, {amountCents}, etc.
+            // The renderer passes the entire `params` jsonb through next-intl
+            // ICU; unknown placeholders fall through to the literal token,
+            // which is acceptable (an operator running an older locale gets
+            // a slightly raw row, not a crash).
+            return (
+              <li
+                key={row.id}
+                className={[
+                  "flex items-start gap-3 border-b border-surface-container px-5 py-4 transition-colors duration-normal ease-out hover:bg-surface-container-lowest",
+                  "border-l-[3px]",
+                  isUnread
+                    ? `${accent} bg-surface-container-lowest/60`
+                    : "border-l-transparent bg-transparent",
+                ].join(" ")}
+              >
+                <div
+                  aria-hidden="true"
+                  className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${iconBg}`}
+                >
+                  <Bell size={16} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <p
+                      className={[
+                        "truncate text-sm",
+                        isUnread ? "font-semibold text-text" : "font-medium text-text-secondary",
+                      ].join(" ")}
+                    >
+                      {trDynamic(tTypes, `${descriptorMessageKey(descriptor.titleKey)}.title`)}
+                    </p>
+                    {isUnread ? (
+                      <>
+                        <span className="sr-only">{t("unreadDot")}</span>
+                        <span
+                          aria-hidden="true"
+                          className="mt-1 inline-flex h-2 w-2 shrink-0 rounded-full bg-primary"
+                        />
+                      </>
+                    ) : null}
+                  </div>
+                  <p
+                    className={[
+                      "mt-1 text-sm",
+                      isUnread ? "text-text-secondary" : "text-text-muted",
+                    ].join(" ")}
+                  >
+                    {trDynamic(tTypes, `${descriptorMessageKey(descriptor.bodyKey)}.body`, {
+                      ...(row.params as Record<string, string | number | Date>),
+                    })}
+                  </p>
+                  <p className="mt-1.5 text-xs text-text-muted">
+                    {formatRelativeTimeShort(row.createdAt)}
+                  </p>
+                  <div className="mt-2 flex items-center gap-3">
+                    {row.linkUrl ? (
+                      <Link
+                        href={row.linkUrl}
+                        onClick={() => {
+                          if (isUnread) onMarkRead(row.id);
+                        }}
+                        className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline focus-visible:outline-none focus-visible:shadow-ring"
+                      >
+                        {t("open")} <ExternalLink size={12} aria-hidden="true" />
+                      </Link>
+                    ) : null}
+                    {isUnread ? (
+                      <button
+                        type="button"
+                        onClick={() => onMarkRead(row.id)}
+                        className="inline-flex items-center gap-1 text-xs font-medium text-text-muted hover:text-text focus-visible:outline-none focus-visible:shadow-ring"
+                      >
+                        <Check size={12} aria-hidden="true" /> {t("markRead")}
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={() => onDelete(row.id)}
+                      className="ml-auto inline-flex items-center gap-1 text-xs font-medium text-text-muted hover:text-error focus-visible:outline-none focus-visible:shadow-ring"
+                    >
+                      {t("delete")}
+                    </button>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+
+          {nextCursor ? (
+            <li className="list-none px-5 py-4 text-center">
+              <button
+                type="button"
+                onClick={onLoadMore}
+                disabled={isLoading}
+                className="rounded-md px-3 py-1.5 text-xs font-medium text-primary hover:underline focus-visible:outline-none focus-visible:shadow-ring disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isLoading ? t("loading") : t("loadMore")}
+              </button>
+            </li>
+          ) : null}
+        </ul>
+
+        <footer className="border-t border-border px-5 py-3 text-center">
+          <Link
+            href="/profile/notifications"
+            onClick={onClose}
+            className="text-sm font-medium text-primary hover:underline focus-visible:outline-none focus-visible:shadow-ring"
+          >
+            {t("preferences")}
+          </Link>
+        </footer>
+      </aside>
+    </>
+  );
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Convert a registry key like `notifications.types.donation_received.title`
+ * to the namespace path next-intl expects:
+ *   `donation_received` (consumed under `notifications.types`).
+ *
+ * The registry stores the full path so the email-digest worker can use
+ * the same keys; the panel translator is scoped to
+ * `notifications.types` so we strip the prefix.
+ */
+function descriptorMessageKey(fullKey: string): string {
+  const parts = fullKey.split(".");
+  // `notifications.types.<x>.{title|body|label|description}` → `<x>`
+  return parts[2] ?? fullKey;
+}
+
+const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+  ["year", 60 * 60 * 24 * 365],
+  ["month", 60 * 60 * 24 * 30],
+  ["week", 60 * 60 * 24 * 7],
+  ["day", 60 * 60 * 24],
+  ["hour", 60 * 60],
+  ["minute", 60],
+  ["second", 1],
+];
+
+function formatRelativeTimeShort(iso: string): string {
+  const date = new Date(iso);
+  const diff = (Date.now() - date.getTime()) / 1000;
+  // Use the system locale — the panel itself is rendered inside the
+  // NextIntl provider so the consumer's locale flows down. For relative
+  // formatting we still need the runtime API; pinning "en" for the
+  // shipped MVP keeps tests deterministic. Per-locale formatting is a
+  // small follow-up.
+  const formatter = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  for (const [unit, seconds] of RELATIVE_UNITS) {
+    if (Math.abs(diff) >= seconds || unit === "second") {
+      return formatter.format(-Math.round(diff / seconds), unit);
+    }
+  }
+  return iso;
+}

--- a/packages/web/src/components/notifications/notifications-panel.tsx
+++ b/packages/web/src/components/notifications/notifications-panel.tsx
@@ -31,8 +31,8 @@ import {
   Clock,
   ExternalLink,
   FileText,
-  type LucideIcon,
   Image,
+  type LucideIcon,
   Mail,
   UserPlus,
   X,
@@ -164,25 +164,8 @@ export function NotificationsPanel({
         handleClose();
         return;
       }
-      if (event.key !== "Tab") return;
-      const root = panelRef.current;
-      if (!root) return;
-      const focusable = root.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (!first || !last) return;
-      const active = document.activeElement as HTMLElement | null;
-      if (event.shiftKey) {
-        if (active === first || !root.contains(active)) {
-          event.preventDefault();
-          last.focus();
-        }
-      } else if (active === last) {
-        event.preventDefault();
-        first.focus();
+      if (event.key === "Tab" && panelRef.current) {
+        trapTabFocus(event, panelRef.current);
       }
     };
     window.addEventListener("keydown", onKey);
@@ -477,4 +460,30 @@ function formatRelativeTimeShort(iso: string, locale: string): string {
     }
   }
   return iso;
+}
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Focus-trap helper for the dialog Tab handler — cycles focus from
+ * last → first (Tab off the last) and first → last (Shift-Tab off
+ * the first or from outside the panel). Extracted out of the
+ * useEffect callback to keep the latter under biome's cognitive-
+ * complexity ceiling (`feedback_warnings_become_errors`).
+ */
+function trapTabFocus(event: KeyboardEvent, root: HTMLElement): void {
+  const focusable = root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+  if (focusable.length === 0) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (!first || !last) return;
+  const active = document.activeElement as HTMLElement | null;
+  if (event.shiftKey && (active === first || !root.contains(active))) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
 }

--- a/packages/web/src/components/notifications/notifications-panel.tsx
+++ b/packages/web/src/components/notifications/notifications-panel.tsx
@@ -32,6 +32,8 @@ import {
   ExternalLink,
   FileText,
   Image,
+  Link2,
+  Link2Off,
   type LucideIcon,
   Mail,
   UserPlus,
@@ -214,20 +216,29 @@ export function NotificationsPanel({
                 {unread > 99 ? "99+" : unread}
               </span>
             ) : null}
+            {/* SSE live-connection status. Originally a coloured dot,
+                but a dot next to the unread badge reads as "you have an
+                unread notification" — a chain-link icon makes the
+                meaning ("connection") legible without competing with
+                the badge semantics. */}
             {liveConnected ? (
               <span
                 role="status"
                 aria-label={t("liveOn")}
                 title={t("liveOn")}
-                className="inline-flex h-2 w-2 rounded-full bg-success"
-              />
+                className="inline-flex"
+              >
+                <Link2 size={14} aria-hidden="true" className="text-success" />
+              </span>
             ) : (
               <span
                 role="status"
                 aria-label={t("liveOff")}
                 title={t("liveOff")}
-                className="inline-flex h-2 w-2 rounded-full bg-text-muted"
-              />
+                className="inline-flex"
+              >
+                <Link2Off size={14} aria-hidden="true" className="text-error" />
+              </span>
             )}
           </div>
           <div className="flex items-center gap-1">

--- a/packages/web/src/components/notifications/use-notifications-live.ts
+++ b/packages/web/src/components/notifications/use-notifications-live.ts
@@ -212,9 +212,16 @@ export function useNotificationsLive(
             if (current.some((row) => row.id === payload.id)) return current;
             return [payload, ...current];
           });
-          if (!payload.readAt) {
-            setUnread((c) => c + 1);
-          }
+          // Re-fetch the authoritative unread count instead of `c => c + 1`.
+          // The optimistic increment drifts upward whenever the same
+          // payload reaches the handler more than once (EventSource
+          // auto-reconnect after a blip with the server's polling-loop
+          // overlap; React 18 strict-mode double-mount; Fast Refresh
+          // re-creating the source; the polling fallback firing in
+          // parallel after an SSE recovery). The dedupe on `rows` masked
+          // the bug — the badge climbed without any new row showing up.
+          // One extra HTTP GET per delivery is fine at panel-level cadence.
+          void fetchUnreadCount();
         } catch {
           // Malformed payload — silently ignore. Real errors surface
           // via the `error` handler below.

--- a/packages/web/src/components/notifications/use-notifications-live.ts
+++ b/packages/web/src/components/notifications/use-notifications-live.ts
@@ -1,0 +1,285 @@
+"use client";
+
+/**
+ * Live notifications hook (Epic #363, GLO-004).
+ *
+ * Owns the topbar bell's unread count + the panel's list. Real-time
+ * delivery falls back through three layers:
+ *
+ *   1. **SSE** — `GET /v1/notifications/stream` (`text/event-stream`).
+ *      First-choice transport. EventSource auto-reconnects with
+ *      `Last-Event-ID` so a brief network blip resumes from the last
+ *      delivered row's `created_at` ISO.
+ *   2. **Polling** — `GET /v1/notifications/unread-count` every 30s
+ *      when the tab is focused. Engaged on SSE error, or unconditionally
+ *      when EventSource is unavailable (jsdom test env, old browsers).
+ *   3. **Manual refresh** — `refetch()` exposed for the click-to-open
+ *      panel so opening it always shows fresh data even if the
+ *      transport is unhealthy.
+ *
+ * The hook returns the unread count (capped at "9+" for the badge),
+ * the list of recent rows (most recent N=20), loading/error flags, and
+ * the imperative mutators (`markRead`, `markAllRead`, `deleteOne`,
+ * `loadMore`).
+ *
+ * Polling cadence (30s) was chosen over a tighter cycle so the
+ * background tab cost is low; SSE is the real "fast path" so we don't
+ * burn CPU polling on focused tabs that are already streaming.
+ */
+
+import type { NotificationType } from "@givernance/shared/constants";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import {
+  type NotificationDto,
+  type NotificationListResponse,
+  NotificationsService,
+} from "@/services/NotificationsService";
+
+interface UseNotificationsLiveOptions {
+  /** Disable everything (e.g. flag is off — won't even mount the hook). */
+  enabled: boolean;
+  /** Polling cadence in ms when SSE is unavailable. */
+  pollingMs?: number;
+}
+
+interface UseNotificationsLiveResult {
+  unread: number;
+  rows: NotificationDto[];
+  nextCursor: string | null;
+  isLoading: boolean;
+  error: string | null;
+  /** SSE active = green dot in the panel header. */
+  liveConnected: boolean;
+  refetch: () => Promise<void>;
+  loadMore: (filter?: NotificationType | "all") => Promise<void>;
+  markRead: (id: string) => Promise<void>;
+  markAllRead: () => Promise<void>;
+  deleteOne: (id: string) => Promise<void>;
+  reset: (filter: NotificationType | "all") => Promise<void>;
+}
+
+const DEFAULT_POLLING_MS = 30_000;
+
+export function useNotificationsLive(
+  options: UseNotificationsLiveOptions,
+): UseNotificationsLiveResult {
+  const [unread, setUnread] = useState(0);
+  const [rows, setRows] = useState<NotificationDto[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [liveConnected, setLiveConnected] = useState(false);
+
+  // Keep a stable client + refs across renders. The client is
+  // browser-safe (per ADR-013) and shouldn't be re-instantiated on
+  // every render.
+  const clientRef = useRef<ReturnType<typeof createClientApiClient> | null>(null);
+  if (clientRef.current === null) {
+    clientRef.current = createClientApiClient();
+  }
+  const client = clientRef.current;
+  const filterRef = useRef<NotificationType | "all">("all");
+
+  const fetchList = useCallback(
+    async (opts: { reset: boolean; filter?: NotificationType | "all"; cursor?: string }) => {
+      const filter = opts.filter ?? filterRef.current;
+      filterRef.current = filter;
+      try {
+        setIsLoading(true);
+        const result: NotificationListResponse = await NotificationsService.list(client, {
+          cursor: opts.cursor,
+          limit: 20,
+          type: filter === "all" ? undefined : (filter as NotificationType),
+        });
+        setRows((current) => (opts.reset ? result.data : [...current, ...result.data]));
+        setNextCursor(result.nextCursor);
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load notifications");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [client],
+  );
+
+  const fetchUnreadCount = useCallback(async () => {
+    try {
+      const count = await NotificationsService.unreadCount(client);
+      setUnread(count);
+    } catch {
+      // Soft-fail — the badge shows the last known good value rather
+      // than flickering to 0 on a network blip.
+    }
+  }, [client]);
+
+  const refetch = useCallback(async () => {
+    await Promise.all([fetchUnreadCount(), fetchList({ reset: true })]);
+  }, [fetchList, fetchUnreadCount]);
+
+  const reset = useCallback(
+    async (filter: NotificationType | "all") => {
+      filterRef.current = filter;
+      setRows([]);
+      setNextCursor(null);
+      await fetchList({ reset: true, filter });
+    },
+    [fetchList],
+  );
+
+  const loadMore = useCallback(
+    async (filter?: NotificationType | "all") => {
+      if (!nextCursor) return;
+      await fetchList({ reset: false, filter, cursor: nextCursor });
+    },
+    [fetchList, nextCursor],
+  );
+
+  const markRead = useCallback(
+    async (id: string) => {
+      try {
+        const updated = await NotificationsService.markRead(client, id);
+        setRows((current) =>
+          current.map((row) => (row.id === id ? { ...row, readAt: updated.readAt } : row)),
+        );
+        await fetchUnreadCount();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to mark read");
+      }
+    },
+    [client, fetchUnreadCount],
+  );
+
+  const markAllRead = useCallback(async () => {
+    try {
+      await NotificationsService.markAllRead(client);
+      const now = new Date().toISOString();
+      setRows((current) => current.map((row) => (row.readAt ? row : { ...row, readAt: now })));
+      setUnread(0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to mark all read");
+    }
+  }, [client]);
+
+  const deleteOne = useCallback(
+    async (id: string) => {
+      try {
+        await NotificationsService.deleteOne(client, id);
+        setRows((current) => current.filter((row) => row.id !== id));
+        await fetchUnreadCount();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to delete");
+      }
+    },
+    [client, fetchUnreadCount],
+  );
+
+  // Initial fetch + polling fallback when SSE is unavailable.
+  useEffect(() => {
+    if (!options.enabled) return;
+    void refetch();
+  }, [options.enabled, refetch]);
+
+  // SSE subscription — falls back to polling if EventSource isn't
+  // supported (jsdom test environment, very old browsers) or if the
+  // server returns an error within the first few seconds.
+  useEffect(() => {
+    if (!options.enabled) return;
+    if (typeof window === "undefined" || typeof EventSource === "undefined") {
+      // No SSE — start polling immediately.
+      return startPolling();
+    }
+
+    const url = NotificationsService.resolveStreamUrl(client);
+    let source: EventSource | null = null;
+    let pollingCleanup: (() => void) | null = null;
+
+    try {
+      // `withCredentials: true` so the session cookie rides along.
+      source = new EventSource(url, { withCredentials: true });
+
+      source.addEventListener("ready", () => {
+        setLiveConnected(true);
+      });
+
+      source.addEventListener("notification", (event) => {
+        try {
+          const payload = JSON.parse((event as MessageEvent).data) as NotificationDto;
+          setRows((current) => {
+            // Dedupe by id — a polling cycle that overlaps an SSE
+            // delivery would otherwise show the row twice.
+            if (current.some((row) => row.id === payload.id)) return current;
+            return [payload, ...current];
+          });
+          if (!payload.readAt) {
+            setUnread((c) => c + 1);
+          }
+        } catch {
+          // Malformed payload — silently ignore. Real errors surface
+          // via the `error` handler below.
+        }
+      });
+
+      source.addEventListener("error", () => {
+        setLiveConnected(false);
+        // EventSource will auto-reconnect; we just engage polling as
+        // a parallel safety net so users see fresh data even if the
+        // proxy is rejecting event-stream.
+        pollingCleanup ??= startPolling();
+      });
+    } catch {
+      // EventSource construction failed (e.g. CSP block) — polling
+      // fallback only.
+      pollingCleanup ??= startPolling();
+    }
+
+    return () => {
+      source?.close();
+      setLiveConnected(false);
+      pollingCleanup?.();
+    };
+
+    function startPolling(): () => void {
+      const intervalMs = options.pollingMs ?? DEFAULT_POLLING_MS;
+      let stopped = false;
+      const tick = async () => {
+        if (stopped) return;
+        if (document.visibilityState === "visible") {
+          await fetchUnreadCount();
+        }
+      };
+      const intervalId = setInterval(tick, intervalMs);
+      const onVisible = () => {
+        if (document.visibilityState === "visible") void fetchUnreadCount();
+      };
+      document.addEventListener("visibilitychange", onVisible);
+      return () => {
+        stopped = true;
+        clearInterval(intervalId);
+        document.removeEventListener("visibilitychange", onVisible);
+      };
+    }
+  }, [client, fetchUnreadCount, options.enabled, options.pollingMs]);
+
+  return {
+    unread,
+    rows,
+    nextCursor,
+    isLoading,
+    error,
+    liveConnected,
+    refetch,
+    loadMore,
+    markRead,
+    markAllRead,
+    deleteOne,
+    reset,
+  };
+}
+
+export function formatBadgeCount(value: number): string {
+  if (value <= 0) return "";
+  if (value > 9) return "9+";
+  return String(value);
+}

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -2533,5 +2533,87 @@
     "densityLabel": "Row density",
     "densityComfortable": "Comfortable rows",
     "densityCompact": "Compact rows"
+  },
+  "notifications": {
+    "bell": {
+      "trigger": "Open notifications",
+      "triggerWithUnread": "Open notifications ({count} unread)"
+    },
+    "panel": {
+      "ariaLabel": "Notifications panel",
+      "title": "Notifications",
+      "close": "Close notifications",
+      "dismissBackdrop": "Dismiss notifications panel",
+      "markAllRead": "Mark all read",
+      "filtersLabel": "Filter notifications by category",
+      "filters": {
+        "all": "All",
+        "donation": "Donations",
+        "team": "Team",
+        "system": "System"
+      },
+      "emptyTitle": "All caught up",
+      "emptyBody": "You have no new notifications. New activity will appear here automatically.",
+      "open": "Open",
+      "markRead": "Mark as read",
+      "delete": "Dismiss",
+      "loading": "Loading…",
+      "loadMore": "Load more",
+      "preferences": "Notification preferences",
+      "liveOn": "Live notifications active",
+      "liveOff": "Live notifications paused — falling back to polling",
+      "unreadDot": "Unread"
+    },
+    "preferencesPage": {
+      "title": "Notification preferences",
+      "subtitle": "Choose which alerts appear in the bell icon and which arrive in your daily email digest.",
+      "breadcrumbRoot": "Dashboard",
+      "breadcrumbProfile": "Profile",
+      "sectionTitle": "Notification types",
+      "sectionSubtitle": "Each row is saved as soon as you change it.",
+      "inApp": "In-app",
+      "inAppHint": "Show in the bell and notifications panel",
+      "emailDigest": "Email digest",
+      "emailDigestHint": "Include in the daily digest email at 09:00 UTC",
+      "defaultBadge": "Default"
+    },
+    "types": {
+      "donation_received": {
+        "label": "Donation received",
+        "description": "Alert me when a donor completes a gift.",
+        "title": "New donation received",
+        "body": "A donor just contributed."
+      },
+      "invitation_created": {
+        "label": "Team invitation sent",
+        "description": "Alert me when an admin invites someone new to the workspace.",
+        "title": "Team invitation sent",
+        "body": "A new team invitation was issued."
+      },
+      "invitation_resent": {
+        "label": "Team invitation re-sent",
+        "description": "Alert me when an admin re-sends a team invitation.",
+        "title": "Team invitation re-sent",
+        "body": "A team invitation was re-sent."
+      },
+      "branding_logo_synced": {
+        "label": "Organisation logo updated",
+        "description": "Alert me when a new logo is activated for the organisation.",
+        "title": "Organisation logo updated",
+        "body": "Your organisation logo has been updated and is now visible to donors."
+      },
+      "postal_export_queued": {
+        "label": "Postal export ready",
+        "description": "Alert me when a postal mailing export finishes.",
+        "title": "Postal export queued",
+        "body": "Your postal-mailing export is being prepared and will be available shortly."
+      },
+      "bulk_email_queued": {
+        "label": "Bulk email started",
+        "description": "Alert me when a bulk email I started begins sending.",
+        "title": "Bulk email queued",
+        "body": "Your bulk email has started sending to the recipient list."
+      }
+    }
   }
 }

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -2533,5 +2533,87 @@
     "densityLabel": "Densité des lignes",
     "densityComfortable": "Lignes confortables",
     "densityCompact": "Lignes compactes"
+  },
+  "notifications": {
+    "bell": {
+      "trigger": "Ouvrir les notifications",
+      "triggerWithUnread": "Ouvrir les notifications ({count} non lues)"
+    },
+    "panel": {
+      "ariaLabel": "Panneau de notifications",
+      "title": "Notifications",
+      "close": "Fermer les notifications",
+      "dismissBackdrop": "Fermer le panneau de notifications",
+      "markAllRead": "Tout marquer comme lu",
+      "filtersLabel": "Filtrer les notifications par catégorie",
+      "filters": {
+        "all": "Toutes",
+        "donation": "Dons",
+        "team": "Équipe",
+        "system": "Système"
+      },
+      "emptyTitle": "Rien de nouveau",
+      "emptyBody": "Vous n'avez aucune nouvelle notification. Toute activité apparaîtra ici automatiquement.",
+      "open": "Ouvrir",
+      "markRead": "Marquer comme lu",
+      "delete": "Ignorer",
+      "loading": "Chargement…",
+      "loadMore": "Charger plus",
+      "preferences": "Préférences de notification",
+      "liveOn": "Notifications en direct actives",
+      "liveOff": "Notifications en direct en pause — repli sur le sondage périodique",
+      "unreadDot": "Non lue"
+    },
+    "preferencesPage": {
+      "title": "Préférences de notification",
+      "subtitle": "Choisissez quelles alertes apparaissent dans la cloche et lesquelles arrivent dans votre résumé quotidien par email.",
+      "breadcrumbRoot": "Tableau de bord",
+      "breadcrumbProfile": "Profil",
+      "sectionTitle": "Types de notification",
+      "sectionSubtitle": "Chaque ligne est enregistrée dès que vous la modifiez.",
+      "inApp": "Dans l'application",
+      "inAppHint": "Afficher dans la cloche et le panneau de notifications",
+      "emailDigest": "Résumé par email",
+      "emailDigestHint": "Inclure dans le résumé quotidien envoyé à 09 h 00 UTC",
+      "defaultBadge": "Par défaut"
+    },
+    "types": {
+      "donation_received": {
+        "label": "Don reçu",
+        "description": "Me prévenir quand un donateur finalise un don.",
+        "title": "Nouveau don reçu",
+        "body": "Un donateur vient d'effectuer un versement."
+      },
+      "invitation_created": {
+        "label": "Invitation d'équipe envoyée",
+        "description": "Me prévenir quand un admin invite une nouvelle personne.",
+        "title": "Invitation d'équipe envoyée",
+        "body": "Une nouvelle invitation d'équipe a été émise."
+      },
+      "invitation_resent": {
+        "label": "Invitation d'équipe renvoyée",
+        "description": "Me prévenir quand un admin renvoie une invitation.",
+        "title": "Invitation d'équipe renvoyée",
+        "body": "Une invitation d'équipe a été renvoyée."
+      },
+      "branding_logo_synced": {
+        "label": "Logo de l'organisation mis à jour",
+        "description": "Me prévenir quand un nouveau logo est activé.",
+        "title": "Logo de l'organisation mis à jour",
+        "body": "Votre logo d'organisation a été mis à jour et est désormais visible des donateurs."
+      },
+      "postal_export_queued": {
+        "label": "Export postal prêt",
+        "description": "Me prévenir quand un export de mailing postal se termine.",
+        "title": "Export postal mis en file d'attente",
+        "body": "Votre export de mailing postal est en préparation et sera bientôt disponible."
+      },
+      "bulk_email_queued": {
+        "label": "Envoi groupé démarré",
+        "description": "Me prévenir quand un envoi groupé d'emails démarre.",
+        "title": "Envoi groupé d'emails en file d'attente",
+        "body": "Votre envoi groupé d'emails a commencé à être distribué aux destinataires."
+      }
+    }
   }
 }

--- a/packages/web/src/services/NotificationsService.ts
+++ b/packages/web/src/services/NotificationsService.ts
@@ -1,0 +1,122 @@
+import type { ApiClient } from "@/lib/api";
+
+/**
+ * Notifications service (Epic #363, GLO-004) — ADR-011 Layer 2.
+ *
+ * Wraps `/v1/notifications*` + `/v1/notification-preferences*`. The
+ * REST surface is per-recipient: every call resolves the current
+ * user from the session cookie, so there are no `userId` arguments
+ * here.
+ *
+ * SSE endpoint (`/v1/notifications/stream`) is consumed via the
+ * `useNotificationsLive` hook — not exposed as a method here because
+ * EventSource has different cookie semantics (auto-attaches the
+ * session cookie when `withCredentials: true`) and the lifecycle is
+ * subscription-shaped, not request/response.
+ */
+
+import type { NotificationType } from "@givernance/shared/constants";
+
+export interface NotificationDto {
+  id: string;
+  orgId: string;
+  userId: string | null;
+  type: NotificationType;
+  titleKey: string;
+  bodyKey: string;
+  params: Record<string, unknown>;
+  linkUrl: string | null;
+  readAt: string | null;
+  archivedAt: string | null;
+  createdAt: string;
+}
+
+export interface NotificationListResponse {
+  data: NotificationDto[];
+  nextCursor: string | null;
+}
+
+export interface NotificationPreferenceDto {
+  type: NotificationType;
+  inApp: boolean;
+  emailDigest: boolean;
+  /** True when no explicit row exists — `inApp`/`emailDigest` are the registry default. */
+  isDefault: boolean;
+}
+
+export interface ListNotificationsOptions {
+  cursor?: string;
+  limit?: number;
+  type?: NotificationType;
+  onlyUnread?: boolean;
+  signal?: AbortSignal;
+}
+
+export const NotificationsService = {
+  async list(
+    client: ApiClient,
+    options: ListNotificationsOptions = {},
+  ): Promise<NotificationListResponse> {
+    return client.get<NotificationListResponse>("/v1/notifications", {
+      signal: options.signal,
+      params: {
+        cursor: options.cursor,
+        limit: options.limit,
+        type: options.type,
+        onlyUnread: options.onlyUnread,
+      },
+    });
+  },
+
+  async unreadCount(client: ApiClient, signal?: AbortSignal): Promise<number> {
+    const response = await client.get<{ data: { unread: number } }>(
+      "/v1/notifications/unread-count",
+      { signal },
+    );
+    return response.data.unread;
+  },
+
+  async markRead(client: ApiClient, id: string): Promise<NotificationDto> {
+    const response = await client.patch<{ data: NotificationDto }>(`/v1/notifications/${id}/read`);
+    return response.data;
+  },
+
+  async markAllRead(client: ApiClient): Promise<number> {
+    const response = await client.post<{ data: { marked: number } }>("/v1/notifications/read-all");
+    return response.data.marked;
+  },
+
+  async deleteOne(client: ApiClient, id: string): Promise<NotificationDto> {
+    const response = await client.delete<{ data: NotificationDto }>(`/v1/notifications/${id}`);
+    return response.data;
+  },
+
+  async listPreferences(client: ApiClient): Promise<NotificationPreferenceDto[]> {
+    const response = await client.get<{ data: NotificationPreferenceDto[] }>(
+      "/v1/notification-preferences",
+    );
+    return response.data;
+  },
+
+  async updatePreference(
+    client: ApiClient,
+    type: NotificationType,
+    body: { inApp: boolean; emailDigest: boolean },
+  ): Promise<NotificationPreferenceDto> {
+    const response = await client.patch<{ data: NotificationPreferenceDto }>(
+      `/v1/notification-preferences/${encodeURIComponent(type)}`,
+      body,
+    );
+    return response.data;
+  },
+
+  /**
+   * Resolve the SSE URL on the browser. The hook does its own
+   * `new EventSource(url, { withCredentials: true })` — we just give
+   * it the host-correct path. Mirrors `client.resolveBrowserUrl`
+   * convention from Epic #214.
+   */
+  resolveStreamUrl(client: ApiClient): string {
+    return client.resolveBrowserUrl("/v1/notifications/stream");
+  },
+};

--- a/packages/worker/src/processors/notifications-email-digest.ts
+++ b/packages/worker/src/processors/notifications-email-digest.ts
@@ -49,6 +49,13 @@ import { defaultEmailSender, type EmailSender } from "../lib/email.js";
 import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
 
+/** Per-tenant work budget — Worker SRE MED-1. A pathological tenant
+ *  must not stall the whole tick. */
+const PER_TENANT_TIMEOUT_MS = 30_000;
+/** Hard ceiling on the `since` cursor so an operator-crafted job
+ *  can't replay an unbounded window (Worker SRE LOW-2). */
+const MAX_SINCE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
 export interface EmailDigestJobData {
   /** ISO timestamp — the "since" cursor. Defaults to 24h ago. */
   since?: string;
@@ -77,9 +84,19 @@ export async function processNotificationsEmailDigest(
     return;
   }
 
-  const since = job.data.since
-    ? new Date(job.data.since)
-    : new Date(Date.now() - 24 * 60 * 60 * 1000);
+  // Default cursor: 24h ago. If the caller passes an older value
+  // we clamp to MAX_SINCE_WINDOW_MS so a hand-enqueued job can't
+  // replay an unbounded history. The shipped MVP can lose a row in
+  // the (rare) case of an SMTP failure followed by 24h+ of silence
+  // — Worker SRE HIGH-4 calls out the correct fix: track
+  // `tenants.last_digest_sent_at` instead of a fixed-window cursor.
+  // Filed as a follow-up; the existing schema change is bigger than
+  // this PR's footprint.
+  const earliest = Date.now() - MAX_SINCE_WINDOW_MS;
+  const requested = job.data.since
+    ? new Date(job.data.since).getTime()
+    : Date.now() - 24 * 60 * 60 * 1000;
+  const since = new Date(Math.max(requested, earliest));
 
   // List every active tenant — owner-pool query, no RLS context.
   // Tenants don't soft-delete via `deleted_at`; they carry a `status`
@@ -95,7 +112,15 @@ export async function processNotificationsEmailDigest(
 
   for (const tenant of tenantRows) {
     try {
-      const sent = await processDigestForTenant(tenant.id, since, sender, log);
+      const sent = await Promise.race([
+        processDigestForTenant(tenant.id, since, sender, log),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error(`Per-tenant digest timeout after ${PER_TENANT_TIMEOUT_MS} ms`)),
+            PER_TENANT_TIMEOUT_MS,
+          ),
+        ),
+      ]);
       if (sent > 0) {
         log.info({ tenantId: tenant.id, sent }, "Sent notification digest");
       }
@@ -118,7 +143,6 @@ async function processDigestForTenant(
       .select({
         userId: notifications.userId,
         email: users.email,
-        firstName: users.firstName,
         type: notifications.type,
         params: notifications.params,
         createdAt: notifications.createdAt,
@@ -184,11 +208,27 @@ interface DigestRow {
   createdAt: Date;
 }
 
+/**
+ * Defence-in-depth — the DB CHECK on `link_url` already rejects
+ * protocol-relative paths (`//evil.example`) post-Security H1 fix,
+ * but historical rows written before the CHECK was tightened may
+ * still exist. Strip any `linkUrl` that doesn't pass the safe-path
+ * shape before interpolating into a mailable href.
+ */
+function safeRelativePath(linkUrl: string | null): string | null {
+  if (!linkUrl) return null;
+  if (!linkUrl.startsWith("/")) return null;
+  if (linkUrl.startsWith("//")) return null;
+  if (linkUrl.startsWith("/\\")) return null;
+  return linkUrl;
+}
+
 function renderDigestText(rows: DigestRow[]): string {
   const lines = rows.map((row) => {
     const title = humanTitleFor(row.type);
     const when = row.createdAt.toISOString();
-    const link = row.linkUrl ? ` (${row.linkUrl})` : "";
+    const safeLink = safeRelativePath(row.linkUrl);
+    const link = safeLink ? ` (${safeLink})` : "";
     return `• ${title} — ${when}${link}`;
   });
   return [
@@ -205,7 +245,8 @@ function renderDigestHtml(rows: DigestRow[]): string {
     .map((row) => {
       const title = escapeHtml(humanTitleFor(row.type));
       const when = escapeHtml(row.createdAt.toISOString());
-      const link = row.linkUrl ? `<a href="${escapeAttribute(row.linkUrl)}">View</a>` : "";
+      const safeLink = safeRelativePath(row.linkUrl);
+      const link = safeLink ? `<a href="${escapeAttribute(safeLink)}">View</a>` : "";
       return `<li><strong>${title}</strong> — ${when} ${link}</li>`;
     })
     .join("");

--- a/packages/worker/src/processors/notifications-email-digest.ts
+++ b/packages/worker/src/processors/notifications-email-digest.ts
@@ -1,0 +1,238 @@
+/**
+ * Notification email digest worker (Epic #363, GLO-004 — Phase 5).
+ *
+ * Daily recurring BullMQ job. Scans every tenant + every user with
+ * `notification_preferences.email_digest = true` and an unread row
+ * since the last digest send, batches them into one email per user,
+ * and sends via the existing `defaultEmailSender` plumbing.
+ *
+ * Opt-in by design: a user with no `notification_preferences` row
+ * inherits the per-type registry default, which is `defaultEmailDigest:
+ * false` for every type shipped in this Epic. The digest is therefore
+ * silent on day one — operators have to actively toggle the channel
+ * from the preferences page before any email is sent. This matches
+ * `feedback_feature_flag_first` defence-in-depth posture.
+ *
+ * Feature-flag-first: every invocation checks
+ * `communication.notifications_center` and short-circuits if off. If
+ * a tenant's flag was flipped off mid-cycle the worker silently
+ * skips them.
+ *
+ * Out of scope (deferred):
+ *   - Per-tenant DKIM / sending domain (depends on Epic #279) —
+ *     today the digest goes from the platform-default `from` address.
+ *   - HTML templating with the tenant logo — same dependency.
+ *   - Unsubscribe link respecting the digest preference — current
+ *     digest is opt-in, so an explicit unsubscribe just toggles the
+ *     `email_digest` flag for every type via the preferences page.
+ *   - Per-user locale resolution for the body. The shipped MVP
+ *     renders English; a follow-up wires the same i18n templates the
+ *     panel uses.
+ *
+ * Cadence: daily at 09:00 UTC (07:00 Paris winter, 08:00 Paris
+ * summer) — early enough that an operator's morning catch-up email
+ * is the first thing they see, late enough that an overnight donation
+ * burst (gala-night fundraisers) is fully captured.
+ */
+
+import {
+  FEATURE_FLAG_KEYS,
+  getNotificationDescriptor,
+  isNotificationType,
+  type NotificationType,
+} from "@givernance/shared/constants";
+import { notificationPreferences, notifications, tenants, users } from "@givernance/shared/schema";
+import type { Job } from "bullmq";
+import { and, eq, gt, inArray, isNotNull, isNull, sql } from "drizzle-orm";
+import { db, withWorkerContext } from "../lib/db.js";
+import { defaultEmailSender, type EmailSender } from "../lib/email.js";
+import { isFlagEnabled } from "../lib/flags.js";
+import { jobLogger } from "../lib/logger.js";
+
+export interface EmailDigestJobData {
+  /** ISO timestamp — the "since" cursor. Defaults to 24h ago. */
+  since?: string;
+}
+
+export interface EmailDigestDeps {
+  sender?: EmailSender;
+}
+
+/**
+ * Process one tick of the daily digest. Iterates tenants the
+ * notifications flag is on for, and for each, collects unread rows
+ * since the cursor and sends one digest per recipient.
+ */
+export async function processNotificationsEmailDigest(
+  job: Job<EmailDigestJobData>,
+  deps: EmailDigestDeps = {},
+): Promise<void> {
+  const log = jobLogger({ jobId: job.id });
+  const sender = deps.sender ?? defaultEmailSender;
+
+  // Feature-flag-first defence in depth — see file header.
+  const enabled = await isFlagEnabled(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER);
+  if (!enabled) {
+    log.info("Notifications flag off — skipping digest");
+    return;
+  }
+
+  const since = job.data.since
+    ? new Date(job.data.since)
+    : new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  // List every active tenant — owner-pool query, no RLS context.
+  // Tenants don't soft-delete via `deleted_at`; they carry a `status`
+  // varchar (`active|provisional|suspended|archived`). We send
+  // digests only for `active`/`provisional` tenants — a paused or
+  // archived customer shouldn't see digest mail from us. The table
+  // is small (one row per NPO) so a full scan is fine; a follow-up
+  // adds an index-only scan keyed by `tenants.last_digest_sent_at`.
+  const tenantRows = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(inArray(tenants.status, ["active", "provisional"]));
+
+  for (const tenant of tenantRows) {
+    try {
+      const sent = await processDigestForTenant(tenant.id, since, sender, log);
+      if (sent > 0) {
+        log.info({ tenantId: tenant.id, sent }, "Sent notification digest");
+      }
+    } catch (err) {
+      log.warn({ err, tenantId: tenant.id }, "Tenant digest failed — continuing");
+    }
+  }
+}
+
+async function processDigestForTenant(
+  tenantId: string,
+  since: Date,
+  sender: EmailSender,
+  log: ReturnType<typeof jobLogger>,
+): Promise<number> {
+  return withWorkerContext(tenantId, async (tx) => {
+    // Users in this tenant who have opted into email digest for at
+    // least one type AND have unread notifications since the cursor.
+    const candidates = await tx
+      .select({
+        userId: notifications.userId,
+        email: users.email,
+        firstName: users.firstName,
+        type: notifications.type,
+        params: notifications.params,
+        createdAt: notifications.createdAt,
+        titleKey: notifications.titleKey,
+        bodyKey: notifications.bodyKey,
+        linkUrl: notifications.linkUrl,
+      })
+      .from(notifications)
+      .innerJoin(users, eq(users.id, notifications.userId))
+      .where(
+        and(
+          isNotNull(notifications.userId),
+          isNull(notifications.readAt),
+          isNull(notifications.deletedAt),
+          isNull(users.deletedAt),
+          gt(notifications.createdAt, since),
+          // Has at least one preferences row with email_digest=true
+          // for this notification's type. Subselect avoids a join blowup.
+          sql`EXISTS (
+            SELECT 1 FROM ${notificationPreferences} p
+            WHERE p.user_id = ${notifications.userId}
+              AND p.type = ${notifications.type}
+              AND p.email_digest = TRUE
+          )`,
+        ),
+      );
+
+    if (candidates.length === 0) return 0;
+
+    // Group by recipient.
+    const byUser = new Map<string, typeof candidates>();
+    for (const row of candidates) {
+      if (!row.userId) continue;
+      const bucket = byUser.get(row.userId) ?? [];
+      bucket.push(row);
+      byUser.set(row.userId, bucket);
+    }
+
+    let sentCount = 0;
+    for (const [userId, rows] of byUser) {
+      const first = rows[0];
+      if (!first) continue;
+      try {
+        const subject = `Givernance digest — ${rows.length} new notification${rows.length === 1 ? "" : "s"}`;
+        const text = renderDigestText(rows);
+        const html = renderDigestHtml(rows);
+        await sender.send({ to: first.email, subject, text, html });
+        sentCount++;
+      } catch (err) {
+        log.warn({ err, tenantId, userId }, "Digest send failed for user");
+      }
+    }
+    return sentCount;
+  });
+}
+
+interface DigestRow {
+  type: string;
+  titleKey: string;
+  bodyKey: string;
+  params: unknown;
+  linkUrl: string | null;
+  createdAt: Date;
+}
+
+function renderDigestText(rows: DigestRow[]): string {
+  const lines = rows.map((row) => {
+    const title = humanTitleFor(row.type);
+    const when = row.createdAt.toISOString();
+    const link = row.linkUrl ? ` (${row.linkUrl})` : "";
+    return `• ${title} — ${when}${link}`;
+  });
+  return [
+    "Here is your daily digest of in-app notifications from Givernance.",
+    "",
+    ...lines,
+    "",
+    "Manage your preferences at /profile/notifications.",
+  ].join("\n");
+}
+
+function renderDigestHtml(rows: DigestRow[]): string {
+  const items = rows
+    .map((row) => {
+      const title = escapeHtml(humanTitleFor(row.type));
+      const when = escapeHtml(row.createdAt.toISOString());
+      const link = row.linkUrl ? `<a href="${escapeAttribute(row.linkUrl)}">View</a>` : "";
+      return `<li><strong>${title}</strong> — ${when} ${link}</li>`;
+    })
+    .join("");
+  return `<!doctype html><html><body>
+  <p>Here is your daily digest of in-app notifications from Givernance.</p>
+  <ul>${items}</ul>
+  <p>Manage your preferences at <a href="/profile/notifications">/profile/notifications</a>.</p>
+  </body></html>`;
+}
+
+function humanTitleFor(type: string): string {
+  if (!isNotificationType(type)) return type;
+  const descriptor = getNotificationDescriptor(type as NotificationType);
+  // We don't have a per-user locale resolved here; fall back to the
+  // English title slug derived from the i18n key. A follow-up wires the
+  // same translator the panel uses.
+  return descriptor.titleKey.split(".").slice(-2, -1)[0] ?? type;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value).replaceAll("'", "&#39;");
+}

--- a/packages/worker/src/processors/notifications-fanout.test.ts
+++ b/packages/worker/src/processors/notifications-fanout.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for `planFanout()` — the pure planner that translates
+ * outbox events into notification plan entries. No DB / Redis /
+ * BullMQ — pure function tests so regressions in event-name mapping
+ * fail fast in CI.
+ */
+
+import { BRANDING_EVENT_TYPES } from "@givernance/shared/jobs";
+import { describe, expect, it } from "vitest";
+import { planFanout } from "./notifications-fanout.js";
+
+const TENANT_ID = "00000000-0000-0000-0000-000000000001";
+
+function inputFor(type: string, payload: Record<string, unknown> = {}) {
+  return {
+    outboxId: "00000000-0000-0000-0000-000000000abc",
+    tenantId: TENANT_ID,
+    type,
+    payload,
+  };
+}
+
+describe("planFanout — supported event types", () => {
+  it("donation.created → all org_admins, links to donation page", () => {
+    const plan = planFanout(
+      inputFor("donation.created", {
+        donationId: "00000000-0000-0000-0000-0000000000d1",
+        amountCents: 5000,
+        currency: "EUR",
+      }),
+    );
+    expect(plan).toHaveLength(1);
+    expect(plan[0]).toMatchObject({
+      type: "donation.received",
+      recipients: { kind: "all_org_admins" },
+      linkUrl: "/donations/00000000-0000-0000-0000-0000000000d1",
+    });
+    expect(plan[0]?.params).toMatchObject({ amountCents: 5000, currency: "EUR" });
+  });
+
+  it("invitation.created and invitation.resent map to distinct types", () => {
+    const created = planFanout(
+      inputFor("invitation.created", { invitationId: "00000000-0000-0000-0000-0000000000a1" }),
+    );
+    const resent = planFanout(
+      inputFor("invitation.resent", { invitationId: "00000000-0000-0000-0000-0000000000a1" }),
+    );
+    expect(created[0]?.type).toBe("invitation.created");
+    expect(resent[0]?.type).toBe("invitation.resent");
+    expect(created[0]?.recipients).toEqual({ kind: "all_org_admins" });
+    expect(resent[0]?.recipients).toEqual({ kind: "all_org_admins" });
+  });
+
+  it("branding.activate_logo → all org_admins, system visual", () => {
+    const plan = planFanout(
+      inputFor(BRANDING_EVENT_TYPES.ACTIVATE_LOGO, {
+        assetId: "00000000-0000-0000-0000-000000000b1",
+      }),
+    );
+    expect(plan[0]?.type).toBe("branding.logo_synced");
+    expect(plan[0]?.recipients).toEqual({ kind: "all_org_admins" });
+  });
+
+  it("campaign.postal_export_requested with requestedBy → specific user", () => {
+    const plan = planFanout(
+      inputFor("campaign.postal_export_requested", {
+        requestedBy: "00000000-0000-0000-0000-0000000000u1",
+        campaignId: "00000000-0000-0000-0000-0000000000c1",
+        exportId: "00000000-0000-0000-0000-0000000000e1",
+      }),
+    );
+    expect(plan[0]?.recipients).toEqual({
+      kind: "specific_user",
+      userId: "00000000-0000-0000-0000-0000000000u1",
+    });
+    expect(plan[0]?.linkUrl).toBe("/campaigns/00000000-0000-0000-0000-0000000000c1");
+  });
+
+  it("campaign.postal_export_requested without requestedBy → all org_admins fallback", () => {
+    const plan = planFanout(
+      inputFor("campaign.postal_export_requested", {
+        campaignId: "00000000-0000-0000-0000-0000000000c1",
+        exportId: "00000000-0000-0000-0000-0000000000e1",
+      }),
+    );
+    expect(plan[0]?.recipients).toEqual({ kind: "all_org_admins" });
+  });
+
+  it("communication.bulk_email_requested with requestedBy → specific user", () => {
+    const plan = planFanout(
+      inputFor("communication.bulk_email_requested", {
+        requestedBy: "00000000-0000-0000-0000-0000000000u2",
+        bulkEmailJobId: "00000000-0000-0000-0000-0000000000be",
+      }),
+    );
+    expect(plan[0]?.type).toBe("bulk_email.queued");
+    expect(plan[0]?.recipients).toEqual({
+      kind: "specific_user",
+      userId: "00000000-0000-0000-0000-0000000000u2",
+    });
+  });
+});
+
+describe("planFanout — unsupported / malformed events", () => {
+  it("unknown event type → empty plan (worker silently passes through)", () => {
+    const plan = planFanout(inputFor("totally.unknown_type", { foo: "bar" }));
+    expect(plan).toEqual([]);
+  });
+
+  it("donation.created without donationId → empty plan (defensive)", () => {
+    const plan = planFanout(inputFor("donation.created", { amountCents: 5000 }));
+    expect(plan).toEqual([]);
+  });
+
+  it("invitation.created without invitationId → empty plan", () => {
+    const plan = planFanout(inputFor("invitation.created", {}));
+    expect(plan).toEqual([]);
+  });
+});

--- a/packages/worker/src/processors/notifications-fanout.ts
+++ b/packages/worker/src/processors/notifications-fanout.ts
@@ -17,23 +17,33 @@
  * the same outbox event may fan out to multiple recipients (every
  * org_admin of the tenant), and the producer doesn't have that list.
  *
- * Per-user opt-out is enforced at WRITE time: if a user has a
- * `notification_preferences` row with `in_app=false` for the type,
- * we skip the INSERT. Users without a row inherit the per-type
- * default from `NOTIFICATION_TYPE_REGISTRY`. Either way we never
- * write a row the user explicitly opted out of.
+ * Per-user opt-out semantics — **WRITE-time suppression**. A user
+ * with `notification_preferences.in_app = false` for the type does
+ * NOT receive a notification row. Re-enabling the channel later
+ * affects FUTURE events only — historical alerts the user opted out
+ * of are gone. Reviewed by the Worker SRE agent (PR #393 CRIT-2 fix);
+ * the schema doc is kept in sync with this contract.
+ *
+ * Idempotency — every row carries `outbox_event_id` and the table has
+ * a UNIQUE (outbox_event_id, user_id, type) constraint. An outbox
+ * redelivery (relay retry, worker crash mid-fanout) hits
+ * `ON CONFLICT DO NOTHING` and silently no-ops rather than producing
+ * a duplicate row per recipient.
  *
  * Feature-flag-first: every call gates on
  * `communication.notifications_center` per `feedback_feature_flag_first`.
  * Defence in depth — even if a request slipped past the API gate the
  * worker is the second wall.
  *
+ * Critical-path budget — the fanout runs inside the existing
+ * `processDomainEvent` switch, ahead of receipt-PDF and postal-export
+ * routing. We wrap the work in a 2 s `Promise.race` budget so a slow
+ * PG doesn't propagate latency to those downstream side-effects.
+ *
  * Soft errors only — a fanout failure is logged but never thrown back
  * up. The existing routing decision (donation → receipt, branding →
  * activate, etc.) is the hard contract; notifications are best-effort
- * UX. A future Phase will move fanout to a dedicated queue with retry,
- * but until then we'd rather lose a notification row than fail to
- * generate a receipt PDF on the same event.
+ * UX. A future Phase moves fanout to a dedicated retry-bearing queue.
  */
 
 import {
@@ -48,7 +58,7 @@ import {
   notifications,
   users,
 } from "@givernance/shared/schema";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { withWorkerContext } from "../lib/db.js";
 import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
@@ -187,15 +197,29 @@ export function planFanout(input: FanoutInput): FanoutPlanEntry[] {
  * returns instead so the caller's existing routing decision is not
  * blocked.
  */
+/**
+ * Critical-path budget for the fanout work (ms). The fanout runs
+ * inline ahead of receipt-PDF + postal-export routing in
+ * `processDomainEvent`; a slow PG must not propagate latency to
+ * those downstream side-effects. Reviewed by Worker SRE (HIGH-1).
+ */
+const FANOUT_TIMEOUT_MS = 2_000;
+
 export async function fanoutNotifications(input: FanoutInput): Promise<void> {
   const log = jobLogger({ tenantId: input.tenantId, jobId: input.outboxId });
 
   // Feature-flag-first per `feedback_feature_flag_first`. Cheap query,
   // run before any tenant-scoped DB work so the cost of a flagged-off
-  // tenant is minimised.
+  // tenant is minimised. `isFlagEnabled` reads the platform default —
+  // correct today because the flag has `tenant_override_allowed=false`.
+  // When tenant overrides land, swap to the tenant-aware evaluator
+  // (PR #393 Security M3 follow-up).
   const enabled = await isFlagEnabled(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER);
   if (!enabled) {
-    log.debug({ eventType: input.type }, "Notifications flag off — skipping fanout");
+    log.info(
+      { event: "notifications.fanout_skipped_flag_off", eventType: input.type },
+      "Notifications flag off — skipping fanout",
+    );
     return;
   }
 
@@ -205,32 +229,17 @@ export async function fanoutNotifications(input: FanoutInput): Promise<void> {
   }
 
   try {
-    await withWorkerContext(input.tenantId, async (tx) => {
-      for (const entry of plan) {
-        const recipientUserIds = await resolveRecipients(tx, entry.recipients);
-        if (recipientUserIds.length === 0) continue;
+    await Promise.race([
+      runFanoutPlan(input, plan),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`Fanout timeout after ${FANOUT_TIMEOUT_MS} ms`)),
+          FANOUT_TIMEOUT_MS,
+        ),
+      ),
+    ]);
 
-        // Honour per-user preferences. Users with `in_app=false` for
-        // this type are silently dropped at write time so the worker
-        // doesn't pile rows onto a user who opted out of the channel.
-        const enabledRecipients = await filterByPreferences(tx, recipientUserIds, entry.type);
-        if (enabledRecipients.length === 0) continue;
-
-        const rows: NewNotification[] = enabledRecipients.map((userId) => ({
-          orgId: input.tenantId,
-          userId,
-          type: entry.type,
-          titleKey: entry.titleKey,
-          bodyKey: entry.bodyKey,
-          params: entry.params,
-          linkUrl: entry.linkUrl,
-        }));
-
-        await tx.insert(notifications).values(rows);
-      }
-    });
-
-    log.info({ eventType: input.type, planSize: plan.length }, "Notification fanout completed");
+    log.debug({ eventType: input.type, planSize: plan.length }, "Notification fanout completed");
   } catch (err) {
     // Soft-fail — see file header. Notifications are UX, not contract.
     log.error(
@@ -238,6 +247,37 @@ export async function fanoutNotifications(input: FanoutInput): Promise<void> {
       "Notification fanout failed — continuing with existing routing",
     );
   }
+}
+
+async function runFanoutPlan(input: FanoutInput, plan: FanoutPlanEntry[]): Promise<void> {
+  await withWorkerContext(input.tenantId, async (tx) => {
+    for (const entry of plan) {
+      const recipientUserIds = await resolveRecipients(tx, entry.recipients);
+      if (recipientUserIds.length === 0) continue;
+
+      // Honour per-user preferences. Users with `in_app=false` for
+      // this type are silently dropped at write time so the worker
+      // doesn't pile rows onto a user who opted out of the channel.
+      const enabledRecipients = await filterByPreferences(tx, recipientUserIds, entry.type);
+      if (enabledRecipients.length === 0) continue;
+
+      const rows: NewNotification[] = enabledRecipients.map((userId) => ({
+        orgId: input.tenantId,
+        outboxEventId: input.outboxId,
+        userId,
+        type: entry.type,
+        titleKey: entry.titleKey,
+        bodyKey: entry.bodyKey,
+        params: entry.params,
+        linkUrl: entry.linkUrl,
+      }));
+
+      // `ON CONFLICT DO NOTHING` — the natural unique key
+      // (outbox_event_id, user_id, type) catches outbox redeliveries
+      // so a retry doesn't produce a second row per recipient.
+      await tx.insert(notifications).values(rows).onConflictDoNothing();
+    }
+  });
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────
@@ -272,12 +312,20 @@ async function filterByPreferences(
   type: NotificationType,
 ): Promise<string[]> {
   if (userIds.length === 0) return [];
-  // Pull every preference row for these users + this type. A missing
-  // row falls back to the per-type default in the registry.
+  // Pull preference rows for the (recipient set, type) pair only.
+  // Earlier revisions scanned every preference row for the type
+  // (scaling with tenant headcount); Data review H2 flagged the
+  // scope mismatch. The new `inArray(userId, userIds)` clause hits
+  // `notification_preferences_user_idx` directly.
   const rows = await tx
     .select({ userId: notificationPreferences.userId, inApp: notificationPreferences.inApp })
     .from(notificationPreferences)
-    .where(eq(notificationPreferences.type, type));
+    .where(
+      and(
+        eq(notificationPreferences.type, type),
+        inArray(notificationPreferences.userId, userIds),
+      ),
+    );
 
   const defaultInApp = getNotificationDescriptor(type).defaultInApp;
   const explicit = new Map<string, boolean>();

--- a/packages/worker/src/processors/notifications-fanout.ts
+++ b/packages/worker/src/processors/notifications-fanout.ts
@@ -321,10 +321,7 @@ async function filterByPreferences(
     .select({ userId: notificationPreferences.userId, inApp: notificationPreferences.inApp })
     .from(notificationPreferences)
     .where(
-      and(
-        eq(notificationPreferences.type, type),
-        inArray(notificationPreferences.userId, userIds),
-      ),
+      and(eq(notificationPreferences.type, type), inArray(notificationPreferences.userId, userIds)),
     );
 
   const defaultInApp = getNotificationDescriptor(type).defaultInApp;

--- a/packages/worker/src/processors/notifications-fanout.ts
+++ b/packages/worker/src/processors/notifications-fanout.ts
@@ -1,0 +1,299 @@
+/**
+ * Notification fanout — single producer for in-app notifications
+ * (Epic #363, GLO-004).
+ *
+ * Subscribes to outbox events alongside the existing `routeDomainEvent`
+ * routing decision and writes `notifications` rows for the curated
+ * Phase 1 event list:
+ *
+ *   - `donation.created`               → notify every org_admin
+ *   - `invitation.created`             → notify every org_admin
+ *   - `invitation.resent`              → notify every org_admin
+ *   - `branding.activate_logo`         → notify every org_admin
+ *   - `campaign.postal_export_requested` → notify the requester
+ *   - `communication.bulk_email_requested` → notify the requester
+ *
+ * Recipient resolution lives here (not in the API producer) because
+ * the same outbox event may fan out to multiple recipients (every
+ * org_admin of the tenant), and the producer doesn't have that list.
+ *
+ * Per-user opt-out is enforced at WRITE time: if a user has a
+ * `notification_preferences` row with `in_app=false` for the type,
+ * we skip the INSERT. Users without a row inherit the per-type
+ * default from `NOTIFICATION_TYPE_REGISTRY`. Either way we never
+ * write a row the user explicitly opted out of.
+ *
+ * Feature-flag-first: every call gates on
+ * `communication.notifications_center` per `feedback_feature_flag_first`.
+ * Defence in depth — even if a request slipped past the API gate the
+ * worker is the second wall.
+ *
+ * Soft errors only — a fanout failure is logged but never thrown back
+ * up. The existing routing decision (donation → receipt, branding →
+ * activate, etc.) is the hard contract; notifications are best-effort
+ * UX. A future Phase will move fanout to a dedicated queue with retry,
+ * but until then we'd rather lose a notification row than fail to
+ * generate a receipt PDF on the same event.
+ */
+
+import {
+  FEATURE_FLAG_KEYS,
+  getNotificationDescriptor,
+  type NotificationType,
+} from "@givernance/shared/constants";
+import { BRANDING_EVENT_TYPES } from "@givernance/shared/jobs";
+import {
+  type NewNotification,
+  notificationPreferences,
+  notifications,
+  users,
+} from "@givernance/shared/schema";
+import { and, eq, isNull } from "drizzle-orm";
+import { withWorkerContext } from "../lib/db.js";
+import { isFlagEnabled } from "../lib/flags.js";
+import { jobLogger } from "../lib/logger.js";
+
+export interface FanoutInput {
+  /** Outbox event id (logged for correlation). */
+  outboxId: string;
+  /** Tenant scope. */
+  tenantId: string;
+  /** Outbox `type` discriminator. */
+  type: string;
+  /** Outbox `payload`. */
+  payload: Record<string, unknown>;
+  /** W3C trace context for logger correlation. */
+  traceparent?: string;
+}
+
+/**
+ * Plan a fanout — pure function for unit testing. Translates an
+ * outbox event into a list of (notificationType, recipientFilter,
+ * titleKey, bodyKey, params, linkUrl) entries. The filter is applied
+ * at INSERT time by the recipient resolver below.
+ */
+type RecipientFilter = { kind: "all_org_admins" } | { kind: "specific_user"; userId: string };
+
+interface FanoutPlanEntry {
+  type: NotificationType;
+  recipients: RecipientFilter;
+  titleKey: string;
+  bodyKey: string;
+  params: Record<string, unknown>;
+  linkUrl: string | null;
+}
+
+export function planFanout(input: FanoutInput): FanoutPlanEntry[] {
+  const { type, payload } = input;
+
+  if (type === "donation.created") {
+    const donationId = stringOrNull(payload.donationId);
+    if (!donationId) return [];
+    const amountCents = numberOrNull(payload.amountCents);
+    const currency = stringOrNull(payload.currency);
+    return [
+      {
+        type: "donation.received",
+        recipients: { kind: "all_org_admins" },
+        titleKey: getNotificationDescriptor("donation.received").titleKey,
+        bodyKey: getNotificationDescriptor("donation.received").bodyKey,
+        params: {
+          donationId,
+          amountCents,
+          currency,
+        },
+        linkUrl: `/donations/${donationId}`,
+      },
+    ];
+  }
+
+  if (type === "invitation.created" || type === "invitation.resent") {
+    const invitationId = stringOrNull(payload.invitationId);
+    if (!invitationId) return [];
+    const notificationType: NotificationType =
+      type === "invitation.created" ? "invitation.created" : "invitation.resent";
+    return [
+      {
+        type: notificationType,
+        recipients: { kind: "all_org_admins" },
+        titleKey: getNotificationDescriptor(notificationType).titleKey,
+        bodyKey: getNotificationDescriptor(notificationType).bodyKey,
+        params: {
+          invitationId,
+        },
+        linkUrl: `/settings/members`,
+      },
+    ];
+  }
+
+  if (type === BRANDING_EVENT_TYPES.ACTIVATE_LOGO) {
+    return [
+      {
+        type: "branding.logo_synced",
+        recipients: { kind: "all_org_admins" },
+        titleKey: getNotificationDescriptor("branding.logo_synced").titleKey,
+        bodyKey: getNotificationDescriptor("branding.logo_synced").bodyKey,
+        params: {},
+        linkUrl: `/settings`,
+      },
+    ];
+  }
+
+  if (type === "campaign.postal_export_requested") {
+    const requestedBy = stringOrNull(payload.requestedBy);
+    const campaignId = stringOrNull(payload.campaignId);
+    const exportId = stringOrNull(payload.exportId);
+    return [
+      {
+        type: "postal_export.queued",
+        recipients: requestedBy
+          ? { kind: "specific_user", userId: requestedBy }
+          : { kind: "all_org_admins" },
+        titleKey: getNotificationDescriptor("postal_export.queued").titleKey,
+        bodyKey: getNotificationDescriptor("postal_export.queued").bodyKey,
+        params: {
+          campaignId,
+          exportId,
+        },
+        linkUrl: campaignId ? `/campaigns/${campaignId}` : null,
+      },
+    ];
+  }
+
+  if (type === "communication.bulk_email_requested") {
+    const requestedBy = stringOrNull(payload.requestedBy);
+    const bulkEmailJobId = stringOrNull(payload.bulkEmailJobId);
+    return [
+      {
+        type: "bulk_email.queued",
+        recipients: requestedBy
+          ? { kind: "specific_user", userId: requestedBy }
+          : { kind: "all_org_admins" },
+        titleKey: getNotificationDescriptor("bulk_email.queued").titleKey,
+        bodyKey: getNotificationDescriptor("bulk_email.queued").bodyKey,
+        params: {
+          bulkEmailJobId,
+        },
+        linkUrl: `/constituents`,
+      },
+    ];
+  }
+
+  return [];
+}
+
+/**
+ * Run the fanout for one outbox event. Never throws — logs and
+ * returns instead so the caller's existing routing decision is not
+ * blocked.
+ */
+export async function fanoutNotifications(input: FanoutInput): Promise<void> {
+  const log = jobLogger({ tenantId: input.tenantId, jobId: input.outboxId });
+
+  // Feature-flag-first per `feedback_feature_flag_first`. Cheap query,
+  // run before any tenant-scoped DB work so the cost of a flagged-off
+  // tenant is minimised.
+  const enabled = await isFlagEnabled(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER);
+  if (!enabled) {
+    log.debug({ eventType: input.type }, "Notifications flag off — skipping fanout");
+    return;
+  }
+
+  const plan = planFanout(input);
+  if (plan.length === 0) {
+    return;
+  }
+
+  try {
+    await withWorkerContext(input.tenantId, async (tx) => {
+      for (const entry of plan) {
+        const recipientUserIds = await resolveRecipients(tx, entry.recipients);
+        if (recipientUserIds.length === 0) continue;
+
+        // Honour per-user preferences. Users with `in_app=false` for
+        // this type are silently dropped at write time so the worker
+        // doesn't pile rows onto a user who opted out of the channel.
+        const enabledRecipients = await filterByPreferences(tx, recipientUserIds, entry.type);
+        if (enabledRecipients.length === 0) continue;
+
+        const rows: NewNotification[] = enabledRecipients.map((userId) => ({
+          orgId: input.tenantId,
+          userId,
+          type: entry.type,
+          titleKey: entry.titleKey,
+          bodyKey: entry.bodyKey,
+          params: entry.params,
+          linkUrl: entry.linkUrl,
+        }));
+
+        await tx.insert(notifications).values(rows);
+      }
+    });
+
+    log.info({ eventType: input.type, planSize: plan.length }, "Notification fanout completed");
+  } catch (err) {
+    // Soft-fail — see file header. Notifications are UX, not contract.
+    log.error(
+      { err, eventType: input.type },
+      "Notification fanout failed — continuing with existing routing",
+    );
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+async function resolveRecipients(
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle tx type is awkward to spell out — same shape as in API service
+  tx: any,
+  filter: RecipientFilter,
+): Promise<string[]> {
+  if (filter.kind === "specific_user") {
+    // RLS already isolates the tenant; we additionally filter
+    // soft-deleted users.
+    const rows = await tx
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.id, filter.userId), isNull(users.deletedAt)))
+      .limit(1);
+    return rows.map((r: { id: string }) => r.id);
+  }
+  // all_org_admins — RLS isolates the tenant.
+  const rows = await tx
+    .select({ id: users.id })
+    .from(users)
+    .where(and(eq(users.role, "org_admin"), isNull(users.deletedAt)));
+  return rows.map((r: { id: string }) => r.id);
+}
+
+async function filterByPreferences(
+  // biome-ignore lint/suspicious/noExplicitAny: see above
+  tx: any,
+  userIds: string[],
+  type: NotificationType,
+): Promise<string[]> {
+  if (userIds.length === 0) return [];
+  // Pull every preference row for these users + this type. A missing
+  // row falls back to the per-type default in the registry.
+  const rows = await tx
+    .select({ userId: notificationPreferences.userId, inApp: notificationPreferences.inApp })
+    .from(notificationPreferences)
+    .where(eq(notificationPreferences.type, type));
+
+  const defaultInApp = getNotificationDescriptor(type).defaultInApp;
+  const explicit = new Map<string, boolean>();
+  for (const row of rows as Array<{ userId: string; inApp: boolean }>) {
+    explicit.set(row.userId, row.inApp);
+  }
+  return userIds.filter((id) => {
+    const v = explicit.get(id);
+    return v === undefined ? defaultInApp : v;
+  });
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1,6 +1,11 @@
 /** BullMQ Worker entry point — registers all job processors */
 
-import { BRANDING_EVENT_TYPES, QUEUE_NAMES, TENANT_LIFECYCLE_JOBS } from "@givernance/shared/jobs";
+import {
+  BRANDING_EVENT_TYPES,
+  NOTIFICATIONS_DIGEST_JOBS,
+  QUEUE_NAMES,
+  TENANT_LIFECYCLE_JOBS,
+} from "@givernance/shared/jobs";
 import type { Job } from "bullmq";
 import { Queue, Worker } from "bullmq";
 import Redis from "ioredis";
@@ -15,6 +20,8 @@ import { processGenerateCampaignDocuments } from "./processors/campaign-document
 import { processGdprErasure } from "./processors/gdpr-erasure.js";
 import { processGenerateReceipt } from "./processors/generate-receipt.js";
 import { processKeycloakSyncOrgLogo } from "./processors/keycloak-sync-org-logo.js";
+import { processNotificationsEmailDigest } from "./processors/notifications-email-digest.js";
+import { fanoutNotifications } from "./processors/notifications-fanout.js";
 import { processPlatformAdminInviteEmail } from "./processors/platform-admin-invite-email.js";
 import { processGeneratePostalExport } from "./processors/postal-export.js";
 import { processSendBulkEmail } from "./processors/send-bulk-email.js";
@@ -43,6 +50,9 @@ const tenantLifecycleQueue = new Queue(QUEUE_NAMES.TENANT_LIFECYCLE, {
 });
 const brandingQueue = new Queue(QUEUE_NAMES.BRANDING, { connection: queueConnection });
 const keycloakSyncQueue = new Queue(QUEUE_NAMES.KEYCLOAK_SYNC, { connection: queueConnection });
+const notificationsDigestQueue = new Queue(QUEUE_NAMES.NOTIFICATIONS_DIGEST, {
+  connection: queueConnection,
+});
 
 /**
  * Register the nightly provisional-admin expire job.
@@ -58,6 +68,22 @@ async function scheduleRepeatableJobs() {
     {
       jobId: "tenant-provisional-admin-expire-daily",
       repeat: { pattern: "15 3 * * *", tz: "UTC" },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 50 },
+    },
+  );
+
+  // Notifications email digest (Epic #363, Phase 5). Daily at 09:00
+  // UTC — early enough to be the operator's morning catch-up email,
+  // late enough to capture an overnight donation burst. `jobId` is
+  // fixed so re-registering across worker restarts doesn't fan out
+  // to duplicate repeatable schedules.
+  await notificationsDigestQueue.add(
+    NOTIFICATIONS_DIGEST_JOBS.DAILY,
+    {},
+    {
+      jobId: "notifications-digest-daily",
+      repeat: { pattern: "0 9 * * *", tz: "UTC" },
       removeOnComplete: { count: 10 },
       removeOnFail: { count: 50 },
     },
@@ -91,6 +117,14 @@ async function processDomainEvent(job: Job): Promise<void> {
   const log = jobLogger({ tenantId, jobId: job.id, traceId });
 
   log.info({ eventType: type }, "Processing domain event");
+
+  // Notification fanout (Epic #363, GLO-004) runs alongside the
+  // existing routing decision. The helper is feature-flag-gated and
+  // never throws — see `processors/notifications-fanout.ts` header. We
+  // await so a slow PG roundtrip doesn't accumulate orphan promises,
+  // but the existing receipt/email/branding routing below is not
+  // blocked by a fanout failure (the helper logs and returns).
+  await fanoutNotifications({ outboxId: id, tenantId, type, payload, traceparent });
 
   const decision = routeDomainEvent({ id, tenantId, type, payload, traceparent });
 
@@ -416,6 +450,20 @@ function startWorkers() {
     },
   );
 
+  // Notifications email digest (Epic #363, Phase 5).
+  const notificationsDigestWorker = new Worker(
+    QUEUE_NAMES.NOTIFICATIONS_DIGEST,
+    async (job: Job) => processNotificationsEmailDigest(job),
+    {
+      connection: createRedisConnection(),
+      // Concurrency 1: opt-in distribution is small and we'd rather
+      // not flood the SMTP relay. Scale by adding worker pods if a
+      // large tenant ever opts every member into the digest.
+      concurrency: 1,
+      ...defaultJobOpts,
+    },
+  );
+
   const workers = [
     receiptsWorker,
     emailsWorker,
@@ -427,6 +475,7 @@ function startWorkers() {
     tenantLifecycleWorker,
     brandingWorker,
     keycloakSyncWorker,
+    notificationsDigestWorker,
   ];
 
   for (const w of workers) {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -52,6 +52,19 @@ const brandingQueue = new Queue(QUEUE_NAMES.BRANDING, { connection: queueConnect
 const keycloakSyncQueue = new Queue(QUEUE_NAMES.KEYCLOAK_SYNC, { connection: queueConnection });
 const notificationsDigestQueue = new Queue(QUEUE_NAMES.NOTIFICATIONS_DIGEST, {
   connection: queueConnection,
+  // BullMQ Worker constructors don't honour `attempts/backoff` — those
+  // settings live on `Queue` `defaultJobOptions` (and per-`add()`
+  // overrides). Wiring them here so a transient SMTP / PG flake at
+  // 09:00 UTC retries with exponential backoff instead of silently
+  // losing the entire day's digest. Also bounds completed/failed job
+  // retention so the BullMQ keyspace doesn't grow indefinitely.
+  // (PR #393 Worker SRE HIGH-3 / MED for repeatable GC.)
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: { type: "exponential", delay: 60_000 },
+    removeOnComplete: { count: 10 },
+    removeOnFail: { count: 50 },
+  },
 });
 
 /**


### PR DESCRIPTION
## Summary

Ships the **in-app notification centre** end-to-end (Epic #363, screen GLO-004) behind a default-off feature flag (`communication.notifications_center`, scope `tenant`). One PR covers every phase of the Epic:

- **Step 0** — feature flag registered + seeded; every gated route, worker tick, and UI surface checks it.
- **Phase 1 — schema + outbox subscriber + REST API**: `notifications` + `notification_preferences` tables with RLS, FORCE ROW LEVEL SECURITY, partial indexes for the bell-badge query, soft-delete universal. Worker's `processDomainEvent` now calls `fanoutNotifications(event)` alongside the existing routing decision; soft-fails so the existing receipt PDF / postal ZIP / branding pipeline jobs never block on notification writes. Six event producers wired:
  - `donation.created` → notify org_admins
  - `invitation.created` + `invitation.resent` → notify org_admins
  - `branding.activate_logo` → notify org_admins (logo synced)
  - `campaign.postal_export_requested` → notify the requester
  - `communication.bulk_email_requested` → notify the requester
- **Phase 2 — topbar bell + side panel**: matches the GLO-004 mockup (400px aside, filter chips, accent bars by category, mark-all-read, soft-delete, click-through). Polling fallback at 30 s when the tab is focused; bell + panel completely absent when the flag is off (off-state QA per `feedback_feature_flag_first`).
- **Phase 3 — preferences page**: `/profile/notifications` (every authenticated role; not `/settings/*` which is org-admin-only). Optimistic upsert per row, "Default" badge when no explicit row exists yet.
- **Phase 4 — SSE delivery**: `GET /v1/notifications/stream` (`text/event-stream`) with heartbeat every 25 s and `Last-Event-ID` resume. EventSource client swaps polling for SSE and falls back automatically on error.
- **Phase 5 — opt-in email digest**: daily BullMQ recurring job at 09:00 UTC. Sends one batched email per opted-in user via `defaultEmailSender`. Default `email_digest=false` on every type, so the digest is silent on day one.
- **Phase 6 — docs**: `docs/27-notifications.md` (overview + ERD + permissions matrix + GDPR posture + out-of-scope), `docs/adrs/adr-031` (delivery mechanism + event-source + data model decisions with rejected alternatives + revisit triggers), `diagrams/notifications-flow.mmd`, CLAUDE.md file-tree update.

The architecture leans on infrastructure already proven in production: the transactional outbox + BullMQ worker (Epic #274 / #286 / #326), the feature-flag scaffolding (Epic #326 / #365), and the RLS / soft-delete patterns (ADR-021). No new infrastructure, no new tools — one new Fastify module, one new worker processor, one new topbar component.

close #363

## Architecture references

- ADR-031 — delivery mechanism (SSE + polling fallback) + outbox fanout + data model
- GLO-004 spec — `docs/14-screen-inventory.md`
- Mockup — `docs/design/global/notifications.html`
- Domain doc — `docs/27-notifications.md`
- Flow diagram — `diagrams/notifications-flow.mmd`

## Test plan

- [x] **Flag off (default)**: visit `/dashboard`, bell icon is ABSENT in the topbar (not hidden via CSS, not in the DOM); navigate to `/profile/notifications`, returns 404; `curl /v1/notifications` returns 404.
- [x] **Flip flag on** (super-admin Back Office → `communication.notifications_center` → enable): bell appears with a "0" badge; panel opens on click; empty state visible.
- [x] **Create a donation** via `POST /v1/donations` — within ~5 s (SSE) or 30 s (polling) the bell badge increments and the panel shows the new row.
- [x] **Click the row**: navigates to `/donations/<id>`; row becomes "read" (no unread dot); badge decrements.
- [x] **Mark all read**: every unread becomes read; badge drops to 0.
- [x] **Dismiss a row**: row disappears from the panel; the DB row keeps `deleted_at = NOW()` (audit preserved).
- [x] **Filter chips**: "Donations" filters to donation.received rows only; "Team" to invitation.* + bulk_email; "System" to branding + postal export.
- [x] **Preferences**: visit `/profile/notifications`; toggle `donation.received` "In-app" off; create another donation; the row does NOT appear in the panel. Toggle "Email digest" on; the daily 09:00 UTC tick sends one email (Mailpit in dev).
- [x] **Cross-tenant isolation**: tenant B creates a donation; tenant A's panel does NOT show it (test enforced via the integration suite).
- [x] **SSE reconnect**: `kill` the API, wait 30s, restart; the EventSource client reconnects with `Last-Event-ID` and resumes without losing rows created during the outage.
- [x] **i18n**: switch to French; panel + preferences page render in French; backend-stored `params` interpolate correctly into the French template.
- [x] **a11y**: keyboard nav opens panel via Tab+Enter; Esc closes; screen reader announces "Notifications panel" + per-row context + "Unread" status.
- [x] **Off-state regression**: flip the flag off mid-session; the bell vanishes on next page navigation; previously-opened panel becomes inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)