### PR TITLE
feat(search): global Cmd+K command palette + /v1/search backend (Epic #364)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── 26-public-page-styles.md    — Public donation page archetype catalogue (Epic #362): 10 archetypes, schema, three-layer resolution, picker UX, easter-egg policy
 │   ├── 27-notifications.md         — In-app notification centre (Epic #363, GLO-004): bell + side panel + per-user preferences + SSE delivery + opt-in email digest + outbox-fanout producer
 │   ├── 28-bulk-import.md           — Bulk Import Constituents (Epic #373): CSV/Excel upload, async worker pipeline, dedupe, 90-day retention, audit trail
+│   ├── 29-global-search.md         — Global search / Command palette (Epic #364, GLO-001): Cmd+K overlay, Postgres FTS + pg_trgm, /v1/search RLS-scoped grouped results, RBAC-aware quick-create
 │   ├── adrs/                       — Individual ADR files (incl. ADR-023 bucket topology, ADR-024 image pipeline, ADR-025 PDF code boundary, ADR-027 Swiss QR-bill, ADR-028 camt.053 ingestion, ADR-029 Keycloak session revocation, ADR-030 public-page archetype slots — hybrid shell + slot components per Epic #362, ADR-031 notification delivery + outbox fanout — SSE with polling fallback per Epic #363)
 │   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283; launch-prod.md for the production-environment launch — issue #344); each file is plan + live journal + post-mortem. Also: bulk-email-stalled-job.md (recurring SRE triage flow for issue #326's Stalled / Partial bulk-email recovery), feature-flag-rollback.md (emergency psql + redis-cli flip when the Back Office page is unavailable), keycloak-backchannel-logout-cutover.md (per-env override of `backchannel.logout.url` after each realm sync — issue #76), and cross-tenant-rls-hardening-cutover.md (issue #430 — one-shot wiring of the `GIVERNANCE_APP_PASSWORD` secret + `givernance_app` role rotation that closes the staging cross-tenant notification leak)
 │   ├── dev/
@@ -172,7 +173,7 @@ Key ADRs for frontend work:
 - Project name: **Givernance** (not "Libero", not "givernance-npo-platform")
 - Terminology: **NPO** (nonprofit organization), not "NGO"
 - GDPR in English docs, RGPD in French docs
-- All docs are in `docs/`, numbered 01-28 for architecture specs (next free slot: `29-`)
+- All docs are in `docs/`, numbered 01-29 for architecture specs (next free slot: `30-`)
 
 ### 🛑 Documentation discipline (CRITICAL FOR ALL DOMAIN WORK)
 

--- a/docs/29-global-search.md
+++ b/docs/29-global-search.md
@@ -1,0 +1,243 @@
+# 29 — Global search / Command palette (GLO-001)
+
+> Related: [`docs/14-screen-inventory.md`](14-screen-inventory.md) (GLO-001 spec), [`docs/11-design-identity.md`](11-design-identity.md) (Cmd+K as navigation contract), [`docs/18-feature-flags.md`](18-feature-flags.md) (flag pattern), [`docs/27-notifications.md`](27-notifications.md) (parallel global surface — bell vs. palette), [Mockup `docs/design/global/command-palette.html`](design/global/command-palette.html). Schema lives in migration [`0062_search_indexes.sql`](../packages/api/migrations/0062_search_indexes.sql); flag seed in [`0061_command_palette_feature_flag.sql`](../packages/api/migrations/0061_command_palette_feature_flag.sql).
+
+## 0. Why this exists — at a glance
+
+Givernance's MVP shipped with **entity-scoped** search — every list page has its own "search a constituent / campaign / donation" input. That covers focused workflows, but breaks down the moment an operator can't remember which entity the thing they want lives under: *"Was Marie a constituent record, the donor on last week's gift, or the lead on a Spring campaign?"* In every Salesforce-replacement evaluation we've shadowed, the first thing a fundraising manager types is the donor's first name, and they expect the system to find their donor record, their last gift, and the campaign they sponsor — in one drop-down.
+
+**This feature delivers that single drop-down.** Pressing **`Cmd+K`** (Mac) or **`Ctrl+K`** (Windows / Linux) anywhere in the authenticated app opens an overlay that:
+
+1. Searches **constituents**, **campaigns**, and **donations** in one query, with results grouped by entity.
+2. Offers static **"Go to …"** navigation rows so power users can jump to Constituents / Campaigns / Donations without leaving the keyboard.
+3. Surfaces **quick-create** actions (new constituent, new donation, new campaign) for users with the `org_admin` / `user` app role — viewers see the navigation rows but not the create rows.
+
+It's the keyboard-first navigation layer that operators trained by Linear, Notion, and the Stripe Dashboard already expect. Without it, every entity-scoped search input is a separate place to look — and Salesforce's "global search" is one of the few NPSP features users actually praise.
+
+The surface is **gated behind `productivity.command_palette` (default off)**. With the flag off, the overlay, the topbar button, the global keyboard listener, and the `GET /v1/search` route are all completely absent — no inert placeholder anywhere. The full flag rationale + rollback drill is in [§5](#5-feature-flag-productivitycommand_palette).
+
+## 1. User flow — operator searches across entities
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Operator as Operator<br/>(any role)
+    participant Topbar as Topbar<br/>(/_app shell)
+    participant Shell as AppShell<br/>(client)
+    participant Palette as CommandPalette<br/>(cmdk overlay)
+    participant API as Givernance API<br/>(GET /v1/search)
+    participant DB as Postgres<br/>(FTS + pg_trgm)
+
+    Operator->>+Topbar: Press Cmd+K<br/>(or click the search button)
+    Topbar->>Shell: open=true
+    Shell->>Palette: render overlay (focus = input)
+    Palette-->>Operator: empty-state shows<br/>"Go to …" + "Quick create"<br/>(create rows hidden for viewers)
+
+    Operator->>Palette: types "Marie"
+
+    Note over Palette: debounce 200 ms<br/>previous in-flight req aborted
+    Palette->>+API: GET /v1/search?q=Marie<br/>Bearer JWT (HTTP-only cookie)
+    Note over API: 1. requireFlag(productivity.command_palette)<br/>   → 404 if off (anti-disclosure)<br/>2. requireAuth — extract orgId<br/>3. rate limit: 60/min/user
+    API->>+DB: withTenantContext(orgId, ...)<br/>3 parallel queries:<br/>• constituents (FTS + trigram + ILIKE)<br/>• campaigns   (FTS + trigram + ILIKE)<br/>• donations   (JOIN constituents, ref ILIKE)
+    DB-->>-API: rows ranked by ts_rank + similarity,<br/>capped at 5 per group
+    API-->>-Palette: { data: { query, groups } }
+
+    Palette-->>Operator: grouped results render<br/>(Constituents / Campaigns / Donations)
+    Operator->>Palette: ↓ to hit, ⏎ to select
+    Palette->>Shell: onClose() + router.push(href)
+    Shell-->>Operator: target page renders<br/>(palette closed)
+```
+
+**Error branches**
+
+- Query < 2 chars → no DB call, empty state stays (static commands visible).
+- Network error → palette stays open, shows `t("commandPalette.error")`; `aria-live="assertive"` announces it.
+- 429 (rate-limit) → handled as a transient error (same UX); the next keystroke supersedes the failed request.
+- Flag off mid-session (operator just got demoted) → SSR-fetched flag list was stale, the topbar button vanishes on next nav, the API returns 404; the palette is never re-opened. No UI is left half-broken because the entire surface is conditional on `commandPaletteEnabled`.
+
+## 2. Domain model — no new tables
+
+This Epic adds **no new persistent state**. Everything searchable already lives in existing tables (`constituents`, `campaigns`, `donations`). The only DB delta is **four expression indices** to make the queries fast.
+
+```mermaid
+erDiagram
+  CONSTITUENTS ||--o{ DONATIONS : "1—N (constituent_id)"
+  CAMPAIGNS   ||--o{ DONATIONS : "0..1—N (campaign_id, nullable)"
+
+  CONSTITUENTS {
+    uuid    id PK
+    uuid    org_id FK
+    text    first_name
+    text    last_name
+    text    email
+    text    city
+    text    type
+    text    tags
+    timestamptz deleted_at
+    timestamptz updated_at
+    ix_fts  "GIN to_tsvector('simple', first || last || email || city)"
+    ix_trgm "GIN gin_trgm_ops on (first || ' ' || last)"
+  }
+
+  CAMPAIGNS {
+    uuid    id PK
+    uuid    org_id FK
+    text    name
+    text    description
+    text    type
+    text    status
+    timestamptz updated_at
+    ix_fts  "GIN to_tsvector('simple', name || description)"
+    ix_trgm "GIN gin_trgm_ops on name"
+  }
+
+  DONATIONS {
+    uuid    id PK
+    uuid    org_id FK
+    uuid    constituent_id FK
+    int     amount_cents
+    text    currency
+    text    payment_ref
+    text    receipt_number
+    timestamptz donated_at
+  }
+```
+
+Why **expression indices** rather than generated `tsvector` columns:
+
+- The Drizzle schema stays clean — no introspection drift, no migration churn the moment we tune the FTS expression.
+- Writes to constituents / campaigns that don't change a search-relevant field don't pay any index-update cost.
+- Trade-off: the `WHERE` clause must mirror the exact index expression. The service layer is the only caller and pins the form (see [`packages/api/src/modules/search/service.ts`](../packages/api/src/modules/search/service.ts)).
+
+The shared `core-erd.mmd` does **not** need to change — no new tables, no new relationships.
+
+## 3. Architecture & ranking
+
+### 3.1 Search engine choice — Postgres FTS, not Meilisearch
+
+Per the Epic's spike requirement, we evaluated:
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **Postgres FTS + pg_trgm** | Zero new infra. RLS works natively. Joins with the existing permission model are trivial. EU sovereignty already covered by Scaleway Managed Postgres. | French/English stemmer mismatch on shared rows; lower recall than dedicated engines on >1M rows. | **CHOSEN** for Phase 2. NPOs run 2–200 staff — even an enterprise tenant tops out at low-six-figure constituent counts. The performance budget (P95 < 200 ms on a 50k-constituent test tenant) is met by GIN-indexed expression queries. |
+| Meilisearch / Typesense (EU-hosted on Scaleway) | Native typo tolerance, faceting, sub-50 ms queries on millions of rows. | New service to deploy, monitor, secure, GDPR DPA-scope. Permission-sync becomes a distributed-systems problem (RLS doesn't extend out). | **Rejected** for now. Revisit when a single tenant crosses 1M searchable rows OR when faceted search becomes a product requirement. |
+| Elasticsearch | Same pros as Meilisearch, plus aggregations. | Largest operational footprint of the three; no clear win over Meilisearch at our scale. | Rejected. |
+
+### 3.2 Indexing strategy
+
+Migration [`0062_search_indexes.sql`](../packages/api/migrations/0062_search_indexes.sql) ships:
+
+1. **`constituents_search_tsv_idx`** — GIN on `to_tsvector('simple', first || last || email || city)`.
+2. **`constituents_name_trgm_idx`** — GIN with `gin_trgm_ops` on `(first || ' ' || last)`, for typo tolerance ("marie clair" → "Marie-Claire").
+3. **`campaigns_search_tsv_idx`** — GIN on `to_tsvector('simple', name || description)`.
+4. **`campaigns_name_trgm_idx`** — GIN with `gin_trgm_ops` on `name`.
+
+**Why `'simple'` and not `'french'` / `'english'`**: Givernance tenants mix French and English records routinely (Swiss NPOs, EU foundations with international beneficiaries). A stemmed dictionary would corrupt surnames ("Fontaine" → "fontain"), strip stop-words that belong in campaign names ("Help Us End Hunger" → "help us end hunger" minus "us"), and bake the language choice into the index. The `'simple'` config does word-boundary tokenisation only — high recall, language-agnostic. We tighten ranking in the service layer, not in the analyser.
+
+**Donations carry no FTS column**. Their free-form text is sparse (just `payment_ref` and `receipt_number`). We search donations via:
+
+- a **JOIN to constituents** (find Marie's donations by name) — the dominant operator query, and
+- **substring ILIKE** on `payment_ref` / `receipt_number` (look up reference "D-2026-0142").
+
+### 3.3 Ranking
+
+Inside each group:
+
+```
+score = ts_rank(<group's tsvector>, plainto_tsquery('simple', q))
+      + similarity(<group's primary name>, q)
+```
+
+Tiebreaker: `updated_at DESC` for constituents / campaigns; `donated_at DESC` for donations.
+
+We deliberately do **not** apply a global cross-group ranking — the operator's mental model is "I'm looking for a person OR a campaign OR a gift," and forcing those into a single ranked list buries the entity discriminator. Each group is capped at **5 hits** (`PER_GROUP_LIMIT`); total wire size ≤ 15 hits + an envelope.
+
+### 3.4 Tenant scope & RLS
+
+Every query runs inside `withTenantContext(orgId, ...)` (sets the `app.current_organization_id` GUC) and additionally carries **explicit `WHERE org_id = ${orgId}`** clauses (CLAUDE.md §"RLS is the safety net, never the contract", issue #430). The donations JOIN adds `AND c.org_id = d.org_id` so a guessed cross-tenant `constituent_id` can't smuggle a hit through the join.
+
+The boot-time `assertAppRoleSecure` guard in [`packages/api/src/lib/db.ts`](../packages/api/src/lib/db.ts) is the third wall — the runtime role must be NOBYPASSRLS or the container crash-loops at start.
+
+### 3.5 Query safety
+
+The raw user input never reaches the SQL string. It's bound as a single `text` parameter through Drizzle's `sql` template — both for `plainto_tsquery('simple', ${q})` and for the `ILIKE ${"%" + q + "%"}` arms. The service layer additionally:
+
+- caps length at 200 chars (also enforced by the TypeBox route schema),
+- strips C0 (0x00–0x1f) and C1 (0x7f–0x9f) control codepoints — Postgres rejects NUL in text, and the others are noise,
+- collapses internal whitespace,
+- returns an empty result (no DB hit) when the cleaned query is < 2 chars.
+
+`plainto_tsquery` is intentional over `to_tsquery` — it quotes tsquery operators (`&`, `|`, `!`, `:*`, `()`) as plain words, so a curious user typing `!marie` doesn't get a syntax error and a malicious user can't smuggle an operator that explodes the planner. The integration test [`packages/api/src/tests/integration/search.test.ts`](../packages/api/src/tests/integration/search.test.ts) pins all of this with `'; DROP TABLE constituents; --` and friends.
+
+### 3.6 Frontend architecture
+
+- The **CommandPalette** component lives in [`packages/web/src/components/command-palette/command-palette.tsx`](../packages/web/src/components/command-palette/command-palette.tsx).
+- Mounted once inside **AppShell** (conditional on `commandPaletteEnabled`); open/close state is owned by AppShell so the global keyboard listener + the topbar trigger button both share one source of truth.
+- Built on the existing `cmdk` wrapper in [`packages/web/src/components/ui/command.tsx`](../packages/web/src/components/ui/command.tsx) + Radix `Dialog`.
+- Server-side filtering — `shouldFilter={false}` on the `Command` root so cmdk doesn't re-filter server results client-side (which would override the server's relevance ordering and drop hits whose `title` doesn't contain the literal query).
+- 200 ms debounce on input changes. In-flight requests are aborted via `AbortController` when a fresher keystroke supersedes them — eliminates the out-of-order-response race.
+- Static commands ("Go to Dashboard", "Go to Constituents", …) and RBAC-aware quick-create rows ("New constituent", "Record a donation", "New campaign") populate the empty state and remain accessible alongside live results.
+
+## 4. Permissions matrix
+
+| Endpoint / surface | Auth | RBAC | Notes |
+|---|---|---|---|
+| `GET /v1/search?q=…` | Authenticated tenant user (any role) | None beyond auth | Flag-gated 404 when `productivity.command_palette=off`. Rate limit: 60 req/min/user. RLS-scoped to the JWT's `org_id`. |
+| Topbar Cmd+K trigger button | Authenticated tenant user | None | Hidden entirely when the flag is off (off-state QA). |
+| Global Cmd+K / Ctrl+K listener | Authenticated tenant user | None | Listener is NOT mounted when the flag is off — pressing the shortcut is a no-op. |
+| Command palette overlay | Authenticated tenant user | None for the search results; quick-create rows require `org_admin` or `user` (viewers see only the search + Go-to rows). | Component is not loaded at all when the flag is off. |
+| "New constituent" / "Record a donation" / "New campaign" rows | Authenticated tenant user | `org_admin` OR `user` (the `requireWrite` boundary) | Reused existing entity-create flows — no new endpoints. |
+
+Search results respect each entity's existing RLS: a viewer sees the same hits as an org_admin within the tenant (the palette is a navigation aid, not a permissioned data surface), and tenant isolation prevents any cross-tenant leakage.
+
+## 5. Feature flag — `productivity.command_palette`
+
+| Field | Value |
+|---|---|
+| Key | `productivity.command_palette` |
+| Default | `false` |
+| Scope | `tenant` |
+| Tenant override allowed | `true` (org-admin self-serves from `/settings/feature-flags`) |
+| Public projection | `true` (the topbar trigger + global listener need to know at page-load) |
+| Registry | [`packages/shared/src/constants/feature-flags.ts`](../packages/shared/src/constants/feature-flags.ts) |
+| Seed migration | [`0061_command_palette_feature_flag.sql`](../packages/api/migrations/0061_command_palette_feature_flag.sql) |
+| Gated surfaces | `GET /v1/search` route, topbar trigger button, global Cmd+K listener, the CommandPalette component (never imported when off via the conditional in AppShell) |
+| Off-state QA | With the flag off: the trigger button is **absent** (not greyed out), the Cmd+K keypress is a **no-op** (listener not mounted), and the API returns **404** (not 403). |
+| Emergency rollback | See [`docs/runbooks/feature-flag-rollback.md`](runbooks/feature-flag-rollback.md). One `UPDATE feature_flags SET enabled=false WHERE key='productivity.command_palette';` + `redis-cli DEL flags:global`. |
+
+The public-projection caveat in CLAUDE.md applies — the key name is intentionally descriptive (`productivity.command_palette`) and not teasing an unannounced surprise, so its presence in `GET /v1/feature-flags` for every authenticated tenant user is acceptable.
+
+## 6. Privacy / GDPR posture
+
+- **No new PII storage**: search reads from existing tables only. The `constituents.deleted_at` soft-delete filter is applied; deleted donor records are invisible to the palette.
+- **Audit trail**: read-only search hits do **not** generate audit rows — every authenticated tenant user can already list constituents / campaigns / donations, and the audit log already records the *resulting* navigation (e.g. opening a constituent detail page emits the existing read audit, unchanged).
+- **Logs**: the `requireFlag` guard logs `flag.route_gated` when a disabled tenant hits the route (existing pattern, low cardinality — path is the route TEMPLATE, not the raw URL). The search handler emits the standard request log line via Fastify's pino — **the raw query string `q` is not redacted** because it doesn't carry PII by design (an operator's typed substring of a donor's name is far less sensitive than what the constituent detail page itself emits to the same log channel). If a future tenant requests stricter posture, redacting `q` to a hash is a single-line change in [`packages/shared/src/constants/log-redact-paths.ts`](../packages/shared/src/constants/log-redact-paths.ts).
+- **Erasure**: a constituent erasure cascade already removes their `donations`. After erasure, the palette returns zero hits for any query that previously matched — no separate index to rebuild because the expression indices reference the live row.
+
+## 7. Out of scope (deferred)
+
+The Epic explicitly carves these out so a prospect reading this doc understands what Phase 2 covers vs. what the broader GLO-001 vision implies:
+
+- **Grants & programs** — the Epic acceptance lists "≥ 5 entity types"; only **3 ship in this PR** (constituents, donations, campaigns) because grants and programs **don't have schema yet**. Adding them is a one-migration follow-up the moment those tables land.
+- **Saved searches / advanced filters** — the palette is a quick-jump aid; advanced querying belongs in the entity list pages.
+- **Recently-visited surfaces** — Epic mentions sessionStorage-backed recents when the query is empty. Deferred; the static "Go to …" rows fill that slot for now.
+- **Highlight match in result rows** — visual polish, deferred to a follow-up.
+- **Search telemetry** — the per-query log is enough for SRE; product telemetry (hashed query → click-through) is a separate analytics workstream and intentionally not bolted on here.
+- **AI-suggested actions** ("Suggestions contextuelles basées sur la navigation récente" in the GLO-001 spec) — Phase 3 / AI Modes work ([`docs/13-ai-modes.md`](13-ai-modes.md)).
+- **Conversational search** ("how many donors gave more than €100 last month?") — separate Epic, see [`docs/vision/conversational-mode.md`](vision/conversational-mode.md).
+- **Semantic / embedding search** — requires an EU-hosted embeddings stack; revisit when volume justifies.
+- **Full-text search inside attachments** (PDFs, emails) — content-extraction worker is a separate concern.
+- **External search engine** (Meilisearch / Typesense / Elasticsearch) — see [§3.1](#31-search-engine-choice--postgres-fts-not-meilisearch) for the revisit criteria.
+
+## 8. Adding a new entity to global search
+
+When a new tenant-scoped table joins the searchable graph (e.g. grants, programs, volunteers):
+
+1. Add an expression index on the table's name / description fields in a new migration (mirror [`0062_search_indexes.sql`](../packages/api/migrations/0062_search_indexes.sql)).
+2. Add a query branch in [`packages/api/src/modules/search/service.ts`](../packages/api/src/modules/search/service.ts) — same `withTenantContext` + explicit `org_id` filter + capped `LIMIT PER_GROUP_LIMIT`.
+3. Extend the `SearchResult.groups` type + the route's `SearchResponse` TypeBox schema.
+4. Add a `CommandGroup` in [`packages/web/src/components/command-palette/command-palette.tsx`](../packages/web/src/components/command-palette/command-palette.tsx).
+5. Add translations under `appShell.commandPalette.groups.*` in `en.json` and `fr.json`.
+6. Add RLS-isolation + happy-path tests in [`packages/api/src/tests/integration/search.test.ts`](../packages/api/src/tests/integration/search.test.ts).
+
+The flag stays the same — adding a new entity is not "a new feature", it's an extension of an already-shipped surface.

--- a/docs/29-global-search.md
+++ b/docs/29-global-search.md
@@ -51,8 +51,9 @@ sequenceDiagram
 **Error branches**
 
 - Query < 2 chars → no DB call, empty state stays (static commands visible).
-- Network error → palette stays open, shows `t("commandPalette.error")`; `aria-live="assertive"` announces it.
-- 429 (rate-limit) → handled as a transient error (same UX); the next keystroke supersedes the failed request.
+- Network error → palette stays open, shows the generic `t("commandPalette.error")` ("Could not run the search. Try again in a moment."); `aria-live="assertive"` + `role="alert"` announce it to assistive tech. The next valid keystroke supersedes the failed request.
+- 429 (rate-limit) → surfaced as the **same** generic error banner (no distinct toast) — we deliberately keep one error path rather than expose the rate-limit as a separate UX, because a sustained burst hitting the cap is usually a runaway typing loop, not a state the operator can fix differently.
+- Unauthenticated request mid-session (cookie expired between renders) → the global axios-style 401 handler in [`packages/web/src/lib/api/client.ts`](../packages/web/src/lib/api/client.ts) already routes through the auth refresh path; the palette catches the resulting rejection and surfaces the generic error until the next debounced refetch succeeds.
 - Flag off mid-session (operator just got demoted) → SSR-fetched flag list was stale, the topbar button vanishes on next nav, the API returns 404; the palette is never re-opened. No UI is left half-broken because the entire surface is conditional on `commandPaletteEnabled`.
 
 ## 2. Domain model — no new tables

--- a/packages/api/migrations/0061_command_palette_feature_flag.sql
+++ b/packages/api/migrations/0061_command_palette_feature_flag.sql
@@ -1,0 +1,28 @@
+-- Migration: 0061_command_palette_feature_flag
+--
+-- Seeds the `productivity.command_palette` feature flag added in Epic
+-- #364 (GLO-001). Off by default; each org-admin self-serves the toggle
+-- from /settings/feature-flags (scope='tenant', tenant_override_allowed=TRUE)
+-- once they're ready to roll out the global Cmd+K search to their team —
+-- no platform-level precondition like DKIM, only operational caution
+-- while we monitor performance and search-quality signals.
+--
+-- Idempotent: `ON CONFLICT (key) DO NOTHING` so existing values
+-- (including operator-toggled `enabled`) are preserved across redeploys.
+--
+-- Keep `label` + `description` + `scope` + `tenant_override_allowed`
+-- + `public` in lockstep with FEATURE_FLAG_REGISTRY in
+-- `packages/shared/src/constants/feature-flags.ts`. The parity
+-- integration test (`feature-flags.test.ts`) fails CI on drift.
+
+INSERT INTO feature_flags (key, enabled, label, description, scope, tenant_override_allowed, public)
+VALUES (
+  'productivity.command_palette',
+  FALSE,
+  'Keyboard quick search (Cmd+K / Ctrl+K)',
+  'Adds a quick search panel that opens with Cmd+K (Mac) or Ctrl+K (Windows / Linux) from any page. Type to find a constituent, donation, or campaign, jump to a section, or start a new record. Off by default while we monitor performance and search quality — flip it on from this page when you''re ready.',
+  'tenant',
+  TRUE,
+  TRUE
+)
+ON CONFLICT (key) DO NOTHING;

--- a/packages/api/migrations/0062_search_indexes.sql
+++ b/packages/api/migrations/0062_search_indexes.sql
@@ -1,0 +1,69 @@
+-- Migration: 0062_search_indexes
+--
+-- Indexes that back the global search / command-palette endpoint
+-- (Epic #364, GLO-001, `GET /v1/search`).
+--
+-- Strategy is documented in docs/29-global-search.md §3:
+--   - Postgres FTS via `to_tsvector('simple', …)` IMMUTABLE expressions
+--     over name / description fields, indexed with GIN. We use the
+--     'simple' configuration (not 'french' / 'english') so the search
+--     is language-agnostic — Givernance tenants mix French and English
+--     constituent records and we don't want a French stemmer eating
+--     English surnames or vice versa. Word-boundary tokenisation is
+--     enough for a quick-jump command palette; recall is high, and
+--     ranking is tightened by an entity-type weight + recency boost
+--     in the service layer (NOT here).
+--   - `pg_trgm` GIN indices on short, frequently-mistyped fields
+--     (constituent first/last name, campaign name) so a user typing
+--     "marie clair" still finds "Marie-Claire". `pg_trgm` is already
+--     enabled by migration 0007.
+--
+-- Why expression indices instead of generated columns: keeping the
+-- tsvector OUT of the table schema means Drizzle's introspection is
+-- untouched and we don't pay write-amplification on every constituents
+-- UPDATE that doesn't actually change a search-relevant field. Trade-
+-- off: the SELECT must re-evaluate the same expression in the WHERE
+-- clause (matching the index) — the service layer is the only caller
+-- and uses the exact expression.
+--
+-- `IMMUTABLE`: required for an expression index. `to_tsvector(regconfig, …)`
+-- is marked IMMUTABLE in Postgres only when the regconfig is a literal
+-- (not a variable); the literal form below satisfies that.
+
+-- ─── Constituents: name + email + city, simple FTS ───────────────────────────
+CREATE INDEX IF NOT EXISTS "constituents_search_tsv_idx"
+  ON "constituents"
+  USING GIN (
+    to_tsvector(
+      'simple',
+      coalesce("first_name", '') || ' ' ||
+      coalesce("last_name", '') || ' ' ||
+      coalesce("email", '') || ' ' ||
+      coalesce("city", '')
+    )
+  );
+
+-- ─── Constituents: trigram on first_name + last_name (typo tolerance) ────────
+-- The combined column lets a single index serve both "marie clair" and
+-- "fontaine marie" queries. `gin_trgm_ops` is what makes `ILIKE '%foo%'`
+-- index-backed.
+CREATE INDEX IF NOT EXISTS "constituents_name_trgm_idx"
+  ON "constituents"
+  USING GIN (
+    (coalesce("first_name", '') || ' ' || coalesce("last_name", '')) gin_trgm_ops
+  );
+
+-- ─── Campaigns: name + description, simple FTS ───────────────────────────────
+CREATE INDEX IF NOT EXISTS "campaigns_search_tsv_idx"
+  ON "campaigns"
+  USING GIN (
+    to_tsvector(
+      'simple',
+      coalesce("name", '') || ' ' || coalesce("description", '')
+    )
+  );
+
+-- ─── Campaigns: trigram on name (typo tolerance on short strings) ────────────
+CREATE INDEX IF NOT EXISTS "campaigns_name_trgm_idx"
+  ON "campaigns"
+  USING GIN ("name" gin_trgm_ops);

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -428,6 +428,20 @@
       "when": 1778140000000,
       "tag": "0060_tenant_isolation_hardening",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1778150000000,
+      "tag": "0061_command_palette_feature_flag",
+      "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1778160000000,
+      "tag": "0062_search_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/modules/search/routes.ts
+++ b/packages/api/src/modules/search/routes.ts
@@ -24,7 +24,12 @@ import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
 import { requireFlag } from "../../lib/flags/flag-guard.js";
 import { requireAuth } from "../../lib/guards.js";
-import { ErrorResponses, problemDetail, UuidSchema } from "../../lib/schemas.js";
+import {
+  ErrorResponses,
+  ProblemDetailSchema,
+  problemDetail,
+  UuidSchema,
+} from "../../lib/schemas.js";
 import { MAX_QUERY_LENGTH, search } from "./service.js";
 
 // ─── Schemas ────────────────────────────────────────────────────────────────
@@ -71,15 +76,22 @@ export async function searchRoutes(app: FastifyInstance) {
       // is comfortably above any realistic human typing speed. The
       // bulk-import polling endpoint uses the same value.
       config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
+      // Quiet the per-keystroke 200s so a sustained typing burst
+      // doesn't flood stdout (and Loki) with the raw `q` substring.
+      // Errors (4xx / 5xx) still emit at warn+. The flag-gate denial
+      // path emits its own structured `flag.route_gated` log line at
+      // info via `requireFlag` (kept) — that one is bounded by route
+      // template, not the user's query.
+      logLevel: "warn",
       schema: {
         tags: ["Search"],
         summary: "Cross-entity global search backing the command palette",
         querystring: SearchQuerystring,
         response: {
           200: SearchResponse,
-          400: ErrorResponses[404],
+          400: ProblemDetailSchema,
           ...ErrorResponses,
-          429: ErrorResponses[404],
+          429: ProblemDetailSchema,
         },
       },
     },

--- a/packages/api/src/modules/search/routes.ts
+++ b/packages/api/src/modules/search/routes.ts
@@ -1,0 +1,97 @@
+/**
+ * Global search routes (Epic #364, GLO-001).
+ *
+ * `GET /v1/search?q=<query>` returns RLS-scoped, grouped hits across
+ * constituents, donations, and campaigns. Backs the `Cmd+K` palette in
+ * the web app.
+ *
+ * preHandler order: `requireFlag` is FIRST so a tenant with the flag
+ * off gets 404 (indistinguishable from a typo'd URL), then `requireAuth`
+ * resolves the JWT. RBAC: every authenticated tenant member can search;
+ * RLS in the service layer enforces tenant scope, and viewers see the
+ * same set as users / admins (the palette is a navigation aid, not a
+ * permissioned data surface).
+ *
+ * Rate limit: 60 requests/minute/user. The frontend debounces input by
+ * 200 ms, so a sustained keystroke burst lands around 5 req/s — the
+ * cap absorbs that while leaving headroom for legitimate use without
+ * paging on misbehaviour. (Tighter caps risk false-positive 429s on
+ * fast typists.)
+ */
+
+import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
+import { Type } from "@sinclair/typebox";
+import type { FastifyInstance } from "fastify";
+import { requireFlag } from "../../lib/flags/flag-guard.js";
+import { requireAuth } from "../../lib/guards.js";
+import { ErrorResponses, problemDetail, UuidSchema } from "../../lib/schemas.js";
+import { MAX_QUERY_LENGTH, search } from "./service.js";
+
+// ─── Schemas ────────────────────────────────────────────────────────────────
+
+const SearchQuerystring = Type.Object({
+  q: Type.String({ minLength: 1, maxLength: MAX_QUERY_LENGTH }),
+});
+
+const SearchHitSchema = Type.Object({
+  type: Type.Union([
+    Type.Literal("constituent"),
+    Type.Literal("campaign"),
+    Type.Literal("donation"),
+  ]),
+  id: UuidSchema,
+  title: Type.String(),
+  subtitle: Type.String(),
+  href: Type.String(),
+});
+
+const SearchResponse = Type.Object({
+  data: Type.Object({
+    query: Type.String(),
+    groups: Type.Object({
+      constituents: Type.Array(SearchHitSchema),
+      campaigns: Type.Array(SearchHitSchema),
+      donations: Type.Array(SearchHitSchema),
+    }),
+  }),
+});
+
+// ─── Routes ─────────────────────────────────────────────────────────────────
+
+export async function searchRoutes(app: FastifyInstance) {
+  app.get(
+    "/search",
+    {
+      // Flag-gate FIRST so a disabled tenant looks identical to a typo'd
+      // URL (404). Auth runs second. (Doc 18 §6.1, mirrors notifications
+      // and bulk-email routes.)
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.PRODUCTIVITY_COMMAND_PALETTE), requireAuth],
+      // 60 req/min/user: matches the debounce-friendly cadence the
+      // frontend can produce (5 req/s sustained at the upper bound) and
+      // is comfortably above any realistic human typing speed. The
+      // bulk-import polling endpoint uses the same value.
+      config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
+      schema: {
+        tags: ["Search"],
+        summary: "Cross-entity global search backing the command palette",
+        querystring: SearchQuerystring,
+        response: {
+          200: SearchResponse,
+          400: ErrorResponses[404],
+          ...ErrorResponses,
+          429: ErrorResponses[404],
+        },
+      },
+    },
+    async (request, reply) => {
+      const orgId = request.auth?.orgId;
+      if (!orgId) {
+        return reply.status(401).send(problemDetail(401, "Unauthorized", "Missing tenant context"));
+      }
+
+      const { q } = request.query as { q: string };
+      const result = await search(orgId, q);
+      return { data: result };
+    },
+  );
+}

--- a/packages/api/src/modules/search/service.ts
+++ b/packages/api/src/modules/search/service.ts
@@ -1,0 +1,342 @@
+/**
+ * Global search service — backs `GET /v1/search` (Epic #364, GLO-001).
+ *
+ * Strategy (full rationale in docs/29-global-search.md §3):
+ *
+ *   - Postgres FTS via `to_tsvector('simple', …)` + GIN indices on the
+ *     concatenated name / description fields (migration 0062). The
+ *     'simple' dictionary is intentional: Givernance tenants mix French
+ *     and English records and a stemmed dictionary would corrupt
+ *     surnames ("Fontaine" → "fontain") and English brand-name campaigns.
+ *
+ *   - `pg_trgm` similarity for typo tolerance on short fields (donor
+ *     names, campaign names). Combined with `ILIKE '%q%'`, this catches
+ *     partial typed queries ("mar" → "Marie") that FTS misses because
+ *     `plainto_tsquery` needs a full lexeme.
+ *
+ *   - Three queries per request (one per entity), executed inside a
+ *     single transaction with `withTenantContext` set. RLS is the
+ *     safety net; the application code carries explicit
+ *     `eq(<table>.orgId, orgId)` per the CLAUDE.md §"RLS is the safety
+ *     net, never the contract" rule (issue #430).
+ *
+ *   - Each entity is capped at `PER_GROUP_LIMIT` so a flood of donor
+ *     matches can't bury campaigns or donations. Total wire size is
+ *     bounded by `3 × PER_GROUP_LIMIT`.
+ *
+ *   - Ranking inside a group is `ts_rank + trigram-similarity`, tiebroken
+ *     on recency. Donations rank by name-similarity + a payment-ref /
+ *     receipt-number exact-match boost.
+ *
+ * Query-injection safety:
+ *   - The user's query is NEVER concatenated into SQL. It's bound as a
+ *     parameter via Drizzle's `sql` template, both for the FTS arm
+ *     (`plainto_tsquery('simple', ${q})`) and the trigram arm
+ *     (where `likeQ` is a pre-built `%…%` string bound as a single
+ *     parameter).
+ *   - We sanitise the raw query (length cap, NUL / C0 / C1 control-byte
+ *     strip, whitespace collapse) before binding. Anything else passes
+ *     through to the parameter binder unchanged — pg's parameteriser
+ *     handles the escape.
+ */
+
+import { campaigns, constituents, donations } from "@givernance/shared/schema";
+import { sql } from "drizzle-orm";
+import { withTenantContext } from "../../lib/db.js";
+
+/** Hard cap on result rows per entity group. Keeps the wire payload bounded. */
+export const PER_GROUP_LIMIT = 5;
+
+/** Minimum query length before we hit the DB. Anything shorter is too noisy. */
+export const MIN_QUERY_LENGTH = 2;
+
+/** Hard cap on accepted query length. Mirrors the route schema. */
+export const MAX_QUERY_LENGTH = 200;
+
+export interface SearchHit {
+  /** Entity type discriminator — drives the icon + href on the frontend. */
+  type: "constituent" | "campaign" | "donation";
+  /** Stable entity id (UUID). */
+  id: string;
+  /** Primary display label (e.g. constituent full name, campaign name, donation reference). */
+  title: string;
+  /** Secondary line (e.g. "donor · Marseille", "500 EUR · 25 Feb 2026"). May be empty. */
+  subtitle: string;
+  /** Frontend route to navigate to on selection (no host, no locale prefix). */
+  href: string;
+}
+
+export interface SearchResult {
+  query: string;
+  groups: {
+    constituents: SearchHit[];
+    campaigns: SearchHit[];
+    donations: SearchHit[];
+  };
+}
+
+/**
+ * Normalise a raw query string into a form safe to bind as an FTS /
+ * trigram parameter. Returns `null` if the result is too short to be
+ * useful (covers empty / whitespace-only / control-char-only queries).
+ *
+ * Length is enforced at the route schema (`MAX_QUERY_LENGTH`) so this
+ * is purely defensive — never trust the caller.
+ */
+export function normaliseQuery(raw: string): string | null {
+  // Drop NUL + C0 / C1 control characters before pg's parameter binder
+  // sees the string. Postgres rejects NUL in text outright, and the
+  // other controls are useless noise in a search box. Codepoint
+  // filtering avoids Biome's `noControlCharactersInRegex` rule.
+  let scrubbed = "";
+  for (const ch of raw) {
+    const cp = ch.codePointAt(0) ?? 0;
+    // Allow tab / LF / CR through as whitespace (collapsed below);
+    // strip everything else in C0 (0x00-0x1f) and C1 (0x7f-0x9f).
+    if (cp === 0x09 || cp === 0x0a || cp === 0x0d) {
+      scrubbed += " ";
+      continue;
+    }
+    if (cp < 0x20 || (cp >= 0x7f && cp <= 0x9f)) continue;
+    scrubbed += ch;
+  }
+  const cleaned = scrubbed.replace(/\s+/g, " ").trim();
+
+  if (cleaned.length < MIN_QUERY_LENGTH) return null;
+  if (cleaned.length > MAX_QUERY_LENGTH) return cleaned.slice(0, MAX_QUERY_LENGTH);
+  return cleaned;
+}
+
+export async function search(orgId: string, rawQuery: string): Promise<SearchResult> {
+  const q = normaliseQuery(rawQuery);
+  if (!q) {
+    return {
+      query: rawQuery,
+      groups: { constituents: [], campaigns: [], donations: [] },
+    };
+  }
+
+  // `%q%` for ILIKE / trigram. `plainto_tsquery` handles the FTS arm.
+  const likeQ = `%${q}%`;
+  const limit = PER_GROUP_LIMIT;
+
+  return withTenantContext(orgId, async (tx) => {
+    // ─── Constituents ───────────────────────────────────────────────────
+    // Combine FTS (token boundary) + trigram (typo tolerance) + ILIKE
+    // (substring). Rank: ts_rank + similarity, tiebreak on recency.
+    //
+    // RLS provides defence in depth, but the explicit `org_id = ${orgId}`
+    // filter is the contract (CLAUDE.md §"RLS is the safety net").
+    const constituentRows = await tx.execute<{
+      id: string;
+      first_name: string;
+      last_name: string;
+      type: string | null;
+      city: string | null;
+      score: number;
+    }>(sql`
+      SELECT
+        c.id,
+        c.first_name,
+        c.last_name,
+        c.type,
+        c.city,
+        (
+          ts_rank(
+            to_tsvector(
+              'simple',
+              coalesce(c.first_name, '') || ' ' ||
+              coalesce(c.last_name, '') || ' ' ||
+              coalesce(c.email, '') || ' ' ||
+              coalesce(c.city, '')
+            ),
+            plainto_tsquery('simple', ${q})
+          )
+          + similarity(coalesce(c.first_name, '') || ' ' || coalesce(c.last_name, ''), ${q})
+        )::float AS score
+      FROM ${constituents} c
+      WHERE c.org_id = ${orgId}
+        AND c.deleted_at IS NULL
+        AND (
+          to_tsvector(
+            'simple',
+            coalesce(c.first_name, '') || ' ' ||
+            coalesce(c.last_name, '') || ' ' ||
+            coalesce(c.email, '') || ' ' ||
+            coalesce(c.city, '')
+          ) @@ plainto_tsquery('simple', ${q})
+          OR (coalesce(c.first_name, '') || ' ' || coalesce(c.last_name, '')) ILIKE ${likeQ}
+          OR coalesce(c.email, '') ILIKE ${likeQ}
+        )
+      ORDER BY score DESC, c.updated_at DESC
+      LIMIT ${limit}
+    `);
+
+    // ─── Campaigns ──────────────────────────────────────────────────────
+    const campaignRows = await tx.execute<{
+      id: string;
+      name: string;
+      type: string;
+      status: string;
+      score: number;
+    }>(sql`
+      SELECT
+        c.id,
+        c.name,
+        c.type,
+        c.status,
+        (
+          ts_rank(
+            to_tsvector('simple', coalesce(c.name, '') || ' ' || coalesce(c.description, '')),
+            plainto_tsquery('simple', ${q})
+          )
+          + similarity(coalesce(c.name, ''), ${q})
+        )::float AS score
+      FROM ${campaigns} c
+      WHERE c.org_id = ${orgId}
+        AND (
+          to_tsvector('simple', coalesce(c.name, '') || ' ' || coalesce(c.description, ''))
+            @@ plainto_tsquery('simple', ${q})
+          OR c.name ILIKE ${likeQ}
+        )
+      ORDER BY score DESC, c.updated_at DESC
+      LIMIT ${limit}
+    `);
+
+    // ─── Donations ──────────────────────────────────────────────────────
+    // Donations have no FTS column (free-form text is sparse — only
+    // `payment_ref` and `receipt_number`). We search:
+    //   - donations whose constituent name matches the query (JOIN +
+    //     trigram on the constituent's name) — this is the dominant
+    //     use case ("find Marie's donations")
+    //   - donations whose payment_ref or receipt_number matches the
+    //     literal query (case-insensitive substring) — covers the
+    //     "look up D-2026-0142" path
+    //
+    // The JOIN carries `eq(donations.orgId, orgId)` AND
+    // `eq(constituents.orgId, orgId)` so a leaked / guessed constituent
+    // UUID cannot smuggle a cross-tenant join hit.
+    const donationRows = await tx.execute<{
+      id: string;
+      amount_cents: number;
+      currency: string;
+      donated_at: Date;
+      payment_ref: string | null;
+      receipt_number: string | null;
+      first_name: string;
+      last_name: string;
+      score: number;
+    }>(sql`
+      SELECT
+        d.id,
+        d.amount_cents,
+        d.currency,
+        d.donated_at,
+        d.payment_ref,
+        d.receipt_number,
+        c.first_name,
+        c.last_name,
+        (
+          similarity(coalesce(c.first_name, '') || ' ' || coalesce(c.last_name, ''), ${q})
+          + CASE
+              WHEN coalesce(d.payment_ref, '') ILIKE ${likeQ} THEN 0.5
+              WHEN coalesce(d.receipt_number, '') ILIKE ${likeQ} THEN 0.5
+              ELSE 0
+            END
+        )::float AS score
+      FROM ${donations} d
+      JOIN ${constituents} c
+        ON c.id = d.constituent_id
+        AND c.org_id = d.org_id
+      WHERE d.org_id = ${orgId}
+        AND c.org_id = ${orgId}
+        AND c.deleted_at IS NULL
+        AND (
+          (coalesce(c.first_name, '') || ' ' || coalesce(c.last_name, '')) ILIKE ${likeQ}
+          OR coalesce(d.payment_ref, '') ILIKE ${likeQ}
+          OR coalesce(d.receipt_number, '') ILIKE ${likeQ}
+        )
+      ORDER BY score DESC, d.donated_at DESC
+      LIMIT ${limit}
+    `);
+
+    return {
+      query: q,
+      groups: {
+        constituents: constituentRows.rows.map((row) => formatConstituent(row)),
+        campaigns: campaignRows.rows.map((row) => formatCampaign(row)),
+        donations: donationRows.rows.map((row) => formatDonation(row)),
+      },
+    };
+  });
+}
+
+// ─── Formatters ──────────────────────────────────────────────────────────────
+
+function formatConstituent(row: {
+  id: string;
+  first_name: string;
+  last_name: string;
+  type: string | null;
+  city: string | null;
+}): SearchHit {
+  const fullName = [row.first_name, row.last_name].filter(Boolean).join(" ").trim();
+  const subtitleParts = [row.type, row.city].filter((v): v is string => Boolean(v && v.length > 0));
+  return {
+    type: "constituent",
+    id: row.id,
+    title: fullName || "—",
+    subtitle: subtitleParts.join(" · "),
+    href: `/constituents/${row.id}`,
+  };
+}
+
+function formatCampaign(row: {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
+}): SearchHit {
+  const subtitleParts = [row.type, row.status].filter(Boolean);
+  return {
+    type: "campaign",
+    id: row.id,
+    title: row.name,
+    subtitle: subtitleParts.join(" · "),
+    href: `/campaigns/${row.id}`,
+  };
+}
+
+function formatDonation(row: {
+  id: string;
+  amount_cents: number;
+  currency: string;
+  donated_at: Date | string;
+  payment_ref: string | null;
+  receipt_number: string | null;
+  first_name: string;
+  last_name: string;
+}): SearchHit {
+  const donorName = [row.first_name, row.last_name].filter(Boolean).join(" ").trim();
+  const amount = formatAmount(row.amount_cents, row.currency);
+  const donatedAt = row.donated_at instanceof Date ? row.donated_at : new Date(row.donated_at);
+  const dateStr = Number.isNaN(donatedAt.getTime()) ? "" : donatedAt.toISOString().slice(0, 10);
+  const title = row.receipt_number
+    ? `Don ${row.receipt_number}`
+    : row.payment_ref
+      ? `Don ${row.payment_ref}`
+      : `Don ${row.id.slice(0, 8)}`;
+  const subtitleParts = [amount, donorName, dateStr].filter(Boolean);
+  return {
+    type: "donation",
+    id: row.id,
+    title,
+    subtitle: subtitleParts.join(" · "),
+    href: `/donations/${row.id}`,
+  };
+}
+
+function formatAmount(cents: number, currency: string): string {
+  const major = (cents / 100).toFixed(2);
+  return `${major} ${currency}`;
+}

--- a/packages/api/src/modules/search/service.ts
+++ b/packages/api/src/modules/search/service.ts
@@ -166,7 +166,6 @@ export async function search(orgId: string, rawQuery: string): Promise<SearchRes
             coalesce(c.city, '')
           ) @@ plainto_tsquery('simple', ${q})
           OR (coalesce(c.first_name, '') || ' ' || coalesce(c.last_name, '')) ILIKE ${likeQ}
-          OR coalesce(c.email, '') ILIKE ${likeQ}
         )
       ORDER BY score DESC, c.updated_at DESC
       LIMIT ${limit}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -33,6 +33,7 @@ import { paymentRoutes, stripeWebhookRoute } from "./modules/payments/routes.js"
 import { pledgeRoutes } from "./modules/pledges/routes.js";
 import { publicDonationRoutes } from "./modules/public/routes.js";
 import { reportsRoutes } from "./modules/reports/routes.js";
+import { searchRoutes } from "./modules/search/routes.js";
 import { sessionRoutes } from "./modules/session/routes.js";
 import { signupRoutes } from "./modules/signup/routes.js";
 import { tenantAdminRoutes } from "./modules/tenant-admin/routes.js";
@@ -203,6 +204,7 @@ export async function createServer(opts: CreateServerOpts = {}): Promise<Fastify
   await app.register(publicDonationRoutes, { prefix: "/v1" });
   await app.register(signupRoutes, { prefix: "/v1" });
   await app.register(reportsRoutes, { prefix: "/v1" });
+  await app.register(searchRoutes, { prefix: "/v1" });
   await app.register(impersonationRoutes, { prefix: "/v1" });
   await app.register(platformAdminsRoutes, { prefix: "/v1" });
   await app.register(featureFlagsRoutes, { prefix: "/v1" });

--- a/packages/api/src/tests/integration/search.test.ts
+++ b/packages/api/src/tests/integration/search.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Global search integration tests (Epic #364, GLO-001).
+ *
+ * Coverage matrix:
+ *   1. Off-state flag — `GET /v1/search` returns 404 when the flag is
+ *      off, INCLUDING for unauthenticated callers (flag gate fires
+ *      before auth — anti-disclosure).
+ *   2. On-state flag — happy path returns grouped hits with the
+ *      `{ data: { query, groups } }` envelope.
+ *   3. RLS isolation — Tenant A's records never appear in Tenant B's
+ *      search results, even when the literal query matches both.
+ *   4. Query-injection safety — pg-flavoured payloads (NUL byte, SQL
+ *      meta-characters, `to_tsquery` operators) don't crash and don't
+ *      escape the parameter binder.
+ *   5. Schema parity — the `productivity.command_palette` row matches
+ *      `FEATURE_FLAG_REGISTRY` (drift guard).
+ *   6. RFC 9457 body shape on the off-state 404.
+ */
+
+import { FEATURE_FLAG_KEYS, FEATURE_FLAG_REGISTRY } from "@givernance/shared/constants";
+import { campaigns, constituents, donations, featureFlags } from "@givernance/shared/schema";
+import { eq, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { db } from "../../lib/db.js";
+import { flagService } from "../../lib/flags/flag-service.js";
+import { createServer } from "../../server.js";
+import {
+  authHeader,
+  ensureTestTenants,
+  ORG_A,
+  ORG_B,
+  signToken,
+  signTokenB,
+} from "../helpers/auth.js";
+
+const FLAG_KEY = FEATURE_FLAG_KEYS.PRODUCTIVITY_COMMAND_PALETTE;
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+});
+
+afterAll(async () => {
+  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+  await app.close();
+});
+
+beforeEach(async () => {
+  // Clean only the rows this suite seeds — other suites share the
+  // schema and may have their own fixtures live.
+  await db.execute(sql`DELETE FROM donations WHERE payment_ref LIKE 'SEARCH-TEST-%'`);
+  await db.execute(sql`DELETE FROM campaigns WHERE name LIKE 'SEARCH-TEST-%'`);
+  await db.execute(sql`DELETE FROM constituents WHERE first_name LIKE 'SEARCH-TEST-%'`);
+  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+});
+
+afterEach(async () => {
+  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+});
+
+async function setFlag(enabled: boolean): Promise<void> {
+  await db.update(featureFlags).set({ enabled }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+}
+
+async function seedConstituent(
+  orgId: string,
+  firstName: string,
+  lastName: string,
+): Promise<string> {
+  // owner-pool insert bypasses RLS so we can seed for any tenant.
+  const id = crypto.randomUUID();
+  await db
+    .insert(constituents)
+    .values({
+      id,
+      orgId,
+      firstName,
+      lastName,
+      type: "donor",
+    })
+    .execute();
+  return id;
+}
+
+async function seedCampaign(orgId: string, name: string): Promise<string> {
+  const id = crypto.randomUUID();
+  await db
+    .insert(campaigns)
+    .values({
+      id,
+      orgId,
+      name,
+      type: "digital",
+      status: "active",
+    })
+    .execute();
+  return id;
+}
+
+async function seedDonation(
+  orgId: string,
+  constituentId: string,
+  paymentRef: string,
+): Promise<string> {
+  const id = crypto.randomUUID();
+  await db
+    .insert(donations)
+    .values({
+      id,
+      orgId,
+      constituentId,
+      amountCents: 25_000,
+      currency: "EUR",
+      amountBaseCents: 25_000,
+      paymentMethod: "manual",
+      paymentRef,
+      donatedAt: new Date("2026-02-25T10:00:00Z"),
+    })
+    .execute();
+  return id;
+}
+
+// ─── 1. Off-state flag (anti-disclosure) ─────────────────────────────
+
+describe("Search — off-state flag (anti-disclosure)", () => {
+  it("returns 404 on GET /v1/search when flag is off (authenticated)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=marie",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("unauthenticated GET /v1/search also returns 404 (gate before auth)", async () => {
+    const res = await app.inject({ method: "GET", url: "/v1/search?q=marie" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("off-state 404 body conforms to RFC 9457 (status + title members)", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=marie",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{ status?: number; title?: string }>();
+    expect(body.status).toBe(404);
+    expect(body.title).toBe("Not Found");
+  });
+});
+
+// ─── 2. Happy path ───────────────────────────────────────────────────
+
+describe("Search — happy path", () => {
+  beforeEach(async () => {
+    await setFlag(true);
+    // Use highly-unique fixture names so other test suites' constituents
+    // (e.g. constituents.test.ts seeds "Marie" rows of its own) don't
+    // crowd this query past the PER_GROUP_LIMIT=5 cap.
+    const marie = await seedConstituent(ORG_A, "SEARCH-TEST-Marie", "Quotaxis");
+    await seedConstituent(ORG_A, "SEARCH-TEST-Ahmed", "Benali");
+    await seedCampaign(ORG_A, "SEARCH-TEST-SpringQuotaxis");
+    await seedDonation(ORG_A, marie, "SEARCH-TEST-PAY-Quotaxis-001");
+  });
+
+  it("returns grouped hits matching the query", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=Quotaxis",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        query: string;
+        groups: {
+          constituents: Array<{ id: string; type: string; title: string; href: string }>;
+          campaigns: Array<{ id: string; title: string }>;
+          donations: Array<{ id: string; title: string }>;
+        };
+      };
+    }>();
+
+    expect(body.data.query).toBe("Quotaxis");
+    expect(body.data.groups.constituents.length).toBeGreaterThanOrEqual(1);
+
+    const marieHit = body.data.groups.constituents.find((h) => h.title.includes("Quotaxis"));
+    expect(marieHit).toBeDefined();
+    expect(marieHit?.type).toBe("constituent");
+    expect(marieHit?.href).toMatch(/^\/constituents\//);
+
+    // Donation joined via constituent name comes through.
+    const donationHit = body.data.groups.donations.find((h) =>
+      h.title.includes("SEARCH-TEST-PAY-Quotaxis-001"),
+    );
+    expect(donationHit).toBeDefined();
+  });
+
+  it("returns the campaign group when the campaign name matches", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=SpringQuotaxis",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { groups: { campaigns: Array<{ title: string }> } };
+    }>();
+    const hit = body.data.groups.campaigns.find((h) => h.title.includes("SpringQuotaxis"));
+    expect(hit).toBeDefined();
+  });
+
+  it("returns empty groups when the query has no matches", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=zzznomatchzzz",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: {
+        groups: {
+          constituents: unknown[];
+          campaigns: unknown[];
+          donations: unknown[];
+        };
+      };
+    }>();
+    expect(body.data.groups.constituents).toEqual([]);
+    expect(body.data.groups.campaigns).toEqual([]);
+    expect(body.data.groups.donations).toEqual([]);
+  });
+
+  it("rejects an empty `q` with a 400", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a missing `q` with a 400", async () => {
+    const token = signToken(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search",
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ─── 3. RLS isolation ────────────────────────────────────────────────
+
+describe("Search — RLS isolation across tenants", () => {
+  it("Tenant B cannot see Tenant A constituents matching the same query", async () => {
+    await setFlag(true);
+    // Both tenants own a "SEARCH-TEST-Camille". RLS must not leak A's
+    // row to B and vice versa.
+    await seedConstituent(ORG_A, "SEARCH-TEST-Camille", "AlphaOnly");
+    await seedConstituent(ORG_B, "SEARCH-TEST-Camille", "BravoOnly");
+
+    const tokenB = signTokenB(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=Camille",
+      headers: authHeader(tokenB),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { groups: { constituents: Array<{ title: string }> } };
+    }>();
+    // Bravo (B's row) is allowed; Alpha (A's row) MUST be absent.
+    const titles = body.data.groups.constituents.map((h) => h.title);
+    expect(titles.some((t) => t.includes("BravoOnly"))).toBe(true);
+    expect(titles.some((t) => t.includes("AlphaOnly"))).toBe(false);
+  });
+
+  it("Tenant A's campaigns are not visible to Tenant B", async () => {
+    await setFlag(true);
+    await seedCampaign(ORG_A, "SEARCH-TEST-AlphaSecretCampaign");
+
+    const tokenB = signTokenB(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=AlphaSecret",
+      headers: authHeader(tokenB),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ data: { groups: { campaigns: Array<{ title: string }> } } }>();
+    expect(body.data.groups.campaigns).toEqual([]);
+  });
+});
+
+// ─── 4. Query-injection safety ───────────────────────────────────────
+
+describe("Search — query-injection safety", () => {
+  beforeEach(async () => {
+    await setFlag(true);
+    await seedConstituent(ORG_A, "SEARCH-TEST-Probe-Marie", "Fontaine");
+  });
+
+  it("a NUL byte in `q` is stripped without crashing pg", async () => {
+    const token = signToken(app);
+    // NUL byte ( ) — pg rejects this if it ever reaches the binder.
+    // Our normaliser strips C0 chars; this asserts the path is clean.
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/search?q=${encodeURIComponent("Mar ie")}`,
+      headers: authHeader(token),
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("tsquery meta-operators are accepted via plainto_tsquery (no syntax errors)", async () => {
+    const token = signToken(app);
+    // `plainto_tsquery` quotes operators as plain words, so `&`, `|`,
+    // `!`, `()` are not parsed as boolean operators and do not crash.
+    const probes = ["marie & fontaine", "marie | x", "!marie", "marie:*", "(marie)"];
+    for (const probe of probes) {
+      const res = await app.inject({
+        method: "GET",
+        url: `/v1/search?q=${encodeURIComponent(probe)}`,
+        headers: authHeader(token),
+      });
+      expect(res.statusCode).toBe(200);
+    }
+  });
+
+  it("a SQL-meta-character query does not cause a 500", async () => {
+    const token = signToken(app);
+    // Classic injection probes — all should be bound as parameters.
+    const probes = ["'; DROP TABLE constituents; --", '"; SELECT * FROM users; --', "%' OR 1=1 --"];
+    for (const probe of probes) {
+      const res = await app.inject({
+        method: "GET",
+        url: `/v1/search?q=${encodeURIComponent(probe)}`,
+        headers: authHeader(token),
+      });
+      // 200 (no hits, or whatever the literal happens to match) — never 500.
+      expect(res.statusCode).toBe(200);
+    }
+
+    // Verify the constituent we seeded still exists (table NOT dropped).
+    const survived = await db.execute<{ count: string }>(sql`
+      SELECT COUNT(*)::text AS count FROM constituents WHERE first_name = 'SEARCH-TEST-Probe-Marie'
+    `);
+    expect(Number(survived.rows[0]?.count ?? "0")).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── 5. Registry parity ──────────────────────────────────────────────
+
+describe("Search — feature-flag registry parity", () => {
+  it("DB row for productivity.command_palette matches FEATURE_FLAG_REGISTRY", async () => {
+    const row = await db.query.featureFlags.findFirst({
+      where: eq(featureFlags.key, FLAG_KEY),
+    });
+    expect(row).toBeDefined();
+
+    const expected = FEATURE_FLAG_REGISTRY.find((r) => r.key === FLAG_KEY);
+    expect(expected).toBeDefined();
+    if (!row || !expected) return;
+
+    expect(row.label).toBe(expected.label);
+    expect(row.description).toBe(expected.description);
+    expect(row.scope).toBe(expected.scope);
+    expect(row.tenantOverrideAllowed).toBe(expected.tenantOverrideAllowed);
+    expect(row.public).toBe(expected.public);
+  });
+});

--- a/packages/api/src/tests/integration/search.test.ts
+++ b/packages/api/src/tests/integration/search.test.ts
@@ -52,10 +52,15 @@ afterAll(async () => {
 
 beforeEach(async () => {
   // Clean only the rows this suite seeds — other suites share the
-  // schema and may have their own fixtures live.
+  // schema and may have their own fixtures live. Match BOTH first_name
+  // and last_name on the prefix so the soft-delete + cap fixtures
+  // (which intentionally vary the last name) still get reaped.
   await db.execute(sql`DELETE FROM donations WHERE payment_ref LIKE 'SEARCH-TEST-%'`);
   await db.execute(sql`DELETE FROM campaigns WHERE name LIKE 'SEARCH-TEST-%'`);
-  await db.execute(sql`DELETE FROM constituents WHERE first_name LIKE 'SEARCH-TEST-%'`);
+  await db.execute(sql`
+    DELETE FROM constituents
+    WHERE first_name LIKE 'SEARCH-TEST-%' OR last_name LIKE 'SEARCH-TEST-%'
+  `);
   await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
   await flagService.invalidate();
 });
@@ -248,7 +253,7 @@ describe("Search — happy path", () => {
     expect(body.data.groups.donations).toEqual([]);
   });
 
-  it("rejects an empty `q` with a 400", async () => {
+  it("rejects an empty `q` with a 400 and an RFC 9457 body", async () => {
     const token = signToken(app);
     const res = await app.inject({
       method: "GET",
@@ -256,6 +261,11 @@ describe("Search — happy path", () => {
       headers: authHeader(token),
     });
     expect(res.statusCode).toBe(400);
+    const body = res.json<{ status?: number; title?: string }>();
+    // Pin the well-known RFC 9457 members so a future "throw new
+    // Error" regression returns 400 with a plain string instead.
+    expect(body.status).toBe(400);
+    expect(typeof body.title).toBe("string");
   });
 
   it("rejects a missing `q` with a 400", async () => {
@@ -266,6 +276,69 @@ describe("Search — happy path", () => {
       headers: authHeader(token),
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  it("excludes soft-deleted constituents from the result set", async () => {
+    const token = signToken(app);
+    // Seed an active row + a soft-deleted row with the same searchable
+    // token, so the filter (not the absence of data) is what removes it.
+    await seedConstituent(ORG_A, "SEARCH-TEST-SoftDeleteToken", "Active");
+    const deletedId = await seedConstituent(ORG_A, "SEARCH-TEST-SoftDeleteToken", "Deleted");
+    await db.execute(sql`
+      UPDATE constituents SET deleted_at = now() WHERE id = ${deletedId}
+    `);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=SoftDeleteToken",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { groups: { constituents: Array<{ id: string; subtitle: string }> } };
+    }>();
+    const ids = body.data.groups.constituents.map((h) => h.id);
+    expect(ids).not.toContain(deletedId);
+  });
+
+  it("caps each group at PER_GROUP_LIMIT (5) hits", async () => {
+    const token = signToken(app);
+    // Seven matches; the cap should drop to five.
+    for (let i = 0; i < 7; i++) {
+      await seedConstituent(ORG_A, `SEARCH-TEST-CapToken${i}`, "Cap");
+    }
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=CapToken",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { groups: { constituents: unknown[] } };
+    }>();
+    expect(body.data.groups.constituents.length).toBe(5);
+  });
+
+  it("ranks the closer match above the weaker one", async () => {
+    const token = signToken(app);
+    // Both rows tokenise on "Rankseed"; only the second carries it as
+    // the first name (similarity boost), so it must rank first.
+    await seedConstituent(ORG_A, "SEARCH-TEST-Unrelated", "Rankseed-Surname");
+    await seedConstituent(ORG_A, "SEARCH-TEST-Rankseed", "Closer");
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/search?q=Rankseed",
+      headers: authHeader(token),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      data: { groups: { constituents: Array<{ title: string }> } };
+    }>();
+    expect(body.data.groups.constituents[0]?.title).toContain("SEARCH-TEST-Rankseed");
   });
 });
 

--- a/packages/shared/src/constants/feature-flags.ts
+++ b/packages/shared/src/constants/feature-flags.ts
@@ -245,6 +245,54 @@ export const FEATURE_FLAG_KEYS = {
    * if the Back Office is unavailable.
    */
   ADMIN_IMPERSONATION_REPLICATE: "admin.impersonation_replicate",
+
+  /**
+   * Gates the global search / command palette feature (Epic #364, GLO-001).
+   *
+   * Adds a `Cmd+K` / `Ctrl+K` keyboard binding that opens a `cmdk` overlay
+   * with grouped, RLS-scoped cross-entity search across constituents,
+   * donations, and campaigns, plus static "go to …" navigation commands and
+   * RBAC-aware quick-create actions (new constituent, new donation,
+   * new campaign).
+   *
+   * `scope='tenant'`: every NPO is independent. A tenant on Postgres FTS
+   * is the entire feature today, but if Givernance later swaps to an
+   * external search engine (Meilisearch / Typesense, hosted EU on
+   * Scaleway), the per-tenant gate is the rollout knob — we can pilot
+   * the new backend with a single tenant override before flipping the
+   * platform default.
+   *
+   * `tenant_override_allowed=true`: there is no platform-level
+   * precondition (no DKIM-style external dependency); each org-admin can
+   * self-serve the toggle from `/settings/feature-flags` once we're past
+   * the initial rollout.
+   *
+   * `public=true`: the topbar's `Cmd+K` button + keyboard binding +
+   * SSR-rendered overlay shell all need to know the effective value at
+   * page-load time. A private projection would unconditionally hide the
+   * surface and defeat the Epic.
+   *
+   * Surfaces gated by this key:
+   *   - API: GET /v1/search (`requireFlag` is the FIRST preHandler — a
+   *     disabled tenant gets 404, indistinguishable from a typo'd URL,
+   *     so a scanner can't enumerate the feature).
+   *   - Web: the topbar `Cmd+K` button is completely absent when the
+   *     flag is off (no greyed-out placeholder).
+   *   - Web: the global `Cmd+K` / `Ctrl+K` keydown listener is NOT
+   *     mounted when the flag is off (off-state QA: pressing the
+   *     shortcut does nothing).
+   *   - Web: the command palette overlay component is not loaded at
+   *     all when the flag is off.
+   *
+   * Public-projection caveat: per the CLAUDE.md feature-flag-first
+   * rule, the key name `productivity.command_palette` is intentionally
+   * descriptive and not teasing an unannounced surprise, so its
+   * presence in `/v1/feature-flags` for every authenticated tenant
+   * user is acceptable.
+   *
+   * Emergency rollback: see `docs/runbooks/feature-flag-rollback.md`.
+   */
+  PRODUCTIVITY_COMMAND_PALETTE: "productivity.command_palette",
 } as const;
 
 export type FeatureFlagKey = (typeof FEATURE_FLAG_KEYS)[keyof typeof FEATURE_FLAG_KEYS];
@@ -350,6 +398,16 @@ export const FEATURE_FLAG_REGISTRY: ReadonlyArray<{
       "Adds a Replicate action next to each past support session on the Back Office, so support staff can re-enter the same session in one click without retyping the target and reason. The same security checks still apply on every replicate.",
     scope: "platform",
     tenantOverrideAllowed: false,
+    public: true,
+  },
+  {
+    key: FEATURE_FLAG_KEYS.PRODUCTIVITY_COMMAND_PALETTE,
+    defaultEnabled: false,
+    label: "Keyboard quick search (Cmd+K / Ctrl+K)",
+    description:
+      "Adds a quick search panel that opens with Cmd+K (Mac) or Ctrl+K (Windows / Linux) from any page. Type to find a constituent, donation, or campaign, jump to a section, or start a new record. Off by default while we monitor performance and search quality — flip it on from this page when you're ready.",
+    scope: "tenant",
+    tenantOverrideAllowed: true,
     public: true,
   },
 ];

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -110,6 +110,10 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     publicFlags,
     FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER,
   );
+  const commandPaletteEnabled = isFlagEnabled(
+    publicFlags,
+    FEATURE_FLAG_KEYS.PRODUCTIVITY_COMMAND_PALETTE,
+  );
 
   // Broken state: a non-super-admin reached the authenticated layout but
   // we couldn't resolve their tenant memberships. Two failure modes:
@@ -157,6 +161,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         canManageBranding={auth.roles.includes("org_admin")}
         orgLogo={orgLogo}
         notificationsEnabled={notificationsEnabled}
+        commandPaletteEnabled={commandPaletteEnabled}
       >
         {children}
       </AppShell>

--- a/packages/web/src/components/command-palette/command-palette.test.tsx
+++ b/packages/web/src/components/command-palette/command-palette.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * CommandPalette tests — covers the stateful surface added by Epic
+ * #364 (GLO-001): debounce, AbortController supersede, RBAC gating on
+ * quick-create rows, render branches.
+ *
+ * Mocks `SearchService.search` (so tests don't need a server),
+ * `next/navigation`'s `useRouter` (so `router.push` is observable), and
+ * `useAuth` (so role coverage is parametrised per test). The Dialog
+ * uses Radix portals; Testing Library renders portals into the JSDOM
+ * body by default so queries work.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, userEvent, waitFor } from "@/tests/test-utils";
+
+const mockSearch = vi.fn();
+const mockRouterPush = vi.fn();
+const mockHasAppRole = vi.fn();
+
+vi.mock("@/services/SearchService", () => ({
+  SearchService: {
+    search: (...args: unknown[]) => mockSearch(...args),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+vi.mock("@/lib/api/client-browser", () => ({
+  createClientApiClient: () => ({}),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({
+    hasAppRole: mockHasAppRole,
+  }),
+}));
+
+const { CommandPalette } = await import("./command-palette");
+
+const ONE_HIT_RESULT = {
+  query: "marie",
+  groups: {
+    constituents: [
+      {
+        type: "constituent" as const,
+        id: "11111111-1111-1111-1111-111111111111",
+        title: "Marie Fontaine",
+        subtitle: "donor · Marseille",
+        href: "/constituents/11111111-1111-1111-1111-111111111111",
+      },
+    ],
+    campaigns: [],
+    donations: [],
+  },
+};
+
+beforeEach(() => {
+  mockSearch.mockReset();
+  mockRouterPush.mockReset();
+  mockHasAppRole.mockReset();
+  // Default: org_admin role so quick-create rows render. Per-test
+  // overrides flip to "viewer" for the role-coverage check.
+  mockHasAppRole.mockImplementation((role: string) => role === "org_admin");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("CommandPalette — empty-state surfaces", () => {
+  it("renders static Go-to and Quick-create rows for an org_admin", () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+    // Navigation rows visible.
+    expect(screen.getByRole("option", { name: /go to dashboard/i })).toBeDefined();
+    expect(screen.getByRole("option", { name: /go to constituents/i })).toBeDefined();
+    expect(screen.getByRole("option", { name: /go to campaigns/i })).toBeDefined();
+    expect(screen.getByRole("option", { name: /go to donations/i })).toBeDefined();
+    // Quick-create rows visible (org_admin → canWrite=true).
+    expect(screen.getByRole("option", { name: /new constituent/i })).toBeDefined();
+    expect(screen.getByRole("option", { name: /record a donation/i })).toBeDefined();
+    expect(screen.getByRole("option", { name: /new campaign/i })).toBeDefined();
+  });
+
+  it("hides quick-create rows for a viewer (RBAC parity, both directions)", () => {
+    mockHasAppRole.mockImplementation(() => false);
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+    expect(screen.getByRole("option", { name: /go to dashboard/i })).toBeDefined();
+    expect(screen.queryByRole("option", { name: /new constituent/i })).toBeNull();
+    expect(screen.queryByRole("option", { name: /record a donation/i })).toBeNull();
+    expect(screen.queryByRole("option", { name: /new campaign/i })).toBeNull();
+  });
+
+  it("shows quick-create rows for a user role (the other positive case)", () => {
+    mockHasAppRole.mockImplementation((role: string) => role === "user");
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+    expect(screen.getByRole("option", { name: /new constituent/i })).toBeDefined();
+  });
+});
+
+describe("CommandPalette — debounce + search", () => {
+  // Note: these tests use REAL timers and the actual 200 ms debounce.
+  // user-event + fake timers + Radix Dialog's internal effects deadlock
+  // each other; falling back to `fireEvent.change` + waitFor on the
+  // mock-call assertion is more reliable and only adds ~250 ms per test.
+
+  it("does NOT call SearchService.search for a 1-char query (MIN_QUERY_LENGTH=2)", async () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "m" } });
+    // Wait past the debounce window; mock must remain uncalled.
+    await new Promise((res) => setTimeout(res, 300));
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it("debounces the fetch and only fires the latest keystroke", async () => {
+    mockSearch.mockResolvedValue(ONE_HIT_RESULT);
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ma" } });
+    fireEvent.change(input, { target: { value: "mar" } });
+    fireEvent.change(input, { target: { value: "mari" } });
+    await waitFor(
+      () => {
+        expect(mockSearch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 1000 },
+    );
+    expect(mockSearch).toHaveBeenCalledWith(expect.anything(), "mari", expect.anything());
+  });
+
+  it("renders the loading state while the fetch is in flight", async () => {
+    let resolveFetch: (v: typeof ONE_HIT_RESULT) => void = () => {};
+    mockSearch.mockReturnValue(
+      new Promise<typeof ONE_HIT_RESULT>((res) => {
+        resolveFetch = res;
+      }),
+    );
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "marie" } });
+    // Loading message arrives after the debounce window elapses.
+    await waitFor(() => {
+      expect(screen.getByText(/searching/i)).toBeDefined();
+    });
+    // Resolve so the in-flight promise doesn't leak past the test.
+    resolveFetch(ONE_HIT_RESULT);
+  });
+
+  it("renders the error branch when SearchService rejects (non-abort)", async () => {
+    mockSearch.mockRejectedValue(new Error("boom"));
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "marie" } });
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+    });
+  });
+});
+
+describe("CommandPalette — selection navigates and closes", () => {
+  it("calls onClose() before router.push when a navigation row is selected", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<CommandPalette open={true} onClose={onClose} />);
+    await user.click(screen.getByRole("option", { name: /go to dashboard/i }));
+    expect(onClose).toHaveBeenCalled();
+    expect(mockRouterPush).toHaveBeenCalledWith("/dashboard");
+    // Order matters: close FIRST so the overlay isn't visible on top
+    // of the destination page.
+    expect(onClose.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRouterPush.mock.invocationCallOrder[0] ?? Infinity,
+    );
+  });
+
+  it("quick-create routes go to /<entity>/new (not ?new=1)", async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+    await user.click(screen.getByRole("option", { name: /new constituent/i }));
+    expect(mockRouterPush).toHaveBeenCalledWith("/constituents/new");
+  });
+});

--- a/packages/web/src/components/command-palette/command-palette.tsx
+++ b/packages/web/src/components/command-palette/command-palette.tsx
@@ -187,19 +187,19 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
     return [
       {
         id: "create-constituent",
-        href: "/constituents?new=1",
+        href: "/constituents/new",
         label: t("create.constituent"),
         icon: UserPlus,
       },
       {
         id: "create-donation",
-        href: "/donations?new=1",
+        href: "/donations/new",
         label: t("create.donation"),
         icon: PlusCircle,
       },
       {
         id: "create-campaign",
-        href: "/campaigns?new=1",
+        href: "/campaigns/new",
         label: t("create.campaign"),
         icon: Calendar,
       },

--- a/packages/web/src/components/command-palette/command-palette.tsx
+++ b/packages/web/src/components/command-palette/command-palette.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+/**
+ * CommandPalette — the global Cmd+K / Ctrl+K overlay (Epic #364, GLO-001).
+ *
+ * Mounted ONCE in `AppShell` (so the overlay is in the DOM regardless of
+ * which page is current), but the trigger to *open* it is owned by the
+ * shell: pressing Cmd+K (Mac) / Ctrl+K (others) anywhere in the app
+ * flips `open=true`, and the topbar surfaces a visible button for
+ * pointer / touch users who don't know the shortcut.
+ *
+ * Behaviour:
+ *   - Type 2+ chars → debounced (200 ms) fetch to `GET /v1/search`.
+ *     In-flight requests are aborted when a newer keystroke supersedes
+ *     them, so a slow earlier response never overwrites a later one.
+ *   - Results are grouped by entity type. Static "Go to …" commands
+ *     and RBAC-aware quick-create actions appear when the query is
+ *     empty.
+ *   - Arrow keys / Enter / Esc all handled by the underlying `cmdk`
+ *     primitive (which manages focus + roving tabindex + ARIA combobox
+ *     roles).
+ *   - On select: navigate via `next/navigation` `router.push`, then
+ *     close the palette.
+ *
+ * a11y:
+ *   - `cmdk` renders the input with role="combobox" and the list with
+ *     role="listbox" by default. We add an explicit `aria-label` on the
+ *     dialog so screen-readers announce "Quick search" rather than
+ *     "Dialog".
+ *   - The footer hint row is `aria-hidden` — it's a visual affordance
+ *     for sighted users; assistive tech already knows the keys.
+ */
+
+import {
+  Calendar,
+  Heart,
+  LayoutDashboard,
+  Megaphone,
+  PlusCircle,
+  User as UserIcon,
+  UserPlus,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { createClientApiClient } from "@/lib/api/client-browser";
+import { useAuth } from "@/lib/auth";
+import { type SearchGroups, type SearchHit, SearchService } from "@/services/SearchService";
+
+const DEBOUNCE_MS = 200;
+const MIN_QUERY_LENGTH = 2;
+
+export interface CommandPaletteProps {
+  /** Controlled open state — owned by `AppShell`. */
+  open: boolean;
+  /** Close handler — `AppShell` flips `open` to `false`. */
+  onClose: () => void;
+}
+
+const EMPTY_GROUPS: SearchGroups = {
+  constituents: [],
+  campaigns: [],
+  donations: [],
+};
+
+export function CommandPalette({ open, onClose }: CommandPaletteProps) {
+  const router = useRouter();
+  const t = useTranslations("appShell.commandPalette");
+  const { hasAppRole } = useAuth();
+
+  const canWrite = hasAppRole("org_admin") || hasAppRole("user");
+
+  const [query, setQuery] = useState("");
+  const [groups, setGroups] = useState<SearchGroups>(EMPTY_GROUPS);
+  const [loading, setLoading] = useState(false);
+  const [errored, setErrored] = useState(false);
+
+  // Stable API client across renders. `createClientApiClient` is cheap
+  // but new-ing it every render breaks the AbortController identity
+  // tracking below.
+  const apiClient = useMemo(() => createClientApiClient(), []);
+
+  // Track the in-flight fetch so a later keystroke can abort an earlier
+  // request — otherwise a slow first response can overwrite a fresher
+  // result (classic out-of-order race).
+  const inflightRef = useRef<AbortController | null>(null);
+
+  // Reset transient state every time the palette opens — otherwise the
+  // user sees stale results from the last session.
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setGroups(EMPTY_GROUPS);
+      setLoading(false);
+      setErrored(false);
+    }
+    return () => {
+      inflightRef.current?.abort();
+      inflightRef.current = null;
+    };
+  }, [open]);
+
+  // Debounced fetch: schedule with `setTimeout`, cancel on next keystroke.
+  useEffect(() => {
+    if (!open) return;
+    const trimmed = query.trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      // Cancel any in-flight request and clear results — back to the
+      // "empty query → show static commands" state.
+      inflightRef.current?.abort();
+      inflightRef.current = null;
+      setGroups(EMPTY_GROUPS);
+      setLoading(false);
+      setErrored(false);
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      // Supersede any prior in-flight request.
+      inflightRef.current?.abort();
+      const controller = new AbortController();
+      inflightRef.current = controller;
+
+      setLoading(true);
+      setErrored(false);
+      SearchService.search(apiClient, trimmed, controller.signal)
+        .then((result) => {
+          if (controller.signal.aborted) return;
+          setGroups(result.groups);
+          setLoading(false);
+        })
+        .catch((err: unknown) => {
+          if (controller.signal.aborted) return;
+          // AbortError is the normal supersede path — don't flag it.
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          setErrored(true);
+          setLoading(false);
+        });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [open, query, apiClient]);
+
+  const handleSelect = useCallback(
+    (href: string) => {
+      onClose();
+      router.push(href);
+    },
+    [onClose, router],
+  );
+
+  // Static "Go to …" commands stay in sync with the sidebar. Keep this
+  // list short — the palette is a quick-jump aid, not a sitemap.
+  const navigationCommands = useMemo(
+    () => [
+      { id: "nav-dashboard", href: "/dashboard", label: t("nav.dashboard"), icon: LayoutDashboard },
+      {
+        id: "nav-constituents",
+        href: "/constituents",
+        label: t("nav.constituents"),
+        icon: UserIcon,
+      },
+      { id: "nav-campaigns", href: "/campaigns", label: t("nav.campaigns"), icon: Megaphone },
+      { id: "nav-donations", href: "/donations", label: t("nav.donations"), icon: Heart },
+    ],
+    [t],
+  );
+
+  // Quick-create actions — gated on `canWrite` so viewers don't see
+  // them at all (RBAC). Each links to the existing entity-create flow;
+  // we don't open a new modal here.
+  const quickCreateCommands = useMemo(() => {
+    if (!canWrite) return [];
+    return [
+      {
+        id: "create-constituent",
+        href: "/constituents?new=1",
+        label: t("create.constituent"),
+        icon: UserPlus,
+      },
+      {
+        id: "create-donation",
+        href: "/donations?new=1",
+        label: t("create.donation"),
+        icon: PlusCircle,
+      },
+      {
+        id: "create-campaign",
+        href: "/campaigns?new=1",
+        label: t("create.campaign"),
+        icon: Calendar,
+      },
+    ];
+  }, [canWrite, t]);
+
+  const hasQuery = query.trim().length >= MIN_QUERY_LENGTH;
+  const hasResults =
+    groups.constituents.length > 0 || groups.campaigns.length > 0 || groups.donations.length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? null : onClose())}>
+      <DialogContent
+        className="overflow-hidden p-0 shadow-modal max-w-[640px]"
+        aria-label={t("title")}
+      >
+        {/* `DialogTitle` is visually hidden but required by Radix for SR
+            announcement. The visible heading is the input placeholder. */}
+        <DialogTitle className="sr-only">{t("title")}</DialogTitle>
+        {/*
+          `shouldFilter={false}` — `cmdk` defaults to client-side
+          fuzzy filtering on the `value` of each Item. Our results
+          already come from the server pre-filtered + pre-ranked, so
+          letting `cmdk` re-filter would (a) drop server hits whose
+          title doesn't contain the literal query and (b) override
+          the server's relevance ordering. The static "Go to …" and
+          quick-create rows are always shown alongside, so the user
+          can still trigger them with any query.
+        */}
+        <Command
+          shouldFilter={false}
+          className="[&_[cmdk-input]]:h-12"
+          // The combobox role + listbox are applied by `cmdk` on the
+          // input + list elements automatically. We override label
+          // here so the SR announcement is meaningful.
+          label={t("title")}
+        >
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder={t("placeholder")}
+            autoFocus
+            aria-label={t("placeholder")}
+          />
+          <CommandList>
+            {/* Empty state branches:
+                  - No query → static nav + quick-create groups
+                  - With query, loading → "Searching…"
+                  - With query, errored → "Couldn't search"
+                  - With query, no hits → "No results" */}
+            {hasQuery && loading ? (
+              <div className="py-6 text-center text-sm text-on-surface-variant" aria-live="polite">
+                {t("loading")}
+              </div>
+            ) : null}
+            {hasQuery && errored ? (
+              <div
+                className="py-6 text-center text-sm text-error"
+                aria-live="assertive"
+                role="alert"
+              >
+                {t("error")}
+              </div>
+            ) : null}
+            {hasQuery && !loading && !errored && !hasResults ? (
+              <CommandEmpty>{t("noResults")}</CommandEmpty>
+            ) : null}
+
+            {hasQuery && hasResults ? (
+              <>
+                {groups.constituents.length > 0 ? (
+                  <CommandGroup heading={t("groups.constituents")}>
+                    {groups.constituents.map((hit) => (
+                      <HitRow key={hit.id} hit={hit} onSelect={handleSelect} icon={UserIcon} />
+                    ))}
+                  </CommandGroup>
+                ) : null}
+
+                {groups.campaigns.length > 0 ? (
+                  <CommandGroup heading={t("groups.campaigns")}>
+                    {groups.campaigns.map((hit) => (
+                      <HitRow key={hit.id} hit={hit} onSelect={handleSelect} icon={Megaphone} />
+                    ))}
+                  </CommandGroup>
+                ) : null}
+
+                {groups.donations.length > 0 ? (
+                  <CommandGroup heading={t("groups.donations")}>
+                    {groups.donations.map((hit) => (
+                      <HitRow key={hit.id} hit={hit} onSelect={handleSelect} icon={Heart} />
+                    ))}
+                  </CommandGroup>
+                ) : null}
+              </>
+            ) : null}
+
+            {!hasQuery ? (
+              <>
+                <CommandGroup heading={t("groups.navigation")}>
+                  {navigationCommands.map((cmd) => (
+                    <CommandItem
+                      key={cmd.id}
+                      value={cmd.id}
+                      onSelect={() => handleSelect(cmd.href)}
+                    >
+                      <cmd.icon size={16} aria-hidden="true" />
+                      <span>{cmd.label}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+
+                {quickCreateCommands.length > 0 ? (
+                  <>
+                    <CommandSeparator />
+                    <CommandGroup heading={t("groups.quickCreate")}>
+                      {quickCreateCommands.map((cmd) => (
+                        <CommandItem
+                          key={cmd.id}
+                          value={cmd.id}
+                          onSelect={() => handleSelect(cmd.href)}
+                        >
+                          <cmd.icon size={16} aria-hidden="true" />
+                          <span>{cmd.label}</span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </>
+                ) : null}
+              </>
+            ) : null}
+          </CommandList>
+
+          <div
+            className="flex items-center justify-center gap-4 border-t border-outline-variant bg-surface-container-low px-4 py-2 text-xs text-on-surface-variant"
+            aria-hidden="true"
+          >
+            <FooterHint label={t("footer.navigate")} keys={["↑", "↓"]} />
+            <FooterHint label={t("footer.select")} keys={["⏎"]} />
+            <FooterHint label={t("footer.close")} keys={["Esc"]} />
+          </div>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface HitRowProps {
+  hit: SearchHit;
+  onSelect: (href: string) => void;
+  icon: typeof UserIcon;
+}
+
+function HitRow({ hit, onSelect, icon: Icon }: HitRowProps) {
+  // `cmdk` uses `value` as the key for keyboard navigation; pair it
+  // with the type so two entities with the same display name don't
+  // collide on selection (e.g. "Marie" the constituent vs. "Marie"
+  // a quick-create suggestion).
+  const value = `${hit.type}:${hit.id}`;
+  return (
+    <CommandItem value={value} onSelect={() => onSelect(hit.href)}>
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-surface-container-low">
+        <Icon size={14} aria-hidden="true" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm text-on-surface">{hit.title}</span>
+        {hit.subtitle ? (
+          <span className="truncate text-xs text-on-surface-variant">{hit.subtitle}</span>
+        ) : null}
+      </span>
+    </CommandItem>
+  );
+}
+
+interface FooterHintProps {
+  label: string;
+  keys: string[];
+}
+
+function FooterHint({ label, keys }: FooterHintProps) {
+  return (
+    <span className="flex items-center gap-1">
+      {keys.map((k) => (
+        <kbd
+          key={k}
+          className="rounded-sm border border-outline-variant bg-surface-container px-1 py-px font-mono text-xs"
+        >
+          {k}
+        </kbd>
+      ))}
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/packages/web/src/components/layout/app-shell.test.tsx
+++ b/packages/web/src/components/layout/app-shell.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * AppShell tests — focused on the global Cmd+K listener wiring added by
+ * Epic #364 (GLO-001). The shell composes Sidebar / Topbar / Banners /
+ * CommandPalette; this suite only asserts behaviours the shell itself
+ * owns (the keydown listener + off-state mounting). The downstream
+ * components have their own tests.
+ *
+ * Mocks every collaborator that fetches or routes so the test exercises
+ * just the AppShell wiring.
+ */
+
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/tests/test-utils";
+
+function fireKeydown(opts: KeyboardEventInit) {
+  // `act` flushes the React state update triggered by the global
+  // `keydown` listener AppShell attached to `document`. Without `act`
+  // the assertion races the render and the palette sentinel hasn't
+  // landed in the DOM yet.
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent("keydown", { ...opts, bubbles: true }));
+  });
+}
+
+// ─── Mocks ───────────────────────────────────────────────────────────
+
+const mockCommandPalette = vi.fn();
+
+vi.mock("@/components/command-palette/command-palette", () => ({
+  CommandPalette: (props: { open: boolean; onClose: () => void }) => {
+    mockCommandPalette(props);
+    // Render a sentinel only when open so the test can assert presence
+    // via DOM query rather than spying on props.
+    return props.open ? <div data-testid="cmdk-palette">palette</div> : null;
+  },
+}));
+
+vi.mock("@/components/branding/add-logo-banner", () => ({
+  AddLogoBanner: () => null,
+}));
+
+vi.mock("./impersonation-banner", () => ({
+  ImpersonationBanner: () => null,
+}));
+
+vi.mock("./provisional-admin-banner", () => ({
+  ProvisionalAdminBanner: () => null,
+}));
+
+vi.mock("./sidebar", () => ({
+  Sidebar: () => <aside data-testid="sidebar" />,
+}));
+
+vi.mock("./topbar", () => ({
+  Topbar: () => <header data-testid="topbar" />,
+}));
+
+// Import AFTER the mocks so the module picks them up.
+const { AppShell } = await import("./app-shell");
+
+beforeEach(() => {
+  mockCommandPalette.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderShell(props: { commandPaletteEnabled: boolean }) {
+  return render(
+    <AppShell
+      impersonation={undefined}
+      impersonationUserName={undefined}
+      commandPaletteEnabled={props.commandPaletteEnabled}
+    >
+      <main data-testid="children">child</main>
+    </AppShell>,
+  );
+}
+
+describe("AppShell — command palette off-state", () => {
+  it("does not render the CommandPalette component when the flag is off", () => {
+    renderShell({ commandPaletteEnabled: false });
+    expect(screen.queryByTestId("cmdk-palette")).toBeNull();
+    expect(mockCommandPalette).not.toHaveBeenCalled();
+  });
+
+  it("Cmd+K is a no-op when the flag is off (listener not mounted)", () => {
+    renderShell({ commandPaletteEnabled: false });
+    fireKeydown({ key: "k", metaKey: true });
+    expect(screen.queryByTestId("cmdk-palette")).toBeNull();
+    expect(mockCommandPalette).not.toHaveBeenCalled();
+  });
+});
+
+describe("AppShell — command palette on-state", () => {
+  it("renders the CommandPalette component (closed) when the flag is on", () => {
+    renderShell({ commandPaletteEnabled: true });
+    // Mount = the mock was called once with open=false; the sentinel
+    // is absent because open=false.
+    expect(mockCommandPalette).toHaveBeenCalledWith(expect.objectContaining({ open: false }));
+    expect(screen.queryByTestId("cmdk-palette")).toBeNull();
+  });
+
+  it("opens the palette when Meta+K is pressed", () => {
+    renderShell({ commandPaletteEnabled: true });
+    fireKeydown({ key: "k", metaKey: true });
+    expect(screen.getByTestId("cmdk-palette")).toBeDefined();
+  });
+
+  it("opens the palette when Ctrl+K is pressed (non-Mac)", () => {
+    renderShell({ commandPaletteEnabled: true });
+    fireKeydown({ key: "k", ctrlKey: true });
+    expect(screen.getByTestId("cmdk-palette")).toBeDefined();
+  });
+
+  it("does NOT open on Meta+Shift+K (devtools chord)", () => {
+    renderShell({ commandPaletteEnabled: true });
+    fireKeydown({ key: "k", metaKey: true, shiftKey: true });
+    expect(screen.queryByTestId("cmdk-palette")).toBeNull();
+  });
+
+  it("does NOT open on Alt+K alone", () => {
+    renderShell({ commandPaletteEnabled: true });
+    fireKeydown({ key: "k", altKey: true });
+    expect(screen.queryByTestId("cmdk-palette")).toBeNull();
+  });
+
+  it("toggles closed when Meta+K is pressed a second time", () => {
+    renderShell({ commandPaletteEnabled: true });
+    fireKeydown({ key: "k", metaKey: true });
+    expect(screen.getByTestId("cmdk-palette")).toBeDefined();
+    fireKeydown({ key: "k", metaKey: true });
+    expect(screen.queryByTestId("cmdk-palette")).toBeNull();
+  });
+});

--- a/packages/web/src/components/layout/app-shell.tsx
+++ b/packages/web/src/components/layout/app-shell.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { AddLogoBanner } from "@/components/branding/add-logo-banner";
+import { CommandPalette } from "@/components/command-palette/command-palette";
 import type { ImpersonationInfo } from "@/lib/auth";
 import type { OrgLogo } from "@/models/branding";
 
@@ -43,6 +44,14 @@ interface AppShellProps {
    */
   notificationsEnabled?: boolean;
   /**
+   * Whether the `productivity.command_palette` feature flag is on for
+   * this tenant (Epic #364). Resolved SSR so the global Cmd+K
+   * listener + topbar button don't flash in/out on hydration. When
+   * `false`, the listener is never mounted and the overlay is never
+   * rendered — off-state QA per `feedback_feature_flag_first`.
+   */
+  commandPaletteEnabled?: boolean;
+  /**
    * Server-resolved org logo (Epic #286 / PR #287 review, major 4).
    * Threaded down to `Sidebar` and `AddLogoBanner` so they don't each
    * re-fetch `/v1/branding/org-logo` on every navigation. `null` means
@@ -77,8 +86,10 @@ export function AppShell({
   canManageBranding = false,
   orgLogo = null,
   notificationsEnabled = false,
+  commandPaletteEnabled = false,
 }: AppShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
 
   const handleMenuToggle = useCallback(() => {
@@ -91,6 +102,14 @@ export function AppShell({
     hamburgerRef.current?.focus();
   }, []);
 
+  const handleCommandPaletteOpen = useCallback(() => {
+    setCommandPaletteOpen(true);
+  }, []);
+
+  const handleCommandPaletteClose = useCallback(() => {
+    setCommandPaletteOpen(false);
+  }, []);
+
   // Prevent scroll and tab-behind when mobile sidebar is open
   useEffect(() => {
     if (!sidebarOpen) return;
@@ -99,6 +118,26 @@ export function AppShell({
       document.body.style.overflow = "";
     };
   }, [sidebarOpen]);
+
+  // Global Cmd+K / Ctrl+K binding (Epic #364, GLO-001). Mounted ONLY
+  // when the flag is on so an off-state user pressing the shortcut
+  // does nothing — off-state QA per `feedback_feature_flag_first`.
+  // Guards against firing inside a text field or with modifier
+  // combinations the OS already owns (Cmd+K is normally free; Ctrl+K
+  // shadows a browser address-bar shortcut in Firefox, which we accept
+  // — the palette is the higher-value surface for an authenticated
+  // app).
+  useEffect(() => {
+    if (!commandPaletteEnabled) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      const isShortcut = (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key === "k";
+      if (!isShortcut) return;
+      e.preventDefault();
+      setCommandPaletteOpen((prev) => !prev);
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [commandPaletteEnabled]);
 
   return (
     <div className="flex min-h-screen">
@@ -119,6 +158,8 @@ export function AppShell({
           sidebarOpen={sidebarOpen}
           hamburgerRef={hamburgerRef}
           notificationsEnabled={notificationsEnabled}
+          commandPaletteEnabled={commandPaletteEnabled}
+          onCommandPaletteOpen={handleCommandPaletteOpen}
         />
 
         <main
@@ -128,6 +169,10 @@ export function AppShell({
           <div className="space-y-6 sm:space-y-8">{children}</div>
         </main>
       </div>
+
+      {commandPaletteEnabled ? (
+        <CommandPalette open={commandPaletteOpen} onClose={handleCommandPaletteClose} />
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/components/layout/topbar.test.tsx
+++ b/packages/web/src/components/layout/topbar.test.tsx
@@ -212,3 +212,48 @@ describe("Topbar account menu", () => {
     });
   });
 });
+
+// ─── Command palette trigger (Epic #364, GLO-001) ────────────────────────
+
+function renderTopbarWithPalette(
+  opts: { enabled: boolean; onOpen?: () => void } = {
+    enabled: false,
+  },
+) {
+  const hamburgerRef = createRef<HTMLButtonElement>();
+  return render(
+    <Topbar
+      onMenuToggle={vi.fn()}
+      sidebarOpen={false}
+      hamburgerRef={hamburgerRef as React.RefObject<HTMLButtonElement | null>}
+      commandPaletteEnabled={opts.enabled}
+      onCommandPaletteOpen={opts.onOpen}
+    />,
+  );
+}
+
+describe("Topbar command-palette trigger", () => {
+  it("is completely absent when the flag is off (off-state QA)", () => {
+    renderTopbarWithPalette({ enabled: false });
+    // Neither the explicit aria-label nor any button matching the
+    // placeholder should appear. We use a regex on the EN aria-label
+    // ("Open quick search") and assert null.
+    expect(screen.queryByRole("button", { name: /open quick search/i })).toBeNull();
+  });
+
+  it("renders a button with aria-haspopup=dialog when the flag is on", () => {
+    renderTopbarWithPalette({ enabled: true, onOpen: vi.fn() });
+    const trigger = screen.getByRole("button", { name: /open quick search/i });
+    expect(trigger.tagName).toBe("BUTTON");
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+  });
+
+  it("invokes onCommandPaletteOpen when clicked", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    renderTopbarWithPalette({ enabled: true, onOpen });
+    const trigger = screen.getByRole("button", { name: /open quick search/i });
+    await user.click(trigger);
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web/src/components/layout/topbar.tsx
+++ b/packages/web/src/components/layout/topbar.tsx
@@ -36,6 +36,17 @@ interface TopbarProps {
    * flash in then out on hydration.
    */
   notificationsEnabled?: boolean;
+  /**
+   * Whether the `productivity.command_palette` flag is on for this
+   * tenant (Epic #364). When `false`, the Cmd+K trigger button is
+   * completely absent — off-state QA per `feedback_feature_flag_first`.
+   */
+  commandPaletteEnabled?: boolean;
+  /**
+   * Open the global command palette overlay (owned by AppShell).
+   * Required when `commandPaletteEnabled=true`.
+   */
+  onCommandPaletteOpen?: () => void;
 }
 
 const avatarTriggerClasses =
@@ -47,10 +58,13 @@ export function Topbar({
   sidebarOpen,
   hamburgerRef,
   notificationsEnabled = false,
+  commandPaletteEnabled = false,
+  onCommandPaletteOpen,
 }: TopbarProps) {
   const { user, logout } = useAuth();
   const t = useTranslations("appShell.topbar");
   const tMenu = useTranslations("appShell.topbar.accountMenu");
+  const tPalette = useTranslations("appShell.commandPalette");
   const locale = useLocale() as Locale;
   const router = useRouter();
   const [isLocalePending, startLocaleTransition] = useTransition();
@@ -124,22 +138,30 @@ export function Topbar({
         </div>
       </div>
 
-      <div className="relative mx-auto hidden max-w-[400px] flex-1 md:block">
-        <Search
-          size={16}
-          className="pointer-events-none absolute top-1/2 left-3.5 -translate-y-1/2 text-text-muted"
-          aria-hidden="true"
-        />
-        <input
-          type="text"
-          className="h-10 w-full rounded-pill border border-[var(--color-border-light)] bg-surface-container-lowest pl-10 pr-14 text-sm text-text placeholder:text-text-muted focus-visible:outline-none focus-visible:border-primary focus-visible:shadow-ring"
-          placeholder={t("searchPlaceholder")}
-          aria-label={t("searchLabel")}
-        />
-        <kbd className="pointer-events-none absolute top-1/2 right-2.5 -translate-y-1/2 rounded-sm border border-border bg-surface-container-low px-1.5 py-px font-mono text-xs text-text-muted">
-          ⌘K
-        </kbd>
-      </div>
+      {/*
+        Cmd+K trigger button (Epic #364, GLO-001). When the flag is off,
+        the surface is COMPLETELY absent (off-state QA per
+        `feedback_feature_flag_first`) — no inert placeholder input.
+        When on, this button opens the command palette via the
+        AppShell-owned state. Visual mimics the mockup's input look
+        (pill, search icon left, ⌘K badge right) but it's a button so
+        pointer + keyboard activation both go through one path.
+      */}
+      {commandPaletteEnabled && onCommandPaletteOpen ? (
+        <button
+          type="button"
+          onClick={onCommandPaletteOpen}
+          aria-label={tPalette("openTrigger")}
+          aria-haspopup="dialog"
+          className="relative mx-auto hidden h-10 max-w-[400px] flex-1 cursor-text items-center gap-2 rounded-pill border border-[var(--color-border-light)] bg-surface-container-lowest pl-3.5 pr-2.5 text-left text-sm text-text-muted hover:text-text focus-visible:outline-none focus-visible:border-primary focus-visible:shadow-ring md:flex"
+        >
+          <Search size={16} aria-hidden="true" />
+          <span className="flex-1 truncate">{tPalette("placeholder")}</span>
+          <kbd className="rounded-sm border border-border bg-surface-container-low px-1.5 py-px font-mono text-xs text-text-muted">
+            {tPalette("shortcutBadge")}
+          </kbd>
+        </button>
+      ) : null}
 
       <div className="flex items-center gap-3">
         {/*

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -321,8 +321,6 @@
       "openMenu": "Open menu",
       "closeMenu": "Close menu",
       "breadcrumbDefault": "Dashboard",
-      "searchPlaceholder": "Search...",
-      "searchLabel": "Search",
       "notifications": "Notifications",
       "profileOf": "Profile of {name}",
       "accountMenu": {
@@ -332,6 +330,38 @@
         "language": "Language",
         "signOut": "Sign out",
         "signOutAriaLabel": "Sign out — ends your session"
+      }
+    },
+    "commandPalette": {
+      "title": "Quick search",
+      "openTrigger": "Open quick search (Cmd+K)",
+      "placeholder": "Search constituents, campaigns, donations…",
+      "shortcutBadge": "⌘K",
+      "loading": "Searching…",
+      "error": "Could not run the search. Try again in a moment.",
+      "noResults": "No results.",
+      "groups": {
+        "navigation": "Navigation",
+        "quickCreate": "Quick create",
+        "constituents": "Constituents",
+        "campaigns": "Campaigns",
+        "donations": "Donations"
+      },
+      "nav": {
+        "dashboard": "Go to Dashboard",
+        "constituents": "Go to Constituents",
+        "campaigns": "Go to Campaigns",
+        "donations": "Go to Donations"
+      },
+      "create": {
+        "constituent": "New constituent",
+        "donation": "Record a donation",
+        "campaign": "New campaign"
+      },
+      "footer": {
+        "navigate": "to navigate",
+        "select": "to select",
+        "close": "to close"
       }
     },
     "impersonation": {

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -321,8 +321,6 @@
       "openMenu": "Ouvrir le menu",
       "closeMenu": "Fermer le menu",
       "breadcrumbDefault": "Tableau de bord",
-      "searchPlaceholder": "Rechercher...",
-      "searchLabel": "Rechercher",
       "notifications": "Notifications",
       "profileOf": "Profil de {name}",
       "accountMenu": {
@@ -332,6 +330,38 @@
         "language": "Langue",
         "signOut": "Se déconnecter",
         "signOutAriaLabel": "Se déconnecter — termine votre session"
+      }
+    },
+    "commandPalette": {
+      "title": "Recherche rapide",
+      "openTrigger": "Ouvrir la recherche rapide (Cmd+K)",
+      "placeholder": "Rechercher un contact, une campagne, un don…",
+      "shortcutBadge": "⌘K",
+      "loading": "Recherche…",
+      "error": "La recherche a échoué. Réessayez dans un instant.",
+      "noResults": "Aucun résultat.",
+      "groups": {
+        "navigation": "Navigation",
+        "quickCreate": "Création rapide",
+        "constituents": "Contacts",
+        "campaigns": "Campagnes",
+        "donations": "Dons"
+      },
+      "nav": {
+        "dashboard": "Aller au tableau de bord",
+        "constituents": "Aller aux contacts",
+        "campaigns": "Aller aux campagnes",
+        "donations": "Aller aux dons"
+      },
+      "create": {
+        "constituent": "Nouveau contact",
+        "donation": "Enregistrer un don",
+        "campaign": "Nouvelle campagne"
+      },
+      "footer": {
+        "navigate": "pour naviguer",
+        "select": "pour sélectionner",
+        "close": "pour fermer"
       }
     },
     "impersonation": {

--- a/packages/web/src/services/SearchService.ts
+++ b/packages/web/src/services/SearchService.ts
@@ -1,0 +1,42 @@
+import type { ApiClient } from "@/lib/api";
+
+/**
+ * Global search service — backs the Command Palette (Epic #364, GLO-001).
+ *
+ * Wire format follows the Givernance `{ data: ... }` envelope. The shape
+ * mirrors `packages/api/src/modules/search/service.ts` SearchResult.
+ */
+
+export interface SearchHit {
+  type: "constituent" | "campaign" | "donation";
+  id: string;
+  title: string;
+  subtitle: string;
+  /** Path relative to the app root, no host, no locale prefix. */
+  href: string;
+}
+
+export interface SearchGroups {
+  constituents: SearchHit[];
+  campaigns: SearchHit[];
+  donations: SearchHit[];
+}
+
+export interface SearchResult {
+  query: string;
+  groups: SearchGroups;
+}
+
+interface SearchResponse {
+  data: SearchResult;
+}
+
+export const SearchService = {
+  async search(client: ApiClient, q: string, signal?: AbortSignal): Promise<SearchResult> {
+    const response = await client.get<SearchResponse>("/v1/search", {
+      params: { q },
+      signal,
+    });
+    return response.data;
+  },
+};


### PR DESCRIPTION
## Summary

Implements GLO-001 — the global **Cmd+K / Ctrl+K command palette** — end-to-end behind the new `productivity.command_palette` feature flag (default **off**).

- **Backend**: `GET /v1/search?q=…` with Postgres FTS + pg_trgm, RLS-scoped, rate-limited, flag-gated 404 anti-disclosure.
- **Frontend**: `cmdk`-based overlay with grouped results, debounced + AbortController-superseded fetch, RBAC-aware quick-create rows.
- **Docs**: full `docs/29-global-search.md` spec.

close #364

## Why one PR

The Epic's phases are tightly coupled — the flag without the backend is dead config, the backend without the overlay is invisible, the overlay without the flag is an unflagged feature. Shipping them together lets reviewers verify the full surface as one coherent thing AND keeps the flag's off-state QA load on a single PR rather than three.

## What's in scope

| Layer | Files |
|---|---|
| Flag | [`packages/shared/src/constants/feature-flags.ts`](packages/shared/src/constants/feature-flags.ts), [`packages/api/migrations/0061_command_palette_feature_flag.sql`](packages/api/migrations/0061_command_palette_feature_flag.sql) |
| Indices | [`packages/api/migrations/0062_search_indexes.sql`](packages/api/migrations/0062_search_indexes.sql) |
| API route + service | [`packages/api/src/modules/search/routes.ts`](packages/api/src/modules/search/routes.ts), [`packages/api/src/modules/search/service.ts`](packages/api/src/modules/search/service.ts) |
| API tests | [`packages/api/src/tests/integration/search.test.ts`](packages/api/src/tests/integration/search.test.ts) (14 tests) |
| Web overlay | [`packages/web/src/components/command-palette/command-palette.tsx`](packages/web/src/components/command-palette/command-palette.tsx), [`packages/web/src/services/SearchService.ts`](packages/web/src/services/SearchService.ts) |
| AppShell wiring | [`packages/web/src/components/layout/app-shell.tsx`](packages/web/src/components/layout/app-shell.tsx), [`packages/web/src/components/layout/topbar.tsx`](packages/web/src/components/layout/topbar.tsx), [`packages/web/src/app/(app)/layout.tsx`](packages/web/src/app/(app)/layout.tsx) |
| i18n | [`packages/web/src/messages/en.json`](packages/web/src/messages/en.json), [`packages/web/src/messages/fr.json`](packages/web/src/messages/fr.json) |
| Docs | [`docs/29-global-search.md`](docs/29-global-search.md), [`CLAUDE.md`](CLAUDE.md) file-tree |

## Out of scope (deferred, documented in §7 of the doc)

- **Grants & programs** entity branches — schemas don't exist yet.
- **Recently-visited / saved searches** — empty state is filled by static "Go to …" rows for now.
- **Search telemetry** — request log line is enough for SRE; product analytics is a separate workstream.
- **Highlight match in result rows** — visual polish, deferred.
- AI-suggested actions, conversational search, semantic search, attachment search — all already carved out by the Epic.

## Security posture (one-line summary)

Flag gate is the **first** preHandler (404 not 403); RLS + explicit `eq(orgId, ...)` filter + boot-time NOBYPASSRLS guard form three walls; user input is parameter-bound (`plainto_tsquery` quotes operators), length-capped, and control-char-stripped; tests pin `'; DROP TABLE constituents; --` and the constituent table is still there afterwards. Full posture in `docs/29-global-search.md` §3.4 — §3.5.

## Test plan — manual acceptance checklist

Flag **OFF** (default) on a fresh tenant:
- [x] No Cmd+K trigger button anywhere in the topbar
- [x] Pressing `Cmd+K` / `Ctrl+K` does nothing (listener not mounted)
- [x] `GET /v1/search?q=marie` returns **404** (not 403, not blank) — both authenticated and unauthenticated
- [x] Unauthorised scanner can't tell the route exists

Flag **ON** for the tenant:
- [x] Topbar shows the Cmd+K trigger pill on `md+` screens, with `⌘K` badge
- [x] Pressing `Cmd+K` (Mac) / `Ctrl+K` (others) opens the overlay from any authenticated page
- [x] Clicking the trigger opens the same overlay
- [x] `Esc` closes it
- [x] Empty query → shows "Navigation" group (Go to Dashboard / Constituents / Campaigns / Donations) and "Quick create" group (New constituent / Record a donation / New campaign)
- [x] Viewer role → empty query shows only "Navigation", no "Quick create" rows
- [x] Typing 2+ chars → debounced (200 ms) fetch, results grouped by entity
- [x] Arrow keys navigate, Enter follows the highlighted row, palette closes
- [x] Slow / flaky network → no out-of-order updates (older response overwriting newer)
- [x] Search across constituents / campaigns / donations finds the expected rows
- [x] Search for a constituent's name returns their donations too (JOIN path)
- [x] Tenant A's data never appears in Tenant B's search (RLS)

API:
- [x] `GET /v1/feature-flags` lists `productivity.command_palette` with the right effective `enabled` state per tenant
- [x] `GET /v1/search?q=` returns 400 (empty `q`)
- [x] `GET /v1/search` (no `q`) returns 400
- [x] 60 req/min/user rate limit holds; 61st returns 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)