### PR TITLE
fix(notifications): channels decoupled + absolute URLs + auto-mark-read + digest trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,32 @@ Apply this in `gh pr create` / `gh pr edit` bodies, in commit messages that clos
 
 Valid uses for Organization attributes: non-sensitive identifiers (`org_id`, slug), feature flags that don't imply entitlements (`theme`, `locale`), public-facing labels. Anything else belongs in the application database (`tenants` table) with RLS.
 
+### 🛑 Drizzle migrations: journal must stay in sync with the folder
+
+**Adding a `.sql` file to [`packages/api/migrations/`](packages/api/migrations/) is not enough — the migration must also be registered in [`packages/api/migrations/meta/_journal.json`](packages/api/migrations/meta/_journal.json).** `drizzle-kit migrate` (run by CI as `pnpm db:migrate` before tests) only applies migrations listed in the journal; unregistered SQL files are silently skipped. The Epic #363 follow-up hit this exact gap — `0056_notifications_panel_visible.sql` was on disk but missing from the journal, so CI's test Postgres never got the new column and every integration test that touched it failed with `42703 column … does not exist`. Local dev didn't catch it because the developer had `psql < 0056_*.sql`'d the column in by hand while iterating.
+
+**When this rule fires** (audit the journal in each of these cases):
+- **Adding a hand-written migration** (you're not running `drizzle-kit generate`): append a journal entry yourself.
+- **Rebasing onto `main`** when both your branch and main added migrations in parallel: re-check that `idx` is contiguous, `tag`s match filenames, and `when` is strictly increasing.
+- **Cherry-picking a commit** that included a migration: confirm the journal change rode along (not just the `.sql`).
+- **Resolving a merge conflict that touched `_journal.json`**: walk every entry by hand — `git`'s line-based merge does not know that journal entries are positional.
+
+**How to append manually** (for hand-written migrations like new columns / constraints / seeds that don't come from a schema diff):
+1. Decide on the next free `NNNN` prefix for the filename. Check the highest current `idx` in the journal.
+2. Add an entry at the end of `entries[]`:
+   ```json
+   {
+     "idx": <highestIdx + 1>,
+     "version": "7",
+     "when": <previousEntry.when + 10_000_000_000>,
+     "tag": "<filename without .sql>",
+     "breakpoints": true
+   }
+   ```
+3. `tag` must match the filename exactly (minus `.sql`). The `when` field is an arbitrary monotonic counter in this repo, not a real timestamp — preserve the +10b spacing so future rebases stay easy.
+
+**Automated guard**: [`packages/api/src/tests/integration/migrations-journal-parity.test.ts`](packages/api/src/tests/integration/migrations-journal-parity.test.ts) fails CI on orphan files, phantom journal entries, gappy `idx`, and non-monotonic `when`. If that test goes red after an edit, the journal is the thing to fix — never the test.
+
 ---
 
 ## 🛑 DEV PROCESS (CRITICAL FOR CI)

--- a/docs/27-notifications.md
+++ b/docs/27-notifications.md
@@ -182,9 +182,9 @@ erDiagram
 
 The worker's `planFanout(event)` resolves recipients per the table in [§ 1](#1-end-to-end-user-flow). For "specific user" rules (postal export, bulk email), the payload carries `requestedBy` — if absent (older events, super-admin actions), the rule falls back to "all org_admins". The fanout writes a `notifications` row when EITHER `in_app` OR `email_digest` is enabled for the recipient's (user, type) pair; the row's `panel_visible` column records the panel-side decision at write time so the in-app surface honours `in_app=false` while the digest worker can still pick the row up. Users who opted out of BOTH channels are silently dropped before any row is written.
 
-### Channel decoupling (`panel_visible`, migration 0056)
+### Channel decoupling (`panel_visible`, migration 0058)
 
-`in_app` and `email_digest` are two independent delivery channels. The original Epic #363 contract coupled them — `in_app=false` short-circuited the row insert, leaving the digest worker with nothing to read. Migration 0056 introduces `notifications.panel_visible BOOLEAN NOT NULL DEFAULT TRUE`, set at fanout time to the recipient's effective `in_app` preference:
+`in_app` and `email_digest` are two independent delivery channels. The original Epic #363 contract coupled them — `in_app=false` short-circuited the row insert, leaving the digest worker with nothing to read. Migration 0058 introduces `notifications.panel_visible BOOLEAN NOT NULL DEFAULT TRUE`, set at fanout time to the recipient's effective `in_app` preference:
 
 | Effective `in_app` | Effective `email_digest` | Row written? | `panel_visible` | Panel sees it? | Digest sees it? |
 |---|---|---|---|---|---|

--- a/docs/27-notifications.md
+++ b/docs/27-notifications.md
@@ -203,7 +203,7 @@ A notification stays unread until the recipient acts on it. The canonical trigge
 Implementation:
 
 - The bell hook (mounted in the topbar of every authenticated page) calls `usePathname()` and, on every change, fires `NotificationsService.markReadByLink(client, pathname)`.
-- `POST /v1/notifications/mark-read-by-link` marks every panel-visible unread notification for the current user whose `link_url` matches the body. Idempotent — every navigation hits the endpoint; the common case is `marked: 0`.
+- `POST /v1/notifications/mark-read-by-link` marks every unread notification for the current user whose `link_url` matches the body — REGARDLESS of `panel_visible`. A digest-only row (`panel_visible = false`) whose resource the user just visited is "consumed" exactly like a panel row; leaving it unread would feed it back into tomorrow's digest as a stale recap. Idempotent — every navigation hits the endpoint; the common case is `marked: 0`.
 - The body's `linkUrl` shares the same shape constraint as the DB CHECK on `notifications.link_url` (`^/(?!/).*$`) so a malformed payload 400s before reaching the SQL.
 - The hook soft-fails on any error (5xx / 401 mid-navigation): the bell stays in its prior state rather than burst a global error banner on every page change.
 

--- a/docs/27-notifications.md
+++ b/docs/27-notifications.md
@@ -151,6 +151,7 @@ erDiagram
     varchar(128) body_key
     jsonb params
     text link_url
+    boolean panel_visible
     timestamptz read_at
     timestamptz archived_at
     timestamptz deleted_at
@@ -173,13 +174,27 @@ erDiagram
 
 - **`type` is `varchar(64)`** with a CHECK constraint on shape (`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$`), NOT a Postgres enum. Adding a new type is a code change + producer wiring, never a migration.
 - **`(title_key, body_key, params)` instead of frozen `text`** — i18n resolution at READ time. A French recipient sees French regardless of the worker's session locale.
-- **`link_url` is a relative path** (CHECK `link_url LIKE '/%'`). Frontend prepends `APP_URL`. Absolute URLs would break for tenants on custom subdomains (Epic #279 follow-up).
+- **`link_url` is a relative path** (CHECK `link_url LIKE '/%'`). Frontend prepends `APP_URL`. Absolute URLs would break for tenants on custom subdomains (Epic #279 follow-up). The **email digest renderer** prepends `APP_URL` itself before serialising the href: an email client renders against its own base URL (in dev, Mailpit at `http://localhost:8025`), so a stored relative path would deliver a broken link. Resolution happens in `notifications-email-digest.ts → absoluteUrl()`.
 - **`deleted_at` (soft-delete)** per `feedback_soft_delete_universal` — a panel "delete" sets the column; the row stays for audit + GDPR DSR replay.
 - **Partial index `(user_id) WHERE read_at IS NULL AND deleted_at IS NULL`** keeps the bell badge query O(log N) on a noisy tenant.
 
 ### Recipient resolution
 
-The worker's `planFanout(event)` resolves recipients per the table in [§ 1](#1-end-to-end-user-flow). For "specific user" rules (postal export, bulk email), the payload carries `requestedBy` — if absent (older events, super-admin actions), the rule falls back to "all org_admins". A user with `notification_preferences.in_app = false` for the type is silently dropped at write time so the worker doesn't pile rows onto an opted-out user.
+The worker's `planFanout(event)` resolves recipients per the table in [§ 1](#1-end-to-end-user-flow). For "specific user" rules (postal export, bulk email), the payload carries `requestedBy` — if absent (older events, super-admin actions), the rule falls back to "all org_admins". The fanout writes a `notifications` row when EITHER `in_app` OR `email_digest` is enabled for the recipient's (user, type) pair; the row's `panel_visible` column records the panel-side decision at write time so the in-app surface honours `in_app=false` while the digest worker can still pick the row up. Users who opted out of BOTH channels are silently dropped before any row is written.
+
+### Channel decoupling (`panel_visible`, migration 0056)
+
+`in_app` and `email_digest` are two independent delivery channels. The original Epic #363 contract coupled them — `in_app=false` short-circuited the row insert, leaving the digest worker with nothing to read. Migration 0056 introduces `notifications.panel_visible BOOLEAN NOT NULL DEFAULT TRUE`, set at fanout time to the recipient's effective `in_app` preference:
+
+| Effective `in_app` | Effective `email_digest` | Row written? | `panel_visible` | Panel sees it? | Digest sees it? |
+|---|---|---|---|---|---|
+| true | any | yes | `true` | yes | yes (if `email_digest=true`) |
+| false | true | yes | `false` | no | yes |
+| false | false | no | n/a | n/a | n/a |
+
+The decision is **frozen** at write time — toggling `in_app=true` later does NOT retroactively reveal historical digest-only rows. This preserves the "decision captured at write time" semantics from the original design without locking out the email channel.
+
+Reads that target the panel apply `panel_visible = true` as an extra predicate: `listNotifications`, `getUnreadCount`, `streamNotifications` (SSE), and the mutating endpoints (`markRead`, `markAllRead`, `softDeleteNotification`) all filter so a digest-only row is invisible to the bell, can't be marked-read from the panel, and isn't dragged into "mark all read". The digest worker is unchanged — it already filters by `notification_preferences.email_digest = true` and now finds the rows it needs.
 
 ### Identifier discipline (`users.id` vs `keycloak_id`)
 

--- a/docs/27-notifications.md
+++ b/docs/27-notifications.md
@@ -196,6 +196,24 @@ The decision is **frozen** at write time — toggling `in_app=true` later does N
 
 Reads that target the panel apply `panel_visible = true` as an extra predicate: `listNotifications`, `getUnreadCount`, `streamNotifications` (SSE), and the mutating endpoints (`markRead`, `markAllRead`, `softDeleteNotification`) all filter so a digest-only row is invisible to the bell, can't be marked-read from the panel, and isn't dragged into "mark all read". The digest worker is unchanged — it already filters by `notification_preferences.email_digest = true` and now finds the rows it needs.
 
+### Auto-mark-read on consumption
+
+A notification stays unread until the recipient acts on it. The canonical trigger is **landing on the notification's `link_url`** — at that point the operator has visibly consumed the linked resource and the bell ping is stale.
+
+Implementation:
+
+- The bell hook (mounted in the topbar of every authenticated page) calls `usePathname()` and, on every change, fires `NotificationsService.markReadByLink(client, pathname)`.
+- `POST /v1/notifications/mark-read-by-link` marks every panel-visible unread notification for the current user whose `link_url` matches the body. Idempotent — every navigation hits the endpoint; the common case is `marked: 0`.
+- The body's `linkUrl` shares the same shape constraint as the DB CHECK on `notifications.link_url` (`^/(?!/).*$`) so a malformed payload 400s before reaching the SQL.
+- The hook soft-fails on any error (5xx / 401 mid-navigation): the bell stays in its prior state rather than burst a global error banner on every page change.
+
+**Contract for new notification types** (also captured in ADR-031 § 4): pick a `link_url` such that landing on it is a meaningful "I have consumed this" signal:
+
+- Resource-scoped events (`donation.received`, `branding.logo_synced`) → resource detail / settings page.
+- Index-page events (`bulk_email.queued`, `invitation.created`) → the list view where the new item appears.
+- Avoid `link_url`s that are too broad — they collapse unrelated notifications into one auto-read sweep.
+- If a future type cannot satisfy the contract, ship it with `link_url = NULL` so the sweep never matches; the panel's explicit "Marquer comme lu" button is the only way to clear it.
+
 ### Identifier discipline (`users.id` vs `keycloak_id`)
 
 Every column on `notifications` / `notification_preferences` that points at a person is `user_id uuid REFERENCES users(id)` — the application's row UUID, NOT the Keycloak `sub`. Real seeds (and the impersonation playground tenant) keep `users.id ≠ users.keycloak_id`, so confusing the two is silent: queries return zero rows, fanout writes zero recipients, and the bell never lights up.
@@ -215,6 +233,7 @@ The same discipline applies to other FK columns pointing at `users.id` across th
 | `/v1/notifications/unread-count` | GET | `communication.notifications_center` | `requireAuth` | Caller-scoped count. |
 | `/v1/notifications/:id/read` | PATCH | `communication.notifications_center` | `requireAuth` | Caller-scoped — 404 if not owned. Idempotent. |
 | `/v1/notifications/read-all` | POST | `communication.notifications_center` | `requireAuth` | Idempotent — returns count of rows touched. |
+| `/v1/notifications/mark-read-by-link` | POST | `communication.notifications_center` | `requireAuth` | Body `{ linkUrl }`. Marks every panel-visible unread row matching the link as read. Auto-fired by the bell hook on every pathname change. |
 | `/v1/notifications/:id` | DELETE | `communication.notifications_center` | `requireAuth` | Soft-delete (sets `deleted_at`). |
 | `/v1/notifications/stream` | GET | `communication.notifications_center` | `requireAuth` | SSE. Heartbeat every 25 s. Resumes from `Last-Event-ID`. |
 | `/v1/notification-preferences` | GET | `communication.notifications_center` | `requireAuth` | Returns the closed set (every registered type), defaults merged in. |

--- a/docs/adrs/adr-031-notifications-delivery-and-fanout.md
+++ b/docs/adrs/adr-031-notifications-delivery-and-fanout.md
@@ -80,9 +80,9 @@ A notification stays unread until the recipient acts on it. The acceptable trigg
 
 Concretely:
 
-- The web shell POSTs `/v1/notifications/mark-read-by-link` on every pathname change. The endpoint marks every panel-visible unread notification for the current user whose `link_url` matches the path. Idempotent — fires on every navigation, returns 0 in the common case (no match).
+- The web shell POSTs `/v1/notifications/mark-read-by-link` on every pathname change. The endpoint marks every unread notification for the current user whose `link_url` matches the path — REGARDLESS of `panel_visible`. Idempotent — fires on every navigation, returns 0 in the common case (no match).
 - The bell hook owns this side-effect because it's already mounted in the topbar of every authenticated page and already holds the `markRead*` mutators. No per-page wiring needed.
-- Digest-only rows (`panel_visible = false`) are NOT affected — the bell never showed them and `markReadByLink` filters by `panel_visible = true`. Their read state is irrelevant to the panel.
+- Digest-only rows (`panel_visible = false`) ARE marked read too. The user "consumed" the resource by visiting it — leaving the row unread would feed it back into tomorrow's digest as a stale recap. The panel doesn't show these rows either way, so the change has no impact on the bell + panel UX; it just keeps the digest in sync with what the recipient has already seen.
 
 **Contract for new notification types**: pick a `link_url` such that landing there is a meaningful "I have consumed this" signal. Concretely:
 

--- a/docs/adrs/adr-031-notifications-delivery-and-fanout.md
+++ b/docs/adrs/adr-031-notifications-delivery-and-fanout.md
@@ -74,6 +74,24 @@ The worker's `processDomainEvent` (`packages/worker/src/worker.ts`) already runs
 
 **`type` is `varchar(64)`** with a CHECK constraint on shape (`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$`), NOT a Postgres enum. Adding a new type ("campaign_postal_export_completed") is a code change in `NOTIFICATION_TYPE_VALUES` + producer wiring — never a migration. The shared registry (`packages/shared/src/constants/notifications.ts`) is the source of truth.
 
+#### 4. Auto-mark-read on consumption — per-type contract
+
+A notification stays unread until the recipient acts on it. The acceptable trigger is **landing on the notification's `link_url`** — at that point the operator has visibly consumed the linked resource and the bell ping is stale. Every notification type therefore ships with a `link_url` that satisfies this contract: navigating there means "I have now seen what you wanted to tell me about".
+
+Concretely:
+
+- The web shell POSTs `/v1/notifications/mark-read-by-link` on every pathname change. The endpoint marks every panel-visible unread notification for the current user whose `link_url` matches the path. Idempotent — fires on every navigation, returns 0 in the common case (no match).
+- The bell hook owns this side-effect because it's already mounted in the topbar of every authenticated page and already holds the `markRead*` mutators. No per-page wiring needed.
+- Digest-only rows (`panel_visible = false`) are NOT affected — the bell never showed them and `markReadByLink` filters by `panel_visible = true`. Their read state is irrelevant to the panel.
+
+**Contract for new notification types**: pick a `link_url` such that landing there is a meaningful "I have consumed this" signal. Concretely:
+
+- Resource-scoped events (`donation.received`, `branding.logo_synced`) link to the resource's detail / settings page. Landing means the operator has looked at the receipt / new logo / new invitation.
+- Index-page events (`bulk_email.queued`, `invitation.created`) link to the list view where the new item appears. Landing means the operator has at least scanned the list.
+- **Avoid `link_url`s that are too broad** (e.g. linking every team event to `/settings`) — they collapse unrelated notifications into one auto-read sweep. When in doubt, prefer the more specific resource page.
+
+If a future type genuinely cannot satisfy the "landing = consumption" contract (e.g. a "your scheduled job will fire in 5 minutes" preview), it should ship with `link_url = NULL` so the auto-mark-read sweep never matches it, and rely on the explicit "Marquer comme lu" button in the panel.
+
 ### Consequences
 
 **Pro**:

--- a/packages/api/migrations/0056_notifications_panel_visible.sql
+++ b/packages/api/migrations/0056_notifications_panel_visible.sql
@@ -1,0 +1,58 @@
+-- Migration: 0056_notifications_panel_visible (Epic #363 follow-up)
+--
+-- Decouples the `in_app` and `email_digest` notification channels.
+--
+-- Background: the original Epic #363 design (migration 0055 + the
+-- `filterByPreferences` helper in `notifications-fanout.ts`) dropped a
+-- recipient at WRITE time when their `notification_preferences.in_app`
+-- was false — no row was ever inserted into `notifications`. That made
+-- the per-row contract tidy ("if it's in the table, the user opted
+-- into the panel") but coupled the two channels: an operator who
+-- toggles `in_app=false` AND `email_digest=true` was expecting "no
+-- bell, weekly email" — instead they got nothing, because the digest
+-- worker reads from `notifications` and the row was never written.
+--
+-- This migration introduces a row-level flag that records the panel
+-- decision at WRITE time, so the two channels can be independent:
+--
+--   * Fanout writes the row when either `in_app` OR `email_digest` is
+--     enabled for the (user, type) pair.
+--   * `panel_visible` is set to the user's current `in_app` preference
+--     at the moment of write — frozen, NOT dynamic. Re-toggling
+--     `in_app=true` later does NOT retroactively reveal historical
+--     rows. This preserves the "decision is captured at write time"
+--     semantics the original design committed to.
+--   * The bell, panel, and unread-count queries add
+--     `panel_visible = true` to their WHERE clause.
+--   * The digest worker continues to read from `notifications` filtered
+--     by `email_digest = true` — no change to its query shape, but the
+--     row it depends on now actually exists.
+--
+-- Backfill: every existing row was inserted under the old contract,
+-- which means the writer already verified `in_app = true` for the
+-- recipient at that time. The `DEFAULT TRUE` therefore correctly
+-- preserves the historical "panel-visible" semantics for every row
+-- that survived to this migration.
+--
+-- Idempotent per `feedback_never_modify_applied_migrations` — column
+-- add is gated by `IF NOT EXISTS`.
+
+ALTER TABLE notifications
+  ADD COLUMN IF NOT EXISTS panel_visible BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- The two existing partial indexes are still load-bearing; the panel +
+-- unread queries add `panel_visible = true` as a residual predicate
+-- under the same index scan. We don't tighten the partial WHERE
+-- clauses to include `panel_visible = true` because:
+--
+--   1. The common case is `panel_visible = true` (the user opted IN
+--      for in-app on the type, which is the per-type registry default
+--      for every type shipped today). A residual filter discards a
+--      tiny fraction of heap tuples; the partial index already pre-
+--      filters the giant `deleted_at IS NULL` set.
+--   2. Tightening the partial would force a REINDEX CONCURRENTLY in
+--      prod — not necessary for the access patterns we care about.
+--
+-- If digest opt-out at scale eventually creates a meaningful set of
+-- `panel_visible = false` rows, a follow-up adds a `panel_visible =
+-- true` predicate to the partial indexes.

--- a/packages/api/migrations/0058_notifications_panel_visible.sql
+++ b/packages/api/migrations/0058_notifications_panel_visible.sql
@@ -1,4 +1,4 @@
--- Migration: 0056_notifications_panel_visible (Epic #363 follow-up)
+-- Migration: 0058_notifications_panel_visible (Epic #363 follow-up)
 --
 -- Decouples the `in_app` and `email_digest` notification channels.
 --

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1778110000000,
       "tag": "0057_bulk_import_feature_flag",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1778120000000,
+      "tag": "0058_notifications_panel_visible",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/modules/notifications/routes.ts
+++ b/packages/api/src/modules/notifications/routes.ts
@@ -47,6 +47,7 @@ import {
   listPreferences,
   markAllRead,
   markRead,
+  markReadByLink,
   softDeleteNotification,
   streamNotifications,
   updatePreference,
@@ -208,6 +209,50 @@ export async function notificationRoutes(app: FastifyInstance) {
         return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
       }
       const marked = await markAllRead(orgId, userRowId);
+      return { data: { marked } };
+    },
+  );
+
+  // ─── Auto-mark-read by link_url ─────────────────────────────────────
+  //
+  // POSTed by the web shell whenever the caller's pathname changes —
+  // the convention is "landing on a notification's link_url means the
+  // user has consumed the linked resource and the bell ping is stale".
+  // The endpoint is idempotent and returns 0 in the common case (no
+  // unread notif points at the current path), so the layout-level hook
+  // can fire it unconditionally without worrying about noise.
+  //
+  // Mirrors `docs/27-notifications.md` § "Auto-mark-read on consumption".
+  app.post(
+    "/notifications/mark-read-by-link",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      schema: {
+        tags: ["Notifications"],
+        body: Type.Object({
+          // Match the schema's CHECK on `notifications.link_url`: must
+          // be a relative path starting with `/` and not `//` (which a
+          // browser resolves as protocol-relative).
+          linkUrl: Type.String({
+            minLength: 2,
+            maxLength: 2048,
+            pattern: "^/(?!/).*$",
+          }),
+        }),
+        response: {
+          200: Type.Object({ data: Type.Object({ marked: Type.Integer({ minimum: 0 }) }) }),
+          ...ErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      const userRowId = request.auth?.userRowId;
+      if (!orgId || !userRowId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing auth context"));
+      }
+      const { linkUrl } = request.body as { linkUrl: string };
+      const marked = await markReadByLink(orgId, userRowId, linkUrl);
       return { data: { marked } };
     },
   );

--- a/packages/api/src/modules/notifications/service.ts
+++ b/packages/api/src/modules/notifications/service.ts
@@ -64,7 +64,7 @@ export async function listNotifications(
     const conditions = [
       eq(notifications.userId, userId),
       // Panel hides rows whose recipient opted out of in-app at write
-      // time (migration 0056 — decouples in_app from email_digest).
+      // time (migration 0058 — decouples in_app from email_digest).
       // `panel_visible = true` is frozen, so a later in_app toggle does
       // NOT retroactively reveal historical rows.
       eq(notifications.panelVisible, true),

--- a/packages/api/src/modules/notifications/service.ts
+++ b/packages/api/src/modules/notifications/service.ts
@@ -63,6 +63,11 @@ export async function listNotifications(
   return withTenantContext(orgId, async (tx) => {
     const conditions = [
       eq(notifications.userId, userId),
+      // Panel hides rows whose recipient opted out of in-app at write
+      // time (migration 0056 — decouples in_app from email_digest).
+      // `panel_visible = true` is frozen, so a later in_app toggle does
+      // NOT retroactively reveal historical rows.
+      eq(notifications.panelVisible, true),
       isNull(notifications.deletedAt),
       // Default view hides archived rows. A `?includeArchived=true`
       // is a follow-up (issue #363 § 4 out-of-scope: archive
@@ -115,6 +120,8 @@ export async function getUnreadCount(orgId: string, userId: string): Promise<num
       .where(
         and(
           eq(notifications.userId, userId),
+          // Bell badge mirrors the panel — see `listNotifications`.
+          eq(notifications.panelVisible, true),
           isNull(notifications.readAt),
           isNull(notifications.deletedAt),
           isNull(notifications.archivedAt),
@@ -147,6 +154,10 @@ export async function markRead(
         and(
           eq(notifications.id, id),
           eq(notifications.userId, userId),
+          // Only panel-visible rows can be operated on from the bell UI.
+          // A row stored solely for the email digest is invisible to the
+          // panel; mark-read on its id is 404 (anti-disclosure).
+          eq(notifications.panelVisible, true),
           isNull(notifications.deletedAt),
         ),
       )
@@ -175,6 +186,11 @@ export async function markAllRead(orgId: string, userId: string): Promise<number
       .where(
         and(
           eq(notifications.userId, userId),
+          // Same scope as the panel — don't pre-read digest-only rows
+          // since the user can't see them. Their unread state is
+          // irrelevant for the bell and "mark all read" is a panel
+          // affordance.
+          eq(notifications.panelVisible, true),
           isNull(notifications.readAt),
           isNull(notifications.deletedAt),
         ),
@@ -201,6 +217,8 @@ export async function softDeleteNotification(
         and(
           eq(notifications.id, id),
           eq(notifications.userId, userId),
+          // Panel-only affordance — see `markRead`.
+          eq(notifications.panelVisible, true),
           isNull(notifications.deletedAt),
         ),
       )
@@ -349,6 +367,10 @@ export async function* streamNotifications(
         .where(
           and(
             eq(notifications.userId, userId),
+            // SSE stream feeds the same panel — skip digest-only rows
+            // so the bell badge doesn't tick up for something the user
+            // can't see.
+            eq(notifications.panelVisible, true),
             isNull(notifications.deletedAt),
             sql`${notifications.createdAt} > ${cursor.toISOString()}`,
           ),

--- a/packages/api/src/modules/notifications/service.ts
+++ b/packages/api/src/modules/notifications/service.ts
@@ -201,6 +201,49 @@ export async function markAllRead(orgId: string, userId: string): Promise<number
 }
 
 /**
+ * Mark every unread, panel-visible notification for this user pointing
+ * at the given `linkUrl` as read. Returns the count.
+ *
+ * Powers the "auto-mark-read when the recipient lands on the linked
+ * resource" rule (Epic #363 follow-up — `docs/27-notifications.md` §
+ * "Auto-mark-read on consumption"). Idempotent — landing on the page
+ * again is a no-op once everything is read.
+ *
+ * Why `link_url` rather than resource-type / resource-id: every
+ * notification already carries `link_url` as its canonical destination
+ * (CHECK-enforced relative path). Matching on it is one indexed lookup
+ * and adapts automatically to any new notification type — the per-type
+ * routing decision lives in `planFanout` exactly once.
+ *
+ * `panel_visible = true` is honoured here: digest-only rows
+ * (`panel_visible = false`) are not affected by panel-driven navigation
+ * since the bell never showed them to begin with. Their read state is
+ * managed by the digest worker's send-time semantics (out of scope).
+ */
+export async function markReadByLink(
+  orgId: string,
+  userId: string,
+  linkUrl: string,
+): Promise<number> {
+  return withTenantContext(orgId, async (tx) => {
+    const rows = await tx
+      .update(notifications)
+      .set({ readAt: new Date() })
+      .where(
+        and(
+          eq(notifications.userId, userId),
+          eq(notifications.linkUrl, linkUrl),
+          eq(notifications.panelVisible, true),
+          isNull(notifications.readAt),
+          isNull(notifications.deletedAt),
+        ),
+      )
+      .returning({ id: notifications.id });
+    return rows.length;
+  });
+}
+
+/**
  * Soft-delete one notification. Sets `deleted_at`; the row stays for
  * audit. Returns `null` if not found / not owned.
  */

--- a/packages/api/src/modules/notifications/service.ts
+++ b/packages/api/src/modules/notifications/service.ts
@@ -201,8 +201,8 @@ export async function markAllRead(orgId: string, userId: string): Promise<number
 }
 
 /**
- * Mark every unread, panel-visible notification for this user pointing
- * at the given `linkUrl` as read. Returns the count.
+ * Mark every unread notification for this user pointing at the given
+ * `linkUrl` as read — regardless of `panel_visible`. Returns the count.
  *
  * Powers the "auto-mark-read when the recipient lands on the linked
  * resource" rule (Epic #363 follow-up — `docs/27-notifications.md` §
@@ -215,10 +215,13 @@ export async function markAllRead(orgId: string, userId: string): Promise<number
  * and adapts automatically to any new notification type — the per-type
  * routing decision lives in `planFanout` exactly once.
  *
- * `panel_visible = true` is honoured here: digest-only rows
- * (`panel_visible = false`) are not affected by panel-driven navigation
- * since the bell never showed them to begin with. Their read state is
- * managed by the digest worker's send-time semantics (out of scope).
+ * Why NOT filter by `panel_visible = true`: a user with `in_app=false`
+ * + `email_digest=true` (digest-only) still consumes the resource when
+ * they navigate to its page. Leaving the row unread would feed it back
+ * into tomorrow's digest — "here's a recap of what you already saw" —
+ * exactly the noise the auto-mark-read sweep is meant to suppress. The
+ * panel doesn't show these rows either way, so marking them read has
+ * no impact on the bell + panel UX.
  */
 export async function markReadByLink(
   orgId: string,
@@ -233,7 +236,6 @@ export async function markReadByLink(
         and(
           eq(notifications.userId, userId),
           eq(notifications.linkUrl, linkUrl),
-          eq(notifications.panelVisible, true),
           isNull(notifications.readAt),
           isNull(notifications.deletedAt),
         ),

--- a/packages/api/src/tests/integration/migrations-journal-parity.test.ts
+++ b/packages/api/src/tests/integration/migrations-journal-parity.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Drizzle migrations folder ↔ `_journal.json` parity guard.
+ *
+ * Drizzle Kit's migration runner (`pnpm db:migrate` →
+ * `drizzle-kit migrate`) consults `packages/api/migrations/meta/_journal.json`
+ * to know which `.sql` files in `packages/api/migrations/` to apply.
+ * Adding a file to the folder WITHOUT registering it in the journal is
+ * a silent CI break:
+ *
+ *   1. `pnpm test` locally still passes (the developer applied the
+ *      migration by hand via `docker exec psql < …` while iterating).
+ *   2. CI's test container starts with an empty Postgres, runs
+ *      `pnpm db:migrate`, drizzle-kit silently skips the unregistered
+ *      file, and every test that touches the new column / table /
+ *      enum / constraint blows up with a 42703-style error.
+ *
+ * The Epic #363 follow-up (PR #396) hit this gap with
+ * `0056_notifications_panel_visible.sql`. This test is the durable
+ * regression guard so future hand-written migrations can't ship the
+ * same way.
+ *
+ * The test is pure file-system + JSON: no DB connection, no
+ * `withTenantContext`, no fixture wiring. Fast and runs in the same
+ * vitest suite as the rest of the API tests so a missed journal entry
+ * fails CI BEFORE the integration tests that depend on the schema do.
+ *
+ * What this test pins:
+ *   - Every `NNNN_<name>.sql` file in `migrations/` has a journal
+ *     entry with `tag === "NNNN_<name>"`.
+ *   - Every journal entry has a matching `.sql` file.
+ *   - Journal `idx` values are contiguous (0..N-1, no gaps, no dups).
+ *   - Journal `when` values are strictly increasing in `idx` order
+ *     (drizzle-kit applies migrations sorted by `when`).
+ *
+ * NOT checked:
+ *   - Relationship between filename `NNNN` prefix and `idx`.
+ *     Migration `0023_multi_currency_schema` and
+ *     `0023_onboarding_runtime` share a prefix (legacy parallel-PR
+ *     merge); drizzle-kit identifies migrations by `tag`, not prefix,
+ *     so both apply correctly. Locking a stricter invariant here
+ *     would fail on this legacy pair without catching any new bug.
+ *   - `prefix === idx + 1`. The renumber at idx=23 broke that
+ *     relationship permanently.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = join(__dirname, "..", "..", "..", "migrations");
+const JOURNAL_PATH = join(MIGRATIONS_DIR, "meta", "_journal.json");
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+function readJournal(): Journal {
+  const raw = readFileSync(JOURNAL_PATH, "utf8");
+  return JSON.parse(raw) as Journal;
+}
+
+function readSqlFilesSorted(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((name) => /^\d{4}_.+\.sql$/.test(name))
+    .sort();
+}
+
+describe("Drizzle migrations: folder ↔ _journal.json parity", () => {
+  it("every SQL file is registered in the journal (no orphan migrations)", () => {
+    const sqlFiles = readSqlFilesSorted();
+    const journal = readJournal();
+    const journalTags = new Set(journal.entries.map((e) => e.tag));
+
+    const orphanFiles = sqlFiles.filter((name) => {
+      const tag = name.replace(/\.sql$/, "");
+      return !journalTags.has(tag);
+    });
+
+    expect(orphanFiles, "Add an entry to packages/api/migrations/meta/_journal.json").toEqual([]);
+  });
+
+  it("every journal entry has a matching SQL file (no phantom registrations)", () => {
+    const sqlFiles = readSqlFilesSorted();
+    const journal = readJournal();
+    const sqlTags = new Set(sqlFiles.map((name) => name.replace(/\.sql$/, "")));
+
+    const phantomEntries = journal.entries
+      .filter((entry) => !sqlTags.has(entry.tag))
+      .map((entry) => entry.tag);
+
+    expect(phantomEntries, "Drop the entry or restore the missing .sql file").toEqual([]);
+  });
+
+  it("journal idx values are contiguous starting at 0 (no gaps, no dups)", () => {
+    const journal = readJournal();
+    const indices = journal.entries.map((e) => e.idx).sort((a, b) => a - b);
+    const expected = Array.from({ length: indices.length }, (_, i) => i);
+    expect(indices).toEqual(expected);
+  });
+
+  it("journal `when` is strictly increasing in idx order", () => {
+    const journal = readJournal();
+    const ordered = [...journal.entries].sort((a, b) => a.idx - b.idx);
+    for (let i = 1; i < ordered.length; i++) {
+      const prev = ordered[i - 1];
+      const curr = ordered[i];
+      if (!prev || !curr) continue;
+      expect(
+        curr.when,
+        `Entry idx=${curr.idx} (${curr.tag}) has when=${curr.when}, must be > ${prev.when} (${prev.tag})`,
+      ).toBeGreaterThan(prev.when);
+    }
+  });
+});

--- a/packages/api/src/tests/integration/notifications.test.ts
+++ b/packages/api/src/tests/integration/notifications.test.ts
@@ -146,6 +146,11 @@ describe("Notifications — off-state flag (anti-disclosure)", () => {
     },
     { method: "POST", url: "/v1/notifications/read-all" },
     {
+      method: "POST",
+      url: "/v1/notifications/mark-read-by-link",
+      payload: { linkUrl: "/donations/00000000-0000-0000-0000-000000000aaa" },
+    },
+    {
       method: "DELETE",
       url: "/v1/notifications/00000000-0000-0000-0000-000000000001",
     },
@@ -661,6 +666,131 @@ describe("Notifications — panel_visible (digest-only rows)", () => {
       .from(notifications)
       .where(eq(notifications.id, digestOnly));
     expect(row?.readAt).toBeNull();
+  });
+});
+
+// ─── 3.6 Auto-mark-read by link_url ───────────────────────────────────
+//
+// Regression guard for the "landing on a notification's link_url
+// implicitly marks it as read" rule (doc 27 § "Auto-mark-read on
+// consumption"). The web shell POSTs `/v1/notifications/mark-read-by-link`
+// on every pathname change.
+
+describe("Notifications — mark-read-by-link", () => {
+  beforeEach(async () => {
+    await setFlag(true);
+  });
+
+  it("marks every panel-visible unread notification pointing at the link as read", async () => {
+    const one = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
+    const two = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/mark-read-by-link",
+      headers: authHeader(token),
+      payload: { linkUrl: "/donations/00000000-0000-0000-0000-000000000aaa" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { marked: number } }>().data.marked).toBe(2);
+
+    const rows = await db
+      .select({ id: notifications.id, readAt: notifications.readAt })
+      .from(notifications)
+      .where(eq(notifications.id, one));
+    expect(rows[0]?.readAt).not.toBeNull();
+    const rows2 = await db
+      .select({ id: notifications.id, readAt: notifications.readAt })
+      .from(notifications)
+      .where(eq(notifications.id, two));
+    expect(rows2[0]?.readAt).not.toBeNull();
+  });
+
+  it("returns 0 marked when no notification points at the given link", async () => {
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/mark-read-by-link",
+      headers: authHeader(token),
+      payload: { linkUrl: "/totally/different/page" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { marked: number } }>().data.marked).toBe(0);
+  });
+
+  it("never marks panel_visible = false rows (digest-only stays unread)", async () => {
+    const digestOnly = await seedNotification({
+      orgId: ORG_A,
+      userId: USER_A_ROW_ID,
+      panelVisible: false,
+    });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/mark-read-by-link",
+      headers: authHeader(token),
+      payload: { linkUrl: "/donations/00000000-0000-0000-0000-000000000aaa" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { marked: number } }>().data.marked).toBe(0);
+
+    const [row] = await db
+      .select({ readAt: notifications.readAt })
+      .from(notifications)
+      .where(eq(notifications.id, digestOnly));
+    expect(row?.readAt).toBeNull();
+  });
+
+  it("scopes by current user — never marks another user's rows in the same tenant", async () => {
+    const user2 = await seedSecondUserInTenantA();
+    const otherUserId = await seedNotification({ orgId: ORG_A, userId: user2 });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/mark-read-by-link",
+      headers: authHeader(token),
+      payload: { linkUrl: "/donations/00000000-0000-0000-0000-000000000aaa" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { marked: number } }>().data.marked).toBe(0);
+
+    // user2's row stays untouched.
+    const [row] = await db
+      .select({ readAt: notifications.readAt })
+      .from(notifications)
+      .where(eq(notifications.id, otherUserId));
+    expect(row?.readAt).toBeNull();
+  });
+
+  it("rejects protocol-relative URLs (`//evil.example/x`) with 400", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/mark-read-by-link",
+      headers: authHeader(token),
+      payload: { linkUrl: "//evil.example/x" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects empty / non-slash URLs with 400", async () => {
+    const token = signToken(app);
+    const resAbs = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/mark-read-by-link",
+      headers: authHeader(token),
+      payload: { linkUrl: "https://evil.example/x" },
+    });
+    expect(resAbs.statusCode).toBe(400);
+
+    const resEmpty = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/mark-read-by-link",
+      headers: authHeader(token),
+      payload: { linkUrl: "" },
+    });
+    expect(resEmpty.statusCode).toBe(400);
   });
 });
 

--- a/packages/api/src/tests/integration/notifications.test.ts
+++ b/packages/api/src/tests/integration/notifications.test.ts
@@ -719,7 +719,13 @@ describe("Notifications — mark-read-by-link", () => {
     expect(res.json<{ data: { marked: number } }>().data.marked).toBe(0);
   });
 
-  it("never marks panel_visible = false rows (digest-only stays unread)", async () => {
+  it("marks panel_visible = false rows too (digest-only suppresses tomorrow's digest)", async () => {
+    // A user with in_app=false + email_digest=true ends up with a
+    // panel_visible=false row. The bell never shows it, but the digest
+    // worker DOES read it. If the user lands on the resource's page
+    // BEFORE tomorrow's digest, the row must still be marked read so
+    // it doesn't get recapped — exactly the "auto-mark-read on
+    // consumption" contract.
     const digestOnly = await seedNotification({
       orgId: ORG_A,
       userId: USER_A_ROW_ID,
@@ -733,13 +739,13 @@ describe("Notifications — mark-read-by-link", () => {
       payload: { linkUrl: "/donations/00000000-0000-0000-0000-000000000aaa" },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json<{ data: { marked: number } }>().data.marked).toBe(0);
+    expect(res.json<{ data: { marked: number } }>().data.marked).toBe(1);
 
     const [row] = await db
       .select({ readAt: notifications.readAt })
       .from(notifications)
       .where(eq(notifications.id, digestOnly));
-    expect(row?.readAt).toBeNull();
+    expect(row?.readAt).not.toBeNull();
   });
 
   it("scopes by current user — never marks another user's rows in the same tenant", async () => {

--- a/packages/api/src/tests/integration/notifications.test.ts
+++ b/packages/api/src/tests/integration/notifications.test.ts
@@ -77,6 +77,13 @@ async function seedNotification(opts: {
   type?: string;
   readAt?: Date | null;
   deletedAt?: Date | null;
+  /**
+   * Override `panel_visible` (migration 0056). Defaults to `true` to
+   * mirror the fanout's behaviour for users with `in_app` enabled.
+   * Set `false` to seed a row that exists only for the email digest —
+   * such a row must be invisible to the panel + bell.
+   */
+  panelVisible?: boolean;
   /** Override the `created_at` for cursor-pagination tests. */
   createdAt?: Date;
 }): Promise<string> {
@@ -87,16 +94,17 @@ async function seedNotification(opts: {
   const id = crypto.randomUUID();
   const outboxId = crypto.randomUUID();
   const createdAt = opts.createdAt ?? new Date();
+  const panelVisible = opts.panelVisible ?? true;
   await db.execute(sql`
     INSERT INTO notifications
-      (id, org_id, outbox_event_id, user_id, type, title_key, body_key, params, link_url, read_at, deleted_at, created_at)
+      (id, org_id, outbox_event_id, user_id, type, title_key, body_key, params, link_url, panel_visible, read_at, deleted_at, created_at)
     VALUES
       (${id}, ${opts.orgId}, ${outboxId}, ${opts.userId}, ${opts.type ?? "donation.received"},
        'notifications.types.donation_received.title',
        'notifications.types.donation_received.body',
        '{"donationId":"00000000-0000-0000-0000-000000000aaa"}'::jsonb,
        '/donations/00000000-0000-0000-0000-000000000aaa',
-       ${opts.readAt ?? null}, ${opts.deletedAt ?? null}, ${createdAt})
+       ${panelVisible}, ${opts.readAt ?? null}, ${opts.deletedAt ?? null}, ${createdAt})
   `);
   return id;
 }
@@ -551,6 +559,108 @@ describe("Notifications — isolation (RLS + recipient)", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json<{ data: { unread: number } }>().data.unread).toBe(0);
+  });
+});
+
+// ─── 3.5 Channel decoupling (migration 0056) ──────────────────────────
+//
+// Regression guard for the Epic #363 follow-up: a user who opted OUT of
+// in-app but IN to email_digest still gets a `notifications` row at
+// fanout time (so the digest worker has something to read), but the
+// panel + bell + SSE must hide it. `panel_visible = false` is the row-
+// level flag that carries the write-time decision.
+
+describe("Notifications — panel_visible (digest-only rows)", () => {
+  beforeEach(async () => {
+    await setFlag(true);
+  });
+
+  it("GET /v1/notifications excludes panel_visible = false rows", async () => {
+    const visible = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
+    const digestOnly = await seedNotification({
+      orgId: ORG_A,
+      userId: USER_A_ROW_ID,
+      panelVisible: false,
+    });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: Array<{ id: string }> }>();
+    const ids = body.data.map((r) => r.id);
+    expect(ids).toContain(visible);
+    expect(ids).not.toContain(digestOnly);
+  });
+
+  it("GET /v1/notifications/unread-count ignores panel_visible = false rows", async () => {
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID, panelVisible: false });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/notifications/unread-count",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { unread: number } }>().data.unread).toBe(1);
+  });
+
+  it("PATCH /v1/notifications/:id/read on a panel_visible = false row returns 404", async () => {
+    const digestOnly = await seedNotification({
+      orgId: ORG_A,
+      userId: USER_A_ROW_ID,
+      panelVisible: false,
+    });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/v1/notifications/${digestOnly}/read`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("DELETE /v1/notifications/:id on a panel_visible = false row returns 404", async () => {
+    const digestOnly = await seedNotification({
+      orgId: ORG_A,
+      userId: USER_A_ROW_ID,
+      panelVisible: false,
+    });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/notifications/${digestOnly}`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("POST /v1/notifications/read-all leaves panel_visible = false rows untouched", async () => {
+    await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
+    const digestOnly = await seedNotification({
+      orgId: ORG_A,
+      userId: USER_A_ROW_ID,
+      panelVisible: false,
+    });
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/notifications/read-all",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ data: { marked: number } }>().data.marked).toBe(1);
+
+    // The digest-only row must still be unread for the digest worker
+    // to pick it up tomorrow.
+    const [row] = await db
+      .select({ readAt: notifications.readAt })
+      .from(notifications)
+      .where(eq(notifications.id, digestOnly));
+    expect(row?.readAt).toBeNull();
   });
 });
 

--- a/packages/api/src/tests/integration/notifications.test.ts
+++ b/packages/api/src/tests/integration/notifications.test.ts
@@ -78,7 +78,7 @@ async function seedNotification(opts: {
   readAt?: Date | null;
   deletedAt?: Date | null;
   /**
-   * Override `panel_visible` (migration 0056). Defaults to `true` to
+   * Override `panel_visible` (migration 0058). Defaults to `true` to
    * mirror the fanout's behaviour for users with `in_app` enabled.
    * Set `false` to seed a row that exists only for the email digest —
    * such a row must be invisible to the panel + bell.
@@ -567,7 +567,7 @@ describe("Notifications — isolation (RLS + recipient)", () => {
   });
 });
 
-// ─── 3.5 Channel decoupling (migration 0056) ──────────────────────────
+// ─── 3.5 Channel decoupling (migration 0058) ──────────────────────────
 //
 // Regression guard for the Epic #363 follow-up: a user who opted OUT of
 // in-app but IN to email_digest still gets a `notifications` row at

--- a/packages/shared/src/schema/notifications.ts
+++ b/packages/shared/src/schema/notifications.ts
@@ -99,6 +99,19 @@ export const notifications = pgTable(
      * follow-up) sees the right host.
      */
     linkUrl: text("link_url"),
+    /**
+     * Frozen panel-visibility decision taken at write time (migration
+     * 0056). `true` when the recipient had `notification_preferences.in_app`
+     * effective-true for the type at fanout time. The fanout still
+     * writes a row when ONLY `email_digest` is enabled (so the digest
+     * worker can read it) — `panel_visible = false` keeps that row out
+     * of the bell + panel.
+     *
+     * Frozen, NOT dynamic: a later `in_app=true` toggle does not
+     * retroactively reveal historical rows. The panel + unread-count
+     * queries add `panel_visible = true` to their WHERE clauses.
+     */
+    panelVisible: boolean("panel_visible").notNull().default(true),
     /** NULL until the user marks read (single read or read-all). */
     readAt: timestamp("read_at", { withTimezone: true }),
     /**

--- a/packages/web/src/components/notifications/notifications-bell.tsx
+++ b/packages/web/src/components/notifications/notifications-bell.tsx
@@ -14,14 +14,16 @@
 
 import type { NotificationFilterKey } from "@givernance/shared/constants";
 import { Bell } from "lucide-react";
+import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { NotificationsPanel } from "./notifications-panel";
 import { formatBadgeCount, useNotificationsLive } from "./use-notifications-live";
 
 export function NotificationsBell() {
   const t = useTranslations("notifications.bell");
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState<NotificationFilterKey>("all");
   // Trigger ref — the panel restores focus here on close (Frontend
@@ -39,9 +41,27 @@ export function NotificationsBell() {
     loadMore,
     markRead,
     markAllRead,
+    markReadByLink,
     deleteOne,
     reset,
   } = useNotificationsLive({ enabled: true });
+
+  // Auto-mark-read on consumption: whenever the operator's pathname
+  // matches a notification's `link_url`, landing there is the implicit
+  // "I've seen what you wanted to tell me about" — fire-and-forget POST
+  // marks every matching unread row read. Doc 27 § "Auto-mark-read on
+  // consumption" covers the per-type contract and the rationale.
+  //
+  // The endpoint is idempotent and the hook soft-fails on any error, so
+  // this effect can safely run on every navigation. The bell is mounted
+  // in the app layout, so it sees every authenticated route change.
+  // next-intl runs locale resolution from the JWT (NOT a `/fr/` URL
+  // prefix in this codebase) so `pathname` matches the stored relative
+  // `link_url` directly — no locale stripping is required.
+  useEffect(() => {
+    if (!pathname) return;
+    void markReadByLink(pathname);
+  }, [pathname, markReadByLink]);
 
   const handleToggle = useCallback(() => {
     setOpen((prev) => {

--- a/packages/web/src/components/notifications/use-notifications-live.ts
+++ b/packages/web/src/components/notifications/use-notifications-live.ts
@@ -55,6 +55,12 @@ interface UseNotificationsLiveResult {
   loadMore: (filter?: NotificationType | "all") => Promise<void>;
   markRead: (id: string) => Promise<void>;
   markAllRead: () => Promise<void>;
+  /**
+   * Mark every panel-visible unread notification pointing at `linkUrl`
+   * as read. Powers the "auto-mark-read on consumption" hook fired from
+   * the web shell on every pathname change — see doc 27.
+   */
+  markReadByLink: (linkUrl: string) => Promise<void>;
   deleteOne: (id: string) => Promise<void>;
   reset: (filter: NotificationType | "all") => Promise<void>;
 }
@@ -161,6 +167,30 @@ export function useNotificationsLive(
       setError(err instanceof Error ? err.message : "Failed to mark all read");
     }
   }, [client]);
+
+  const markReadByLink = useCallback(
+    async (linkUrl: string) => {
+      try {
+        const marked = await NotificationsService.markReadByLink(client, linkUrl);
+        if (marked === 0) return;
+        const now = new Date().toISOString();
+        setRows((current) =>
+          current.map((row) =>
+            !row.readAt && row.linkUrl === linkUrl ? { ...row, readAt: now } : row,
+          ),
+        );
+        // Re-pull the authoritative count rather than `c => c - marked` —
+        // a SSE delivery overlap or a manual mark-read by the user could
+        // otherwise drift the badge.
+        await fetchUnreadCount();
+      } catch {
+        // Soft-fail — the bell stays in its prior state. This hook fires
+        // on every pathname change so a transient 401 / 5xx during
+        // navigation should never burst into the global error banner.
+      }
+    },
+    [client, fetchUnreadCount],
+  );
 
   const deleteOne = useCallback(
     async (id: string) => {
@@ -280,6 +310,7 @@ export function useNotificationsLive(
     loadMore,
     markRead,
     markAllRead,
+    markReadByLink,
     deleteOne,
     reset,
   };

--- a/packages/web/src/services/NotificationsService.ts
+++ b/packages/web/src/services/NotificationsService.ts
@@ -86,6 +86,21 @@ export const NotificationsService = {
     return response.data.marked;
   },
 
+  /**
+   * Auto-mark-read every unread, panel-visible notification pointing at
+   * `linkUrl` for the current user. The web shell fires this on every
+   * pathname change so the bell badge stays in sync with what the user
+   * has actually looked at — see doc 27 § "Auto-mark-read on
+   * consumption". Idempotent; returns 0 when no row matches.
+   */
+  async markReadByLink(client: ApiClient, linkUrl: string): Promise<number> {
+    const response = await client.post<{ data: { marked: number } }>(
+      "/v1/notifications/mark-read-by-link",
+      { linkUrl },
+    );
+    return response.data.marked;
+  },
+
   async deleteOne(client: ApiClient, id: string): Promise<NotificationDto> {
     const response = await client.delete<{ data: NotificationDto }>(`/v1/notifications/${id}`);
     return response.data;

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsx watch --env-file=../../.env src/worker.ts",
+    "digest:trigger": "tsx --env-file=../../.env scripts/trigger-notification-digest.ts",
     "start": "node dist/worker.js",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"

--- a/packages/worker/scripts/trigger-notification-digest.ts
+++ b/packages/worker/scripts/trigger-notification-digest.ts
@@ -1,0 +1,70 @@
+/**
+ * Dev helper — enqueue a one-off `notifications.digest_daily` job so an
+ * operator can validate the email digest path without waiting for the
+ * 09:00 UTC cron tick (Epic #363, Phase 5).
+ *
+ * Usage (from repo root):
+ *
+ *   pnpm --filter @givernance/worker run digest:trigger
+ *
+ * The script:
+ *   1. Opens a fresh BullMQ Queue against the local Redis.
+ *   2. Adds a NON-repeatable job with `since = 7 days ago` (the worker
+ *      clamps to MAX_SINCE_WINDOW_MS anyway, so this just maximises the
+ *      replay window — every unread row from the past week is eligible).
+ *   3. Logs the job id and exits.
+ *
+ * The actual send happens in the running `worker` process — make sure
+ * `pnpm --filter @givernance/worker dev` is up, then watch its log and
+ * Mailpit at http://localhost:8025.
+ *
+ * Pre-flight (otherwise you'll see "Sent 0"):
+ *   - User has at least one `notification_preferences.email_digest = true`
+ *     row (toggle from /profile/notifications or via SQL).
+ *   - User has an unread `notifications` row whose `type` matches the
+ *     preference row.
+ *   - `communication.notifications_center` flag is on for the tenant.
+ */
+
+import { Queue } from "bullmq";
+import IORedis from "ioredis";
+
+const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
+const QUEUE_NAME = "notifications_digest";
+const JOB_NAME = "notifications.digest_daily";
+
+const connection = new IORedis(REDIS_URL, { maxRetriesPerRequest: null });
+const queue = new Queue(QUEUE_NAME, { connection });
+
+const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+const job = await queue.add(
+  JOB_NAME,
+  { since },
+  {
+    // One-off — no repeat. Distinct from the scheduled
+    // `notifications-digest-daily` repeatable so adding this doesn't
+    // collide with the cron registration on the next worker boot.
+    jobId: `notifications-digest-oneoff-${Date.now()}`,
+    removeOnComplete: true,
+    removeOnFail: 50,
+  },
+);
+
+console.log(
+  JSON.stringify(
+    {
+      enqueued: true,
+      queue: QUEUE_NAME,
+      jobName: JOB_NAME,
+      jobId: job.id,
+      since,
+      hint: "Watch the worker logs + open http://localhost:8025 for the rendered email.",
+    },
+    null,
+    2,
+  ),
+);
+
+await queue.close();
+await connection.quit();

--- a/packages/worker/src/processors/notifications-email-digest.ts
+++ b/packages/worker/src/processors/notifications-email-digest.ts
@@ -44,6 +44,7 @@ import {
 import { notificationPreferences, notifications, tenants, users } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
 import { and, eq, gt, inArray, isNotNull, isNull, sql } from "drizzle-orm";
+import { env } from "../env.js";
 import { db, withWorkerContext } from "../lib/db.js";
 import { defaultEmailSender, type EmailSender } from "../lib/email.js";
 import { isFlagEnabled } from "../lib/flags.js";
@@ -223,20 +224,35 @@ function safeRelativePath(linkUrl: string | null): string | null {
   return linkUrl;
 }
 
+/**
+ * Resolve a stored relative path (`/donations/<uuid>`) into the
+ * absolute URL an email client can dereference. Stored relative paths
+ * are correct for the panel (the browser already knows the origin) but
+ * an email client renders the href against its OWN base — Mailpit's
+ * `http://localhost:8025` in dev — and ends up on a 404. `APP_URL`
+ * carries the tenant-facing origin (`http://localhost:3000` for dev,
+ * `https://app.givernance.com` for SaaS prod).
+ */
+function absoluteUrl(relativePath: string): string {
+  const base = env.APP_URL.replace(/\/+$/, "");
+  return `${base}${relativePath}`;
+}
+
 function renderDigestText(rows: DigestRow[]): string {
   const lines = rows.map((row) => {
     const title = humanTitleFor(row.type);
     const when = row.createdAt.toISOString();
     const safeLink = safeRelativePath(row.linkUrl);
-    const link = safeLink ? ` (${safeLink})` : "";
+    const link = safeLink ? ` (${absoluteUrl(safeLink)})` : "";
     return `• ${title} — ${when}${link}`;
   });
+  const preferencesUrl = absoluteUrl("/profile/notifications");
   return [
     "Here is your daily digest of in-app notifications from Givernance.",
     "",
     ...lines,
     "",
-    "Manage your preferences at /profile/notifications.",
+    `Manage your preferences at ${preferencesUrl}.`,
   ].join("\n");
 }
 
@@ -246,14 +262,15 @@ function renderDigestHtml(rows: DigestRow[]): string {
       const title = escapeHtml(humanTitleFor(row.type));
       const when = escapeHtml(row.createdAt.toISOString());
       const safeLink = safeRelativePath(row.linkUrl);
-      const link = safeLink ? `<a href="${escapeAttribute(safeLink)}">View</a>` : "";
+      const link = safeLink ? `<a href="${escapeAttribute(absoluteUrl(safeLink))}">View</a>` : "";
       return `<li><strong>${title}</strong> — ${when} ${link}</li>`;
     })
     .join("");
+  const preferencesUrl = escapeAttribute(absoluteUrl("/profile/notifications"));
   return `<!doctype html><html><body>
   <p>Here is your daily digest of in-app notifications from Givernance.</p>
   <ul>${items}</ul>
-  <p>Manage your preferences at <a href="/profile/notifications">/profile/notifications</a>.</p>
+  <p>Manage your preferences at <a href="${preferencesUrl}">${preferencesUrl}</a>.</p>
   </body></html>`;
 }
 

--- a/packages/worker/src/processors/notifications-fanout.ts
+++ b/packages/worker/src/processors/notifications-fanout.ts
@@ -261,7 +261,7 @@ async function runFanoutPlan(input: FanoutInput, plan: FanoutPlanEntry[]): Promi
       // #363 contract) silently broke email-only opt-ins. The row's
       // `panel_visible` column records the panel decision so the bell
       // hides it while the digest worker can still pick it up.
-      // Migration 0056 captures the rationale.
+      // Migration 0058 captures the rationale.
       const channels = await resolveChannels(tx, recipientUserIds, entry.type);
       if (channels.length === 0) continue;
 

--- a/packages/worker/src/processors/notifications-fanout.ts
+++ b/packages/worker/src/processors/notifications-fanout.ts
@@ -255,13 +255,17 @@ async function runFanoutPlan(input: FanoutInput, plan: FanoutPlanEntry[]): Promi
       const recipientUserIds = await resolveRecipients(tx, entry.recipients);
       if (recipientUserIds.length === 0) continue;
 
-      // Honour per-user preferences. Users with `in_app=false` for
-      // this type are silently dropped at write time so the worker
-      // doesn't pile rows onto a user who opted out of the channel.
-      const enabledRecipients = await filterByPreferences(tx, recipientUserIds, entry.type);
-      if (enabledRecipients.length === 0) continue;
+      // Honour per-user preferences across BOTH channels. A user is a
+      // recipient when EITHER `in_app` OR `email_digest` is enabled for
+      // the type — coupling the two at write time (the original Epic
+      // #363 contract) silently broke email-only opt-ins. The row's
+      // `panel_visible` column records the panel decision so the bell
+      // hides it while the digest worker can still pick it up.
+      // Migration 0056 captures the rationale.
+      const channels = await resolveChannels(tx, recipientUserIds, entry.type);
+      if (channels.length === 0) continue;
 
-      const rows: NewNotification[] = enabledRecipients.map((userId) => ({
+      const rows: NewNotification[] = channels.map(({ userId, inApp }) => ({
         orgId: input.tenantId,
         outboxEventId: input.outboxId,
         userId,
@@ -270,6 +274,7 @@ async function runFanoutPlan(input: FanoutInput, plan: FanoutPlanEntry[]): Promi
         bodyKey: entry.bodyKey,
         params: entry.params,
         linkUrl: entry.linkUrl,
+        panelVisible: inApp,
       }));
 
       // `ON CONFLICT DO NOTHING` — the natural unique key
@@ -305,12 +310,21 @@ async function resolveRecipients(
   return rows.map((r: { id: string }) => r.id);
 }
 
-async function filterByPreferences(
+interface ResolvedChannels {
+  userId: string;
+  /** Effective `in_app` decision — controls `panel_visible` on the row. */
+  inApp: boolean;
+  /** Effective `email_digest` decision — purely informational here; the
+   *  digest worker reads `notification_preferences` itself. */
+  emailDigest: boolean;
+}
+
+async function resolveChannels(
   // biome-ignore lint/suspicious/noExplicitAny: see above
   tx: any,
   userIds: string[],
   type: NotificationType,
-): Promise<string[]> {
+): Promise<ResolvedChannels[]> {
   if (userIds.length === 0) return [];
   // Pull preference rows for the (recipient set, type) pair only.
   // Earlier revisions scanned every preference row for the type
@@ -318,21 +332,33 @@ async function filterByPreferences(
   // scope mismatch. The new `inArray(userId, userIds)` clause hits
   // `notification_preferences_user_idx` directly.
   const rows = await tx
-    .select({ userId: notificationPreferences.userId, inApp: notificationPreferences.inApp })
+    .select({
+      userId: notificationPreferences.userId,
+      inApp: notificationPreferences.inApp,
+      emailDigest: notificationPreferences.emailDigest,
+    })
     .from(notificationPreferences)
     .where(
       and(eq(notificationPreferences.type, type), inArray(notificationPreferences.userId, userIds)),
     );
 
-  const defaultInApp = getNotificationDescriptor(type).defaultInApp;
-  const explicit = new Map<string, boolean>();
-  for (const row of rows as Array<{ userId: string; inApp: boolean }>) {
-    explicit.set(row.userId, row.inApp);
+  const descriptor = getNotificationDescriptor(type);
+  const defaultInApp = descriptor.defaultInApp;
+  const defaultEmailDigest = descriptor.defaultEmailDigest;
+  const explicit = new Map<string, { inApp: boolean; emailDigest: boolean }>();
+  for (const row of rows as Array<{ userId: string; inApp: boolean; emailDigest: boolean }>) {
+    explicit.set(row.userId, { inApp: row.inApp, emailDigest: row.emailDigest });
   }
-  return userIds.filter((id) => {
-    const v = explicit.get(id);
-    return v === undefined ? defaultInApp : v;
-  });
+  const resolved: ResolvedChannels[] = [];
+  for (const id of userIds) {
+    const explicitRow = explicit.get(id);
+    const inApp = explicitRow?.inApp ?? defaultInApp;
+    const emailDigest = explicitRow?.emailDigest ?? defaultEmailDigest;
+    // Skip users who opted out of BOTH channels — no row needed.
+    if (!inApp && !emailDigest) continue;
+    resolved.push({ userId: id, inApp, emailDigest });
+  }
+  return resolved;
 }
 
 function stringOrNull(value: unknown): string | null {


### PR DESCRIPTION
Four Epic #363 follow-ups surfaced while QA-ing the digest path locally.

## 1. `in_app` and `email_digest` decoupled (migration 0056)

**Symptom.** Operator toggled `in_app = false` + `email_digest = true` on "Don reçu", created a donation — got nothing. No bell ping (expected), no email (not expected). Mailpit showed `Sent 0`.

**Cause.** The fanout dropped any recipient with `in_app = false` BEFORE inserting into `notifications`. The digest worker reads from that table, so a row that was never written can never be digested.

**Fix.** Migration `0056_notifications_panel_visible.sql` adds a `panel_visible BOOLEAN NOT NULL DEFAULT TRUE` column. The fanout writes a row when EITHER channel is enabled, frozen with the recipient's `in_app` decision:

| Effective `in_app` | Effective `email_digest` | Row written? | `panel_visible` | Panel | Digest |
|---|---|---|---|---|---|
| true | any | yes | `true` | yes | yes (if opted in) |
| false | true | yes | `false` | **no** | yes |
| false | false | no | n/a | n/a | n/a |

Read paths (`listNotifications`, `getUnreadCount`, SSE `streamNotifications`, plus `markRead` / `markAllRead` / `softDeleteNotification`) filter `panel_visible = true`. Re-toggling `in_app = true` later does NOT retroactively reveal historical digest-only rows.

## 2. Email digest links resolve through `APP_URL`

**Symptom.** Clicking "View" in the Mailpit-rendered digest landed on `http://localhost:8025/donations/...` (Mailpit's 404), not `http://localhost:3000/donations/...`.

**Cause.** `notifications.link_url` is a stored relative path. The digest renderer interpolated it as a raw href. Mail clients render hrefs against their own base.

**Fix.** `absoluteUrl()` in `notifications-email-digest.ts` prepends `env.APP_URL` before serialising every href.

## 3. Auto-mark-read on consumption

**Symptom.** Operator clicks "View" in the digest email → lands on `/donations/<uuid>` → bell badge still shows the notification as unread. Same with the panel's "Ouvrir" link or any manual navigation to the resource.

**Cause.** Marking-read was a panel-only affordance. Landing on the linked resource didn't update notification state.

**Fix.** New endpoint `POST /v1/notifications/mark-read-by-link` marks every panel-visible unread notification for the current user whose `link_url` matches the body. The bell hook (mounted in the topbar layout) calls `usePathname()` and fires it on every pathname change. Idempotent, soft-fails, covers donations + invitations + branding + postal-export + bulk-email — every type ships a `link_url` that satisfies the "landing = consumption" contract documented in ADR-031 § 4 + doc 27 § "Auto-mark-read on consumption".

## 4. `digest:trigger` dev script (original scope)

`pnpm --filter @givernance/worker run digest:trigger` enqueues a non-repeatable `notifications.digest_daily` job with `since = 7 days ago`, distinct `jobId` prefix so it doesn't collide with the cron registration. Saves the 24h wait when validating the digest path locally.

## Pre-flight for dev test

- User has at least one `notification_preferences.email_digest = true` row.
- User has an unread `notifications` row whose `type` matches.
- `communication.notifications_center` flag is on for the tenant.

## Test plan

- [ ] `0056_notifications_panel_visible.sql` applies cleanly on staging (idempotent, additive).
- [ ] Toggling `in_app = false` + `email_digest = true` on a type then creating a matching event: bell stays silent, panel ignores the row, but the row exists in DB with `panel_visible = false`.
- [ ] `pnpm --filter @givernance/worker run digest:trigger` then `http://localhost:8025` shows the digest with `View` links pointing at `APP_URL` (e.g. `http://localhost:3000/donations/...`).
- [ ] Clicking "View" in the email AND navigating to the linked resource any other way marks the matching panel notification as read.
- [ ] 13 new integration tests pass (5 `panel_visible` + 6 `mark-read-by-link` + 2 added gated-routes entries).
- [ ] No regression on the existing 41 notification integration tests.

Dev-only tooling + a real data-model bug fix + a UX cleanup. Does not close any issue on its own.