### PR TITLE
feat(api,web): admin cache-flush route + UI button + CLAUDE.md convention (#449)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,27 @@ Valid uses for Organization attributes: non-sensitive identifiers (`org_id`, slu
 
 **Automated guard**: [`packages/api/src/tests/integration/migrations-journal-parity.test.ts`](packages/api/src/tests/integration/migrations-journal-parity.test.ts) fails CI on orphan files, phantom journal entries, gappy `idx`, and non-monotonic `when`. If that test goes red after an edit, the journal is the thing to fix — never the test.
 
+### 🛑 Cached endpoints ship a flush route in the same PR (issue #449)
+
+**Any new endpoint that populates a Redis cache with a TTL > 1 minute MUST ship a matching operator-facing flush route in the SAME PR.** No exception. The cache stays useful (low DB load), but the operator never has to SSH the host + fight `redis-cli -a` AUTH gymnastics just to refresh after an out-of-band data change.
+
+**Why this is a hard rule**: PR #441 shipped the `/v1/superadmin/finance/summary` endpoint with a 5-minute Redis cache but no flush route. After PR #448 re-seeded the demo data on staging, the operator had to SSH the host and run `redis-cli` to invalidate the cache — which itself blew up on AUTH password URL-encoding (`WRONGPASS invalid username-password pair`). The 5-minute TTL eventually saved us, but the friction was avoidable.
+
+**How to apply when you add a cached endpoint** ([`packages/api/src/modules/superadmin/finance/routes.ts`](packages/api/src/modules/superadmin/finance/routes.ts) is the reference implementation):
+
+1. Pick a cache-key prefix as a `const` at module scope — never inline the literal. The flush route reuses the same constant for its SCAN pattern.
+2. Ship a POST route at `…/cache/flush` (or a name that reads as obviously-an-invalidation) in the same PR, same preHandler chain as the cached route (`requireFlag → requireSuperAdmin` for super-admin surfaces; `requireFlag → requireAuth` for tenant surfaces).
+3. **Pattern is HARDCODED server-side.** No body, no query, no header. The Redis SCAN target is built from the module-scoped prefix constant, NEVER from client input — otherwise `pattern=*` flushes the entire DB.
+4. **Rate-limit via `@fastify/rate-limit`** at a low cap (5 / minute / IP). Defends against a compromised-credential DoS that pounds the cache to force expensive SQL aggregation re-runs (cache-stampede).
+5. **Audit log on every call**: `action='cache.flushed', resource_type=<same as cached route>, metadata={pattern, keysDeleted, ipHash, correlationId}`. GDPR Art. 5(2) accountability.
+6. Use `redis.unlink(...)` (non-blocking, Redis 4+) rather than `redis.del(...)` for the deletion step — safer when the match set is large.
+7. **Response shape strict**: `{ data: { keysDeleted: number, pattern: string } }` with `additionalProperties: false`. Never echo the deleted KEYS themselves — they carry tenantId + period filters and leak usage patterns.
+8. **Add a discreet UI affordance** on the page that consumes the cached endpoint (small underlined "Forcer un rafraîchissement" link in the audit footer is the established pattern — opt-in, no high-traffic placement, rare-use). The UI dispatches the same POST with a toast on success/failure.
+9. **Tests** (integration): the same RBAC matrix as the cached endpoint (super_admin 200, others 404, unauth 401), flag-off → 404, decoy key with a different prefix MUST survive the flush (proof the pattern-scope is strict), client-supplied `?pattern=*` body / query / header MUST be ignored (server-side pattern is the only source of truth), idempotent re-call returns `keysDeleted: 0`.
+10. **`beforeEach`** in the test file clears `redis.keys("fastify-rate-limit-*")` so the 5/min cap doesn't bleed across test cases.
+
+Reference: [`packages/api/src/modules/superadmin/finance/routes.ts`](packages/api/src/modules/superadmin/finance/routes.ts) (route), [`packages/api/src/tests/integration/superadmin-finance.test.ts`](packages/api/src/tests/integration/superadmin-finance.test.ts) (test pattern), [`packages/web/src/services/SuperAdminFinanceService.ts`](packages/web/src/services/SuperAdminFinanceService.ts) (client wiring).
+
 ---
 
 ## 🛑 DEV PROCESS (CRITICAL FOR CI)

--- a/packages/api/src/modules/superadmin/finance/routes.ts
+++ b/packages/api/src/modules/superadmin/finance/routes.ts
@@ -28,6 +28,7 @@ import {
 } from "../../../lib/schemas.js";
 import { PeriodValidationError, resolvePeriod } from "./period.js";
 import {
+  CacheFlushResponse,
   InvitationIdParams,
   LaunchBody,
   LaunchResponse,
@@ -125,6 +126,31 @@ async function emitAuditView(
     request.log.error(
       { err, audit: "INSERT_FAILED" },
       "CRITICAL: super-admin finance view audit insert failed — GDPR accountability gap",
+    );
+  }
+}
+
+async function emitAuditCacheFlush(
+  request: FastifyRequest,
+  metadata: { pattern: string; keysDeleted: number },
+): Promise<void> {
+  const platformOrgId = await getPlatformOrgId();
+  try {
+    await systemDb.insert(auditLogs).values({
+      orgId: platformOrgId,
+      userId: request.auth?.userId ?? null,
+      actorId: request.auth?.userId ?? null,
+      action: "cache.flushed",
+      resourceType: "platform_finance_summary",
+      resourceId: null,
+      newValues: metadata,
+      ipHash: hashIp(request.ip),
+      userAgent: request.headers["user-agent"] ?? undefined,
+    });
+  } catch (err) {
+    request.log.error(
+      { err, audit: "INSERT_FAILED", ...metadata },
+      "CRITICAL: super-admin finance cache flush audit insert failed — GDPR accountability gap",
     );
   }
 }
@@ -455,6 +481,73 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
           submittedAt: result.submittedAt.toISOString(),
         },
       };
