### PR TITLE
fix(seed): clamp future refunded_at so refund-rate KPI surfaces (#447 follow-up)

### DIFF
--- a/packages/api/scripts/seed.ts
+++ b/packages/api/scripts/seed.ts
@@ -723,9 +723,22 @@ async function seedOrgData(orgId: string, tenantLabel: string) {
       // first dashboard render rather than waiting on a worker pass.
       const platformFeeCents = Math.max(30, Math.round(amountCents * 0.015) + 30);
       const platformFeeBaseCents = Math.round(platformFeeCents * rate);
+      // Refund timing: a refund-delay of 1-30 days after donation; if
+      // that would land in the future (recent donations + delay), clamp
+      // refunded_at to a short recent past so the dashboard's 30d
+      // refund-rate KPI actually surfaces a non-zero rate. Earlier
+      // version generated future refunded_at dates — visible row in
+      // the DB, but filtered out by `donated_at >= NOW() - 30d AND
+      // refunded_at IS NOT NULL` → KPI stayed at 0%.
       const isRefunded = Math.random() < REFUND_RATE;
+      const nowMs = Date.now();
+      const proposedRefundMs = donatedAt.getTime() + randomInt(1, 30) * 24 * 3600_000;
       const refundedAt = isRefunded
-        ? new Date(donatedAt.getTime() + randomInt(1, 30) * 24 * 3600_000)
+        ? new Date(
+            proposedRefundMs > nowMs
+              ? nowMs - randomInt(0, 7) * 24 * 3600_000 // clamp future → recent past
+              : proposedRefundMs,
+          )
         : null;
       return {
         orgId,


### PR DESCRIPTION
## Summary

Follow-up to PR #448. User report on local dev: refund-rate KPI stays at 0% on the dashboard even after `SEED_DESTRUCTIVE_WIPE` re-seed.

## Root cause

Refund timing in the seed was \`refunded_at = donated_at + randomInt(1, 30) days\`. For donations made in the last 30 days (the same window the dashboard queries), that pushes \`refunded_at\` **into the future** for ~half the recent refunded rows. The dashboard's WHERE clause filters those out — KPI shows 0% even though refunded rows exist in the DB.

SQL audit on the seeded local DB confirmed it:

| tenant | status | total | last 30d |
|---|---|---|---|
| c1 | cleared | 2791 | 219 |
| c1 | refunded | 19 | **1** |
| b1 | cleared | 2797 | 221 |
| b1 | refunded | 14 | **0** |

## Fix

Clamp future \`refunded_at\` values to a short recent past (\`now - 0..7 days\`). Old-donation refunds with a past refunded_at are unchanged. After re-seed:

| tenant | refunded last-30d | sum |
|---|---|---|
| c1 | 2 | €16.93 |
| b1 | 1 | €3.12 |

Refund-rate gauge now shows 0.5-1% with the cursor in the green zone — the #447 demo posture as designed.

## Test plan

- [x] `pnpm --filter @givernance/api typecheck` ✓
- [x] Local re-seed via `SEED_DESTRUCTIVE_WIPE=true pnpm --filter @givernance/api db:seed:local` → SQL audit shows refunds in last-30d > 0 on both demo tenants
- [ ] Post-merge: re-trigger `SEED_DESTRUCTIVE_WIPE=true` on staging → verify the gauge cursor moves off 0%

## How to apply on staging after merge

Same as the previous seed PR workflow:

```bash
ssh givernance-staging
docker exec -e SEED_DESTRUCTIVE_WIPE=true \
  $(docker ps --format '{{.Names}}' | grep givernance-api | head -1) \
  pnpm --filter @givernance/api db:seed
```

Then click "Forcer un rafraîchissement" on the dashboard (assuming PR #450 ships first) OR wait 5 min for cache TTL.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>