+    },
+  );
+
+  // ─── POST /v1/superadmin/finance/cache/flush (#449) ─────────────────
+  // Invalidates the Redis cache for the platform finance summary so the
+  // dashboard surfaces fresh data immediately after a manual SQL refresh
+  // (e.g. SEED_DESTRUCTIVE_WIPE re-seed). Replaces the previous operator
+  // workflow of SSH + redis-cli + URL-encoded AUTH gymnastics.
+  //
+  // Security posture (per issue #449 callout — "ne doit pas être une
+  // faille"):
+  //  - preHandler chain identical to other superadmin routes: requireFlag
+  //    fires BEFORE requireSuperAdmin so a flag-off probe gets 404
+  //    without revealing the route.
+  //  - No request body / query / header. The Redis SCAN pattern is
+  //    hardcoded server-side; a compromised super-admin can NOT extend
+  //    the pattern to flush arbitrary keys (e.g. `*` to nuke the entire
+  //    DB).
+  //  - Rate-limited at 5 requests / minute / IP via @fastify/rate-limit.
+  //    Defends against DoS via cache pounding (each flush forces the
+  //    next request to re-run the expensive SQL aggregation; an
+  //    attacker holding super-admin credentials could otherwise produce
+  //    a cache-stampede load profile).
+  //  - Idempotent: flushing twice is a safe no-op. No Idempotency-Key
+  //    needed.
+  //  - Audit log on every call (action='cache.flushed', resource_type=
+  //    'platform_finance_summary'). GDPR Art. 5(2) accountability.
+  //  - Response shape strict — only { keysDeleted, pattern }. No cache
+  //    KEY listing exposed (keys carry tenantId + period filters which
+  //    would leak usage patterns).
+  app.post(
+    "/superadmin/finance/cache/flush",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      schema: {
+        tags: ["Superadmin", "Finance"],
+        response: {
+          200: CacheFlushResponse,
+          ...ErrorResponses,
+        },
+      },
+      config: {
+        rateLimit: {
+          max: 5,
+          timeWindow: "1 minute",
+        },
+      },
+    },
+    async (request) => {
+      // Pattern is HARDCODED — no client-controlled SCAN scope.
+      const pattern = `${SUMMARY_CACHE_PREFIX}:*`;
+      const keys: string[] = [];
+      let cursor = "0";
+      do {
+        const [nextCursor, batch] = await redis.scan(cursor, "MATCH", pattern, "COUNT", 100);
+        keys.push(...batch);
+        cursor = nextCursor;
+      } while (cursor !== "0");
+
+      // UNLINK is the non-blocking sibling of DEL (Redis 4+). Safer for
+      // a potentially large match set; falls back to no-op when keys is
+      // empty.
+      const keysDeleted = keys.length > 0 ? await redis.unlink(...keys) : 0;
+
+      await emitAuditCacheFlush(request, { pattern, keysDeleted });
+
+      return { data: { keysDeleted, pattern } };
     },
   );
 }

--- a/packages/api/src/modules/superadmin/finance/schemas.ts
+++ b/packages/api/src/modules/superadmin/finance/schemas.ts
@@ -292,3 +292,20 @@ export const RespondResponse = Type.Object(
   },
   { additionalProperties: false },
 );
+
+// ─── Cache flush (#449) ─────────────────────────────────────────────────
+// Response shape for POST /v1/superadmin/finance/cache/flush. No request
+// body — pattern is hardcoded server-side to prevent any client-controlled
+// SCAN scope.
+export const CacheFlushResponse = Type.Object(
+  {
+    data: StrictObject(
+      {
+        keysDeleted: Type.Integer({ minimum: 0 }),
+        pattern: Type.String(),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);

--- a/packages/api/src/tests/integration/superadmin-finance.test.ts
+++ b/packages/api/src/tests/integration/superadmin-finance.test.ts
@@ -761,3 +761,128 @@ describe("POST /v1/surveys/:invitationId/respond", () => {
     expect(res.statusCode).toBe(404);
   });
 });
+
+describe("POST /v1/superadmin/finance/cache/flush (#449)", () => {
+  const CACHE_KEY_A = "superadmin:finance:summary:v1:30d:_:_:all:all";
+  const CACHE_KEY_B = "superadmin:finance:summary:v1:90d:_:_:EUR:all";
+  // Decoy key with a different prefix — must NOT be touched by the flush.
+  const DECOY_KEY = "notifications:test:fixture-449";
+
+  beforeEach(async () => {
+    // Clear @fastify/rate-limit state — keys live under
+    // `fastify-rate-limit-*` (see filters.test.ts pattern). Without
+    // this, the 5/min cap on /cache/flush bleeds across test cases
+    // and a single 429 cascades the whole suite.
+    const rlKeys = await redis.keys("fastify-rate-limit-*");
+    if (rlKeys.length > 0) await redis.del(...rlKeys);
+    await redis.set(CACHE_KEY_A, JSON.stringify({ data: "seeded-30d" }), "EX", 300);
+    await redis.set(CACHE_KEY_B, JSON.stringify({ data: "seeded-90d" }), "EX", 300);
+    await redis.set(DECOY_KEY, "untouched", "EX", 300);
+  });
+  afterEach(async () => {
+    await redis.del(CACHE_KEY_A, CACHE_KEY_B, DECOY_KEY);
+  });
+
+  describe("RBAC matrix", () => {
+    it("super_admin → 200 + keysDeleted reflects the flushed count", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/cache/flush",
+        headers: authHeader(superAdminToken()),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as {
+        data: { keysDeleted: number; pattern: string };
+      };
+      expect(body.data.pattern).toBe("superadmin:finance:summary:v1:*");
+      expect(body.data.keysDeleted).toBeGreaterThanOrEqual(2);
+      // Seeded cache keys are gone.
+      expect(await redis.exists(CACHE_KEY_A)).toBe(0);
+      expect(await redis.exists(CACHE_KEY_B)).toBe(0);
+      // Decoy key with different prefix is INTACT — pattern-scope is strict.
+      expect(await redis.exists(DECOY_KEY)).toBe(1);
+    });
+
+    it("org_admin → 404 (anti-disclosure)", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/cache/flush",
+        headers: authHeader(signToken(app)),
+      });
+      expect(res.statusCode).toBe(404);
+      // Cache keys still present — RBAC blocked the operation.
+      expect(await redis.exists(CACHE_KEY_A)).toBe(1);
+    });
+
+    it("user role → 404", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/cache/flush",
+        headers: authHeader(signToken(app, { role: "user" })),
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("viewer role → 404", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/cache/flush",
+        headers: authHeader(signToken(app, { role: "viewer" })),
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("unauthenticated → 401", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/cache/flush",
+      });
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  it("flag off → 404", async () => {
+    await setFlag(false);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/cache/flush",
+      headers: authHeader(superAdminToken()),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("idempotent: flushing twice keeps decoy keys intact and returns 0 the second time", async () => {
+    await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/cache/flush",
+      headers: authHeader(superAdminToken()),
+    });
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/cache/flush",
+      headers: authHeader(superAdminToken()),
+    });
+    expect(second.statusCode).toBe(200);
+    const body = second.json() as { data: { keysDeleted: number } };
+    expect(body.data.keysDeleted).toBe(0);
+    expect(await redis.exists(DECOY_KEY)).toBe(1);
+  });
+
+  it("does NOT accept a client-supplied pattern (no body / query / header)", async () => {
+    // Even when sending a payload + query trying to extend the scan
+    // scope, the server must ignore it and only flush
+    // `superadmin:finance:summary:v1:*`.
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/cache/flush?pattern=*",
+      headers: authHeader(superAdminToken()),
+      payload: { pattern: "*" },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { data: { pattern: string } };
+    expect(body.data.pattern).toBe("superadmin:finance:summary:v1:*");
+    // Decoy with `notifications:*` prefix MUST still be intact —
+    // proof the client-supplied `*` was ignored.
+    expect(await redis.exists(DECOY_KEY)).toBe(1);
+  });
+});

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -12,7 +12,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { VolumeRevenueChart } from "@/components/admin/finance";
+import { toast, VolumeRevenueChart } from "@/components/admin/finance";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import type { FinancePeriod, FinanceSummary } from "@/models/superadmin-finance";
 import { SuperAdminFinanceService } from "@/services/SuperAdminFinanceService";
@@ -109,8 +109,31 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   const [summary, setSummary] = useState<FinanceSummary | null>(initialSummary);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<boolean>(initialError);
+  const [flushing, setFlushing] = useState(false);
 
   const handlePeriodChange = useCallback((next: FinancePeriod) => setPeriod(next), []);
+
+  const handleFlushCache = useCallback(async () => {
+    if (flushing) return;
+    setFlushing(true);
+    try {
+      const api = createClientApiClient();
+      const result = await SuperAdminFinanceService.flushCache(api);
+      toast.success(`Cache vidé · ${result.keysDeleted} entrée(s) supprimée(s)`);
+      // Re-fetch with current period/filters to populate the freshly-
+      // flushed cache and update the view.
+      const data = await SuperAdminFinanceService.fetchSummary(api, {
+        period,
+        currency: filters.currency === "all" ? undefined : filters.currency,
+        tenantId: filters.tenantId === "all" ? undefined : filters.tenantId,
+      });
+      setSummary(data);
+    } catch {
+      toast.error("Le flush a échoué — réessayez dans une minute.");
+    } finally {
+      setFlushing(false);
+    }
+  }, [flushing, period, filters.currency, filters.tenantId]);
   const handleCurrencyChange = useCallback(
     (next: FinanceFilters["currency"]) => setFilters((f) => ({ ...f, currency: next })),
     [],
@@ -1039,6 +1062,27 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         Cette vue a été chargée à {lastTimestamp}. Source :{" "}
         <code>/v1/superadmin/finance/summary</code>. Cache 5 min. Toute consultation est tracée dans{" "}
         <code>audit_logs</code>.
+        {/* Discreet operator action — used in rare cases (e.g. just
+            after an out-of-band SQL refresh). Server-side rate-limited
+            to 5/min, audited. Issue #449. */}
+        <button
+          type="button"
+          onClick={handleFlushCache}
+          disabled={flushing}
+          style={{
+            marginLeft: "var(--space-3)",
+            appearance: "none",
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            font: "inherit",
+            color: "var(--color-on-surface-variant)",
+            textDecoration: "underline",
+            cursor: flushing ? "wait" : "pointer",
+          }}
+        >
+          {flushing ? "Flush en cours…" : "Forcer un rafraîchissement"}
+        </button>
       </div>
 
       {loading && (

--- a/packages/web/src/services/SuperAdminFinanceService.ts
+++ b/packages/web/src/services/SuperAdminFinanceService.ts
@@ -64,4 +64,17 @@ export const SuperAdminFinanceService = {
     );
     return response.data;
   },
+
+  /**
+   * Force-flush the 5-minute Redis cache for the finance summary.
+   * Rare-use operator action — surfaces fresh data after an out-of-
+   * band SQL refresh (e.g. seed re-run). Server enforces rate-limit
+   * (5/min/IP) + audits each call. Issue #449.
+   */
+  async flushCache(client: ApiClient): Promise<{ keysDeleted: number; pattern: string }> {
+    const response = await client.post<{
+      data: { keysDeleted: number; pattern: string };
+    }>("/v1/superadmin/finance/cache/flush", {});
+    return response.data;
+  },
 };


### PR DESCRIPTION
## Summary

Closes #449.

Removes the operator friction of SSH + `redis-cli -a AUTH` gymnastics to invalidate the finance dashboard's 5-min Redis cache. After a `SEED_DESTRUCTIVE_WIPE` refresh (or any out-of-band SQL change), one POST clears the cache; the dashboard surfaces fresh data immediately.

## What ships

**API** — `POST /v1/superadmin/finance/cache/flush`
- preHandler: `requireFlag(admin.finance_dashboard)` → `requireSuperAdmin`
- Pattern hardcoded server-side (`superadmin:finance:summary:v1:*`); no body / query / header accepted
- Rate-limited 5 req / min / IP via `@fastify/rate-limit`
- `redis.unlink(...)` (non-blocking) over `redis.del`
- Audit log per call (`action='cache.flushed'`)
- Strict response shape `{ data: { keysDeleted, pattern } }` — never echoes the keys themselves

**Web** — discreet "Forcer un rafraîchissement" link in the audit footer of `/admin/finance` (low-traffic placement per the issue's "rare cases" framing). Toasts on success/failure; auto re-fetches the summary so the freshly-flushed cache repopulates immediately.

**CLAUDE.md** — new convention codifying the pattern so future cached endpoints don't repeat the PR #441 mistake of shipping a cache without an invalidation route.

## Security posture (per the issue's "pas une faille" callout)

1. RBAC strict — flag + super-admin
2. No client-controlled SCAN scope
3. Rate-limit defends against cache-stampede DoS via a compromised super-admin
4. CSRF via existing double-submit cookie
5. Audit on every call
6. Idempotent (no need for Idempotency-Key, rate-limit handles abuse)
7. Pattern-scope confirmed in tests with a decoy key (`notifications:test:*`) that MUST survive the flush

## Test plan

- [x] `pnpm --filter @givernance/api test --run src/tests/integration/superadmin-finance` — 43/43 pass (8 new for the cache-flush route)
- [x] `pnpm --filter @givernance/web typecheck`, `pnpm biome check .`, web finance page test — all green
- [ ] Post-merge staging deploy: trigger `SEED_DESTRUCTIVE_WIPE=true` re-seed → hit the "Forcer un rafraîchissement" button → dashboard surfaces the new data without waiting for the 5-min TTL

## How an operator uses it post-merge

1. Re-seed via SSH (operator action that the seed PR already documents)
2. Refresh `/admin/finance` in the browser — cache still serves the OLD data for up to 5 min
3. Scroll to the audit footer at the bottom of the page
4. Click "Forcer un rafraîchissement" — toast confirms `Cache vidé · N entrée(s) supprimée(s)`, page auto-updates with fresh data

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>