### PR TITLE
feat(superadmin/finance): monthly platform finance report PDF (#443)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,9 @@ S3_SECRET_ACCESS_KEY=givernance_dev
 S3_REGION=fr-par
 S3_RECEIPTS_BUCKET=receipts
 S3_CAMPAIGNS_BUCKET=campaigns
+# Super-admin monthly platform finance reports (issue #443) — private
+# bucket, streamed back through the API. ADR-023.
+S3_REPORTS_BUCKET=reports
 # Org-branding bucket (Epic #286) — public-read so the Keycloak login
 # template and donation pages can serve logos without a signed-URL hop.
 # Objects are content-addressed under `{org_id}/logo/{logo_id}/{variant}.{ext}`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Givernance is a purpose-built CRM for European nonprofits (2-200 staff), designe
 │   ├── 30-advanced-filters.md      — Advanced Constituent Filters (Epic #418, PR #421): query DSL + pattern detection (LYBUNT, SYBUNT, RECURRING, LAPSED, MAJOR_DONOR), preset templates, real-time preview, persisted per-campaign segmentation
 │   ├── 31-tenant-mobilization-score.md      — Tenant Mobilisation Score (Epic #434): formula, weights, k-anonymity, re-evaluation hook
 │   ├── 32-survey-infrastructure.md         — In-house GDPR-native surveys (Epic #434, issue #439): PMF/NPS/CSAT, DPO-review gate, k-anonymity, 24-month retention, erasure cascade
+│   ├── 33-platform-finance-reports.md      — Super-admin monthly PDF finance report (Epic #434, issue #443): idempotent POST + BullMQ worker + S3 stream-back, kpi_snapshot for GDPR Art. 5(2) accountability
 │   ├── adrs/                       — Individual ADR files (incl. ADR-023 bucket topology, ADR-024 image pipeline, ADR-025 PDF code boundary, ADR-027 Swiss QR-bill, ADR-028 camt.053 ingestion, ADR-029 Keycloak session revocation, ADR-030 public-page archetype slots — hybrid shell + slot components per Epic #362, ADR-031 notification delivery + outbox fanout — SSE with polling fallback per Epic #363, ADR-032 multi-currency strategy — fund/account settlement model + FX rate policy, ADR-033 advanced constituent filter architecture — query DSL + pattern detection per Epic #418)
 │   ├── runbooks/                   — Operator-driven one-shot ops (e.g. migrate-staging-keycloak-db.md for issue #283; launch-prod.md for the production-environment launch — issue #344); each file is plan + live journal + post-mortem. Also: bulk-email-stalled-job.md (recurring SRE triage flow for issue #326's Stalled / Partial bulk-email recovery), feature-flag-rollback.md (emergency psql + redis-cli flip when the Back Office page is unavailable), keycloak-backchannel-logout-cutover.md (per-env override of `backchannel.logout.url` after each realm sync — issue #76), and cross-tenant-rls-hardening-cutover.md (issue #430 — one-shot wiring of the `GIVERNANCE_APP_PASSWORD` secret + `givernance_app` role rotation that closes the staging cross-tenant notification leak)
 │   ├── dev/
@@ -176,7 +177,7 @@ Key ADRs for frontend work:
 - Project name: **Givernance** (not "Libero", not "givernance-npo-platform")
 - Terminology: **NPO** (nonprofit organization), not "NGO"
 - GDPR in English docs, RGPD in French docs
-- All docs are in `docs/`, numbered 01-32 for architecture specs (next free slot: `33-`)
+- All docs are in `docs/`, numbered 01-33 for architecture specs (next free slot: `34-`)
 
 ### 🛑 Documentation discipline (CRITICAL FOR ALL DOMAIN WORK)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,11 @@ services:
       # presigned URLs, no public-read. 90-day lifecycle matches the
       # row_data retention in `bulk_import_results` (see docs/26 §5).
       S3_BULK_IMPORT_BUCKET: ${S3_BULK_IMPORT_BUCKET:-bulk-imports}
+      # Platform monthly finance reports (issue #443) — **private**.
+      # Cross-tenant aggregated finance PDFs, super-admin only. Served
+      # back through the API stream-through (never presigned URL nor
+      # public-read). ADR-023.
+      S3_REPORTS_BUCKET: ${S3_REPORTS_BUCKET:-reports}
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -134,6 +139,7 @@ services:
         mc mb --ignore-existing "local/$$S3_CAMPAIGNS_BUCKET"
         mc mb --ignore-existing "local/$$S3_BRANDING_BUCKET"
         mc mb --ignore-existing "local/$$S3_BULK_IMPORT_BUCKET"
+        mc mb --ignore-existing "local/$$S3_REPORTS_BUCKET"
         # GC orphan multipart parts after 1 day. The postal-export worker
         # streams a ZIP into S3 via @aws-sdk/lib-storage's multipart Upload;
         # if the source stream is destroyed mid-upload (worker crash, S3
@@ -147,6 +153,14 @@ services:
         mc ilm rule add --abort-incomplete-multipart-days 1 "local/$$S3_RECEIPTS_BUCKET" || true
         mc ilm rule add --abort-incomplete-multipart-days 1 "local/$$S3_BRANDING_BUCKET" || true
         mc ilm rule add --abort-incomplete-multipart-days 1 "local/$$S3_BULK_IMPORT_BUCKET" || true
+        mc ilm rule add --abort-incomplete-multipart-days 1 "local/$$S3_REPORTS_BUCKET" || true
+        # Reports bucket — 12-month retention. Each monthly report is
+        # one ~50 KB PDF; over a year that's ~600 KB. Keep the rolling
+        # 12-month window for board-pack reference, prune anything
+        # older.
+        mc ilm rule add --expire-days 365 "local/$$S3_REPORTS_BUCKET" || true
+        # Reports bucket is private — explicit deny matches prod Scaleway.
+        mc anonymous set none "local/$$S3_REPORTS_BUCKET" || true
         # Bulk-import bucket — 90-day retention to match the row_data
         # snapshot retention in `bulk_import_results`. Operators can
         # re-download files within the window for audit; older files

--- a/docs/33-platform-finance-reports.md
+++ b/docs/33-platform-finance-reports.md
@@ -1,0 +1,141 @@
+# 33 — Platform monthly finance report (PDF)
+
+> Related: [`docs/14-screen-inventory.md`](14-screen-inventory.md) (super-admin Finance), [`docs/31-tenant-mobilization-score.md`](31-tenant-mobilization-score.md), [`docs/32-survey-infrastructure.md`](32-survey-infrastructure.md), [`docs/15-infra-adr.md`](15-infra-adr.md) (ADR-023 bucket topology), [Epic #434](https://github.com/purposestack/givernance/issues/434), [Issue #443](https://github.com/purposestack/givernance/issues/443).
+>
+> Migration that ships the schema: [`packages/api/migrations/0079_platform_finance_reports.sql`](../packages/api/migrations/0079_platform_finance_reports.sql).
+> Feature flag: gated under the existing `admin.finance_dashboard` (default off; same flag as the rest of Epic #434).
+> S3 bucket: `S3_REPORTS_BUCKET` (private, ADR-023).
+
+## 0. Why this exists — at a glance
+
+The super-admin "Finance plateforme" dashboard (Epic #434) is interactive — period selector, currency filter, tenant filter, drill-downs — and the numbers are live, cached for 5 minutes. It does its job for day-to-day operations.
+
+A **monthly PDF snapshot** plays a different role: it's the artefact super-admins keep for the board pack, for accounting reconciliation, and for the GDPR Art. 5(2) accountability story ("here is what the dashboard said on day X for month Y"). The dashboard is a live view; the PDF is a closed-period statement.
+
+This shipped MVP gives super-admins a one-click "Rapport mensuel" button on `/admin/finance` that:
+1. Resolves the most recent fully-completed calendar month (default; an explicit `month` body param re-runs an older period).
+2. Freezes the full `SummaryServiceResult` payload into a `kpi_snapshot` JSONB column.
+3. Streams a PDFKit render into the private `reports` bucket.
+4. Returns a same-host URL the browser can download from (streamed through the API per issue #214 — no presigned URLs that leak the MinIO hostname into a SigV4 signature).
+
+Same-month re-clicks are idempotent (one PDF per month). The `kpi_snapshot` is the canonical record of what numbers the super-admin saw, decoupled from later schema/SQL drift.
+
+## 1. End-to-end user flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor SA as Super-admin
+  participant Web as Next.js dashboard
+  participant API as Fastify API
+  participant DB as Postgres (systemDb / BYPASSRLS)
+  participant Q as BullMQ (PLATFORM_REPORTS queue)
+  participant Worker as BullMQ worker
+  participant S3 as S3 (reports bucket)
+
+  SA->>Web: clicks "Rapport mensuel"
+  Web->>API: POST /v1/superadmin/finance/reports/monthly
+  API->>API: validate month (default: previous full month)
+  API->>DB: SELECT live row for month (pending|ready)
+  alt Live row exists
+    API-->>Web: 200 { id, status, pdfUrl? } (idempotent replay)
+  else No live row
+    API->>API: buildFinanceSummary(period for month)
+    API->>DB: INSERT platform_finance_reports (pending, kpi_snapshot=…)
+    API->>Q: enqueue generate-monthly-finance-report { reportId, month }
+    API->>DB: INSERT audit_logs (resource_type='platform_finance_report', action='generate')
+    API-->>Web: 202 { id, status:'pending' }
+  end
+  Web->>Web: poll every 2s
+  loop until ready / failed
+    Web->>API: GET /v1/superadmin/finance/reports/:id
+    API->>DB: SELECT row
+    API-->>Web: { status, pdfUrl }
+  end
+  Q->>Worker: pickup job
+  Worker->>DB: SELECT row + kpi_snapshot
+  Worker->>Worker: PDFKit render from snapshot
+  Worker->>S3: PUT monthly/YYYY-MM/<reportId>.pdf
+  Worker->>DB: UPDATE row SET status='ready', pdf_s3_key=…, ready_at=NOW()
+  Web->>API: GET /v1/superadmin/finance/reports/:id/pdf
+  API->>DB: SELECT row (still ready)
+  API->>DB: INSERT audit_logs (action='download')
+  API->>S3: GetObjectCommand
+  S3-->>API: stream
+  API-->>Web: 200 application/pdf (streamed)
+```
+
+**Failure path**: a worker error sets `status='failed'` + `failure_reason`, then BullMQ retries with exponential backoff (`attempts=3`, delay 60s). After all attempts the job lands in BullMQ's `failed` set; the partial unique index is scoped to `('pending','ready')`, so a fresh re-POST creates a new row (the failed row stays as a forensic record).
+
+## 2. Domain model
+
+```mermaid
+erDiagram
+  platform_admins ||--o{ platform_finance_reports : "requested by"
+  platform_finance_reports {
+    uuid id PK
+    char(7) month "YYYY-MM"
+    text status "pending|ready|failed"
+    text pdf_s3_key "monthly/{month}/{id}.pdf"
+    jsonb kpi_snapshot "SummaryServiceResult frozen at request time"
+    text failure_reason
+    uuid requested_by_platform_admin_id FK
+    text job_id "monthly-finance-report-{id}"
+    timestamptz created_at
+    timestamptz ready_at
+  }
+```
+
+**Partial unique index** on `(month) WHERE status IN ('pending','ready')` enforces the "one live PDF per month" idempotency contract while leaving older `failed` rows in place. The schema check constraint pins `month` to a real calendar month (`^\d{4}-(0[1-9]|1[0-2])$`).
+
+**Platform-level**: no `org_id`, no RLS. Reads/writes go through `systemDb` (BYPASSRLS owner pool). `REVOKE ALL ON platform_finance_reports FROM givernance_app` so an accidental query through the tenant-scoped pool fails loud.
+
+## 3. Architecture
+
+| Concern | Owner | Notes |
+|---|---|---|
+| Route handlers | [`packages/api/src/modules/superadmin/finance/routes.ts`](../packages/api/src/modules/superadmin/finance/routes.ts) | Three new routes (POST, GET, GET pdf). Guard chain `requireFlag(ADMIN_FINANCE_DASHBOARD) → requireSuperAdmin` — flag first so a scanner gets 404 without enumerating the role requirement. |
+| Service / idempotency | [`packages/api/src/modules/superadmin/finance/monthly-report.ts`](../packages/api/src/modules/superadmin/finance/monthly-report.ts) | Month resolution, snapshot build, INSERT, enqueue. Same-month race collapses to the existing row via the partial unique index (catch + re-SELECT). |
+| Snapshot source | [`packages/api/src/modules/superadmin/finance/service.ts`](../packages/api/src/modules/superadmin/finance/service.ts) (`buildFinanceSummary`) | Same SQL as the live dashboard. The 5-min Redis cache covers the typical "view dashboard → click Generate" flow. |
+| Worker processor | [`packages/worker/src/processors/generate-monthly-finance-report.ts`](../packages/worker/src/processors/generate-monthly-finance-report.ts) | Reads snapshot from row, renders PDF, uploads, flips status. |
+| PDF renderer | [`packages/worker/src/services/platform-report-pdf.ts`](../packages/worker/src/services/platform-report-pdf.ts) | PDFKit; A4; FR locale. 5 sections matching the issue spec. |
+| S3 upload | [`packages/worker/src/lib/s3.ts`](../packages/worker/src/lib/s3.ts) (`uploadPlatformReportPdf`) | Private bucket `S3_REPORTS_BUCKET`. ACL=private, SSE=AES256. Key shape: `monthly/{YYYY-MM}/{id}.pdf`. |
+| S3 stream-back | [`packages/api/src/lib/s3.ts`](../packages/api/src/lib/s3.ts) (`fetchPlatformReportObject`) | Same `Readable`-piping pattern as receipts / postal exports (issue #214 — keeps URL on the app's apex). |
+| Queue | `PLATFORM_REPORTS` in [`packages/shared/src/jobs/index.ts`](../packages/shared/src/jobs/index.ts) | Concurrency 1 per worker pod; bound by S3 upload latency. |
+| Frontend | [`packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx`](../packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx) | Button restored, polling loop (every 2s, 60-attempt ceiling), `window.location.assign(pdfUrl)` to trigger the download. |
+| Service facade | [`packages/web/src/services/SuperAdminFinanceService.ts`](../packages/web/src/services/SuperAdminFinanceService.ts) | `requestMonthlyReport()` + `fetchReport()`. |
+
+**Sync vs async split**: the API runs the SQL aggregation synchronously (warm cache → ~50ms; cold ~1s) so the snapshot is frozen at request time, even if the SQL behind `buildFinanceSummary` later drifts. The PDF render + S3 upload run in the worker so a slow upload doesn't block the HTTP 202.
+
+## 4. Permissions matrix
+
+| Route | super_admin | org_admin / user / viewer | unauth |
+|---|---|---|---|
+| `POST /v1/superadmin/finance/reports/monthly` | 202 (or 200 replay) | 404 (anti-disclosure) | 401 |
+| `GET /v1/superadmin/finance/reports/:id` | 200 / 404 | 404 | 401 |
+| `GET /v1/superadmin/finance/reports/:id/pdf` | 200 stream / 409 / 404 | 404 | 401 |
+
+Every route's `preHandler` is `requireFlag(ADMIN_FINANCE_DASHBOARD) → requireSuperAdmin` (order matters — flag-off returns 404 without revealing the role requirement, consistent with the rest of Epic #434).
+
+## 5. Privacy / GDPR posture
+
+- **PII**: none. The report aggregates cross-tenant donation volumes, platform revenue, Stripe fees, and Mobilisation Score; no donor names or emails ever reach the PDF. The "Top 10 tenants" section uses tenant display names (operator-public).
+- **k-anonymity gate**: the survey snapshot section honours the `isStatisticallySignificant` flag built by `aggregateSurveys` — surveys below the k-anonymity threshold render as "anonymisé (n=N < seuil k-anonymity)" instead of leaking the score.
+- **Audit trail**: every `generate` and `download` writes an `audit_logs` row on the platform sentinel tenant, with `resource_type='platform_finance_report'`, `resource_id=<row.id>`, the super-admin's keycloak `sub` as `user_id` / `actor_id`, and a 16-char SHA-256 prefix of the IP. The `kpi_snapshot` JSONB on the row itself is the canonical record of "what numbers did the super-admin see" — decoupled from later schema drift in donations / pledges.
+- **Soft-delete**: `requested_by_platform_admin_id` is `ON DELETE SET NULL`, consistent with ADR-021 — the report stays auditable even after a super-admin is offboarded.
+- **Storage isolation**: ADR-023 — the `reports` bucket is **private** (ACL=private, SSE=AES256). Never co-locate with public-read assets (branding). Served back through the API only.
+
+## 6. Out of scope (deferred follow-ups)
+
+- **Cadences other than monthly**: weekly / quarterly / annual reports — deferred.
+- **Automated email distribution**: a "send to the super-admin team" pipeline is deferred; today the PDF is download-only.
+- **Tenant-level branding**: the PDF is platform-branded (Givernance). Per-tenant white-label PDFs for the operator-facing reports are docs/24 territory and unrelated.
+- **CSV export of the same data**: covered by issue #442 — separate row of the same toolbar; intentionally not wired in this PR (`feedback_no_anticipatory_ui`).
+- **Re-rendering an existing snapshot with a fresh template** (e.g. design refresh while keeping the audit-trail numbers): a future "re-render" route would re-use `kpi_snapshot` without re-querying. Not needed yet.
+- **Public projection to the donor-facing site**: never. The report aggregates cross-tenant data and is super-admin-only by design.
+
+## 7. Operating notes
+
+- **DLQ candidate signal**: the dashboard's polling loop runs for up to ~2 min (60 × 2 s). If the row is still `pending` after that, BullMQ has likely failed three times and the job is in the `failed` set — check Loki logs filtered by `worker=platform_reports, dlq=true`.
+- **Re-running a failed month**: just re-POST. The partial unique index allows it; the existing `failed` row stays as a forensic record.
+- **Local dev**: the bucket is provisioned automatically by the MinIO init container (every `S3_*_BUCKET` in the env schema gets created on boot). If you renamed the env var, restart the `givernance-minio` container.

--- a/docs/33-platform-finance-reports.md
+++ b/docs/33-platform-finance-reports.md
@@ -112,6 +112,7 @@ erDiagram
 | Route | super_admin | org_admin / user / viewer | unauth |
 |---|---|---|---|
 | `POST /v1/superadmin/finance/reports/monthly` | 202 (or 200 replay) | 404 (anti-disclosure) | 401 |
+| `POST /v1/superadmin/finance/reports/backfill` | 200 (rate-limited 2/min/IP) | 404 | 401 |
 | `GET /v1/superadmin/finance/reports/:id` | 200 / 404 | 404 | 401 |
 | `GET /v1/superadmin/finance/reports/:id/pdf` | 200 stream / 409 / 404 | 404 | 401 |
 
@@ -124,6 +125,20 @@ Every route's `preHandler` is `requireFlag(ADMIN_FINANCE_DASHBOARD) → requireS
 - **Audit trail**: every `generate` and `download` writes an `audit_logs` row on the platform sentinel tenant, with `resource_type='platform_finance_report'`, `resource_id=<row.id>`, the super-admin's keycloak `sub` as `user_id` / `actor_id`, and a 16-char SHA-256 prefix of the IP. The `kpi_snapshot` JSONB on the row itself is the canonical record of "what numbers did the super-admin see" — decoupled from later schema drift in donations / pledges.
 - **Soft-delete**: `requested_by_platform_admin_id` is `ON DELETE SET NULL`, consistent with ADR-021 — the report stays auditable even after a super-admin is offboarded.
 - **Storage isolation**: ADR-023 — the `reports` bucket is **private** (ACL=private, SSE=AES256). Never co-locate with public-read assets (branding). Served back through the API only.
+
+## 5b. Automatic generation + backfill
+
+Two non-manual paths feed into the same `requestMonthlyReport()` flow:
+
+- **Boot-time backfill** — on every API process start, `startMonthlyReportScheduler` walks the last 12 fully-completed calendar months and idempotently enqueues a report for any month that doesn't already have a live row. Failures are logged but never block boot. Keeps the 12-month retention window populated after a fresh deploy.
+- **Recurring monthly cron** — the same scheduler also chains a `setTimeout` for `03:30 UTC on the 1st of each month`. On fire it calls `requestMonthlyReport()` for the previous month and re-schedules itself. The timer is `unref()`-ed so it doesn't keep the process alive on its own; an `onClose` Fastify hook cancels it on graceful shutdown.
+- **Manual backfill button** — `POST /v1/superadmin/finance/reports/backfill` powers the dashboard's "Backfill 12 mois" secondary button. Rate-limited at 2/min/IP because the 12 sequential `buildFinanceSummary` runs are a real load spike on the SQL pool. Audits as `action='backfill', resource_type='platform_finance_report', resource_id=NULL` with the enqueued/skipped month lists in `new_values`.
+
+**Multi-replica safety** — the cron and the boot-time backfill BOTH check `findLiveByMonth` before INSERTing; concurrent replicas race the partial unique index, and the loser catches the violation + replays the existing row. No coordination service required.
+
+**Flag gating** — both the boot-time backfill and the cron's fire-time fire re-check `ADMIN_FINANCE_DASHBOARD` and no-op when off, so a paused rollout doesn't churn Postgres.
+
+**Tests** — `disableSchedulers: true` on `createServer` opts is the test-only opt-out so integration suites don't enqueue spurious jobs. Production callers always get the scheduler.
 
 ## 6. Out of scope (deferred follow-ups)
 

--- a/packages/api/migrations/0079_platform_finance_reports.sql
+++ b/packages/api/migrations/0079_platform_finance_reports.sql
@@ -1,0 +1,79 @@
+-- Migration: 0079_platform_finance_reports (Epic #434 follow-up, issue #443)
+--
+-- Tracks the monthly PDF finance reports generated for the super-admin
+-- "Finance plateforme" dashboard (route `POST /v1/superadmin/finance/
+-- reports/monthly`).
+--
+-- One row per (month, attempt). The report covers the most recent
+-- fully-completed calendar month — generated on demand by a
+-- super-admin clicking "Rapport mensuel". A `status='ready'` or
+-- `status='pending'` row makes the same-month re-submit idempotent:
+-- the route returns the existing row instead of re-enqueuing a job.
+-- A `status='failed'` row does NOT block a fresh attempt — the
+-- partial unique index below scopes the constraint to the live
+-- statuses only.
+--
+-- PLATFORM-LEVEL TABLE: no `org_id`, no RLS. Reports aggregate
+-- cross-tenant finance data (`donations.platform_fee_base_cents`,
+-- `donations.stripe_fee_cents`, Mobilisation Score per tenant) and
+-- are authored / consumed by super-admins exclusively. Accessed
+-- through `systemDb` (BYPASSRLS owner pool); REVOKE on
+-- `givernance_app` so an accidental query through the tenant-scoped
+-- pool fails loud.
+--
+-- `month` is the YYYY-MM label of the period the report covers.
+-- CHECK-constrained to a real calendar month so a malformed value
+-- (e.g. `2026-13`) can't reach the worker.
+--
+-- `pdf_s3_key` is the path inside `S3_REPORTS_BUCKET` (private,
+-- streamed back through the API per the streaming-through-API
+-- convention from issue #214). NULL until the worker uploads.
+--
+-- `kpi_snapshot` is the full `SummaryServiceResult` payload that
+-- powered the PDF, frozen at generation time. Lets the future "PDF
+-- viewer" + GDPR Art. 5(2) accountability ("what numbers did the
+-- super-admin actually see?") work without re-running the SQL.
+--
+-- `requested_by_platform_admin_id` is the super-admin who clicked
+-- the button — feeds the per-generate audit_log row.
+
+CREATE TABLE platform_finance_reports (
+  id                              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- YYYY-MM label of the calendar month the report covers.
+  month                           CHAR(7)      NOT NULL,
+  -- 'pending' until the worker finishes, then 'ready' (or 'failed').
+  status                          TEXT         NOT NULL DEFAULT 'pending',
+  pdf_s3_key                      TEXT,
+  kpi_snapshot                    JSONB,
+  failure_reason                  TEXT,
+  requested_by_platform_admin_id  UUID         REFERENCES platform_admins(id) ON DELETE SET NULL,
+  -- BullMQ job id (`monthly-finance-report-<id>`), kept for the
+  -- `/finance/reports/:id` polling lookup so the API can hint at
+  -- BullMQ state when the row is still `pending` after several
+  -- minutes (DLQ candidate signal).
+  job_id                          TEXT,
+  created_at                      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  ready_at                        TIMESTAMPTZ,
+
+  CONSTRAINT platform_finance_reports_month_chk
+    CHECK (month ~ '^\d{4}-(0[1-9]|1[0-2])$'),
+  CONSTRAINT platform_finance_reports_status_chk
+    CHECK (status IN ('pending', 'ready', 'failed'))
+);
+
+-- Partial unique on `month` scoped to live statuses — same month +
+-- (pending|ready) collapses to a single row (idempotent POST). A
+-- prior `failed` row does not block a fresh attempt; the API filters
+-- by `status IN ('pending','ready')` when checking for an existing
+-- report.
+CREATE UNIQUE INDEX platform_finance_reports_month_live_uniq
+  ON platform_finance_reports (month)
+  WHERE status IN ('pending', 'ready');
+
+CREATE INDEX platform_finance_reports_status_idx
+  ON platform_finance_reports (status);
+
+CREATE INDEX platform_finance_reports_month_idx
+  ON platform_finance_reports (month DESC);
+
+REVOKE ALL ON platform_finance_reports FROM givernance_app;

--- a/packages/api/migrations/0080_platform_admins_locale.sql
+++ b/packages/api/migrations/0080_platform_admins_locale.sql
@@ -1,0 +1,22 @@
+-- Migration: 0080_platform_admins_locale
+--
+-- The `/v1/users/me` profile page lets every authenticated user pick
+-- their UI language (FR / EN). For tenant users this stores into
+-- `users.locale`; super-admins go through `platform_admins` (ADR-022,
+-- disjoint identity surface) and that table never had a `locale`
+-- column — so `PATCH /v1/users/me` 404'd for super-admins, blocking
+-- the profile page entirely for that role.
+--
+-- This adds the missing column. NULL means "inherit the browser /
+-- platform default" — same semantics as `users.locale = NULL`.
+-- The CHECK constraint mirrors the tenant-side enum so the two
+-- surfaces stay in lockstep.
+
+ALTER TABLE platform_admins
+  ADD COLUMN IF NOT EXISTS locale TEXT;
+
+ALTER TABLE platform_admins
+  DROP CONSTRAINT IF EXISTS platform_admins_locale_chk;
+ALTER TABLE platform_admins
+  ADD CONSTRAINT platform_admins_locale_chk
+  CHECK (locale IS NULL OR locale IN ('en', 'fr'));

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -561,6 +561,13 @@
       "when": 1928180000000,
       "tag": "0079_platform_finance_reports",
       "breakpoints": true
+    },
+    {
+      "idx": 80,
+      "version": "7",
+      "when": 1938180000000,
+      "tag": "0080_platform_admins_locale",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -554,6 +554,13 @@
       "when": 1918180000000,
       "tag": "0078_admin_finance_dashboard_flag_label_update",
       "breakpoints": true
+    },
+    {
+      "idx": 79,
+      "version": "7",
+      "when": 1928180000000,
+      "tag": "0079_platform_finance_reports",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -51,6 +51,14 @@ const EnvSchema = Type.Object({
    * ADR-023 (one bucket per visibility class).
    */
   S3_BULK_IMPORT_BUCKET: Type.String({ minLength: 1, default: "bulk-imports" }),
+  /**
+   * S3 bucket for super-admin monthly finance reports (issue #443).
+   * **Private** — PDFs aggregate cross-tenant donation volume,
+   * platform revenue, Stripe fees and Mobilisation Score per tenant.
+   * Served back through the API only (streaming-through-API per issue
+   * #214); never via presigned URL nor public-read. ADR-023.
+   */
+  S3_REPORTS_BUCKET: Type.String({ minLength: 1, default: "reports" }),
   /** S3 region */
   S3_REGION: Type.String({ minLength: 1, default: "us-east-1" }),
   /**

--- a/packages/api/src/lib/s3.ts
+++ b/packages/api/src/lib/s3.ts
@@ -52,6 +52,29 @@ export async function fetchReceiptObject(s3Path: string): Promise<{
 }
 
 /**
+ * Fetch a super-admin monthly finance report PDF from MinIO/S3 (issue
+ * #443) — same streaming-through-API rationale as `fetchReceiptObject`
+ * (issue #214). The route `GET /v1/superadmin/finance/reports/:id/pdf`
+ * pipes this through `reply.send` with a `content-disposition:
+ * attachment` header.
+ */
+export async function fetchPlatformReportObject(s3Path: string): Promise<{
+  body: Readable;
+  contentLength: number | undefined;
+}> {
+  const command = new GetObjectCommand({
+    Bucket: env.S3_REPORTS_BUCKET,
+    Key: s3Path,
+  });
+  const response = await s3.send(command);
+  const body = response.Body as Readable | undefined;
+  if (!body) {
+    throw new Error(`S3 object missing body: ${s3Path}`);
+  }
+  return { body, contentLength: response.ContentLength };
+}
+
+/**
  * Fetch a campaign export ZIP from MinIO/S3 — same streaming-through-API
  * rationale as `fetchReceiptObject` (issue #214). The route
  * `GET /v1/campaigns/:id/postal-exports/:exportId/download` pipes this

--- a/packages/api/src/modules/superadmin/finance/auto-monthly-cron.ts
+++ b/packages/api/src/modules/superadmin/finance/auto-monthly-cron.ts
@@ -1,0 +1,151 @@
+// Issue #443 — automatic monthly report generation + startup backfill.
+//
+// Two responsibilities, both in-process in the API:
+//
+//   1. **Boot-time backfill** — on the first ready event the API
+//      checks the `platform_finance_reports` table and idempotently
+//      enqueues a report for every fully-completed calendar month in
+//      the trailing-12 window that doesn't already have a live row.
+//      Rationale: the bucket retains 12 months, so this keeps the
+//      retention window populated even after a fresh deploy into a
+//      tenant pool that already has historical donations.
+//
+//   2. **Monthly auto-cron** — a `setTimeout` chain that fires at
+//      03:30 UTC on the 1st of each month and calls
+//      `requestMonthlyReport()` for the previous month. The unique
+//      index handles multi-replica races (only one INSERT wins; the
+//      others see the live row and replay).
+//
+// Both paths funnel through `requestMonthlyReport` so the worker
+// queue, snapshot semantics, S3 layout and audit shape are identical
+// to the manual button.
+//
+// The cron is gated by the `ADMIN_FINANCE_DASHBOARD` feature flag
+// (re-checked at each fire, so a paused rollout doesn't churn
+// Postgres for nothing).
+
+import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
+import type { FastifyBaseLogger } from "fastify";
+import { flagService } from "../../../lib/flags/flag-service.js";
+import { backfillLast12Months, previousMonth, requestMonthlyReport } from "./monthly-report.js";
+
+const CRON_HOUR_UTC = 3;
+const CRON_MINUTE_UTC = 30;
+
+/**
+ * Return the next firing instant (a `Date`) at the next 1st-of-month
+ * at 03:30 UTC, strictly after `now`.
+ */
+export function nextMonthlyFire(now: Date = new Date()): Date {
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth(); // 0-indexed
+  // Candidate: 1st of the CURRENT month at 03:30 UTC.
+  let candidate = new Date(Date.UTC(y, m, 1, CRON_HOUR_UTC, CRON_MINUTE_UTC, 0, 0));
+  if (candidate.getTime() <= now.getTime()) {
+    // Already past — roll forward to the 1st of the NEXT month.
+    candidate = new Date(Date.UTC(y, m + 1, 1, CRON_HOUR_UTC, CRON_MINUTE_UTC, 0, 0));
+  }
+  return candidate;
+}
+
+interface SchedulerHandle {
+  cancel: () => void;
+}
+
+/**
+ * Start both the boot-time backfill and the recurring monthly cron.
+ * The returned handle's `cancel()` should be wired to Fastify's
+ * `onClose` hook so test suites and graceful-shutdown paths don't
+ * leak the scheduled timer.
+ */
+export function startMonthlyReportScheduler(log: FastifyBaseLogger): SchedulerHandle {
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  let cancelled = false;
+
+  async function fire(): Promise<void> {
+    if (cancelled) return;
+
+    const enabled = await flagService.isEnabled(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD);
+    if (!enabled) {
+      log.info(
+        { cron: "monthly_finance_report" },
+        "Monthly report cron fired but flag is off — no-op",
+      );
+      return;
+    }
+
+    try {
+      const result = await requestMonthlyReport({
+        requestedByPlatformAdminId: null,
+        month: previousMonth(),
+      });
+      log.info(
+        {
+          cron: "monthly_finance_report",
+          reportId: result.row.id,
+          month: result.row.month,
+          replayed: result.replayed,
+        },
+        "Monthly report cron fired",
+      );
+    } catch (err) {
+      log.error(
+        { err, cron: "monthly_finance_report" },
+        "Monthly report cron threw — will retry at next 1st-of-month",
+      );
+    }
+  }
+
+  function schedule(): void {
+    if (cancelled) return;
+    const next = nextMonthlyFire();
+    const delay = Math.max(1000, next.getTime() - Date.now());
+    log.info(
+      { cron: "monthly_finance_report", nextFire: next.toISOString() },
+      "Monthly report cron scheduled",
+    );
+    timeoutHandle = setTimeout(() => {
+      void fire().finally(() => schedule());
+    }, delay);
+    // Never let a long setTimeout keep the process alive on its own —
+    // the HTTP server is the lifecycle owner.
+    timeoutHandle.unref?.();
+  }
+
+  // Boot-time backfill — fire-and-forget; failures are logged but
+  // never block server boot.
+  async function backfill(): Promise<void> {
+    const enabled = await flagService.isEnabled(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD);
+    if (!enabled) {
+      log.info({ backfill: "monthly_finance_report" }, "Boot-time backfill skipped — flag is off");
+      return;
+    }
+    try {
+      const result = await backfillLast12Months({ requestedByPlatformAdminId: null });
+      log.info(
+        {
+          backfill: "monthly_finance_report",
+          enqueuedCount: result.enqueued.length,
+          skippedCount: result.skipped.length,
+          enqueuedMonths: result.enqueued.map((r) => r.month),
+        },
+        "Boot-time backfill complete",
+      );
+    } catch (err) {
+      log.error({ err, backfill: "monthly_finance_report" }, "Boot-time backfill threw");
+    }
+  }
+
+  void backfill();
+  schedule();
+
+  return {
+    cancel: () => {
+      cancelled = true;
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
+      }
+    },
+  };
+}

--- a/packages/api/src/modules/superadmin/finance/monthly-report.test.ts
+++ b/packages/api/src/modules/superadmin/finance/monthly-report.test.ts
@@ -6,7 +6,9 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { nextMonthlyFire } from "./auto-monthly-cron.js";
 import {
+  lastNMonths,
   MonthValidationError,
   periodForMonth,
   previousMonth,
@@ -87,5 +89,50 @@ describe("periodForMonth", () => {
     // `comparisonTo === from` (no overlap, no gap).
     expect(p.comparisonTo.toISOString()).toBe(p.from.toISOString());
     expect(p.comparisonFrom.getTime()).toBeLessThan(p.from.getTime());
+  });
+});
+
+describe("lastNMonths (backfill window)", () => {
+  it("returns N most recent completed months, oldest first", () => {
+    const now = new Date("2026-05-25T12:00:00Z");
+    const months = lastNMonths(12, now);
+    expect(months).toHaveLength(12);
+    expect(months[months.length - 1]).toBe("2026-04");
+    expect(months[0]).toBe("2025-05");
+  });
+
+  it("walks across the year boundary", () => {
+    const now = new Date("2026-02-10T12:00:00Z");
+    // Previous completed month = 2026-01; 12 months back = 2025-02.
+    const months = lastNMonths(12, now);
+    expect(months[0]).toBe("2025-02");
+    expect(months[months.length - 1]).toBe("2026-01");
+  });
+
+  it("N=1 → just the previous month", () => {
+    const now = new Date("2026-05-25T12:00:00Z");
+    expect(lastNMonths(1, now)).toEqual(["2026-04"]);
+  });
+});
+
+describe("nextMonthlyFire (auto-cron)", () => {
+  it("from mid-month → fires on the 1st of next month at 03:30 UTC", () => {
+    const now = new Date("2026-05-15T12:00:00Z");
+    expect(nextMonthlyFire(now).toISOString()).toBe("2026-06-01T03:30:00.000Z");
+  });
+
+  it("from the 1st at midnight → fires same day at 03:30 UTC", () => {
+    const now = new Date("2026-06-01T00:00:00Z");
+    expect(nextMonthlyFire(now).toISOString()).toBe("2026-06-01T03:30:00.000Z");
+  });
+
+  it("from the 1st just after 03:30 → fires on the 1st of NEXT month", () => {
+    const now = new Date("2026-06-01T03:31:00Z");
+    expect(nextMonthlyFire(now).toISOString()).toBe("2026-07-01T03:30:00.000Z");
+  });
+
+  it("December rollover → fires on Jan 1 of next year", () => {
+    const now = new Date("2026-12-20T12:00:00Z");
+    expect(nextMonthlyFire(now).toISOString()).toBe("2027-01-01T03:30:00.000Z");
   });
 });

--- a/packages/api/src/modules/superadmin/finance/monthly-report.test.ts
+++ b/packages/api/src/modules/superadmin/finance/monthly-report.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests — month resolution + validation helpers (issue #443).
+ * These are pure functions so we can pin behaviour around the calendar
+ * boundaries (Jan/Dec rollover, leap year, platform floor) without
+ * booting the API server or a Postgres connection.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MonthValidationError,
+  periodForMonth,
+  previousMonth,
+  validateMonth,
+} from "./monthly-report.js";
+
+describe("previousMonth", () => {
+  it("mid-month → previous calendar month", () => {
+    expect(previousMonth(new Date("2026-05-15T10:00:00Z"))).toBe("2026-04");
+  });
+
+  it("on the 1st of January → December of the previous year", () => {
+    expect(previousMonth(new Date("2026-01-01T00:00:00Z"))).toBe("2025-12");
+  });
+
+  it("on the 1st of March → February (handles non-leap years)", () => {
+    expect(previousMonth(new Date("2027-03-01T00:00:00Z"))).toBe("2027-02");
+  });
+});
+
+describe("validateMonth", () => {
+  const now = new Date("2026-05-25T12:00:00Z");
+
+  it("accepts the previous month", () => {
+    expect(() => validateMonth("2026-04", now)).not.toThrow();
+  });
+
+  it("accepts an older month", () => {
+    expect(() => validateMonth("2024-06", now)).not.toThrow();
+  });
+
+  it("rejects the current month (not yet complete)", () => {
+    expect(() => validateMonth("2026-05", now)).toThrow(MonthValidationError);
+  });
+
+  it("rejects a future month", () => {
+    expect(() => validateMonth("2027-01", now)).toThrow(MonthValidationError);
+  });
+
+  it("rejects months before the 2024-01 platform floor", () => {
+    expect(() => validateMonth("2023-12", now)).toThrow(MonthValidationError);
+  });
+
+  it("rejects malformed strings", () => {
+    expect(() => validateMonth("2026-13", now)).toThrow(MonthValidationError);
+    expect(() => validateMonth("not-a-month", now)).toThrow(MonthValidationError);
+    expect(() => validateMonth("", now)).toThrow(MonthValidationError);
+  });
+});
+
+describe("periodForMonth", () => {
+  it("April 2026 → from=2026-04-01 UTC, to=2026-05-01 UTC", () => {
+    const p = periodForMonth("2026-04");
+    expect(p.from.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+    expect(p.to.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    expect(p.label).toBe("2026-04");
+  });
+
+  it("comparison window mirrors the target month length", () => {
+    // April 2026 = 30 days. comparisonTo === from, and comparisonFrom
+    // is the same length back — the dashboard delta semantics need an
+    // equal-length previous window, not necessarily "the previous
+    // calendar month boundary" (which is what the live "today / 7d /
+    // 30d / 90d" period helper also enforces).
+    const p = periodForMonth("2026-04");
+    const months = (p.to.getTime() - p.from.getTime()) / (24 * 60 * 60 * 1000);
+    expect(months).toBe(30);
+    expect(p.comparisonTo.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+    expect((p.comparisonTo.getTime() - p.comparisonFrom.getTime()) / (24 * 60 * 60 * 1000)).toBe(
+      30,
+    );
+  });
+
+  it("Jan → comparison spills back into the previous year (UTC arithmetic)", () => {
+    const p = periodForMonth("2026-01");
+    // Comparison-window length equals the target-month length; the
+    // boundary that matters for the dashboard delta semantics is that
+    // `comparisonTo === from` (no overlap, no gap).
+    expect(p.comparisonTo.toISOString()).toBe(p.from.toISOString());
+    expect(p.comparisonFrom.getTime()).toBeLessThan(p.from.getTime());
+  });
+});

--- a/packages/api/src/modules/superadmin/finance/monthly-report.ts
+++ b/packages/api/src/modules/superadmin/finance/monthly-report.ts
@@ -1,0 +1,285 @@
+// Issue #443 — Super-admin monthly platform finance report.
+//
+// Single module for the "Rapport mensuel" feature wired off the
+// `/admin/finance` dashboard. Three responsibilities:
+//
+//  1. Resolve the target month — the most recent fully-completed
+//     calendar month (e.g., on 2026-05-25 the target is 2026-04). The
+//     route also accepts an explicit `month` body param (YYYY-MM) for
+//     re-running an older month after a fix or for QA.
+//
+//  2. Idempotent INSERT into `platform_finance_reports` — the partial
+//     unique index on `(month) WHERE status IN ('pending','ready')`
+//     makes a same-month POST return the existing row instead of
+//     re-enqueuing the worker.
+//
+//  3. Build the `kpi_snapshot` synchronously (re-uses
+//     `buildFinanceSummary`) and enqueue the worker for the
+//     PDF render + S3 upload (CPU + network IO that we keep off the
+//     HTTP path).
+//
+// PLATFORM-LEVEL: every query goes through `systemDb`. The route
+// guard chain `requireFlag(ADMIN_FINANCE_DASHBOARD) →
+// requireSuperAdmin` is enforced in routes.ts (flag first so a
+// scanner gets 404 without revealing the role requirement).
+
+import { QUEUE_NAMES } from "@givernance/shared/jobs";
+import { platformFinanceReports } from "@givernance/shared/schema";
+import { Queue } from "bullmq";
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { systemDb } from "../../../lib/db.js";
+import { redis } from "../../../lib/redis.js";
+import type { ResolvedPeriod } from "./period.js";
+import { buildFinanceSummary, type SummaryServiceResult } from "./service.js";
+
+const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+let cachedQueue: Queue | null = null;
+function reportsQueue(): Queue {
+  if (cachedQueue) return cachedQueue;
+  cachedQueue = new Queue(QUEUE_NAMES.PLATFORM_REPORTS, { connection: redis });
+  return cachedQueue;
+}
+
+export class MonthValidationError extends Error {
+  readonly detail: string;
+  constructor(detail: string) {
+    super(detail);
+    this.name = "MonthValidationError";
+    this.detail = detail;
+  }
+}
+
+/**
+ * Resolve the most recent fully-completed calendar month as `YYYY-MM`,
+ * relative to `now` (UTC). On 2026-05-25 returns "2026-04".
+ */
+export function previousMonth(now: Date = new Date()): string {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth(); // 0-indexed
+  // Step into the previous month — month=0 (Jan) → Dec of prev year.
+  const targetYear = month === 0 ? year - 1 : year;
+  const targetMonth = month === 0 ? 12 : month;
+  return `${targetYear}-${String(targetMonth).padStart(2, "0")}`;
+}
+
+/**
+ * Validate a `YYYY-MM` string. Throws `MonthValidationError` for
+ * malformed values, future months, and months before the 2024-01
+ * platform floor (the same floor `period.ts` enforces).
+ */
+export function validateMonth(value: string, now: Date = new Date()): void {
+  if (!MONTH_REGEX.test(value)) {
+    throw new MonthValidationError(`month must match YYYY-MM (got '${value}')`);
+  }
+  const [yearStr, monthStr] = value.split("-");
+  const year = Number.parseInt(yearStr ?? "", 10);
+  const month = Number.parseInt(monthStr ?? "", 10);
+  // Platform floor — same epoch as `period.ts`.
+  if (year < 2024 || (year === 2024 && month < 1)) {
+    throw new MonthValidationError("month is before the 2024-01 platform floor");
+  }
+  // Reject the current month (not yet complete) and any future month.
+  const current = previousMonth(now);
+  if (value > current) {
+    throw new MonthValidationError(
+      `month '${value}' is not a fully-completed calendar month yet (most recent: '${current}')`,
+    );
+  }
+}
+
+/**
+ * Build a ResolvedPeriod that covers a full calendar month, with the
+ * comparison window being the month before it.
+ */
+export function periodForMonth(month: string): ResolvedPeriod {
+  const [yearStr, monthStr] = month.split("-");
+  const year = Number.parseInt(yearStr ?? "", 10);
+  const m = Number.parseInt(monthStr ?? "", 10);
+  // Month boundaries in UTC. `from` is the 1st at 00:00, `to` is the
+  // 1st of the next month at 00:00 (exclusive) — matches the
+  // [from, to) convention `buildFinanceSummary` expects.
+  const from = new Date(Date.UTC(year, m - 1, 1, 0, 0, 0, 0));
+  const to = new Date(Date.UTC(year, m, 1, 0, 0, 0, 0));
+  const windowMs = to.getTime() - from.getTime();
+  const comparisonTo = from;
+  const comparisonFrom = new Date(comparisonTo.getTime() - windowMs);
+  return {
+    from,
+    to,
+    label: month,
+    comparisonFrom,
+    comparisonTo,
+    clamped: false,
+  };
+}
+
+export type ReportStatus = "pending" | "ready" | "failed";
+
+export interface ReportRow {
+  id: string;
+  month: string;
+  status: ReportStatus;
+  pdfS3Key: string | null;
+  failureReason: string | null;
+  createdAt: string;
+  readyAt: string | null;
+}
+
+function rowToDto(row: typeof platformFinanceReports.$inferSelect): ReportRow {
+  return {
+    id: row.id,
+    month: row.month,
+    status: row.status as ReportStatus,
+    pdfS3Key: row.pdfS3Key,
+    failureReason: row.failureReason,
+    createdAt: row.createdAt.toISOString(),
+    readyAt: row.readyAt?.toISOString() ?? null,
+  };
+}
+
+/**
+ * Look up an existing live (pending or ready) report for a given
+ * month. Returns null if none — the caller can then attempt the
+ * idempotent INSERT path.
+ */
+async function findLiveByMonth(month: string): Promise<ReportRow | null> {
+  const [row] = await systemDb
+    .select()
+    .from(platformFinanceReports)
+    .where(
+      and(
+        eq(platformFinanceReports.month, month),
+        inArray(platformFinanceReports.status, ["pending", "ready"]),
+      ),
+    )
+    .limit(1);
+  return row ? rowToDto(row) : null;
+}
+
+export async function findById(id: string): Promise<ReportRow | null> {
+  const [row] = await systemDb
+    .select()
+    .from(platformFinanceReports)
+    .where(eq(platformFinanceReports.id, id))
+    .limit(1);
+  return row ? rowToDto(row) : null;
+}
+
+export interface RequestMonthlyReportInput {
+  month: string;
+  requestedByPlatformAdminId: string | null;
+  traceparent?: string;
+}
+
+export interface RequestMonthlyReportResult {
+  row: ReportRow;
+  replayed: boolean;
+  snapshot: SummaryServiceResult | null;
+}
+
+/**
+ * Idempotent request entry point. Always validates the month, then:
+ *   - returns the live row if one exists (replayed=true, no enqueue);
+ *   - else builds the snapshot, INSERTs a pending row, enqueues the
+ *     worker job and returns replayed=false.
+ *
+ * The `kpi_snapshot` is built synchronously here (not in the worker)
+ * because the underlying SQL aggregation reuses the dashboard's
+ * 5-minute Redis cache when the super-admin has just viewed the same
+ * period — the typical "view dashboard, click Generate report" flow
+ * hits a warm cache. Pushing it into the worker would re-run the
+ * aggregation cold.
+ */
+export async function requestMonthlyReport(
+  input: RequestMonthlyReportInput,
+  now: Date = new Date(),
+): Promise<RequestMonthlyReportResult> {
+  validateMonth(input.month, now);
+
+  const existing = await findLiveByMonth(input.month);
+  if (existing) {
+    return { row: existing, replayed: true, snapshot: null };
+  }
+
+  // Build the snapshot for the month. The aggregation tolerates an
+  // empty platform (no donations yet) — the KPIs come back as zeros
+  // and the PDF still renders.
+  const period = periodForMonth(input.month);
+  const snapshot = await buildFinanceSummary({ period, filters: {} });
+
+  // INSERT pending row + capture the assigned id for the BullMQ job
+  // payload. The partial unique index protects against a same-month
+  // race: if a second concurrent POST INSERTed first, the unique
+  // violation surfaces as a Postgres error — we catch it and replay
+  // the existing row.
+  let inserted: typeof platformFinanceReports.$inferSelect;
+  try {
+    const rows = await systemDb
+      .insert(platformFinanceReports)
+      .values({
+        month: input.month,
+        status: "pending",
+        kpiSnapshot: snapshot,
+        requestedByPlatformAdminId: input.requestedByPlatformAdminId,
+      })
+      .returning();
+    if (!rows[0]) {
+      throw new Error("INSERT into platform_finance_reports returned no row");
+    }
+    inserted = rows[0];
+  } catch (err) {
+    // Race: another concurrent POST already inserted the live row —
+    // collapse to the existing row instead of failing the caller.
+    const replayed = await findLiveByMonth(input.month);
+    if (replayed) {
+      return { row: replayed, replayed: true, snapshot: null };
+    }
+    throw err;
+  }
+
+  // Stamp the row with the BullMQ job id so the polling GET can hint
+  // at BullMQ state when the row is still pending after several
+  // minutes (DLQ candidate signal).
+  const jobId = `monthly-finance-report-${inserted.id}`;
+  await reportsQueue().add(
+    "generate-monthly-finance-report",
+    {
+      reportId: inserted.id,
+      month: input.month,
+      traceparent: input.traceparent,
+    },
+    {
+      jobId,
+      attempts: 3,
+      backoff: { type: "exponential", delay: 60_000 },
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 50 },
+    },
+  );
+
+  await systemDb
+    .update(platformFinanceReports)
+    .set({ jobId })
+    .where(eq(platformFinanceReports.id, inserted.id));
+
+  return {
+    row: { ...rowToDto(inserted), pdfS3Key: null },
+    replayed: false,
+    snapshot,
+  };
+}
+
+/**
+ * List the N most recent reports (any status). Powers a future
+ * "previous reports" panel on the dashboard — not exposed by issue
+ * #443 itself but trivial to add and keeps the API surface coherent.
+ */
+export async function listRecent(limit = 12): Promise<ReportRow[]> {
+  const rows = await systemDb
+    .select()
+    .from(platformFinanceReports)
+    .orderBy(desc(platformFinanceReports.createdAt))
+    .limit(limit);
+  return rows.map(rowToDto);
+}

--- a/packages/api/src/modules/superadmin/finance/monthly-report.ts
+++ b/packages/api/src/modules/superadmin/finance/monthly-report.ts
@@ -157,6 +157,82 @@ async function findLiveByMonth(month: string): Promise<ReportRow | null> {
   return row ? rowToDto(row) : null;
 }
 
+/**
+ * Mark an existing report row as superseded — set `status='failed'`
+ * with a recognisable `failure_reason`. The partial unique index is
+ * scoped to `pending|ready`, so flipping to `failed` frees up the
+ * month slot for a fresh `requestMonthlyReport` call. The old row
+ * stays in the table forever (RGPD Art. 5.2 accountability — we
+ * never lose the audit trail of what was generated).
+ */
+async function markSuperseded(id: string): Promise<void> {
+  await systemDb
+    .update(platformFinanceReports)
+    .set({ status: "failed", failureReason: "Remplacé par régénération" })
+    .where(eq(platformFinanceReports.id, id));
+}
+
+export interface RegenerateResult {
+  /** The new pending row that the worker is about to render. */
+  newRow: ReportRow;
+  /** The row that was just superseded (always `failed` status now). */
+  supersededRow: ReportRow;
+}
+
+export class RegenerateError extends Error {
+  readonly detail: string;
+  readonly statusCode: number;
+  constructor(statusCode: number, detail: string) {
+    super(detail);
+    this.name = "RegenerateError";
+    this.statusCode = statusCode;
+    this.detail = detail;
+  }
+}
+
+/**
+ * Regenerate an existing report. Flow:
+ *  1. Look up the source row.
+ *  2. Refuse if it's still `pending` (worker hasn't finished yet —
+ *     wait or let it fail naturally before regenerating).
+ *  3. Mark the source row `failed` with reason `Remplacé par
+ *     régénération`. The partial unique index is now free.
+ *  4. Call `requestMonthlyReport` for the same month — this builds
+ *     a fresh snapshot with the current SQL + enqueues the worker.
+ *
+ * The caller is responsible for emitting the audit_log row with
+ * `action='regenerate'` and the supersedes pointer.
+ */
+export async function regenerateReport(input: {
+  sourceId: string;
+  requestedByPlatformAdminId: string | null;
+  traceparent?: string;
+}): Promise<RegenerateResult> {
+  const source = await findById(input.sourceId);
+  if (!source) {
+    throw new RegenerateError(404, "Rapport introuvable.");
+  }
+  if (source.status === "pending") {
+    throw new RegenerateError(
+      409,
+      "Le rapport est encore en cours de génération — attendez qu'il soit prêt avant de le régénérer.",
+    );
+  }
+
+  await markSuperseded(source.id);
+
+  const fresh = await requestMonthlyReport({
+    month: source.month,
+    requestedByPlatformAdminId: input.requestedByPlatformAdminId,
+    traceparent: input.traceparent,
+  });
+
+  return {
+    newRow: fresh.row,
+    supersededRow: { ...source, status: "failed", failureReason: "Remplacé par régénération" },
+  };
+}
+
 export async function findById(id: string): Promise<ReportRow | null> {
   const [row] = await systemDb
     .select()

--- a/packages/api/src/modules/superadmin/finance/monthly-report.ts
+++ b/packages/api/src/modules/superadmin/finance/monthly-report.ts
@@ -26,7 +26,7 @@
 import { QUEUE_NAMES } from "@givernance/shared/jobs";
 import { platformFinanceReports } from "@givernance/shared/schema";
 import { Queue } from "bullmq";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { systemDb } from "../../../lib/db.js";
 import { redis } from "../../../lib/redis.js";
 import type { ResolvedPeriod } from "./period.js";
@@ -338,15 +338,51 @@ export async function backfillLast12Months(
 }
 
 /**
- * List the N most recent reports (any status). Powers a future
- * "previous reports" panel on the dashboard — not exposed by issue
- * #443 itself but trivial to add and keeps the API surface coherent.
+ * List the N most recent reports, **one row per month** — preferring
+ * `ready` over `pending` over `failed`. Powers the dashboard's
+ * "Archive" panel. Without the per-month dedup, an operator who hits
+ * the manual button (or any transient `failed` retry burst) would see
+ * the panel pile up with duplicate-month entries.
+ *
+ * Returned in chronological-descending order (most recent month first).
  */
 export async function listRecent(limit = 12): Promise<ReportRow[]> {
-  const rows = await systemDb
-    .select()
-    .from(platformFinanceReports)
-    .orderBy(desc(platformFinanceReports.createdAt))
-    .limit(limit);
-  return rows.map(rowToDto);
+  // DISTINCT ON (month) is the canonical Postgres dedup. The ORDER BY
+  // inside the subquery is the tiebreaker: `ready` first, then
+  // `pending`, then `failed`, and within each status the most-recently
+  // created. The outer ORDER BY then re-sorts by `month DESC` so the
+  // panel shows newest months on top.
+  const rows = await systemDb.execute<{
+    id: string;
+    month: string;
+    status: string;
+    pdf_s3_key: string | null;
+    failure_reason: string | null;
+    created_at: Date;
+    ready_at: Date | null;
+  }>(sql`
+    SELECT id, month, status, pdf_s3_key, failure_reason, created_at, ready_at
+    FROM (
+      SELECT DISTINCT ON (month)
+        id, month, status, pdf_s3_key, failure_reason, created_at, ready_at
+      FROM platform_finance_reports
+      ORDER BY month, CASE status
+        WHEN 'ready' THEN 0
+        WHEN 'pending' THEN 1
+        WHEN 'failed' THEN 2
+        ELSE 3
+      END, created_at DESC
+    ) latest
+    ORDER BY month DESC
+    LIMIT ${limit}
+  `);
+  return rows.rows.map((r) => ({
+    id: r.id,
+    month: r.month,
+    status: r.status as ReportStatus,
+    pdfS3Key: r.pdf_s3_key,
+    failureReason: r.failure_reason,
+    createdAt: new Date(r.created_at).toISOString(),
+    readyAt: r.ready_at ? new Date(r.ready_at).toISOString() : null,
+  }));
 }

--- a/packages/api/src/modules/superadmin/finance/monthly-report.ts
+++ b/packages/api/src/modules/superadmin/finance/monthly-report.ts
@@ -271,6 +271,73 @@ export async function requestMonthlyReport(
 }
 
 /**
+ * Walk the last `n` fully-completed calendar months back from `now`
+ * and return the YYYY-MM labels in chronological order
+ * (oldest first). Used by the backfill route to know which months
+ * deserve a report.
+ */
+export function lastNMonths(n: number, now: Date = new Date()): string[] {
+  const months: string[] = [];
+  const baseYear = now.getUTCFullYear();
+  const baseMonth = now.getUTCMonth() + 1; // 1-indexed
+  const baseTotal = baseYear * 12 + (baseMonth - 1);
+  // Step into the most recent fully-completed month (matches
+  // previousMonth semantics), then walk back n entries.
+  for (let i = n; i >= 1; i -= 1) {
+    const total = baseTotal - i;
+    const y = Math.floor(total / 12);
+    const m = (total % 12) + 1;
+    months.push(`${y}-${String(m).padStart(2, "0")}`);
+  }
+  return months;
+}
+
+export interface BackfillResult {
+  /** Months that did not yet have a live row and were enqueued. */
+  enqueued: ReportRow[];
+  /** Months that already had a live (pending|ready) row — left untouched. */
+  skipped: ReportRow[];
+}
+
+/**
+ * Backfill — for each of the last 12 fully-completed calendar months
+ * (capped to the 2024-01 platform floor), idempotently request a
+ * monthly report. Calls share the same `requestMonthlyReport` flow as
+ * the manual button so the worker queue, S3 layout, audit shape and
+ * snapshot semantics stay identical between manual / backfill /
+ * cron-triggered paths.
+ */
+export async function backfillLast12Months(
+  input: { requestedByPlatformAdminId: string | null; traceparent?: string },
+  now: Date = new Date(),
+): Promise<BackfillResult> {
+  const enqueued: ReportRow[] = [];
+  const skipped: ReportRow[] = [];
+
+  for (const month of lastNMonths(12, now)) {
+    // The 2024-01 floor — silently skip pre-platform months instead of
+    // throwing, so a backfill from 2024-06 still works partially.
+    try {
+      validateMonth(month, now);
+    } catch {
+      continue;
+    }
+    const result = await requestMonthlyReport(
+      {
+        month,
+        requestedByPlatformAdminId: input.requestedByPlatformAdminId,
+        traceparent: input.traceparent,
+      },
+      now,
+    );
+    if (result.replayed) skipped.push(result.row);
+    else enqueued.push(result.row);
+  }
+
+  return { enqueued, skipped };
+}
+
+/**
  * List the N most recent reports (any status). Powers a future
  * "previous reports" panel on the dashboard — not exposed by issue
  * #443 itself but trivial to add and keeps the API surface coherent.

--- a/packages/api/src/modules/superadmin/finance/routes.ts
+++ b/packages/api/src/modules/superadmin/finance/routes.ts
@@ -28,6 +28,7 @@ import {
   problemDetail,
 } from "../../../lib/schemas.js";
 import {
+  backfillLast12Months,
   findById,
   MonthValidationError,
   previousMonth,
@@ -35,6 +36,7 @@ import {
 } from "./monthly-report.js";
 import { PeriodValidationError, resolvePeriod } from "./period.js";
 import {
+  BackfillResponse,
   CacheFlushResponse,
   InvitationIdParams,
   LaunchBody,
@@ -752,6 +754,95 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
         reply.header("content-length", contentLength);
       }
       return reply.send(body);
+    },
+  );
+
+  // ─── POST /v1/superadmin/finance/reports/backfill (issue #443) ──────────
+  // Idempotently requests reports for each of the last 12 fully-completed
+  // calendar months. Same flow as the manual button — re-uses the
+  // partial unique index for same-month dedup. Powers the "Backfill
+  // missing reports" action on the dashboard and the auto-cron that
+  // fires on day 1 of each month (it ALSO calls this codepath through
+  // requestMonthlyReport for resilience to past missed crons).
+  //
+  // Rate-limited at 2/min/IP — 12 sequential snapshot builds is a real
+  // load spike on the SQL pool and we never need to backfill that
+  // often.
+  app.post(
+    "/superadmin/finance/reports/backfill",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      schema: {
+        tags: ["Superadmin", "Finance"],
+        response: {
+          200: BackfillResponse,
+          ...ErrorResponses,
+        },
+      },
+      config: {
+        rateLimit: {
+          max: 2,
+          timeWindow: "1 minute",
+        },
+      },
+    },
+    async (request) => {
+      const platformAdminId = await resolvePlatformAdminId(request.auth?.userId ?? "");
+
+      const result = await backfillLast12Months({
+        requestedByPlatformAdminId: platformAdminId,
+        traceparent:
+          typeof request.headers.traceparent === "string" ? request.headers.traceparent : undefined,
+      });
+
+      // Project internal ReportRow → wire shape. `pdfS3Key` is an
+      // implementation detail (the S3 key is never exposed
+      // client-side; clients use the `pdfUrl` route instead).
+      const toWire = (r: (typeof result.enqueued)[number] | (typeof result.skipped)[number]) => ({
+        id: r.id,
+        month: r.month,
+        status: r.status,
+        failureReason: r.failureReason,
+        createdAt: r.createdAt,
+        readyAt: r.readyAt,
+        pdfUrl: r.status === "ready" ? `/v1/superadmin/finance/reports/${r.id}/pdf` : null,
+      });
+
+      // One audit row summarising the backfill — individual report
+      // enqueues already emit their own audit rows via
+      // requestMonthlyReport → POST handler? No, requestMonthlyReport
+      // itself does NOT audit (the POST route does). For the
+      // backfill path, emit a single summary audit to keep the
+      // audit_logs cardinality bounded.
+      const platformOrgId = await getPlatformOrgId();
+      try {
+        await systemDb.insert(auditLogs).values({
+          orgId: platformOrgId,
+          userId: request.auth?.userId ?? null,
+          actorId: request.auth?.userId ?? null,
+          action: "backfill",
+          resourceType: "platform_finance_report",
+          resourceId: null,
+          newValues: {
+            enqueued: result.enqueued.map((r) => ({ id: r.id, month: r.month })),
+            skipped: result.skipped.map((r) => ({ id: r.id, month: r.month })),
+          },
+          ipHash: hashIp(request.ip),
+          userAgent: request.headers["user-agent"] ?? undefined,
+        });
+      } catch (err) {
+        request.log.error(
+          { err, audit: "INSERT_FAILED" },
+          "CRITICAL: monthly finance report backfill audit insert failed",
+        );
+      }
+
+      return {
+        data: {
+          enqueued: result.enqueued.map(toWire),
+          skipped: result.skipped.map(toWire),
+        },
+      };
     },
   );
 }

--- a/packages/api/src/modules/superadmin/finance/routes.ts
+++ b/packages/api/src/modules/superadmin/finance/routes.ts
@@ -30,6 +30,7 @@ import {
 import {
   backfillLast12Months,
   findById,
+  listRecent,
   MonthValidationError,
   previousMonth,
   requestMonthlyReport,
@@ -41,6 +42,7 @@ import {
   InvitationIdParams,
   LaunchBody,
   LaunchResponse,
+  ListReportsResponse,
   MonthlyReportBody,
   MonthlyReportResponse,
   ReportIdParams,
@@ -644,6 +646,38 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
               ? `/v1/superadmin/finance/reports/${result.row.id}/pdf`
               : null,
         },
+      };
+    },
+  );
+
+  // ─── GET /v1/superadmin/finance/reports (list recent) ───────────────────
+  // Returns the 12 most-recent reports (any status) so the dashboard can
+  // render an "Archive" panel of downloadable monthly PDFs. Filter is
+  // applied client-side; the route returns the full set.
+  app.get(
+    "/superadmin/finance/reports",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      schema: {
+        tags: ["Superadmin", "Finance"],
+        response: {
+          200: ListReportsResponse,
+          ...ErrorResponses,
+        },
+      },
+    },
+    async () => {
+      const rows = await listRecent(24);
+      return {
+        data: rows.map((r) => ({
+          id: r.id,
+          month: r.month,
+          status: r.status,
+          failureReason: r.failureReason,
+          createdAt: r.createdAt,
+          readyAt: r.readyAt,
+          pdfUrl: r.status === "ready" ? `/v1/superadmin/finance/reports/${r.id}/pdf` : null,
+        })),
       };
     },
   );

--- a/packages/api/src/modules/superadmin/finance/routes.ts
+++ b/packages/api/src/modules/superadmin/finance/routes.ts
@@ -20,18 +20,28 @@ import { systemDb } from "../../../lib/db.js";
 import { requireFlag } from "../../../lib/flags/flag-guard.js";
 import { requireAuth, requireSuperAdmin } from "../../../lib/guards.js";
 import { redis } from "../../../lib/redis.js";
+import { fetchPlatformReportObject } from "../../../lib/s3.js";
 import {
   ErrorResponses,
   isUuidV4,
   ProblemDetailSchema,
   problemDetail,
 } from "../../../lib/schemas.js";
+import {
+  findById,
+  MonthValidationError,
+  previousMonth,
+  requestMonthlyReport,
+} from "./monthly-report.js";
 import { PeriodValidationError, resolvePeriod } from "./period.js";
 import {
   CacheFlushResponse,
   InvitationIdParams,
   LaunchBody,
   LaunchResponse,
+  MonthlyReportBody,
+  MonthlyReportResponse,
+  ReportIdParams,
   RespondBody,
   RespondResponse,
   ScheduleBody,
@@ -548,6 +558,200 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
       await emitAuditCacheFlush(request, { pattern, keysDeleted });
 
       return { data: { keysDeleted, pattern } };
+    },
+  );
+
+  // ─── POST /v1/superadmin/finance/reports/monthly (issue #443) ───────────
+  app.post(
+    "/superadmin/finance/reports/monthly",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      schema: {
+        tags: ["Superadmin", "Finance"],
+        body: MonthlyReportBody,
+        response: {
+          200: MonthlyReportResponse,
+          202: MonthlyReportResponse,
+          ...ErrorResponses,
+          400: ProblemDetailSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const body = (request.body ?? {}) as { month?: string };
+      const targetMonth = body.month ?? previousMonth();
+
+      const platformAdminId = await resolvePlatformAdminId(request.auth?.userId ?? "");
+
+      let result: Awaited<ReturnType<typeof requestMonthlyReport>>;
+      try {
+        result = await requestMonthlyReport({
+          month: targetMonth,
+          requestedByPlatformAdminId: platformAdminId,
+          traceparent:
+            typeof request.headers.traceparent === "string"
+              ? request.headers.traceparent
+              : undefined,
+        });
+      } catch (err) {
+        if (err instanceof MonthValidationError) {
+          return reply.status(400).send(problemDetail(400, "Bad Request", err.detail));
+        }
+        throw err;
+      }
+
+      // Emit audit log: GDPR Art. 5(2) accountability — every report
+      // generation is traced to a super-admin, with replay flagged so
+      // a forensic timeline can tell a fresh enqueue from an
+      // idempotent same-month replay.
+      const platformOrgId = await getPlatformOrgId();
+      try {
+        await systemDb.insert(auditLogs).values({
+          orgId: platformOrgId,
+          userId: request.auth?.userId ?? null,
+          actorId: request.auth?.userId ?? null,
+          action: "generate",
+          resourceType: "platform_finance_report",
+          resourceId: result.row.id,
+          newValues: {
+            month: result.row.month,
+            replayed: result.replayed,
+            jobId: `monthly-finance-report-${result.row.id}`,
+          },
+          ipHash: hashIp(request.ip),
+          userAgent: request.headers["user-agent"] ?? undefined,
+        });
+      } catch (err) {
+        request.log.error(
+          { err, audit: "INSERT_FAILED" },
+          "CRITICAL: monthly finance report audit insert failed — GDPR accountability gap",
+        );
+      }
+
+      reply.status(result.replayed ? 200 : 202);
+      return {
+        data: {
+          id: result.row.id,
+          month: result.row.month,
+          status: result.row.status,
+          failureReason: result.row.failureReason,
+          createdAt: result.row.createdAt,
+          readyAt: result.row.readyAt,
+          pdfUrl:
+            result.row.status === "ready"
+              ? `/v1/superadmin/finance/reports/${result.row.id}/pdf`
+              : null,
+        },
+      };
+    },
+  );
+
+  // ─── GET /v1/superadmin/finance/reports/:id (polling) ───────────────────
+  app.get(
+    "/superadmin/finance/reports/:id",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      schema: {
+        tags: ["Superadmin", "Finance"],
+        params: ReportIdParams,
+        response: {
+          200: MonthlyReportResponse,
+          ...ErrorResponses,
+          404: ProblemDetailSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const row = await findById(id);
+      if (!row) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Report not found."));
+      }
+      return {
+        data: {
+          id: row.id,
+          month: row.month,
+          status: row.status,
+          failureReason: row.failureReason,
+          createdAt: row.createdAt,
+          readyAt: row.readyAt,
+          pdfUrl: row.status === "ready" ? `/v1/superadmin/finance/reports/${row.id}/pdf` : null,
+        },
+      };
+    },
+  );
+
+  // ─── GET /v1/superadmin/finance/reports/:id/pdf (streamed PDF) ──────────
+  //
+  // Stream-through-API rather than presigned URL: same rationale as
+  // `fetchReceiptObject` (issue #214) — keeps the donor-/operator-
+  // visible URL on the app's own apex and avoids baking the MinIO
+  // hostname into a SigV4 signature that's only resolvable inside the
+  // Docker network on staging.
+  app.get(
+    "/superadmin/finance/reports/:id/pdf",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      schema: {
+        tags: ["Superadmin", "Finance"],
+        params: ReportIdParams,
+        response: {
+          ...ErrorResponses,
+          404: ProblemDetailSchema,
+          409: ProblemDetailSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const row = await findById(id);
+      if (!row) {
+        return reply.status(404).send(problemDetail(404, "Not Found", "Report not found."));
+      }
+      if (row.status !== "ready" || !row.pdfS3Key) {
+        return reply
+          .status(409)
+          .send(
+            problemDetail(
+              409,
+              "Conflict",
+              `Report is not ready (status='${row.status}'). Poll GET /v1/superadmin/finance/reports/${row.id} until status='ready'.`,
+            ),
+          );
+      }
+
+      // Audit the download — separate `download` action so the
+      // forensic timeline tells a generate from a re-download.
+      const platformOrgId = await getPlatformOrgId();
+      try {
+        await systemDb.insert(auditLogs).values({
+          orgId: platformOrgId,
+          userId: request.auth?.userId ?? null,
+          actorId: request.auth?.userId ?? null,
+          action: "download",
+          resourceType: "platform_finance_report",
+          resourceId: row.id,
+          newValues: { month: row.month },
+          ipHash: hashIp(request.ip),
+          userAgent: request.headers["user-agent"] ?? undefined,
+        });
+      } catch (err) {
+        request.log.error(
+          { err, audit: "INSERT_FAILED" },
+          "CRITICAL: monthly finance report download audit insert failed",
+        );
+      }
+
+      const { body, contentLength } = await fetchPlatformReportObject(row.pdfS3Key);
+      reply.header("content-type", "application/pdf");
+      reply.header(
+        "content-disposition",
+        `attachment; filename="givernance-platform-finance-${row.month}.pdf"`,
+      );
+      if (contentLength !== undefined) {
+        reply.header("content-length", contentLength);
+      }
+      return reply.send(body);
     },
   );
 }

--- a/packages/api/src/modules/superadmin/finance/routes.ts
+++ b/packages/api/src/modules/superadmin/finance/routes.ts
@@ -33,6 +33,8 @@ import {
   listRecent,
   MonthValidationError,
   previousMonth,
+  RegenerateError,
+  regenerateReport,
   requestMonthlyReport,
 } from "./monthly-report.js";
 import { PeriodValidationError, resolvePeriod } from "./period.js";
@@ -45,6 +47,7 @@ import {
   ListReportsResponse,
   MonthlyReportBody,
   MonthlyReportResponse,
+  RegenerateResponse,
   ReportIdParams,
   RespondBody,
   RespondResponse,
@@ -678,6 +681,109 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
           readyAt: r.readyAt,
           pdfUrl: r.status === "ready" ? `/v1/superadmin/finance/reports/${r.id}/pdf` : null,
         })),
+      };
+    },
+  );
+
+  // ─── POST /v1/superadmin/finance/reports/:id/regenerate ─────────────────
+  // Marks the source row as superseded (status='failed', reason
+  // "Remplacé par régénération") and creates a fresh row for the same
+  // month using the current SQL + PDF renderer. The old row stays in
+  // the table for RGPD Art. 5.2 accountability — we never lose the
+  // trail of "what numbers were generated when".
+  //
+  // Rate-limited at 5/min/IP. The audit row carries a pointer to the
+  // superseded id in `new_values.supersedes`, plus the new report id
+  // in `resource_id`, so a forensic timeline can walk back through
+  // every regeneration chain.
+  app.post(
+    "/superadmin/finance/reports/:id/regenerate",
+    {
+      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      schema: {
+        tags: ["Superadmin", "Finance"],
+        params: ReportIdParams,
+        response: {
+          200: RegenerateResponse,
+          ...ErrorResponses,
+          404: ProblemDetailSchema,
+          409: ProblemDetailSchema,
+        },
+      },
+      config: {
+        rateLimit: {
+          max: 5,
+          timeWindow: "1 minute",
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+      const platformAdminId = await resolvePlatformAdminId(request.auth?.userId ?? "");
+
+      let result: Awaited<ReturnType<typeof regenerateReport>>;
+      try {
+        result = await regenerateReport({
+          sourceId: id,
+          requestedByPlatformAdminId: platformAdminId,
+          traceparent:
+            typeof request.headers.traceparent === "string"
+              ? request.headers.traceparent
+              : undefined,
+        });
+      } catch (err) {
+        if (err instanceof RegenerateError) {
+          return reply
+            .status(err.statusCode)
+            .send(
+              problemDetail(
+                err.statusCode,
+                err.statusCode === 404 ? "Not Found" : "Conflict",
+                err.detail,
+              ),
+            );
+        }
+        throw err;
+      }
+
+      const platformOrgId = await getPlatformOrgId();
+      try {
+        await systemDb.insert(auditLogs).values({
+          orgId: platformOrgId,
+          userId: request.auth?.userId ?? null,
+          actorId: request.auth?.userId ?? null,
+          action: "regenerate",
+          resourceType: "platform_finance_report",
+          resourceId: result.newRow.id,
+          newValues: {
+            month: result.newRow.month,
+            supersedes: result.supersededRow.id,
+          },
+          ipHash: hashIp(request.ip),
+          userAgent: request.headers["user-agent"] ?? undefined,
+        });
+      } catch (err) {
+        request.log.error(
+          { err, audit: "INSERT_FAILED" },
+          "CRITICAL: monthly finance report regenerate audit insert failed",
+        );
+      }
+
+      const toWire = (r: typeof result.newRow) => ({
+        id: r.id,
+        month: r.month,
+        status: r.status,
+        failureReason: r.failureReason,
+        createdAt: r.createdAt,
+        readyAt: r.readyAt,
+        pdfUrl: r.status === "ready" ? `/v1/superadmin/finance/reports/${r.id}/pdf` : null,
+      });
+
+      return {
+        data: {
+          newReport: toWire(result.newRow),
+          supersededReport: toWire(result.supersededRow),
+        },
       };
     },
   );

--- a/packages/api/src/modules/superadmin/finance/schemas.ts
+++ b/packages/api/src/modules/superadmin/finance/schemas.ts
@@ -309,3 +309,49 @@ export const CacheFlushResponse = Type.Object(
   },
   { additionalProperties: false },
 );
+
+// ─── Monthly platform finance report (issue #443) ──────────────────────────
+
+const MonthSchema = Type.String({
+  pattern: "^\\d{4}-(0[1-9]|1[0-2])$",
+  description: "Calendar month label YYYY-MM (e.g. '2026-04').",
+});
+
+const ReportStatusSchema = Type.Union([
+  Type.Literal("pending"),
+  Type.Literal("ready"),
+  Type.Literal("failed"),
+]);
+
+export const ReportIdParams = Type.Object({ id: UuidSchema }, { additionalProperties: false });
+
+export const MonthlyReportBody = Type.Object(
+  {
+    /**
+     * Optional explicit month — defaults to the most recent
+     * fully-completed calendar month. Set this to re-run an older
+     * month after a fix or for QA.
+     */
+    month: Type.Optional(MonthSchema),
+  },
+  { additionalProperties: false },
+);
+
+const ReportSchema = StrictObject(
+  {
+    id: UuidSchema,
+    month: MonthSchema,
+    status: ReportStatusSchema,
+    failureReason: Type.Union([Type.String(), Type.Null()]),
+    createdAt: Type.String(),
+    readyAt: Type.Union([Type.String(), Type.Null()]),
+    /** Path-relative URL of the streamed PDF (only when status='ready'). */
+    pdfUrl: Type.Union([Type.String(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+export const MonthlyReportResponse = Type.Object(
+  { data: ReportSchema },
+  { additionalProperties: false },
+);

--- a/packages/api/src/modules/superadmin/finance/schemas.ts
+++ b/packages/api/src/modules/superadmin/finance/schemas.ts
@@ -355,3 +355,16 @@ export const MonthlyReportResponse = Type.Object(
   { data: ReportSchema },
   { additionalProperties: false },
 );
+
+export const BackfillResponse = Type.Object(
+  {
+    data: StrictObject(
+      {
+        enqueued: Type.Array(ReportSchema),
+        skipped: Type.Array(ReportSchema),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);

--- a/packages/api/src/modules/superadmin/finance/schemas.ts
+++ b/packages/api/src/modules/superadmin/finance/schemas.ts
@@ -356,6 +356,19 @@ export const MonthlyReportResponse = Type.Object(
   { additionalProperties: false },
 );
 
+export const RegenerateResponse = Type.Object(
+  {
+    data: StrictObject(
+      {
+        newReport: ReportSchema,
+        supersededReport: ReportSchema,
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
 export const ListReportsResponse = Type.Object(
   {
     data: Type.Array(ReportSchema),

--- a/packages/api/src/modules/superadmin/finance/schemas.ts
+++ b/packages/api/src/modules/superadmin/finance/schemas.ts
@@ -356,6 +356,13 @@ export const MonthlyReportResponse = Type.Object(
   { additionalProperties: false },
 );
 
+export const ListReportsResponse = Type.Object(
+  {
+    data: Type.Array(ReportSchema),
+  },
+  { additionalProperties: false },
+);
+
 export const BackfillResponse = Type.Object(
   {
     data: StrictObject(

--- a/packages/api/src/modules/users/routes.ts
+++ b/packages/api/src/modules/users/routes.ts
@@ -352,6 +352,7 @@ export async function userRoutes(app: FastifyInstance) {
             email: platformAdmins.email,
             firstName: platformAdmins.firstName,
             lastName: platformAdmins.lastName,
+            locale: platformAdmins.locale,
             createdAt: platformAdmins.createdAt,
             updatedAt: platformAdmins.updatedAt,
           })
@@ -380,7 +381,7 @@ export async function userRoutes(app: FastifyInstance) {
             role: "super_admin",
             firstAdmin: false,
             provisionalUntil: null,
-            locale: null,
+            locale: admin.locale as "en" | "fr" | null,
             tenantDefaultLocale: "en" as const,
             orgSlug: "platform",
             orgName: "Givernance Platform",
@@ -472,6 +473,105 @@ export async function userRoutes(app: FastifyInstance) {
       const userId = request.auth?.userId as string;
       const orgId = request.auth?.orgId as string;
       const body = request.body as { locale: "en" | "fr" | null };
+      const isSuperAdmin = request.auth?.roles?.includes("super_admin") ?? false;
+      const isImpersonationSession = !!request.auth?.impersonation;
+
+      // ADR-022 — super-admins outside an impersonation session live in
+      // `platform_admins`, not `users`. Mirror the GET branch: read +
+      // update + audit through the platform-side table instead of the
+      // tenant-scoped `users` row (which doesn't exist for them and
+      // would always 404). Same shape returned to the client so the
+      // profile form's re-base step works uniformly.
+      if (isSuperAdmin && !isImpersonationSession) {
+        const [existing] = await systemDb
+          .select({ id: platformAdmins.id, locale: platformAdmins.locale })
+          .from(platformAdmins)
+          .where(and(eq(platformAdmins.keycloakId, userId), isNull(platformAdmins.deletedAt)))
+          .limit(1);
+
+        if (!existing) {
+          const t = resolveTranslations(request);
+          return reply.status(404).send({
+            type: "https://httpproblems.com/http-status/404",
+            title: "Not Found",
+            status: 404,
+            detail: t("errors.notFound", { resource: t("resources.user") }),
+          });
+        }
+
+        const [updated] = await systemDb
+          .update(platformAdmins)
+          .set({ locale: body.locale, updatedAt: new Date() })
+          .where(eq(platformAdmins.id, existing.id))
+          .returning({
+            id: platformAdmins.id,
+            keycloakId: platformAdmins.keycloakId,
+            email: platformAdmins.email,
+            firstName: platformAdmins.firstName,
+            lastName: platformAdmins.lastName,
+            locale: platformAdmins.locale,
+            createdAt: platformAdmins.createdAt,
+            updatedAt: platformAdmins.updatedAt,
+          });
+        if (!updated) {
+          const t = resolveTranslations(request);
+          return reply.status(404).send({
+            type: "https://httpproblems.com/http-status/404",
+            title: "Not Found",
+            status: 404,
+            detail: t("errors.notFound", { resource: t("resources.user") }),
+          });
+        }
+
+        // Audit log on the platform sentinel tenant — same pattern as
+        // the super-admin finance routes (resource_type carries the
+        // platform-side table name so a forensic timeline distinguishes
+        // tenant-user preferences from super-admin preferences).
+        const [platformTenant] = await systemDb
+          .select({ id: tenants.id, defaultLocale: tenants.defaultLocale })
+          .from(tenants)
+          .where(eq(tenants.slug, "__platform__"))
+          .limit(1);
+        if (platformTenant) {
+          try {
+            await systemDb.insert(auditLogs).values({
+              orgId: platformTenant.id,
+              userId: null,
+              actorId: userId,
+              action: "platform_admin.preferences_updated",
+              resourceType: "platform_admin",
+              resourceId: existing.id,
+              oldValues: { locale: existing.locale },
+              newValues: { locale: body.locale },
+            });
+          } catch (err) {
+            request.log.error(
+              { err, audit: "INSERT_FAILED" },
+              "CRITICAL: platform-admin preferences audit insert failed",
+            );
+          }
+        }
+
+        return reply.send({
+          data: {
+            id: updated.id,
+            orgId,
+            keycloakId: updated.keycloakId,
+            email: updated.email,
+            firstName: updated.firstName,
+            lastName: updated.lastName,
+            role: "super_admin" as const,
+            firstAdmin: false,
+            provisionalUntil: null,
+            locale: updated.locale as "en" | "fr" | null,
+            tenantDefaultLocale: "en" as const,
+            orgSlug: "platform",
+            orgName: "Givernance Platform",
+            createdAt: updated.createdAt.toISOString(),
+            updatedAt: updated.updatedAt.toISOString(),
+          },
+        });
+      }
 
       const result = await withTenantContext(orgId, async (tx) => {
         // Read the existing locale so the audit `oldValues` carries the

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -36,6 +36,7 @@ import { reportsRoutes } from "./modules/reports/routes.js";
 import { searchRoutes } from "./modules/search/routes.js";
 import { sessionRoutes } from "./modules/session/routes.js";
 import { signupRoutes } from "./modules/signup/routes.js";
+import { startMonthlyReportScheduler } from "./modules/superadmin/finance/auto-monthly-cron.js";
 import { superadminFinanceRoutes } from "./modules/superadmin/finance/routes.js";
 import { tenantAdminRoutes } from "./modules/tenant-admin/routes.js";
 import { tenantRoutes } from "./modules/tenants/routes.js";
@@ -59,6 +60,14 @@ export interface CreateServerOpts {
    * Issue #182 (rbac-denial-logs).
    */
   onLogLine?: (line: string) => void;
+  /**
+   * Test-only: when true, the in-process monthly report scheduler
+   * (issue #443) is NOT started. Production callers pass nothing and
+   * get the scheduler. Test suites set this to true so the
+   * boot-time backfill doesn't try to enqueue jobs against a fresh
+   * test Postgres before fixtures land.
+   */
+  disableSchedulers?: boolean;
 }
 
 /** Create and configure the Fastify server instance */
@@ -214,6 +223,24 @@ export async function createServer(opts: CreateServerOpts = {}): Promise<Fastify
   await app.register(disputeRoutes, { prefix: "/v1" });
   await app.register(dashboardRoutes, { prefix: "/v1" });
   await app.register(superadminFinanceRoutes, { prefix: "/v1" });
+
+  // Issue #443 — start the in-process monthly report scheduler
+  // (boot-time backfill of the last 12 months + recurring fire on the
+  // 1st of each month at 03:30 UTC). Gated by the
+  // `ADMIN_FINANCE_DASHBOARD` flag at fire time. Defaults to OFF
+  // under `NODE_ENV=test` so the fire-and-forget backfill doesn't
+  // race the per-test fixture cleanup; the manual + backfill HTTP
+  // routes are still exercised by integration tests.
+  const schedulerEnabled =
+    opts.disableSchedulers === undefined
+      ? process.env.NODE_ENV !== "test"
+      : !opts.disableSchedulers;
+  if (schedulerEnabled) {
+    const handle = startMonthlyReportScheduler(app.log);
+    app.addHook("onClose", async () => {
+      handle.cancel();
+    });
+  }
 
   return app;
 }

--- a/packages/api/src/tests/integration/superadmin-monthly-report.test.ts
+++ b/packages/api/src/tests/integration/superadmin-monthly-report.test.ts
@@ -342,6 +342,66 @@ describe("GET /v1/superadmin/finance/reports/:id", () => {
   });
 });
 
+describe("POST /v1/superadmin/finance/reports/backfill", () => {
+  // The route is rate-limited 2/min/IP — Fastify keys on the test IP
+  // which is constant across `app.inject` calls. We sequence tests so
+  // each describe-it consumes at most one slot and use a distinct
+  // x-forwarded-for header per test where two consecutive calls are
+  // unavoidable.
+  it("flag off → 404 (gated)", async () => {
+    await setFlag(false);
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/reports/backfill",
+      headers: { ...authHeader(superAdminToken()), "x-forwarded-for": "10.0.0.1" },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("org_admin → 404 (anti-disclosure)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/reports/backfill",
+      headers: { ...authHeader(signToken(app)), "x-forwarded-for": "10.0.0.2" },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("super_admin → 200 with enqueued + skipped breakdown; idempotent on replay", async () => {
+    const first = await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/reports/backfill",
+      headers: { ...authHeader(superAdminToken()), "x-forwarded-for": "10.0.0.3" },
+      payload: {},
+    });
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json() as {
+      data: {
+        enqueued: Array<{ id: string; month: string }>;
+        skipped: Array<{ id: string; month: string }>;
+      };
+    };
+    expect(firstBody.data.enqueued.length).toBeGreaterThan(0);
+    expect(firstBody.data.skipped.length).toBe(0);
+
+    // Second call — every row is replayed; enqueued should be empty.
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/reports/backfill",
+      headers: { ...authHeader(superAdminToken()), "x-forwarded-for": "10.0.0.3" },
+      payload: {},
+    });
+    expect(second.statusCode).toBe(200);
+    const secondBody = second.json() as {
+      data: { enqueued: unknown[]; skipped: unknown[] };
+    };
+    expect(secondBody.data.enqueued.length).toBe(0);
+    expect(secondBody.data.skipped.length).toBe(firstBody.data.enqueued.length);
+  });
+});
+
 describe("GET /v1/superadmin/finance/reports/:id/pdf", () => {
   it("409 while pending — body explains why", async () => {
     const created = await app.inject({

--- a/packages/api/src/tests/integration/superadmin-monthly-report.test.ts
+++ b/packages/api/src/tests/integration/superadmin-monthly-report.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Issue #443 — Super-admin monthly platform finance report.
+ *
+ * Coverage:
+ *   - RBAC matrix on POST/GET routes (super_admin → 202/200/404;
+ *     org_admin / user / viewer → 404; unauthenticated → 401).
+ *   - Flag off → 404 on every gated route.
+ *   - Idempotency: two POSTs for the same target month return the
+ *     same `id`, only the first emits status=202 (fresh enqueue).
+ *   - Audit trail: every POST writes a `platform_finance_report`
+ *     `generate` row on `platform_orgId` with the super-admin's user
+ *     id + ipHash.
+ *   - Month validation: future month → 400 RFC-9457; malformed month → 400.
+ *   - GET /:id 404 on unknown UUID; 200 with locked shape when found.
+ *   - GET /:id/pdf 409 while pending; 200 streaming the bytes once
+ *     the row is flipped to `ready` (we manually update the row to
+ *     simulate the worker completing — the worker itself is unit-tested
+ *     elsewhere).
+ */
+
+import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
+import { auditLogs, featureFlags, platformFinanceReports } from "@givernance/shared/schema";
+import { and, desc, eq, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { db, systemDb } from "../../lib/db.js";
+import { flagService } from "../../lib/flags/flag-service.js";
+import { redis } from "../../lib/redis.js";
+import { previousMonth } from "../../modules/superadmin/finance/monthly-report.js";
+import { createServer } from "../../server.js";
+import { authHeader, ensureTestTenants, signToken } from "../helpers/auth.js";
+
+const FLAG_KEY = FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD;
+const SUPER_ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000443ad";
+const SUPER_ADMIN_PLATFORM_ROW_ID = "00000000-0000-0000-0000-0000000443a1";
+const PLATFORM_TENANT_ID = "00000000-0000-0000-0000-0000000000a1";
+
+let app: FastifyInstance;
+
+function superAdminToken() {
+  return signToken(app, {
+    sub: SUPER_ADMIN_KEYCLOAK_ID,
+    realm_access: { roles: ["super_admin"] },
+    role: undefined,
+    email: "super-report@example.org",
+  });
+}
+
+async function setFlag(enabled: boolean): Promise<void> {
+  await db.update(featureFlags).set({ enabled }).where(eq(featureFlags.key, FLAG_KEY));
+  await flagService.invalidate();
+}
+
+async function clearReportsAndAudit(): Promise<void> {
+  // Reports table is platform-level; drop everything per test for
+  // isolation. `audit_logs` is immutable (`prevent_audit_log_mutation`
+  // trigger) — tests scope their assertions by resource_id (UUID) +
+  // most-recent ordering instead of bulk-clearing the table.
+  await systemDb.execute(sql`DELETE FROM platform_finance_reports`);
+  const keys = await redis.keys("superadmin:finance:summary:v1:*");
+  if (keys.length > 0) await redis.del(...keys);
+}
+
+beforeAll(async () => {
+  app = await createServer();
+  await app.ready();
+  await ensureTestTenants();
+
+  await systemDb.execute(sql`
+    INSERT INTO tenants (id, name, slug, status)
+    VALUES (${PLATFORM_TENANT_ID}, 'Givernance Platform (sentinel)', '__platform__', 'archived')
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+  await systemDb.execute(sql`
+    INSERT INTO platform_admins (id, keycloak_id, email, first_name, last_name)
+    VALUES (${SUPER_ADMIN_PLATFORM_ROW_ID}, ${SUPER_ADMIN_KEYCLOAK_ID}, 'super-report@example.org', 'Report', 'Super')
+    ON CONFLICT (id) DO UPDATE SET deleted_at = NULL, keycloak_id = ${SUPER_ADMIN_KEYCLOAK_ID}
+  `);
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(async () => {
+  await clearReportsAndAudit();
+  await setFlag(true);
+});
+
+afterEach(async () => {
+  await setFlag(false);
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+function monthsAgo(n: number, now: Date = new Date()): string {
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1; // 1-indexed
+  // Walk back n months including the +1 step into the previous month already
+  // baked into our "most recent fully-completed month" semantics.
+  const total = y * 12 + (m - 1) - n;
+  const ty = Math.floor(total / 12);
+  const tm = (total % 12) + 1;
+  return `${ty}-${String(tm).padStart(2, "0")}`;
+}
+
+describe("POST /v1/superadmin/finance/reports/monthly", () => {
+  describe("RBAC matrix", () => {
+    it("super_admin → 202 with locked shape", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: {},
+      });
+      expect(res.statusCode).toBe(202);
+      const body = res.json() as {
+        data: {
+          id: string;
+          month: string;
+          status: "pending" | "ready" | "failed";
+          createdAt: string;
+        };
+      };
+      expect(body.data.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(body.data.month).toBe(previousMonth());
+      expect(body.data.status).toBe("pending");
+    });
+
+    it("org_admin → 404 (anti-disclosure)", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(signToken(app)),
+        payload: {},
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("user role → 404", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(signToken(app, { role: "user" })),
+        payload: {},
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("viewer role → 404", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(signToken(app, { role: "viewer" })),
+        payload: {},
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("unauthenticated → 401 with RFC-9457 body", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        payload: {},
+      });
+      expect(res.statusCode).toBe(401);
+      expect(res.json()).toMatchObject({
+        type: "https://httpproblems.com/http-status/401",
+        title: "Unauthorized",
+        status: 401,
+      });
+    });
+
+    it("flag off → 404 (gated route invisible)", async () => {
+      await setFlag(false);
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: {},
+      });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe("month validation", () => {
+    it("future month → 400 RFC-9457", async () => {
+      const future = `${new Date().getUTCFullYear() + 1}-06`;
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: { month: future },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({
+        type: "https://httpproblems.com/http-status/400",
+        title: "Bad Request",
+        status: 400,
+      });
+    });
+
+    it("malformed month → 400 (TypeBox rejects)", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: { month: "2026-13" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("pre-platform-floor month (2023-12) → 400", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: { month: "2023-12" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe("idempotency", () => {
+    it("two same-month POSTs return the same id, second is 200 (replayed)", async () => {
+      const first = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: {},
+      });
+      expect(first.statusCode).toBe(202);
+      const firstId = first.json().data.id;
+
+      const second = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: {},
+      });
+      expect(second.statusCode).toBe(200);
+      expect(second.json().data.id).toBe(firstId);
+
+      // Only one platform_finance_reports row exists.
+      const rows = await systemDb
+        .select({ id: platformFinanceReports.id })
+        .from(platformFinanceReports);
+      expect(rows.length).toBe(1);
+    });
+
+    it("explicit older month creates a separate row", async () => {
+      const olderMonth = monthsAgo(2);
+      const first = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: {},
+      });
+      const second = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: { month: olderMonth },
+      });
+      expect(first.statusCode).toBe(202);
+      expect(second.statusCode).toBe(202);
+      expect(first.json().data.id).not.toBe(second.json().data.id);
+      expect(second.json().data.month).toBe(olderMonth);
+    });
+  });
+
+  describe("audit trail", () => {
+    it("writes a platform_finance_report 'generate' audit row keyed on the report id", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/v1/superadmin/finance/reports/monthly",
+        headers: authHeader(superAdminToken()),
+        payload: {},
+      });
+      const id = res.json().data.id as string;
+
+      const [row] = await systemDb
+        .select()
+        .from(auditLogs)
+        .where(
+          and(
+            eq(auditLogs.resourceType, "platform_finance_report"),
+            eq(auditLogs.resourceId, id),
+            eq(auditLogs.action, "generate"),
+          ),
+        )
+        .orderBy(desc(auditLogs.createdAt))
+        .limit(1);
+      expect(row).toBeDefined();
+      expect(row?.orgId).toBe(PLATFORM_TENANT_ID);
+      expect(row?.userId).toBe(SUPER_ADMIN_KEYCLOAK_ID);
+      // ipHash is a 16-char prefix of sha256(ip).
+      expect(row?.ipHash).toMatch(/^[a-f0-9]{16}$/);
+    });
+  });
+});
+
+describe("GET /v1/superadmin/finance/reports/:id", () => {
+  it("super_admin: existing row → 200 with locked shape; missing → 404", async () => {
+    const created = await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/reports/monthly",
+      headers: authHeader(superAdminToken()),
+      payload: {},
+    });
+    const id = created.json().data.id as string;
+
+    const ok = await app.inject({
+      method: "GET",
+      url: `/v1/superadmin/finance/reports/${id}`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(ok.statusCode).toBe(200);
+    const body = ok.json() as { data: { id: string; status: string; pdfUrl: string | null } };
+    expect(body.data.id).toBe(id);
+    expect(body.data.status).toBe("pending");
+    expect(body.data.pdfUrl).toBeNull();
+
+    const missing = await app.inject({
+      method: "GET",
+      url: `/v1/superadmin/finance/reports/00000000-0000-0000-0000-000000000000`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it("org_admin → 404 (anti-disclosure)", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/superadmin/finance/reports/00000000-0000-0000-0000-000000000000",
+      headers: authHeader(signToken(app)),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("GET /v1/superadmin/finance/reports/:id/pdf", () => {
+  it("409 while pending — body explains why", async () => {
+    const created = await app.inject({
+      method: "POST",
+      url: "/v1/superadmin/finance/reports/monthly",
+      headers: authHeader(superAdminToken()),
+      payload: {},
+    });
+    const id = created.json().data.id as string;
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/v1/superadmin/finance/reports/${id}/pdf`,
+      headers: authHeader(superAdminToken()),
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({
+      type: "https://httpproblems.com/http-status/409",
+      title: "Conflict",
+      status: 409,
+    });
+  });
+
+  it("404 for unknown id", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/superadmin/finance/reports/00000000-0000-0000-0000-000000000000/pdf",
+      headers: authHeader(superAdminToken()),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("org_admin → 404 (anti-disclosure) on the pdf endpoint", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/superadmin/finance/reports/00000000-0000-0000-0000-000000000000/pdf",
+      headers: authHeader(signToken(app)),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/packages/shared/src/jobs/index.ts
+++ b/packages/shared/src/jobs/index.ts
@@ -165,6 +165,26 @@ export interface SignupResendJob {
   };
 }
 
+/**
+ * Generate the monthly platform finance report PDF (issue #443).
+ *
+ * `reportId` is the `platform_finance_reports.id` row the API created
+ * before enqueuing this job. The worker re-reads the row, runs
+ * `buildFinanceSummary` for the target month, renders the PDF,
+ * uploads to `S3_REPORTS_BUCKET`, then flips the row to
+ * `status='ready'` with `pdf_s3_key` set. No PII flows through Redis
+ * — only the row id + the month label (for log readability).
+ */
+export interface GenerateMonthlyFinanceReportJob {
+  name: "generate-monthly-finance-report";
+  data: {
+    reportId: string;
+    /** YYYY-MM target month — denormalised from the row for log readability. */
+    month: string;
+    traceparent?: string;
+  };
+}
+
 // ─── Super-admin finance dashboard (Epic #434, issue #436) ──────────────────
 
 /**
@@ -252,7 +272,8 @@ export type JobDefinition =
   | BrandingGcAssetJob
   | KeycloakSyncOrgLogoJob
   | SignupResendJob
-  | ProcessBulkImportJob;
+  | ProcessBulkImportJob
+  | GenerateMonthlyFinanceReportJob;
 
 /** Queue names */
 export const QUEUE_NAMES = {
@@ -307,6 +328,16 @@ export const QUEUE_NAMES = {
    * every tenant in turn; survey send claims invitations idempotently).
    */
   FINANCE_DASHBOARD: "finance_dashboard",
+  /**
+   * Super-admin monthly finance report PDF generation (issue #443).
+   * One job per `platform_finance_reports` row. Concurrency 1 per
+   * worker process — each job runs the full `buildFinanceSummary`
+   * aggregation (~12 SQL queries through `systemDb`) + a PDFKit
+   * render + a multipart S3 upload; running two side-by-side would
+   * pin both the Postgres pool and the event loop. Scale by adding
+   * worker pods, not concurrency.
+   */
+  PLATFORM_REPORTS: "platform_reports",
 } as const;
 
 /** Job names inside the NOTIFICATIONS_DIGEST queue. */

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -329,6 +329,13 @@ export const platformAdmins = pgTable(
     lastName: varchar("last_name", { length: 255 }).notNull(),
     /** Optional last-login marker so the audit story can answer "who's been active". */
     lastLoginAt: timestamp("last_login_at", { withTimezone: true }),
+    /**
+     * UI language preference. NULL means "inherit the browser / platform
+     * default". DB CHECK constrains to 'en' | 'fr' — mirrors the tenant-side
+     * `users.locale` semantics so `PATCH /v1/users/me` writes through both
+     * code paths uniformly (issue: super-admin can't edit profile, 2026-05-26).
+     */
+    locale: text("locale"),
     /** Soft-delete marker (ADR-021 universal). Listing endpoints filter `deleted_at IS NULL`. */
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -2005,3 +2005,43 @@ export const surveyLaunches = pgTable(
     index("survey_launches_cooldown_idx").on(table.surveyId, table.channel, table.launchedAt),
   ],
 );
+
+/**
+ * Platform-level monthly finance reports (Epic #434 follow-up, issue #443).
+ *
+ * One row per (calendar month, attempt). Rows in `status='ready'` /
+ * `status='pending'` are exclusive per month — the migration declares
+ * a partial unique index on `month WHERE status IN ('pending','ready')`
+ * which the route handler relies on for same-month idempotency.
+ *
+ * PLATFORM-LEVEL — no `org_id`, no RLS. Accessed exclusively through
+ * `systemDb` (BYPASSRLS owner pool). The migration REVOKEs ALL on
+ * `givernance_app`.
+ */
+export const platformFinanceReports = pgTable(
+  "platform_finance_reports",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    /** YYYY-MM label of the calendar month the report covers. DB CHECK enforces shape. */
+    month: varchar("month", { length: 7 }).notNull(),
+    /** 'pending' | 'ready' | 'failed' — DB CHECK enforces. */
+    status: text("status").notNull().default("pending"),
+    /** Path inside `S3_REPORTS_BUCKET` once the worker uploads (NULL while pending/failed). */
+    pdfS3Key: text("pdf_s3_key"),
+    /** Full `SummaryServiceResult` frozen at generation time (numbers the PDF showed). */
+    kpiSnapshot: jsonb("kpi_snapshot"),
+    failureReason: text("failure_reason"),
+    requestedByPlatformAdminId: uuid("requested_by_platform_admin_id").references(
+      () => platformAdmins.id,
+      { onDelete: "set null" },
+    ),
+    /** BullMQ job id (`monthly-finance-report-<id>`) — for the polling-state hint. */
+    jobId: text("job_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    readyAt: timestamp("ready_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("platform_finance_reports_status_idx").on(table.status),
+    index("platform_finance_reports_month_idx").on(table.month),
+  ],
+);

--- a/packages/web/src/app/(admin)/admin/finance/__tests__/page.test.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/__tests__/page.test.tsx
@@ -179,7 +179,11 @@ describe("/admin/finance — flag gate", () => {
     const tree = await FinancePage();
     const { container } = render(tree);
     await waitFor(() => {
-      expect(container.querySelector("h1")?.textContent).toBe("Finance plateforme");
+      // After the i18n migration (#443 follow-up) the dashboard renders
+      // through `useTranslations("admin.finance")`. The test mock uses
+      // the EN locale, so the H1 reads `pageTitlePrefix` + `pageTitleEm`
+      // = "Platform finance" (was "Finance plateforme" pre-migration).
+      expect(container.querySelector("h1")?.textContent).toBe("Platform finance");
     });
     expect(fetchSummaryMock).toHaveBeenCalledTimes(1);
   });
@@ -192,7 +196,7 @@ describe("/admin/finance — empty state", () => {
     const { default: FinancePage } = await import("../page");
     const tree = await FinancePage();
     render(tree);
-    // Empty-state: the chart card renders the "Aucune donnée…" fallback.
-    expect(await screen.findByText(/Aucune donnée pour la période/)).toBeInTheDocument();
+    // Empty-state body — `admin.finance.empty.title` in en.json.
+    expect(await screen.findByText(/No data for this period/)).toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -183,6 +183,48 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     return () => clearTimeout(timer);
   }, [reportMessage, reportBusy]);
 
+  const handleRegenerateReport = useCallback(
+    async (report: MonthlyReport) => {
+      if (reportBusy) return;
+      // Native confirm carries the RGPD warning. Functional super-admins
+      // are typically not on dialog-heavy UIs; a single browser confirm
+      // is the lowest-friction path. Copy mirrors the archive panel
+      // banner so the same information is presented twice — once
+      // ambient, once at decision time.
+      const ok = window.confirm(
+        `Régénérer le rapport de ${report.month} ?\n\n` +
+          "Un nouveau PDF sera généré avec le code et les données actuels. " +
+          "L'ancien rapport sera marqué comme remplacé mais restera dans le système " +
+          "(conformité RGPD Art. 5.2 — traçabilité de chaque génération).\n\n" +
+          "Cette action est tracée dans le journal d'audit.",
+      );
+      if (!ok) return;
+      setReportBusy(true);
+      setReportMessage({
+        tone: "info",
+        text: `Régénération du rapport ${report.month} en cours…`,
+      });
+      try {
+        const api = createClientApiClient();
+        const result = await SuperAdminFinanceService.regenerateReport(api, report.id);
+        setReportMessage({
+          tone: "info",
+          text: `Rapport ${report.month} régénéré — ancien ID ${result.supersededReport.id.slice(0, 8)}… remplacé.`,
+        });
+        void refreshReports();
+      } catch (err) {
+        setReportMessage({
+          tone: "error",
+          text:
+            err instanceof Error ? `Erreur régénération : ${err.message}` : "Erreur régénération.",
+        });
+      } finally {
+        setReportBusy(false);
+      }
+    },
+    [reportBusy, refreshReports],
+  );
+
   const handleBackfillReports = useCallback(async () => {
     if (reportBusy) return;
     setReportBusy(true);
@@ -588,6 +630,27 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
               Un rapport par mois · le plus récent en premier
             </span>
           </header>
+          <p
+            role="note"
+            style={{
+              margin: "0 0 12px 0",
+              padding: "8px 10px",
+              fontSize: 11,
+              lineHeight: 1.5,
+              color: "var(--color-on-surface-variant)",
+              background: "var(--color-surface-container-low, #f9f8f6)",
+              borderLeft: "3px solid var(--color-primary)",
+              borderRadius: 4,
+            }}
+          >
+            <strong style={{ color: "var(--color-on-surface)" }}>
+              Régénération &amp; conformité RGPD
+            </strong>{" "}
+            — Chaque rapport est figé au moment de sa génération (Art. 5.2, principe d'exactitude et
+            de traçabilité). Une régénération crée un nouveau document ; l'ancien est conservé dans
+            le système et reste consultable via le journal d'audit. Toute action est tracée (qui,
+            quand, depuis quelle IP).
+          </p>
           {reports.length === 0 ? (
             <p style={{ fontSize: 12, color: "var(--color-on-surface-variant)", margin: 0 }}>
               Aucun rapport pour l'instant. Clique « Rapport mensuel » ou « Backfill 12 mois ».
@@ -637,28 +700,47 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                         ? (r.failureReason ?? "Erreur")
                         : "—"}
                   </span>
-                  {r.status === "ready" && r.pdfUrl ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        const api = createClientApiClient();
-                        window.location.assign(api.resolveBrowserUrl(r.pdfUrl ?? ""));
-                      }}
-                    >
-                      <span
-                        className="material-symbols-outlined"
-                        style={{ fontSize: 14 }}
-                        aria-hidden
+                  <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
+                    {r.status === "ready" && r.pdfUrl ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          const api = createClientApiClient();
+                          window.location.assign(api.resolveBrowserUrl(r.pdfUrl ?? ""));
+                        }}
                       >
-                        download
-                      </span>
-                      PDF
-                    </Button>
-                  ) : (
-                    <span aria-hidden style={{ width: 80 }} />
-                  )}
+                        <span
+                          className="material-symbols-outlined"
+                          style={{ fontSize: 14 }}
+                          aria-hidden
+                        >
+                          download
+                        </span>
+                        PDF
+                      </Button>
+                    ) : null}
+                    {r.status !== "pending" && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => void handleRegenerateReport(r)}
+                        disabled={reportBusy}
+                        title="Régénère le rapport avec le code et les données actuels. L'ancien sera conservé pour la traçabilité RGPD."
+                      >
+                        <span
+                          className="material-symbols-outlined"
+                          style={{ fontSize: 14 }}
+                          aria-hidden
+                        >
+                          refresh
+                        </span>
+                        Régénérer
+                      </Button>
+                    )}
+                  </div>
                 </li>
               ))}
             </ul>

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -163,10 +163,6 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   // every 2s until `ready` (or `failed`), then trigger a same-tab
   // navigation to the streamed PDF URL.
   const [reportBusy, setReportBusy] = useState(false);
-  const [reportMessage, setReportMessage] = useState<{
-    tone: "info" | "error";
-    text: string;
-  } | null>(null);
   const [reports, setReports] = useState<MonthlyReport[]>([]);
   const [archiveOpen, setArchiveOpen] = useState(false);
   // Holds the report row whose regenerate-confirmation dialog is open.
@@ -206,15 +202,13 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     return () => clearInterval(interval);
   }, [archiveOpen, reports, refreshReports]);
 
-  // Auto-dismiss the report status message after 6s. We only schedule
-  // the timer when the in-flight work is DONE (`reportBusy === false`)
-  // so a long "Génération en cours…" message stays pinned until the
-  // poll loop finishes.
-  useEffect(() => {
-    if (!reportMessage || reportBusy) return;
-    const timer = setTimeout(() => setReportMessage(null), 6000);
-    return () => clearTimeout(timer);
-  }, [reportMessage, reportBusy]);
+  // Status feedback uses the platform sonner Toaster (mounted once in
+  // the root layout). Sticky in-progress notifications use
+  // `toast.loading(...)` which returns an id that we resolve into a
+  // success / error toast with the same id when work completes. This
+  // replaces an earlier inline `<p>` banner that lived inside the
+  // page header and squeezed the title/subtitle to the left when
+  // shown (feedback 2026-05-26).
 
   // Request a regeneration — just opens the design-system AlertDialog;
   // the actual work happens in `confirmRegenerate` only after the
@@ -234,10 +228,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     if (!report || reportBusy) return;
     setReportBusy(true);
     setReportToRegenerate(null);
-    setReportMessage({
-      tone: "info",
-      text: t("reports.messageRegenerating", { month: report.month }),
-    });
+    const toastId = toast.loading(t("reports.messageRegenerating", { month: report.month }));
     // Surface the archive panel so the user can watch the new row
     // tick from `pending` to `ready` via the watcher useEffect.
     setArchiveOpen(true);
@@ -256,37 +247,33 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       }
 
       if (polled.status === "ready") {
-        setReportMessage({
-          tone: "info",
-          text: t("reports.messageRegenerated", {
+        toast.success(
+          t("reports.messageRegenerated", {
             month: report.month,
             shortId: result.supersededReport.id.slice(0, 8),
           }),
-        });
+          { id: toastId },
+        );
         void refreshReports();
       } else if (polled.status === "failed") {
-        setReportMessage({
-          tone: "error",
-          text: polled.failureReason
+        toast.error(
+          polled.failureReason
             ? t("reports.messageFailed", { reason: polled.failureReason })
             : t("reports.messageFailedGeneric"),
-        });
+          { id: toastId },
+        );
       } else {
         // Still pending after the poll window — surface the wait
         // hint instead of silently dropping the "in-progress" state.
-        setReportMessage({
-          tone: "error",
-          text: t("reports.messagePendingTimeout"),
-        });
+        toast.error(t("reports.messagePendingTimeout"), { id: toastId });
       }
     } catch (err) {
-      setReportMessage({
-        tone: "error",
-        text:
-          err instanceof Error
-            ? t("reports.messageRegenerateError", { error: err.message })
-            : t("reports.messageRegenerateErrorGeneric"),
-      });
+      toast.error(
+        err instanceof Error
+          ? t("reports.messageRegenerateError", { error: err.message })
+          : t("reports.messageRegenerateErrorGeneric"),
+        { id: toastId },
+      );
     } finally {
       setReportBusy(false);
     }
@@ -295,26 +282,25 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   const handleBackfillReports = useCallback(async () => {
     if (reportBusy) return;
     setReportBusy(true);
-    setReportMessage({ tone: "info", text: t("reports.messageBackfillRunning") });
+    const toastId = toast.loading(t("reports.messageBackfillRunning"));
     const api = createClientApiClient();
     try {
       const result = await SuperAdminFinanceService.backfillReports(api);
-      setReportMessage({
-        tone: "info",
-        text: t("reports.messageBackfillDone", {
+      toast.success(
+        t("reports.messageBackfillDone", {
           enqueued: result.enqueued.length,
           skipped: result.skipped.length,
         }),
-      });
+        { id: toastId },
+      );
       void refreshReports();
     } catch (err) {
-      setReportMessage({
-        tone: "error",
-        text:
-          err instanceof Error
-            ? t("reports.messageBackfillError", { error: err.message })
-            : t("reports.messageBackfillErrorGeneric"),
-      });
+      toast.error(
+        err instanceof Error
+          ? t("reports.messageBackfillError", { error: err.message })
+          : t("reports.messageBackfillErrorGeneric"),
+        { id: toastId },
+      );
     } finally {
       setReportBusy(false);
     }
@@ -323,7 +309,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   const handleGenerateMonthlyReport = useCallback(async () => {
     if (reportBusy) return;
     setReportBusy(true);
-    setReportMessage({ tone: "info", text: t("reports.messageGenerating") });
+    const toastId = toast.loading(t("reports.messageGenerating"));
     const api = createClientApiClient();
     try {
       let report = await SuperAdminFinanceService.requestMonthlyReport(api);
@@ -335,33 +321,26 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       }
       if (report.status === "ready" && report.pdfUrl) {
         const absoluteUrl = api.resolveBrowserUrl(report.pdfUrl);
-        setReportMessage({
-          tone: "info",
-          text: t("reports.messageReady", { month: report.month }),
-        });
+        toast.success(t("reports.messageReady", { month: report.month }), { id: toastId });
         window.location.assign(absoluteUrl);
         void refreshReports();
       } else if (report.status === "failed") {
-        setReportMessage({
-          tone: "error",
-          text: report.failureReason
+        toast.error(
+          report.failureReason
             ? t("reports.messageFailed", { reason: report.failureReason })
             : t("reports.messageFailedGeneric"),
-        });
+          { id: toastId },
+        );
       } else {
-        setReportMessage({
-          tone: "error",
-          text: t("reports.messagePendingTimeout"),
-        });
+        toast.error(t("reports.messagePendingTimeout"), { id: toastId });
       }
     } catch (err) {
-      setReportMessage({
-        tone: "error",
-        text:
-          err instanceof Error
-            ? t("reports.messageGenerationError", { error: err.message })
-            : t("reports.messageGenerationErrorGeneric"),
-      });
+      toast.error(
+        err instanceof Error
+          ? t("reports.messageGenerationError", { error: err.message })
+          : t("reports.messageGenerationErrorGeneric"),
+        { id: toastId },
+      );
     } finally {
       setReportBusy(false);
     }
@@ -660,21 +639,6 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             </span>
             {archiveOpen ? t("actionArchiveHide") : t("actionArchiveShow")}
           </Button>
-          {reportMessage && (
-            <p
-              role={reportMessage.tone === "error" ? "alert" : "status"}
-              style={{
-                marginTop: 8,
-                fontSize: 12,
-                color:
-                  reportMessage.tone === "error"
-                    ? "var(--color-error)"
-                    : "var(--color-on-surface-variant)",
-              }}
-            >
-              {reportMessage.text}
-            </p>
-          )}
         </div>
       </div>
 

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast, VolumeRevenueChart } from "@/components/admin/finance";
 import { Button } from "@/components/ui/button";
 import { createClientApiClient } from "@/lib/api/client-browser";
-import type { FinancePeriod, FinanceSummary } from "@/models/superadmin-finance";
+import type { FinancePeriod, FinanceSummary, MonthlyReport } from "@/models/superadmin-finance";
 import { SuperAdminFinanceService } from "@/services/SuperAdminFinanceService";
 
 import "./finance-mockup.css";
@@ -153,6 +153,25 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     tone: "info" | "error";
     text: string;
   } | null>(null);
+  const [reports, setReports] = useState<MonthlyReport[]>([]);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+
+  const refreshReports = useCallback(async () => {
+    try {
+      const api = createClientApiClient();
+      const rows = await SuperAdminFinanceService.listReports(api);
+      setReports(rows);
+    } catch {
+      // Non-fatal — the archive panel just stays empty.
+    }
+  }, []);
+
+  // Lazy-fetch the archive list when the panel is first opened.
+  useEffect(() => {
+    if (archiveOpen && reports.length === 0) {
+      void refreshReports();
+    }
+  }, [archiveOpen, reports.length, refreshReports]);
 
   const handleBackfillReports = useCallback(async () => {
     if (reportBusy) return;
@@ -165,6 +184,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         tone: "info",
         text: `Backfill terminé — ${result.enqueued.length} nouveau(x) rapport(s) en file, ${result.skipped.length} déjà présent(s).`,
       });
+      void refreshReports();
     } catch (err) {
       setReportMessage({
         tone: "error",
@@ -173,7 +193,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     } finally {
       setReportBusy(false);
     }
-  }, [reportBusy]);
+  }, [reportBusy, refreshReports]);
 
   const handleGenerateMonthlyReport = useCallback(async () => {
     if (reportBusy) return;
@@ -192,6 +212,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         const absoluteUrl = api.resolveBrowserUrl(report.pdfUrl);
         setReportMessage({ tone: "info", text: `Rapport ${report.month} prêt — téléchargement…` });
         window.location.assign(absoluteUrl);
+        void refreshReports();
       } else if (report.status === "failed") {
         setReportMessage({
           tone: "error",
@@ -216,7 +237,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     } finally {
       setReportBusy(false);
     }
-  }, [reportBusy]);
+  }, [reportBusy, refreshReports]);
 
   // Tracks whether the user has interacted with the period / filter
   // controls since mount. The initial SSR fetch already loaded the
@@ -499,6 +520,19 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             </span>
             Backfill 12 mois
           </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="default"
+            onClick={() => setArchiveOpen((v) => !v)}
+            aria-expanded={archiveOpen}
+            aria-controls="finance-reports-archive"
+          >
+            <span className="material-symbols-outlined" style={{ fontSize: 16 }} aria-hidden>
+              folder_open
+            </span>
+            {archiveOpen ? "Masquer l'archive" : "Voir l'archive"}
+          </Button>
           {reportMessage && (
             <p
               role={reportMessage.tone === "error" ? "alert" : "status"}
@@ -516,6 +550,111 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
           )}
         </div>
       </div>
+
+      {archiveOpen && (
+        <section
+          id="finance-reports-archive"
+          aria-label="Archive des rapports mensuels"
+          style={{
+            marginBottom: 16,
+            padding: 16,
+            background: "var(--color-surface-container)",
+            borderRadius: 8,
+            border: "1px solid var(--color-outline-variant)",
+          }}
+        >
+          <header
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
+              marginBottom: 8,
+            }}
+          >
+            <h2 style={{ fontSize: 14, fontWeight: 600, color: "var(--color-on-surface)" }}>
+              Archive · derniers rapports
+            </h2>
+            <span style={{ fontSize: 11, color: "var(--color-on-surface-variant)" }}>
+              Un rapport par mois · le plus récent en premier
+            </span>
+          </header>
+          {reports.length === 0 ? (
+            <p style={{ fontSize: 12, color: "var(--color-on-surface-variant)", margin: 0 }}>
+              Aucun rapport pour l'instant. Clique « Rapport mensuel » ou « Backfill 12 mois ».
+            </p>
+          ) : (
+            <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+              {reports.map((r) => (
+                <li
+                  key={r.id}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "120px 100px 1fr auto",
+                    gap: 12,
+                    alignItems: "center",
+                    padding: "8px 0",
+                    borderBottom: "1px solid var(--color-outline-variant)",
+                    fontSize: 13,
+                  }}
+                >
+                  <strong style={{ color: "var(--color-on-surface)" }}>{r.month}</strong>
+                  <span
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 500,
+                      color:
+                        r.status === "ready"
+                          ? "var(--color-primary)"
+                          : r.status === "failed"
+                            ? "var(--color-error)"
+                            : "var(--color-on-surface-variant)",
+                    }}
+                  >
+                    {r.status === "ready" ? "Prêt" : r.status === "pending" ? "En cours…" : "Échec"}
+                  </span>
+                  <span
+                    style={{ fontSize: 11, color: "var(--color-on-surface-variant)" }}
+                    title={r.failureReason ?? undefined}
+                  >
+                    {r.readyAt
+                      ? `Généré le ${new Date(r.readyAt).toLocaleString("fr-FR", {
+                          day: "numeric",
+                          month: "short",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}`
+                      : r.status === "failed"
+                        ? (r.failureReason ?? "Erreur")
+                        : "—"}
+                  </span>
+                  {r.status === "ready" && r.pdfUrl ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        const api = createClientApiClient();
+                        window.location.assign(api.resolveBrowserUrl(r.pdfUrl ?? ""));
+                      }}
+                    >
+                      <span
+                        className="material-symbols-outlined"
+                        style={{ fontSize: 14 }}
+                        aria-hidden
+                      >
+                        download
+                      </span>
+                      PDF
+                    </Button>
+                  ) : (
+                    <span aria-hidden style={{ width: 80 }} />
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
 
       <div className="finance-toolbar">
         <div className="segmented" role="radiogroup" aria-label="Période">

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -5,11 +5,11 @@
  * (docs/design/admin/dashboard.html) into JSX with dynamic data slots.
  *
  * First-pass strategy: keep the mockup markup verbatim (same class names,
- * same DOM structure) for guaranteed visual parity. Componentization +
- * i18n refactor will follow in a separate PR once visual fidelity is
- * validated. FR copy lifted from the mockup; EN translation is a follow-up.
+ * same DOM structure) for guaranteed visual parity. Componentization
+ * will follow in a separate PR once visual fidelity is validated.
  */
 
+import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { toast, VolumeRevenueChart } from "@/components/admin/finance";
@@ -25,12 +25,12 @@ interface FinanceDashboardProps {
   initialError: boolean;
 }
 
-const PERIOD_OPTIONS: Array<{ value: FinancePeriod; label: string }> = [
-  { value: "today", label: "Aujourd'hui" },
-  { value: "7d", label: "7 j" },
-  { value: "30d", label: "30 j" },
-  { value: "90d", label: "90 j" },
-  { value: "ytd", label: "YTD" },
+const PERIOD_VALUES = [
+  { value: "today" as FinancePeriod, key: "period.today" as const },
+  { value: "7d" as FinancePeriod, key: "period.7d" as const },
+  { value: "30d" as FinancePeriod, key: "period.30d" as const },
+  { value: "90d" as FinancePeriod, key: "period.90d" as const },
+  { value: "ytd" as FinancePeriod, key: "period.ytd" as const },
 ];
 
 function formatCents(cents: number, currency = "EUR", showCents = true): string {
@@ -111,6 +111,11 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<boolean>(initialError);
   const [flushing, setFlushing] = useState(false);
+  const t = useTranslations("admin.finance");
+
+  const periodOptions: Array<{ value: FinancePeriod; label: string }> = PERIOD_VALUES.map(
+    ({ value, key }) => ({ value, label: t(key) }),
+  );
 
   const handlePeriodChange = useCallback((next: FinancePeriod) => setPeriod(next), []);
 
@@ -120,7 +125,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     try {
       const api = createClientApiClient();
       const result = await SuperAdminFinanceService.flushCache(api);
-      toast.success(`Cache vidé · ${result.keysDeleted} entrée(s) supprimée(s)`);
+      toast.success(t("cacheFlush.successToast", { keysDeleted: result.keysDeleted }));
       // Re-fetch with current period/filters to populate the freshly-
       // flushed cache and update the view.
       const data = await SuperAdminFinanceService.fetchSummary(api, {
@@ -130,11 +135,11 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       });
       setSummary(data);
     } catch {
-      toast.error("Le flush a échoué — réessayez dans une minute.");
+      toast.error(t("cacheFlush.errorToast"));
     } finally {
       setFlushing(false);
     }
-  }, [flushing, period, filters.currency, filters.tenantId]);
+  }, [flushing, period, filters.currency, filters.tenantId, t]);
   const handleCurrencyChange = useCallback(
     (next: FinanceFilters["currency"]) => setFilters((f) => ({ ...f, currency: next })),
     [],
@@ -191,66 +196,71 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       // is the lowest-friction path. Copy mirrors the archive panel
       // banner so the same information is presented twice — once
       // ambient, once at decision time.
-      const ok = window.confirm(
-        `Régénérer le rapport de ${report.month} ?\n\n` +
-          "Un nouveau PDF sera généré avec le code et les données actuels. " +
-          "L'ancien rapport sera marqué comme remplacé mais restera dans le système " +
-          "(conformité RGPD Art. 5.2 — traçabilité de chaque génération).\n\n" +
-          "Cette action est tracée dans le journal d'audit.",
-      );
+      const ok = window.confirm(t("reports.archive.regenerateConfirm", { month: report.month }));
       if (!ok) return;
       setReportBusy(true);
       setReportMessage({
         tone: "info",
-        text: `Régénération du rapport ${report.month} en cours…`,
+        text: t("reports.messageRegenerating", { month: report.month }),
       });
       try {
         const api = createClientApiClient();
         const result = await SuperAdminFinanceService.regenerateReport(api, report.id);
         setReportMessage({
           tone: "info",
-          text: `Rapport ${report.month} régénéré — ancien ID ${result.supersededReport.id.slice(0, 8)}… remplacé.`,
+          text: t("reports.messageRegenerated", {
+            month: report.month,
+            shortId: result.supersededReport.id.slice(0, 8),
+          }),
         });
         void refreshReports();
       } catch (err) {
         setReportMessage({
           tone: "error",
           text:
-            err instanceof Error ? `Erreur régénération : ${err.message}` : "Erreur régénération.",
+            err instanceof Error
+              ? t("reports.messageRegenerateError", { error: err.message })
+              : t("reports.messageRegenerateErrorGeneric"),
         });
       } finally {
         setReportBusy(false);
       }
     },
-    [reportBusy, refreshReports],
+    [reportBusy, refreshReports, t],
   );
 
   const handleBackfillReports = useCallback(async () => {
     if (reportBusy) return;
     setReportBusy(true);
-    setReportMessage({ tone: "info", text: "Backfill des 12 derniers mois en cours…" });
+    setReportMessage({ tone: "info", text: t("reports.messageBackfillRunning") });
     const api = createClientApiClient();
     try {
       const result = await SuperAdminFinanceService.backfillReports(api);
       setReportMessage({
         tone: "info",
-        text: `Backfill terminé — ${result.enqueued.length} nouveau(x) rapport(s) en file, ${result.skipped.length} déjà présent(s).`,
+        text: t("reports.messageBackfillDone", {
+          enqueued: result.enqueued.length,
+          skipped: result.skipped.length,
+        }),
       });
       void refreshReports();
     } catch (err) {
       setReportMessage({
         tone: "error",
-        text: err instanceof Error ? `Erreur backfill : ${err.message}` : "Erreur backfill.",
+        text:
+          err instanceof Error
+            ? t("reports.messageBackfillError", { error: err.message })
+            : t("reports.messageBackfillErrorGeneric"),
       });
     } finally {
       setReportBusy(false);
     }
-  }, [reportBusy, refreshReports]);
+  }, [reportBusy, refreshReports, t]);
 
   const handleGenerateMonthlyReport = useCallback(async () => {
     if (reportBusy) return;
     setReportBusy(true);
-    setReportMessage({ tone: "info", text: "Génération en cours…" });
+    setReportMessage({ tone: "info", text: t("reports.messageGenerating") });
     const api = createClientApiClient();
     try {
       let report = await SuperAdminFinanceService.requestMonthlyReport(api);
@@ -262,20 +272,23 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       }
       if (report.status === "ready" && report.pdfUrl) {
         const absoluteUrl = api.resolveBrowserUrl(report.pdfUrl);
-        setReportMessage({ tone: "info", text: `Rapport ${report.month} prêt — téléchargement…` });
+        setReportMessage({
+          tone: "info",
+          text: t("reports.messageReady", { month: report.month }),
+        });
         window.location.assign(absoluteUrl);
         void refreshReports();
       } else if (report.status === "failed") {
         setReportMessage({
           tone: "error",
           text: report.failureReason
-            ? `Échec : ${report.failureReason}`
-            : "Échec de la génération du rapport.",
+            ? t("reports.messageFailed", { reason: report.failureReason })
+            : t("reports.messageFailedGeneric"),
         });
       } else {
         setReportMessage({
           tone: "error",
-          text: "Rapport encore en attente — réessaie dans quelques minutes.",
+          text: t("reports.messagePendingTimeout"),
         });
       }
     } catch (err) {
@@ -283,13 +296,13 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         tone: "error",
         text:
           err instanceof Error
-            ? `Erreur : ${err.message}`
-            : "Erreur lors de la génération du rapport.",
+            ? t("reports.messageGenerationError", { error: err.message })
+            : t("reports.messageGenerationErrorGeneric"),
       });
     } finally {
       setReportBusy(false);
     }
-  }, [reportBusy, refreshReports]);
+  }, [reportBusy, refreshReports, t]);
 
   // Tracks whether the user has interacted with the period / filter
   // controls since mount. The initial SSR fetch already loaded the
@@ -369,10 +382,10 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     return (
       <main>
         <h1 className="page-title">
-          Finance <em>plateforme</em>
+          {t("pageTitlePrefix")} <em>{t("pageTitleEm")}</em>
         </h1>
         <div role="alert" style={{ padding: 24, color: "var(--color-error)" }}>
-          Impossible de charger le résumé. Vérifie les logs API et réessaie.
+          {t("fetchError.title")}. {t("fetchError.body")}
         </div>
       </main>
     );
@@ -382,9 +395,9 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     return (
       <main>
         <h1 className="page-title">
-          Finance <em>plateforme</em>
+          {t("pageTitlePrefix")} <em>{t("pageTitleEm")}</em>
         </h1>
-        <p style={{ color: "var(--color-on-surface-variant)" }}>Chargement…</p>
+        <p style={{ color: "var(--color-on-surface-variant)" }}>{t("loading")}</p>
       </main>
     );
   }
@@ -396,31 +409,31 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   const heroScore = Math.round(mobilisation.platformScore ?? 0);
   const componentRows: Array<{ label: string; pct: number; weight: number; color: string }> = [
     {
-      label: "Activation",
+      label: t("formula.activation"),
       pct: Math.round(mobilisation.components.activation),
       weight: 25,
       color: "var(--color-primary)",
     },
     {
-      label: "Récurrence",
+      label: t("formula.recurrence"),
       pct: Math.round(mobilisation.components.recurrence),
       weight: 25,
       color: "var(--color-primary-fixed-dim)",
     },
     {
-      label: "Échelle",
+      label: t("formula.scale"),
       pct: Math.round(mobilisation.components.scale),
       weight: 20,
       color: "var(--color-secondary)",
     },
     {
-      label: "Croissance",
+      label: t("formula.growth"),
       pct: Math.round(mobilisation.components.growth),
       weight: 20,
       color: "var(--color-tertiary)",
     },
     {
-      label: "Diversité",
+      label: t("formula.diversity"),
       pct: Math.round(mobilisation.components.diversity),
       weight: 10,
       color: "var(--color-indigo)",
@@ -429,9 +442,9 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
 
   const gradeBuckets: Array<{ key: string; count: number; color: string }> = (() => {
     const counts: Record<string, number> = { "A+": 0, A: 0, B: 0, C: 0, D: 0 };
-    for (const t of mobilisation.perTenant) {
-      if (t.grade && counts[t.grade] !== undefined) {
-        counts[t.grade] = (counts[t.grade] ?? 0) + 1;
+    for (const tenant of mobilisation.perTenant) {
+      if (tenant.grade && counts[tenant.grade] !== undefined) {
+        counts[tenant.grade] = (counts[tenant.grade] ?? 0) + 1;
       }
     }
     const colors: Record<string, string> = {
@@ -450,7 +463,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   const maxBucket = Math.max(1, ...gradeBuckets.map((b) => b.count));
 
   const atRiskCount = mobilisation.perTenant.filter(
-    (t) => t.grade === "D" || (t.grade === "C" && (t.score ?? 100) < 50),
+    (tenant) => tenant.grade === "D" || (tenant.grade === "C" && (tenant.score ?? 100) < 50),
   ).length;
 
   const volumeDelta = kpis.deltas.volumePercent;
@@ -496,7 +509,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       <div className="fin-topchips">
         <span className="topbar-live">
           <span className="live-dot" />
-          Transactions à jour · {lastTimestamp}
+          {t("topbarLive", { timestamp: lastTimestamp })}
         </span>
         {staleSourcesCount > 0 && (
           <a
@@ -509,13 +522,12 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
               textDecoration: "none",
               cursor: "pointer",
             }}
-            title="Une source de données est périmée — cliquer pour aller voir."
+            title={t("topbarStaleSourceTitle")}
           >
             <span className="material-symbols-outlined" style={{ fontSize: 13 }}>
               warning
             </span>
-            {staleSourcesCount} source{staleSourcesCount > 1 ? "s" : ""} périmée
-            {staleSourcesCount > 1 ? "s" : ""}
+            {t("topbarStaleSource", { count: staleSourcesCount })}
           </a>
         )}
       </div>
@@ -526,17 +538,17 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             <span className="material-symbols-outlined" style={{ fontSize: 14 }}>
               stacked_line_chart
             </span>
-            Vue plateforme · {tenantCount} tenants
+            {t("pageEyebrow", { count: tenantCount })}
           </div>
           <h1 className="page-title">
-            Finance <em>plateforme</em>
+            {t("pageTitlePrefix")} <em>{t("pageTitleEm")}</em>
           </h1>
           <p className="page-subtitle">
-            Volume, revenu Givernance, satisfaction et santé du portefeuille de tenants.{" "}
+            {t("pageSubtitle")}{" "}
             <span style={{ color: "var(--color-on-surface)", fontWeight: 500 }}>
-              {PERIOD_OPTIONS.find((o) => o.value === period)?.label} ·{" "}
-              {filters.currency === "all" ? "toutes devises (éq. EUR)" : filters.currency} ·{" "}
-              {filters.tenantId === "all" ? "tous tenants" : "tenant sélectionné"}.
+              {periodOptions.find((o) => o.value === period)?.label} ·{" "}
+              {filters.currency === "all" ? t("filters.currencyAll") : filters.currency} ·{" "}
+              {filters.tenantId === "all" ? t("filters.tenantAll") : t("filters.tenantSelected")}.
             </span>
           </p>
         </div>
@@ -556,7 +568,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             <span className="material-symbols-outlined" style={{ fontSize: 16 }} aria-hidden>
               insights
             </span>
-            {reportBusy ? "Génération…" : "Rapport mensuel"}
+            {reportBusy ? t("actionMonthlyReportBusy") : t("actionMonthlyReport")}
           </Button>
           <Button
             type="button"
@@ -565,12 +577,12 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             onClick={handleBackfillReports}
             disabled={reportBusy}
             aria-busy={reportBusy}
-            title="Génère les rapports manquants des 12 derniers mois (idempotent)."
+            title={t("actionBackfill12MonthsTitle")}
           >
             <span className="material-symbols-outlined" style={{ fontSize: 16 }} aria-hidden>
               history
             </span>
-            Backfill 12 mois
+            {t("actionBackfill12Months")}
           </Button>
           <Button
             type="button"
@@ -583,7 +595,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             <span className="material-symbols-outlined" style={{ fontSize: 16 }} aria-hidden>
               folder_open
             </span>
-            {archiveOpen ? "Masquer l'archive" : "Voir l'archive"}
+            {archiveOpen ? t("actionArchiveHide") : t("actionArchiveShow")}
           </Button>
           {reportMessage && (
             <p
@@ -606,7 +618,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       {archiveOpen && (
         <section
           id="finance-reports-archive"
-          aria-label="Archive des rapports mensuels"
+          aria-label={t("reports.archive.ariaLabel")}
           style={{
             marginBottom: 16,
             padding: 16,
@@ -624,10 +636,10 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             }}
           >
             <h2 style={{ fontSize: 14, fontWeight: 600, color: "var(--color-on-surface)" }}>
-              Archive · derniers rapports
+              {t("reports.archive.title")}
             </h2>
             <span style={{ fontSize: 11, color: "var(--color-on-surface-variant)" }}>
-              Un rapport par mois · le plus récent en premier
+              {t("reports.archive.subtitle")}
             </span>
           </header>
           <p
@@ -644,16 +656,13 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             }}
           >
             <strong style={{ color: "var(--color-on-surface)" }}>
-              Régénération &amp; conformité RGPD
+              {t("reports.archive.rgpdNoticeTitle")}
             </strong>{" "}
-            — Chaque rapport est figé au moment de sa génération (Art. 5.2, principe d'exactitude et
-            de traçabilité). Une régénération crée un nouveau document ; l'ancien est conservé dans
-            le système et reste consultable via le journal d'audit. Toute action est tracée (qui,
-            quand, depuis quelle IP).
+            — {t("reports.archive.rgpdNoticeBody")}
           </p>
           {reports.length === 0 ? (
             <p style={{ fontSize: 12, color: "var(--color-on-surface-variant)", margin: 0 }}>
-              Aucun rapport pour l'instant. Clique « Rapport mensuel » ou « Backfill 12 mois ».
+              {t("reports.archive.empty")}
             </p>
           ) : (
             <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
@@ -683,21 +692,27 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                             : "var(--color-on-surface-variant)",
                     }}
                   >
-                    {r.status === "ready" ? "Prêt" : r.status === "pending" ? "En cours…" : "Échec"}
+                    {r.status === "ready"
+                      ? t("reports.archive.statusReady")
+                      : r.status === "pending"
+                        ? t("reports.archive.statusPending")
+                        : t("reports.archive.statusFailed")}
                   </span>
                   <span
                     style={{ fontSize: 11, color: "var(--color-on-surface-variant)" }}
                     title={r.failureReason ?? undefined}
                   >
                     {r.readyAt
-                      ? `Généré le ${new Date(r.readyAt).toLocaleString("fr-FR", {
-                          day: "numeric",
-                          month: "short",
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })}`
+                      ? t("reports.archive.generatedAt", {
+                          date: new Date(r.readyAt).toLocaleString("fr-FR", {
+                            day: "numeric",
+                            month: "short",
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          }),
+                        })
                       : r.status === "failed"
-                        ? (r.failureReason ?? "Erreur")
+                        ? (r.failureReason ?? t("reports.archive.errorPlaceholder"))
                         : "—"}
                   </span>
                   <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
@@ -718,7 +733,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                         >
                           download
                         </span>
-                        PDF
+                        {t("reports.archive.downloadPdf")}
                       </Button>
                     ) : null}
                     {r.status !== "pending" && (
@@ -728,7 +743,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                         size="sm"
                         onClick={() => void handleRegenerateReport(r)}
                         disabled={reportBusy}
-                        title="Régénère le rapport avec le code et les données actuels. L'ancien sera conservé pour la traçabilité RGPD."
+                        title={t("reports.archive.regenerateTitle")}
                       >
                         <span
                           className="material-symbols-outlined"
@@ -737,7 +752,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                         >
                           refresh
                         </span>
-                        Régénérer
+                        {t("reports.archive.regenerate")}
                       </Button>
                     )}
                   </div>
@@ -749,8 +764,8 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       )}
 
       <div className="finance-toolbar">
-        <div className="segmented" role="radiogroup" aria-label="Période">
-          {PERIOD_OPTIONS.map((opt) => (
+        <div className="segmented" role="radiogroup" aria-label={t("period.ariaLabel")}>
+          {periodOptions.map((opt) => (
             // biome-ignore lint/a11y/useSemanticElements: pill-styled buttons in a radiogroup; native <input type="radio"> would defeat the styling + icon affordances. WCAG-compliant via role="radio" + aria-checked.
             <button
               key={opt.value}
@@ -767,25 +782,25 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         <div className="finance-toolbar-right">
           <select
             className="form-select"
-            aria-label="Devise"
+            aria-label={t("filters.currencyAria")}
             value={filters.currency}
             onChange={(e) => handleCurrencyChange(e.target.value as FinanceFilters["currency"])}
           >
-            <option value="all">Toutes devises (éq. EUR)</option>
+            <option value="all">{t("filters.currencyAll")}</option>
             <option value="EUR">EUR</option>
             <option value="GBP">GBP</option>
             <option value="CHF">CHF</option>
           </select>
           <select
             className="form-select"
-            aria-label="Tenant"
+            aria-label={t("filters.tenantAria")}
             value={filters.tenantId}
             onChange={(e) => handleTenantChange(e.target.value)}
           >
-            <option value="all">Tous les tenants</option>
-            {mobilisation.perTenant.map((t) => (
-              <option key={t.tenantId} value={t.tenantId}>
-                {t.tenantName}
+            <option value="all">{t("filters.tenantAll")}</option>
+            {mobilisation.perTenant.map((tenant) => (
+              <option key={tenant.tenantId} value={tenant.tenantId}>
+                {tenant.tenantName}
               </option>
             ))}
           </select>
@@ -796,12 +811,12 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         <a href="#tenant-health" className="hero-alert" style={{ textDecoration: "none" }}>
           <span className="material-symbols-outlined ha-icon">crisis_alert</span>
           <span className="ha-body">
-            <b>
-              {atRiskCount} tenant{atRiskCount > 1 ? "s" : ""} en alerte
-            </b>{" "}
-            — détracteurs croisés avec un signal de churn. À contacter cette semaine.
+            {t.rich("heroAlert.bodyRich", {
+              count: atRiskCount,
+              b: (chunks) => <b>{chunks}</b>,
+            })}
           </span>
-          <span className="ha-cta">Voir la liste →</span>
+          <span className="ha-cta">{t("heroAlert.cta")}</span>
         </a>
       )}
 
@@ -809,10 +824,10 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         <div className="hero-block">
           <div className="hero-label" id="hero-lab">
             <span className="material-symbols-outlined">monitoring</span>
-            Score de Mobilisation
+            {t("mobilisationHero.title")}
             <span
               className="material-symbols-outlined info-i"
-              title="Indicateur de santé du fundraising — pas un score d'impact bénéficiaire."
+              title={t("mobilisationHero.titleInfo")}
             >
               info
             </span>
@@ -821,24 +836,27 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             <span className={`hero-grade ${heroGradeClass(heroGrade)}`}>{heroGrade ?? "—"}</span>
             <span>
               <span className="hero-score-num">{heroScore}</span>
-              <span className="hero-score-out">&nbsp;/ 100</span>
+              <span className="hero-score-out">&nbsp;{t("mobilisationHero.outOf")}</span>
             </span>
           </div>
           <div className="hero-meta">
             <span className="delta-pill delta-pill--flat">
-              <span className="material-symbols-outlined">remove</span>—
+              <span className="material-symbols-outlined">remove</span>
+              {t("mobilisationHero.deltaPlaceholder")}
             </span>
-            <span className="kpi-foot">vs période préc. · moy. pondérée volume</span>
+            <span className="kpi-foot">{t("mobilisationHero.periodLabel")}</span>
           </div>
           <p className="hero-foot">
-            Santé du fundraising agrégée sur <b>{tenantCount} tenants</b>. Un score A en
-            médico-social ≠ un A en culture — privilégier le <b>delta</b> à l'absolu.
+            {t.rich("mobilisationHero.footnoteRich", {
+              count: tenantCount,
+              b: (chunks) => <b>{chunks}</b>,
+            })}
           </p>
         </div>
         <div className="hero-block">
           <div className="hero-label">
             <span className="material-symbols-outlined">tune</span>
-            Composantes · moyenne plateforme
+            {t("formulaHero.title")}
           </div>
           <ol className="formula-list">
             {componentRows.map((row) => (
@@ -854,8 +872,9 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             ))}
           </ol>
           <p className="hero-foot">
-            La décomposition est affichée par <b>transparence</b>. Chaque composante est plafonnée à
-            100 avant pondération.
+            {t.rich("formulaHero.footnoteRich", {
+              b: (chunks) => <b>{chunks}</b>,
+            })}
           </p>
         </div>
         <GradeHistogram buckets={gradeBuckets} maxBucket={maxBucket} tenantCount={tenantCount} />
@@ -864,7 +883,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       <div className="kpi-grid">
         <article className="kpi reveal">
           <div className="kpi-head">
-            <div className="kpi-label">Volume des dons</div>
+            <div className="kpi-label">{t("kpis.volume.label")}</div>
             <div
               className="kpi-icon"
               style={{
@@ -888,7 +907,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
               {formatPercent(volumeDelta, 1)}%
             </span>
             <span className="kpi-foot">
-              {formatNumber(kpis.donorCount)} dons · vs période préc.
+              {t("kpisExtra.volumeFoot", { count: formatNumber(kpis.donorCount) })}
             </span>
           </div>
         </article>
@@ -896,10 +915,10 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         <article className="kpi reveal">
           <div className="kpi-head">
             <div className="kpi-label">
-              Revenu Givernance{" "}
+              {t("kpis.revenue.label")}{" "}
               <span
                 className="material-symbols-outlined info-i"
-                title="1,5% + 0,30€ par don cleared. Normalisé en EUR."
+                title={t("kpisExtra.revenueInfoTitle")}
               >
                 info
               </span>
@@ -926,17 +945,19 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
               {revenueDelta >= 0 ? "+" : ""}
               {formatPercent(revenueDelta, 1)}%
             </span>
-            <span className="kpi-foot">take-rate {formatPercent(takeRate, 2)}%</span>
+            <span className="kpi-foot">
+              {t("kpisExtra.revenueFoot", { rate: formatPercent(takeRate, 2) })}
+            </span>
           </div>
         </article>
 
         <article className="kpi reveal">
           <div className="kpi-head">
             <div className="kpi-label">
-              Revenu récurrent{" "}
+              {t("kpis.recurring.label")}{" "}
               <span
                 className="material-symbols-outlined info-i"
-                title="Part du revenu issue de pledges actifs. Revenu prévisible."
+                title={t("kpisExtra.recurringInfoTitle")}
               >
                 info
               </span>
@@ -953,14 +974,14 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
           </div>
           <div className="kpi-value">
             {recurringKpi.main}
-            <span className="suffix">/mois</span>
+            <span className="suffix">{t("kpisExtra.recurringSuffix")}</span>
           </div>
           <div className="kpi-meta">
             <span className="delta-pill delta-pill--flat">
               <span className="material-symbols-outlined">remove</span>—
             </span>
             <span className="kpi-foot">
-              {Math.round(recurringRatio)}% du volume · pledges actifs
+              {t("kpisExtra.recurringFoot", { share: Math.round(recurringRatio) })}
             </span>
           </div>
         </article>
@@ -968,10 +989,10 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         <article className="kpi reveal">
           <div className="kpi-head">
             <div className="kpi-label">
-              Frais Stripe{" "}
+              {t("kpis.stripe.label")}{" "}
               <span
                 className="material-symbols-outlined info-i"
-                title="Rail Stripe uniquement. Déduit du compte de la NPO."
+                title={t("kpisExtra.stripeInfoTitle")}
               >
                 info
               </span>
@@ -996,16 +1017,16 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
               {formatPercent(stripeDelta, 1)}%
             </span>
             <span className="kpi-foot">
-              ~{formatPercent(stripeSharePercent, 2)}% du volume carte
+              {t("kpisExtra.stripeFoot", { rate: formatPercent(stripeSharePercent, 2) })}
             </span>
           </div>
         </article>
       </div>
 
       <div className="section-head">
-        <h2>Évolution du volume</h2>
+        <h2>{t("sections.timeline")}</h2>
         <span className="rule" />
-        <span className="hint">Dons clearés / jour · revenu superposé</span>
+        <span className="hint">{t("sectionHints.timeline")}</span>
       </div>
       <div className="fin-card">
         {!isEmpty ? (
@@ -1017,9 +1038,9 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             }))}
             volumeMax={Math.max(...summary.timeseries.map((p) => p.volumeCents / 100), 100)}
             labels={{
-              ariaLabel: "Évolution du volume et du revenu",
-              volumeLabel: "Volume",
-              revenueLabel: "Revenu",
+              ariaLabel: t("chartLabels.ariaLabel"),
+              volumeLabel: t("chartLabels.volumeLabel"),
+              revenueLabel: t("chartLabels.revenueLabel"),
               formatVolumeTick: (v) => `€${Math.round(v / 1000)}k`,
               formatRevenueTick: (v) => `€${Math.round(v)}`,
               formatVolume: (v) => formatCents(Math.round(v * 100), "EUR", false),
@@ -1027,35 +1048,34 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             }}
           />
         ) : (
-          <p style={{ color: "var(--color-on-surface-variant)" }}>
-            Aucune donnée pour la période sélectionnée.
-          </p>
+          <p style={{ color: "var(--color-on-surface-variant)" }}>{t("empty.title")}</p>
         )}
       </div>
 
       <div className="section-head">
-        <h2>Risque &amp; concentration</h2>
+        <h2>{t("sections.risk")}</h2>
         <span className="rule" />
-        <span className="hint">Signaux opérationnels plateforme</span>
+        <span className="hint">{t("sectionHints.risk")}</span>
       </div>
       <div className="risk-grid">
         <div className="risk-item">
           <div className="rl">
-            Concentration (HHI){" "}
+            {t("riskExtra.concentrationLabelWithHhi")}{" "}
             <span
               className="material-symbols-outlined info-i"
-              title="HHI = somme des carrés des parts. < 0,15 = bien diversifié."
+              title={t("riskExtra.concentrationInfoTitle")}
             >
               info
             </span>
           </div>
           <div className="rv">{hhi.toFixed(2)}</div>
           <div className="rs">
-            Top tenant ={" "}
-            {topTenants[0] && kpis.volumeCents > 0
-              ? formatPercent((topTenants[0].volumeCents / kpis.volumeCents) * 100, 1)
-              : "0"}{" "}
-            %
+            {t("riskExtra.concentrationTopTenant", {
+              pct:
+                topTenants[0] && kpis.volumeCents > 0
+                  ? formatPercent((topTenants[0].volumeCents / kpis.volumeCents) * 100, 1)
+                  : "0",
+            })}
           </div>
           <span
             className={`risk-badge risk-badge--${hhiVariant === "alert" ? "watch" : hhiVariant}`}
@@ -1064,18 +1084,18 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
               {hhiVariant === "ok" ? "check_circle" : "warning"}
             </span>
             {hhiVariant === "ok"
-              ? "Bien diversifié"
+              ? t("risk.badges.okConcentration")
               : hhiVariant === "watch"
-                ? "À surveiller"
-                : "Trop concentré"}
+                ? t("riskExtra.concentrationBadgeWatch")
+                : t("riskExtra.concentrationBadgeAlert")}
           </span>
         </div>
         <div className="risk-item">
           <div className="rl">
-            Tenants actifs{" "}
+            {t("risk.activeTenants.label")}{" "}
             <span
               className="material-symbols-outlined info-i"
-              title="Au moins 1 don cleared sur la période."
+              title={t("riskExtra.activeTenantsInfoTitle")}
             >
               info
             </span>
@@ -1089,31 +1109,34 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             </span>
           </div>
           <div className="rs">
-            {tenantCount > 0
-              ? formatPercent((kpis.activeTenantsCount / tenantCount) * 100, 0)
-              : "0"}
-            % actifs · {tenantCount - kpis.activeTenantsCount} dormants
+            {t("riskExtra.activeTenantsSecondary", {
+              active:
+                tenantCount > 0
+                  ? formatPercent((kpis.activeTenantsCount / tenantCount) * 100, 0)
+                  : "0",
+              dormant: tenantCount - kpis.activeTenantsCount,
+            })}
           </div>
         </div>
         <div className="risk-item">
           <div className="rl">
-            Taux d'échec paiement{" "}
+            {t("riskExtra.failureLabelFull")}{" "}
             <span
               className="material-symbols-outlined info-i"
-              title="Stripe uniquement (Mollie non instrumenté)."
+              title={t("riskExtra.failureInfoTitle")}
             >
               info
             </span>
           </div>
           <div className="rv">{formatPercent(failureRate, 1)} %</div>
-          <div className="rs">Sur l'ensemble des tentatives Stripe sur la période.</div>
+          <div className="rs">{t("riskExtra.failureFootnote")}</div>
         </div>
       </div>
 
       <div className="section-head" id="tenant-health">
-        <h2>Santé des tenants</h2>
+        <h2>{t("sections.health")}</h2>
         <span className="rule" />
-        <span className="hint">PMF · NPS · CSAT</span>
+        <span className="hint">{t("health.sectionHint")}</span>
       </div>
       <div className="fin-card">
         <div className="th-grid">
@@ -1125,15 +1148,15 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
               >
                 psychology
               </span>
-              Product/Market Fit (Sean Ellis)
+              {t("pmfExtra.titleFull")}
               {pmfSurvey && (
                 <span className={`fresh-pip fresh-pip--${pmfFreshness}`}>
                   <span className="material-symbols-outlined">schedule</span>
                   {pmfFreshness === "ok"
-                    ? "à jour"
+                    ? t("freshness.fresh")
                     : pmfFreshness === "soon"
-                      ? "bientôt périmé"
-                      : "périmé"}
+                      ? t("freshness.soon")
+                      : t("freshness.stale")}
                 </span>
               )}
             </div>
@@ -1145,14 +1168,16 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                     <span className="pmf-unit">%</span>
                   </span>
                   <span className="pmf-threshold">
-                    « Très déçus » si Givernance disparaît. Seuil PMF = <b>40%</b>.
+                    {t.rich("pmfExtra.headlineRich", {
+                      b: (chunks) => <b>{chunks}</b>,
+                    })}
                   </span>
                 </div>
                 <div className="sentiment-bar-wrap">
                   <div
                     className="sentiment-bar"
                     role="img"
-                    aria-label={`PMF: ${Math.round(pmfPercent)}% très déçus`}
+                    aria-label={t("pmfExtra.ariaLabel", { pct: Math.round(pmfPercent) })}
                   >
                     <div className="sentiment-seg seg-very" style={{ flex: pmfPercent }}>
                       {Math.round(pmfPercent)}%
@@ -1161,41 +1186,43 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                       className="sentiment-seg seg-somewhat"
                       style={{ flex: Math.max(0, 80 - pmfPercent) }}
                     >
-                      moyennement
+                      {t("pmfExtra.segmentSomewhat")}
                     </div>
                     <div className="sentiment-seg seg-not" style={{ flex: 20 }}>
-                      pas déçus
+                      {t("pmfExtra.segmentNot")}
                     </div>
                   </div>
                   <div className="pmf-marker" aria-hidden="true">
                     <span className="line" />
-                    <span className="tag">40% seuil</span>
+                    <span className="tag">{t("pmfExtra.markerLabelShort")}</span>
                   </div>
                 </div>
                 <div className="sentiment-legend">
                   <span className="li">
                     <span className="sw" style={{ background: "var(--color-primary)" }} />
-                    <b>Très déçus</b> : signal positif
+                    {t.rich("pmfExtra.legendVeryRich", {
+                      b: (chunks) => <b>{chunks}</b>,
+                    })}
                   </span>
                   <span className="li">
                     <span
                       className="sw"
                       style={{ background: "var(--color-tertiary-fixed-dim)" }}
                     />{" "}
-                    Moyennement
+                    {t("pmf.legendSomewhat")}
                   </span>
                   <span className="li">
                     <span
                       className="sw"
                       style={{ background: "var(--color-surface-container-highest)" }}
                     />{" "}
-                    Pas déçus
+                    {t("pmf.legendNot")}
                   </span>
                 </div>
               </>
             ) : (
               <p style={{ color: "var(--color-on-surface-variant)", marginTop: 8 }}>
-                Pas encore de réponses PMF. Lance un envoi pour collecter.
+                {t("pmfExtra.noResponsesYet")}
               </p>
             )}
           </div>
@@ -1208,11 +1235,11 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                 >
                   thumb_up
                 </span>
-                NPS
+                {t("health.npsShort")}
                 {npsSurvey && (
                   <span className={`fresh-pip fresh-pip--${npsFreshness}`}>
                     <span className="material-symbols-outlined">schedule</span>
-                    {npsFreshness === "ok" ? "à jour" : "périmé"}
+                    {npsFreshness === "ok" ? t("freshness.fresh") : t("freshness.stale")}
                   </span>
                 )}
               </div>
@@ -1220,9 +1247,9 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                 {npsSurvey?.npsScore !== null && npsSurvey?.npsScore !== undefined
                   ? Math.round(npsSurvey.npsScore)
                   : "—"}
-                <small>/ 100</small>
+                <small>{t("health.npsUnit")}</small>
               </div>
-              <span className="legacy">indicateur historique</span>
+              <span className="legacy">{t("health.npsHistoric")}</span>
             </div>
             <div className="sat-mini">
               <div className="l">
@@ -1232,11 +1259,11 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                 >
                   sentiment_satisfied
                 </span>
-                CSAT post-ticket
+                {t("health.csatLabelFull")}
                 {csatSurvey && (
                   <span className={`fresh-pip fresh-pip--${csatFreshness}`}>
                     <span className="material-symbols-outlined">schedule</span>
-                    {csatFreshness === "ok" ? "à jour" : "périmé"}
+                    {csatFreshness === "ok" ? t("freshness.fresh") : t("freshness.stale")}
                   </span>
                 )}
               </div>
@@ -1244,7 +1271,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                 {csatSurvey?.csatScore !== null && csatSurvey?.csatScore !== undefined
                   ? csatSurvey.csatScore.toFixed(1)
                   : "—"}
-                <small>/ 5</small>
+                <small>{t("health.csatUnit")}</small>
               </div>
             </div>
             {atRiskCount > 0 && (
@@ -1253,11 +1280,13 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                   <span className="material-symbols-outlined" style={{ fontSize: 14 }}>
                     crisis_alert
                   </span>
-                  À recontacter
+                  {t("health.recontactLabel")}
                 </div>
                 <div className="v" style={{ color: "var(--color-on-error-container)" }}>
                   {atRiskCount}
-                  <small style={{ color: "var(--color-on-error-container)" }}>tenants</small>
+                  <small style={{ color: "var(--color-on-error-container)" }}>
+                    {t("health.recontactUnit")}
+                  </small>
                 </div>
               </div>
             )}
@@ -1266,36 +1295,36 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
       </div>
 
       <div className="section-head">
-        <h2>Tenants &amp; flux</h2>
+        <h2>{t("sections.tenants")}</h2>
         <span className="rule" />
-        <span className="hint">Top contributeurs · remboursements · devises</span>
+        <span className="hint">{t("sectionHints.tenants")}</span>
       </div>
       <div className="two-col">
         <div className="fin-card">
           <div className="fin-card-header">
             <div>
-              <div className="fin-card-title">Top tenants · volume</div>
-              <div className="fin-card-subtitle">Par volume de dons clearés sur la période</div>
+              <div className="fin-card-title">{t("topTenantsCard.title")}</div>
+              <div className="fin-card-subtitle">{t("topTenantsCard.subtitle")}</div>
             </div>
           </div>
           {topTenants.length > 0 ? (
             <>
               <div className="tenant-row head">
                 <span />
-                <span>Tenant · part</span>
-                <span style={{ textAlign: "right" }}>Score</span>
-                <span style={{ textAlign: "right" }}>Volume</span>
+                <span>{t("topTenantsCard.headerName")}</span>
+                <span style={{ textAlign: "right" }}>{t("topTenantsCard.headerScore")}</span>
+                <span style={{ textAlign: "right" }}>{t("topTenantsCard.headerVolume")}</span>
               </div>
-              {topTenants.map((t, idx) => {
+              {topTenants.map((tenant, idx) => {
                 const sharePct =
-                  kpis.volumeCents > 0 ? (t.volumeCents / kpis.volumeCents) * 100 : 0;
-                const mob = mobilisation.perTenant.find((m) => m.tenantId === t.tenantId);
+                  kpis.volumeCents > 0 ? (tenant.volumeCents / kpis.volumeCents) * 100 : 0;
+                const mob = mobilisation.perTenant.find((m) => m.tenantId === tenant.tenantId);
                 return (
-                  <div key={t.tenantId} className="tenant-row">
+                  <div key={tenant.tenantId} className="tenant-row">
                     <span className="tenant-rank">{String(idx + 1).padStart(2, "0")}</span>
                     <div style={{ minWidth: 0 }}>
-                      <a href={`/admin/tenants/${t.tenantId}`} className="tenant-name">
-                        {t.tenantName}
+                      <a href={`/admin/tenants/${tenant.tenantId}`} className="tenant-name">
+                        {tenant.tenantName}
                       </a>
                       <div className="tenant-meta">
                         <div className="tenant-track">
@@ -1311,25 +1340,27 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                       </span>
                     </span>
                     <span className="tenant-amount">
-                      {formatCents(t.volumeCents, "EUR", false)}
-                      <small>{formatNumber(t.donationCount)} dons</small>
+                      {formatCents(tenant.volumeCents, "EUR", false)}
+                      <small>
+                        {t("topTenantsCard.donationsCountSuffix", {
+                          count: tenant.donationCount,
+                        })}
+                      </small>
                     </span>
                   </div>
                 );
               })}
             </>
           ) : (
-            <p style={{ color: "var(--color-on-surface-variant)" }}>
-              Aucun tenant avec dons sur la période.
-            </p>
+            <p style={{ color: "var(--color-on-surface-variant)" }}>{t("topTenantsCard.empty")}</p>
           )}
         </div>
         <div className="stack">
           <div className="fin-card">
             <div className="fin-card-header">
               <div>
-                <div className="fin-card-title">Taux de remboursement</div>
-                <div className="fin-card-subtitle">Sain &lt; 1% · alerte &gt; 5%</div>
+                <div className="fin-card-title">{t("sections.refunds")}</div>
+                <div className="fin-card-subtitle">{t("refundCard.subtitle")}</div>
               </div>
             </div>
             <div className="gauge-val">
@@ -1341,27 +1372,29 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             </div>
             <div className="gauge-ticks">
               <span className="t" style={{ left: "0%" }}>
-                0%
+                {t("refundCard.tick0")}
               </span>
               <span className="t" style={{ left: "12.5%" }}>
-                1%
+                {t("refundCard.tick1")}
               </span>
               <span className="t" style={{ left: "62.5%" }}>
-                5%
+                {t("refundCard.tick2")}
               </span>
               <span className="t" style={{ left: "100%" }}>
-                8%+
+                {t("refundCard.tick3")}
               </span>
             </div>
             <p className="kpi-foot" style={{ marginTop: "var(--space-3)" }}>
-              {formatCents(kpis.refundedVolumeCents, "EUR", false)} remboursés.
+              {t("refundCard.amountSuffix", {
+                amount: formatCents(kpis.refundedVolumeCents, "EUR", false),
+              })}
             </p>
           </div>
           <div className="fin-card">
             <div className="fin-card-header">
               <div>
-                <div className="fin-card-title">Devises</div>
-                <div className="fin-card-subtitle">Répartition du volume</div>
+                <div className="fin-card-title">{t("sections.currencies")}</div>
+                <div className="fin-card-subtitle">{t("currenciesCard.subtitle")}</div>
               </div>
             </div>
             <div className="donut-wrap">
@@ -1408,9 +1441,10 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         <span className="material-symbols-outlined" style={{ fontSize: 14 }}>
           fingerprint
         </span>
-        Cette vue a été chargée à {lastTimestamp}. Source :{" "}
-        <code>/v1/superadmin/finance/summary</code>. Cache 5 min. Toute consultation est tracée dans{" "}
-        <code>audit_logs</code>.
+        {t.rich("viewLoadedAt", {
+          timestamp: lastTimestamp,
+          code: (chunks) => <code>{chunks}</code>,
+        })}
         {/* Discreet operator action — used in rare cases (e.g. just
             after an out-of-band SQL refresh). Server-side rate-limited
             to 5/min, audited. Issue #449. */}
@@ -1430,7 +1464,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             cursor: flushing ? "wait" : "pointer",
           }}
         >
-          {flushing ? "Flush en cours…" : "Forcer un rafraîchissement"}
+          {flushing ? t("cacheFlush.busy") : t("cacheFlush.cta")}
         </button>
       </div>
 
@@ -1448,7 +1482,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             fontSize: 13,
           }}
         >
-          Mise à jour…
+          {t("loading")}
         </div>
       )}
     </main>
@@ -1543,6 +1577,7 @@ const MOLE_ROTATION_MS = 1200;
 const GAME_OVER_LINGER_MS = 4000;
 
 function GradeHistogram({ buckets, maxBucket, tenantCount }: GradeHistogramProps) {
+  const t = useTranslations("admin.finance");
   const [gameActive, setGameActive] = useState(false);
   const [gameOver, setGameOver] = useState(false);
   const [score, setScore] = useState(0);
@@ -1635,12 +1670,14 @@ function GradeHistogram({ buckets, maxBucket, tenantCount }: GradeHistogramProps
         }}
       >
         <span className="material-symbols-outlined">bar_chart</span>
-        Répartition · {tenantCount} tenants
+        {t("histogramExtra.label", { count: tenantCount })}
       </button>
       <div
         className="hero-hist"
         role="img"
-        aria-label={buckets.map((b) => `${b.count} tenants ${b.key}`).join(", ")}
+        aria-label={buckets
+          .map((b) => t("histogramExtra.barAriaItem", { count: b.count, grade: b.key }))
+          .join(", ")}
       >
         {buckets.map((b, idx) => {
           const isMole = gameActive && idx === moleIndex;
@@ -1670,10 +1707,10 @@ function GradeHistogram({ buckets, maxBucket, tenantCount }: GradeHistogramProps
       </div>
       <p className="hero-foot" style={{ marginTop: "var(--space-5)" }}>
         {gameActive
-          ? `Score : ${score} · ${timeLeft}s`
+          ? t("histogramExtra.gameScore", { score, timeLeft })
           : gameOver
-            ? `Game over — score final : ${score}`
-            : `Distribution sur ${tenantCount} tenants. Tenants avec < 5 donateurs uniques exclus (k-anonymity).`}
+            ? t("histogramExtra.gameOver", { score })
+            : t("histogramExtra.footnoteFull", { count: tenantCount })}
       </p>
     </div>
   );

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -13,6 +13,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { toast, VolumeRevenueChart } from "@/components/admin/finance";
+import { Button } from "@/components/ui/button";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import type { FinancePeriod, FinanceSummary } from "@/models/superadmin-finance";
 import { SuperAdminFinanceService } from "@/services/SuperAdminFinanceService";
@@ -142,6 +143,59 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     (next: FinanceFilters["tenantId"]) => setFilters((f) => ({ ...f, tenantId: next })),
     [],
   );
+
+  // ─── Monthly PDF report (issue #443) ──────────────────────────────────────
+  // The button is on the page header. Click → POST → poll the row by id
+  // every 2s until `ready` (or `failed`), then trigger a same-tab
+  // navigation to the streamed PDF URL.
+  const [reportBusy, setReportBusy] = useState(false);
+  const [reportMessage, setReportMessage] = useState<{
+    tone: "info" | "error";
+    text: string;
+  } | null>(null);
+
+  const handleGenerateMonthlyReport = useCallback(async () => {
+    if (reportBusy) return;
+    setReportBusy(true);
+    setReportMessage({ tone: "info", text: "Génération en cours…" });
+    const api = createClientApiClient();
+    try {
+      let report = await SuperAdminFinanceService.requestMonthlyReport(api);
+      // Poll every 2s up to 60 attempts (~2 min). The generation is
+      // typically sub-5s — this bound is the DLQ-candidate cutoff.
+      for (let attempt = 0; attempt < 60 && report.status === "pending"; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        report = await SuperAdminFinanceService.fetchReport(api, report.id);
+      }
+      if (report.status === "ready" && report.pdfUrl) {
+        const absoluteUrl = api.resolveBrowserUrl(report.pdfUrl);
+        setReportMessage({ tone: "info", text: `Rapport ${report.month} prêt — téléchargement…` });
+        window.location.assign(absoluteUrl);
+      } else if (report.status === "failed") {
+        setReportMessage({
+          tone: "error",
+          text: report.failureReason
+            ? `Échec : ${report.failureReason}`
+            : "Échec de la génération du rapport.",
+        });
+      } else {
+        setReportMessage({
+          tone: "error",
+          text: "Rapport encore en attente — réessaie dans quelques minutes.",
+        });
+      }
+    } catch (err) {
+      setReportMessage({
+        tone: "error",
+        text:
+          err instanceof Error
+            ? `Erreur : ${err.message}`
+            : "Erreur lors de la génération du rapport.",
+      });
+    } finally {
+      setReportBusy(false);
+    }
+  }, [reportBusy]);
 
   // Tracks whether the user has interacted with the period / filter
   // controls since mount. The initial SSR fetch already loaded the
@@ -392,11 +446,40 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
             </span>
           </p>
         </div>
-        {/* Action buttons (Exporter CSV + Rapport mensuel PDF) intentionally
-            hidden — backend endpoints not yet implemented. Tracked separately
-            so we ship UI when the feature is real, not before
-            (feedback_no_anticipatory_ui).
-            Follow-up issues: Export CSV (#442), Monthly PDF report (#443). */}
+        {/* Action buttons. CSV export (#442) is still not wired —
+            keep that one hidden per feedback_no_anticipatory_ui until
+            the backend lands. The "Rapport mensuel" PDF (#443) is
+            wired below. */}
+        <div className="page-header-actions">
+          <Button
+            type="button"
+            variant="primary"
+            size="default"
+            onClick={handleGenerateMonthlyReport}
+            disabled={reportBusy}
+            aria-busy={reportBusy}
+          >
+            <span className="material-symbols-outlined" style={{ fontSize: 16 }} aria-hidden>
+              insights
+            </span>
+            {reportBusy ? "Génération…" : "Rapport mensuel"}
+          </Button>
+          {reportMessage && (
+            <p
+              role={reportMessage.tone === "error" ? "alert" : "status"}
+              style={{
+                marginTop: 8,
+                fontSize: 12,
+                color:
+                  reportMessage.tone === "error"
+                    ? "var(--color-error)"
+                    : "var(--color-on-surface-variant)",
+              }}
+            >
+              {reportMessage.text}
+            </p>
+          )}
+        </div>
       </div>
 
       <div className="finance-toolbar">

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -154,6 +154,27 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     text: string;
   } | null>(null);
 
+  const handleBackfillReports = useCallback(async () => {
+    if (reportBusy) return;
+    setReportBusy(true);
+    setReportMessage({ tone: "info", text: "Backfill des 12 derniers mois en cours…" });
+    const api = createClientApiClient();
+    try {
+      const result = await SuperAdminFinanceService.backfillReports(api);
+      setReportMessage({
+        tone: "info",
+        text: `Backfill terminé — ${result.enqueued.length} nouveau(x) rapport(s) en file, ${result.skipped.length} déjà présent(s).`,
+      });
+    } catch (err) {
+      setReportMessage({
+        tone: "error",
+        text: err instanceof Error ? `Erreur backfill : ${err.message}` : "Erreur backfill.",
+      });
+    } finally {
+      setReportBusy(false);
+    }
+  }, [reportBusy]);
+
   const handleGenerateMonthlyReport = useCallback(async () => {
     if (reportBusy) return;
     setReportBusy(true);
@@ -463,6 +484,20 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
               insights
             </span>
             {reportBusy ? "Génération…" : "Rapport mensuel"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="default"
+            onClick={handleBackfillReports}
+            disabled={reportBusy}
+            aria-busy={reportBusy}
+            title="Génère les rapports manquants des 12 derniers mois (idempotent)."
+          >
+            <span className="material-symbols-outlined" style={{ fontSize: 16 }} aria-hidden>
+              history
+            </span>
+            Backfill 12 mois
           </Button>
           {reportMessage && (
             <p

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -13,6 +13,15 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { toast, VolumeRevenueChart } from "@/components/admin/finance";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { createClientApiClient } from "@/lib/api/client-browser";
 import type { FinancePeriod, FinanceSummary, MonthlyReport } from "@/models/superadmin-finance";
@@ -160,6 +169,10 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   } | null>(null);
   const [reports, setReports] = useState<MonthlyReport[]>([]);
   const [archiveOpen, setArchiveOpen] = useState(false);
+  // Holds the report row whose regenerate-confirmation dialog is open.
+  // Single-slot — only one regeneration can be running at a time
+  // (gated by `reportBusy`).
+  const [reportToRegenerate, setReportToRegenerate] = useState<MonthlyReport | null>(null);
 
   const refreshReports = useCallback(async () => {
     try {
@@ -178,6 +191,21 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     }
   }, [archiveOpen, reports.length, refreshReports]);
 
+  // Auto-refresh the archive while any row is `pending` — picks up the
+  // worker's status flip without making the user reopen the panel.
+  // Stops itself as soon as every visible row is settled (ready /
+  // failed). Bounded by the panel being open so a backgrounded tab
+  // doesn't poll forever.
+  useEffect(() => {
+    if (!archiveOpen) return;
+    const hasPending = reports.some((r) => r.status === "pending");
+    if (!hasPending) return;
+    const interval = setInterval(() => {
+      void refreshReports();
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [archiveOpen, reports, refreshReports]);
+
   // Auto-dismiss the report status message after 6s. We only schedule
   // the timer when the in-flight work is DONE (`reportBusy === false`)
   // so a long "Génération en cours…" message stays pinned until the
@@ -188,24 +216,46 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     return () => clearTimeout(timer);
   }, [reportMessage, reportBusy]);
 
-  const handleRegenerateReport = useCallback(
-    async (report: MonthlyReport) => {
+  // Request a regeneration — just opens the design-system AlertDialog;
+  // the actual work happens in `confirmRegenerate` only after the
+  // user confirms. Split this way so the confirmation lives in our
+  // own UI (with brand styling + i18n + a11y) instead of the
+  // platform-styled `window.confirm`.
+  const requestRegenerate = useCallback(
+    (report: MonthlyReport) => {
       if (reportBusy) return;
-      // Native confirm carries the RGPD warning. Functional super-admins
-      // are typically not on dialog-heavy UIs; a single browser confirm
-      // is the lowest-friction path. Copy mirrors the archive panel
-      // banner so the same information is presented twice — once
-      // ambient, once at decision time.
-      const ok = window.confirm(t("reports.archive.regenerateConfirm", { month: report.month }));
-      if (!ok) return;
-      setReportBusy(true);
-      setReportMessage({
-        tone: "info",
-        text: t("reports.messageRegenerating", { month: report.month }),
-      });
-      try {
-        const api = createClientApiClient();
-        const result = await SuperAdminFinanceService.regenerateReport(api, report.id);
+      setReportToRegenerate(report);
+    },
+    [reportBusy],
+  );
+
+  const confirmRegenerate = useCallback(async () => {
+    const report = reportToRegenerate;
+    if (!report || reportBusy) return;
+    setReportBusy(true);
+    setReportToRegenerate(null);
+    setReportMessage({
+      tone: "info",
+      text: t("reports.messageRegenerating", { month: report.month }),
+    });
+    // Surface the archive panel so the user can watch the new row
+    // tick from `pending` to `ready` via the watcher useEffect.
+    setArchiveOpen(true);
+    try {
+      const api = createClientApiClient();
+      const result = await SuperAdminFinanceService.regenerateReport(api, report.id);
+      void refreshReports();
+
+      // Poll the newly-created report (initially `pending`) until
+      // the worker flips it to `ready` or `failed`. Same 2s cadence
+      // and 60-attempt ceiling as the main "Rapport mensuel" flow.
+      let polled = result.newReport;
+      for (let attempt = 0; attempt < 60 && polled.status === "pending"; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        polled = await SuperAdminFinanceService.fetchReport(api, polled.id);
+      }
+
+      if (polled.status === "ready") {
         setReportMessage({
           tone: "info",
           text: t("reports.messageRegenerated", {
@@ -214,20 +264,33 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
           }),
         });
         void refreshReports();
-      } catch (err) {
+      } else if (polled.status === "failed") {
         setReportMessage({
           tone: "error",
-          text:
-            err instanceof Error
-              ? t("reports.messageRegenerateError", { error: err.message })
-              : t("reports.messageRegenerateErrorGeneric"),
+          text: polled.failureReason
+            ? t("reports.messageFailed", { reason: polled.failureReason })
+            : t("reports.messageFailedGeneric"),
         });
-      } finally {
-        setReportBusy(false);
+      } else {
+        // Still pending after the poll window — surface the wait
+        // hint instead of silently dropping the "in-progress" state.
+        setReportMessage({
+          tone: "error",
+          text: t("reports.messagePendingTimeout"),
+        });
       }
-    },
-    [reportBusy, refreshReports, t],
-  );
+    } catch (err) {
+      setReportMessage({
+        tone: "error",
+        text:
+          err instanceof Error
+            ? t("reports.messageRegenerateError", { error: err.message })
+            : t("reports.messageRegenerateErrorGeneric"),
+      });
+    } finally {
+      setReportBusy(false);
+    }
+  }, [reportBusy, reportToRegenerate, refreshReports, t]);
 
   const handleBackfillReports = useCallback(async () => {
     if (reportBusy) return;
@@ -741,7 +804,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                         type="button"
                         variant="ghost"
                         size="sm"
-                        onClick={() => void handleRegenerateReport(r)}
+                        onClick={() => requestRegenerate(r)}
                         disabled={reportBusy}
                         title={t("reports.archive.regenerateTitle")}
                       >
@@ -1485,6 +1548,41 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
           {t("loading")}
         </div>
       )}
+
+      <AlertDialog
+        open={reportToRegenerate !== null}
+        onOpenChange={(open) => {
+          if (!open) setReportToRegenerate(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {reportToRegenerate
+                ? t("reports.archive.regenerateDialogTitle", { month: reportToRegenerate.month })
+                : null}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("reports.archive.regenerateDialogBody")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={reportBusy}>
+              {t("reports.archive.regenerateDialogCancel")}
+            </AlertDialogCancel>
+            <Button
+              type="button"
+              variant="primary"
+              onClick={() => void confirmRegenerate()}
+              disabled={reportBusy}
+            >
+              {reportBusy
+                ? t("reports.archive.regenerateDialogConfirmBusy")
+                : t("reports.archive.regenerateDialogConfirm")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </main>
   );
 }

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -173,6 +173,16 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
     }
   }, [archiveOpen, reports.length, refreshReports]);
 
+  // Auto-dismiss the report status message after 6s. We only schedule
+  // the timer when the in-flight work is DONE (`reportBusy === false`)
+  // so a long "Génération en cours…" message stays pinned until the
+  // poll loop finishes.
+  useEffect(() => {
+    if (!reportMessage || reportBusy) return;
+    const timer = setTimeout(() => setReportMessage(null), 6000);
+    return () => clearTimeout(timer);
+  }, [reportMessage, reportBusy]);
+
   const handleBackfillReports = useCallback(async () => {
     if (reportBusy) return;
     setReportBusy(true);

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -257,8 +257,13 @@ export function Sidebar({
                 {tAdmin("section")}
               </h2>
               {[
-                ...ADMIN_NAV_ITEMS,
+                // Finance plateforme is the daily-use dashboard for
+                // super-admins — render it first so the surface follows
+                // the admin-dashboard convention (overview → entities
+                // → operations → config). Flag-gated so the slot is
+                // absent when the rollout is paused.
                 ...(financeDashboardEnabled ? [FINANCE_ADMIN_NAV_ITEM] : []),
+                ...ADMIN_NAV_ITEMS,
               ].map((item) => {
                 const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
                 const Icon = item.icon;

--- a/packages/web/src/components/ui/alert-dialog.tsx
+++ b/packages/web/src/components/ui/alert-dialog.tsx
@@ -40,7 +40,10 @@ export const AlertDialogContent = forwardRef<
       ref={ref}
       className={cn(
         "fixed left-1/2 top-1/2 z-[var(--z-modal)] -translate-x-1/2 -translate-y-1/2",
-        "w-full max-w-lg p-6",
+        // Bumped padding from p-6 → p-8 for breathing room around
+        // the title / body / footer trio (super-admin feedback,
+        // 2026-05-26 "la dialog box fait plate").
+        "w-full max-w-lg p-8",
         "bg-surface-container-lowest text-on-surface",
         "border border-outline-variant rounded-[var(--radius-lg)]",
         "shadow-modal",
@@ -56,13 +59,17 @@ export const AlertDialogContent = forwardRef<
 AlertDialogContent.displayName = "AlertDialogContent";
 
 export function AlertDialogHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("mb-4 flex flex-col gap-1.5 text-left", className)} {...props} />;
+  // gap-3 instead of gap-1.5 — title and description need real
+  // separation; mb-6 below the header for distinct content area.
+  return <div className={cn("mb-6 flex flex-col gap-3 text-left", className)} {...props} />;
 }
 
 export function AlertDialogFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      // mt-8 + gap-3 gives the footer real breathing room from the
+      // body paragraph above (mt-6 + gap-2 felt cramped).
+      className={cn("mt-8 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end", className)}
       {...props}
     />
   );
@@ -74,7 +81,7 @@ export const AlertDialogTitle = forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
     ref={ref}
-    className={cn("font-heading text-xl leading-tight text-on-surface", className)}
+    className={cn("font-heading text-xl leading-snug text-on-surface", className)}
     {...props}
   />
 ));
@@ -86,17 +93,38 @@ export const AlertDialogDescription = forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-on-surface-variant", className)}
+    // leading-relaxed instead of the Tailwind default — long RGPD
+    // bodies read much better with extra line-height.
+    className={cn("text-sm leading-relaxed text-on-surface-variant", className)}
     {...props}
   />
 ));
 AlertDialogDescription.displayName = "AlertDialogDescription";
 
+// Shared cancel/action styling — matches the design-system Button
+// component's `default` size and shape so the two footer buttons
+// look visually balanced. Without this `AlertDialogCancel` ships as
+// an unstyled <button> (Radix Close), which renders as bare text
+// next to a fully-styled primary CTA — the imbalance feedback was
+// raised on 2026-05-26.
+const dialogButtonBase = cn(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap",
+  "rounded-[var(--radius-button)] font-body font-medium",
+  "h-[var(--btn-height-md)] px-6 text-sm",
+  "transition-colors duration-normal ease-out",
+  "focus-visible:outline-none focus-visible:shadow-ring",
+  "disabled:pointer-events-none disabled:opacity-60",
+);
+
 export const AlertDialogAction = forwardRef<
   ElementRef<typeof AlertDialogPrimitive.Close>,
   ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Close>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Close ref={ref} className={cn(className)} {...props} />
+  <AlertDialogPrimitive.Close
+    ref={ref}
+    className={cn(dialogButtonBase, "bg-primary text-on-primary hover:bg-primary-hover", className)}
+    {...props}
+  />
 ));
 AlertDialogAction.displayName = "AlertDialogAction";
 
@@ -104,6 +132,17 @@ export const AlertDialogCancel = forwardRef<
   ElementRef<typeof AlertDialogPrimitive.Close>,
   ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Close>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Close ref={ref} className={cn(className)} {...props} />
+  <AlertDialogPrimitive.Close
+    ref={ref}
+    className={cn(
+      dialogButtonBase,
+      // Secondary affordance — token-filled surface so the button
+      // reads as a real button (vs. the unstyled text it used to
+      // render as), but visually subordinate to the primary action.
+      "bg-surface-container-highest text-on-surface hover:bg-surface-dim",
+      className,
+    )}
+    {...props}
+  />
 ));
 AlertDialogCancel.displayName = "AlertDialogCancel";

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1059,7 +1059,12 @@
           "downloadPdf": "PDF",
           "regenerate": "Regenerate",
           "regenerateTitle": "Regenerates the report with current code and data. The previous one is kept for GDPR traceability.",
-          "regenerateConfirm": "Regenerate the {month} report?\n\nA new PDF will be generated with the current code and data. The previous report will be marked superseded but remain in the system (GDPR Art. 5.2 compliance — every generation is tracked).\n\nThis action is logged in the audit trail."
+          "regenerateConfirm": "Regenerate the {month} report?\n\nA new PDF will be generated with the current code and data. The previous report will be marked superseded but remain in the system (GDPR Art. 5.2 compliance — every generation is tracked).\n\nThis action is logged in the audit trail.",
+          "regenerateDialogTitle": "Regenerate the {month} report?",
+          "regenerateDialogBody": "A new PDF will be generated with the current code and data. The previous report will be marked superseded but remain in the system (GDPR Art. 5.2 compliance — every generation is tracked). This action is logged in the audit trail.",
+          "regenerateDialogCancel": "Cancel",
+          "regenerateDialogConfirm": "Regenerate",
+          "regenerateDialogConfirmBusy": "Regenerating…"
         }
       },
       "filters": {

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1018,15 +1018,56 @@
       "pageSubtitleContext": "Last {period} · all currencies (EUR eq.) · all tenants.",
       "liveIndicator": "Transactions live · {timestamp}",
       "topbarLive": "Transactions live · {timestamp}",
-      "topbarStaleSource": "{count} stale source",
+      "topbarStaleSource": "{count, plural, =1 {1 stale source} other {# stale sources}}",
       "topbarStaleSourceAria": "{count} data source is stale — jump to tenant health",
+      "topbarStaleSourceTitle": "A data source is stale — click to investigate.",
       "actionExport": "Export",
       "actionMonthlyReport": "Monthly report",
+      "actionMonthlyReportBusy": "Generating…",
+      "actionBackfill12Months": "Backfill 12 months",
+      "actionBackfill12MonthsTitle": "Generates missing reports for the last 12 months (idempotent).",
+      "actionArchiveShow": "Show archive",
+      "actionArchiveHide": "Hide archive",
+      "reports": {
+        "messageGenerating": "Generating…",
+        "messageBackfillRunning": "Backfilling the last 12 months…",
+        "messageBackfillDone": "Backfill done — {enqueued, plural, =0 {no new report} =1 {1 new report} other {# new reports}} queued, {skipped, plural, =0 {none already present} =1 {1 already present} other {# already present}}.",
+        "messageBackfillError": "Backfill error: {error}",
+        "messageBackfillErrorGeneric": "Backfill error.",
+        "messageReady": "Report {month} ready — downloading…",
+        "messageFailed": "Failed: {reason}",
+        "messageFailedGeneric": "Report generation failed.",
+        "messagePendingTimeout": "Report still pending — try again in a few minutes.",
+        "messageGenerationError": "Error: {error}",
+        "messageGenerationErrorGeneric": "Error while generating the report.",
+        "messageRegenerating": "Regenerating report {month}…",
+        "messageRegenerated": "Report {month} regenerated — previous id {shortId}… superseded.",
+        "messageRegenerateError": "Regenerate error: {error}",
+        "messageRegenerateErrorGeneric": "Regenerate error.",
+        "archive": {
+          "ariaLabel": "Monthly reports archive",
+          "title": "Archive · recent reports",
+          "subtitle": "One report per month · most recent first",
+          "empty": "No report yet. Click \"Monthly report\" or \"Backfill 12 months\".",
+          "rgpdNoticeTitle": "Regeneration & GDPR compliance",
+          "rgpdNoticeBody": "Each report is frozen at generation time (Art. 5.2, accuracy and traceability principle). Regenerating creates a new document; the previous one is kept in the system and remains accessible via the audit log. Every action is tracked (who, when, from which IP).",
+          "statusReady": "Ready",
+          "statusPending": "Pending…",
+          "statusFailed": "Failed",
+          "generatedAt": "Generated on {date}",
+          "errorPlaceholder": "Error",
+          "downloadPdf": "PDF",
+          "regenerate": "Regenerate",
+          "regenerateTitle": "Regenerates the report with current code and data. The previous one is kept for GDPR traceability.",
+          "regenerateConfirm": "Regenerate the {month} report?\n\nA new PDF will be generated with the current code and data. The previous report will be marked superseded but remain in the system (GDPR Art. 5.2 compliance — every generation is tracked).\n\nThis action is logged in the audit trail."
+        }
+      },
       "filters": {
         "currencyAria": "Currency",
         "currencyAll": "All currencies (EUR eq.)",
         "tenantAria": "Tenant",
-        "tenantAll": "All tenants"
+        "tenantAll": "All tenants",
+        "tenantSelected": "selected tenant"
       },
       "alertStrip": {
         "body": "{count, plural, =1 {1 tenant on alert} other {# tenants on alert}} — detractors crossed with a churn signal. Reach out this week.",
@@ -1205,10 +1246,13 @@
       },
       "health": {
         "npsLabel": "Tenant NPS",
+        "npsShort": "NPS",
         "npsInfo": "Lagging indicator — PMF is the primary signal.",
         "npsUnit": "/ 100",
         "npsLegacy": "lagging indicator · legacy",
+        "npsHistoric": "historical indicator",
         "csatLabel": "Support CSAT",
+        "csatLabelFull": "Post-ticket CSAT",
         "csatInfo": "Post-ticket (1-5). Collected continuously.",
         "csatUnit": "/ 5",
         "csatFreshLabel": "fresh · {days}d",
@@ -1216,7 +1260,100 @@
         "recontactInfo": "Detractors × behavioural signal — your CSM follow-up list.",
         "recontactUnit": "tenants",
         "recontactCta": "View the list",
-        "surveyFreshAria": "Last surveyed {days} days ago"
+        "surveyFreshAria": "Last surveyed {days} days ago",
+        "sectionHint": "PMF · NPS · CSAT"
+      },
+      "freshness": {
+        "fresh": "fresh",
+        "soon": "going stale",
+        "stale": "stale"
+      },
+      "cacheFlush": {
+        "successToast": "Cache flushed · {keysDeleted, plural, =0 {no entry removed} =1 {1 entry removed} other {# entries removed}}",
+        "errorToast": "Flush failed — try again in a minute.",
+        "busy": "Flushing…",
+        "cta": "Force a refresh"
+      },
+      "viewLoadedAt": "This view was loaded at {timestamp}. Source: <code>/v1/superadmin/finance/summary</code>. Cache 5 min. Every consultation is logged to <code>audit_logs</code>.",
+      "heroAlert": {
+        "bodyRich": "<b>{count, plural, =1 {1 tenant on alert} other {# tenants on alert}}</b> — detractors crossed with a churn signal. Reach out this week.",
+        "cta": "See the list →"
+      },
+      "mobilisationHero": {
+        "title": "Mobilisation score",
+        "titleInfo": "Fundraising health indicator — not a beneficiary impact score.",
+        "outOf": "/ 100",
+        "deltaPlaceholder": "—",
+        "periodLabel": "vs prev. period · weighted by volume",
+        "footnoteRich": "Fundraising health aggregated across <b>{count} tenants</b>. An A in healthcare ≠ an A in culture — prefer the <b>delta</b> to the absolute."
+      },
+      "formulaHero": {
+        "title": "Components · platform average",
+        "footnoteRich": "The breakdown is shown for <b>transparency</b>. Each component is capped at 100 before weighting."
+      },
+      "kpisExtra": {
+        "recurringSuffix": "/mo",
+        "recurringFoot": "{share}% of volume · active pledges",
+        "volumeFoot": "{count} donations · vs prev. period",
+        "stripeFoot": "~{rate}% of card volume",
+        "revenueFoot": "take-rate {rate}%",
+        "revenueInfoTitle": "1.5% + €0.30 per cleared donation. Normalised to EUR.",
+        "recurringInfoTitle": "Share of revenue from active pledges. Predictable revenue.",
+        "stripeInfoTitle": "Stripe rail only. Deducted from the NPO's account."
+      },
+      "chartLabels": {
+        "ariaLabel": "Volume and revenue trend",
+        "volumeLabel": "Volume",
+        "revenueLabel": "Revenue"
+      },
+      "riskExtra": {
+        "concentrationLabelWithHhi": "Concentration (HHI)",
+        "concentrationInfoTitle": "HHI = sum of squared shares. < 0.15 = well diversified.",
+        "concentrationTopTenant": "Top tenant = {pct}%",
+        "concentrationBadgeWatch": "To watch",
+        "concentrationBadgeAlert": "Too concentrated",
+        "activeTenantsInfoTitle": "At least 1 cleared donation in the period.",
+        "activeTenantsSecondary": "{active}% active · {dormant} dormant",
+        "failureLabelFull": "Payment failure rate",
+        "failureInfoTitle": "Stripe only (Mollie not instrumented).",
+        "failureFootnote": "Across all Stripe attempts in the period."
+      },
+      "pmfExtra": {
+        "titleFull": "Product/Market Fit (Sean Ellis)",
+        "headlineRich": "\"Very disappointed\" if Givernance went away. PMF threshold = <b>40%</b>.",
+        "ariaLabel": "PMF: {pct}% very disappointed",
+        "segmentSomewhat": "somewhat",
+        "segmentNot": "not disappointed",
+        "markerLabelShort": "40% threshold",
+        "legendVeryRich": "<b>Very disappointed</b>: positive signal",
+        "noResponsesYet": "No PMF responses yet. Launch a campaign to collect."
+      },
+      "topTenantsCard": {
+        "title": "Top tenants · volume",
+        "subtitle": "By cleared donation volume in the period",
+        "headerName": "Tenant · share",
+        "headerScore": "Score",
+        "headerVolume": "Volume",
+        "donationsCountSuffix": "{count, plural, =1 {1 donation} other {# donations}}",
+        "empty": "No tenant with donations in this period."
+      },
+      "refundCard": {
+        "subtitle": "Healthy < 1% · alert > 5%",
+        "tick0": "0%",
+        "tick1": "1%",
+        "tick2": "5%",
+        "tick3": "8%+",
+        "amountSuffix": "{amount} refunded."
+      },
+      "currenciesCard": {
+        "subtitle": "Volume breakdown"
+      },
+      "histogramExtra": {
+        "label": "Distribution · {count} tenants",
+        "gameScore": "Score: {score} · {timeLeft}s",
+        "gameOver": "Game over — final score: {score}",
+        "footnoteFull": "Distribution across {count} tenants. Tenants with < 5 unique donors excluded (k-anonymity).",
+        "barAriaItem": "{count} tenants {grade}"
       }
     }
   },

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1059,7 +1059,12 @@
           "downloadPdf": "PDF",
           "regenerate": "Régénérer",
           "regenerateTitle": "Régénère le rapport avec le code et les données actuels. L'ancien sera conservé pour la traçabilité RGPD.",
-          "regenerateConfirm": "Régénérer le rapport de {month} ?\n\nUn nouveau PDF sera généré avec le code et les données actuels. L'ancien rapport sera marqué comme remplacé mais restera dans le système (conformité RGPD Art. 5.2 — traçabilité de chaque génération).\n\nCette action est tracée dans le journal d'audit."
+          "regenerateConfirm": "Régénérer le rapport de {month} ?\n\nUn nouveau PDF sera généré avec le code et les données actuels. L'ancien rapport sera marqué comme remplacé mais restera dans le système (conformité RGPD Art. 5.2 — traçabilité de chaque génération).\n\nCette action est tracée dans le journal d'audit.",
+          "regenerateDialogTitle": "Régénérer le rapport de {month} ?",
+          "regenerateDialogBody": "Un nouveau PDF sera généré avec le code et les données actuels. L'ancien rapport sera marqué comme remplacé mais restera dans le système (conformité RGPD Art. 5.2 — traçabilité de chaque génération). Cette action est tracée dans le journal d'audit.",
+          "regenerateDialogCancel": "Annuler",
+          "regenerateDialogConfirm": "Régénérer",
+          "regenerateDialogConfirmBusy": "Régénération…"
         }
       },
       "filters": {

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1018,15 +1018,56 @@
       "pageSubtitleContext": "{period} · toutes devises (éq. EUR) · tous tenants.",
       "liveIndicator": "Transactions à jour · {timestamp}",
       "topbarLive": "Transactions à jour · {timestamp}",
-      "topbarStaleSource": "{count} source périmée",
+      "topbarStaleSource": "{count, plural, =1 {1 source périmée} other {# sources périmées}}",
       "topbarStaleSourceAria": "{count} source de données est périmée — aller à la santé des tenants",
+      "topbarStaleSourceTitle": "Une source de données est périmée — cliquer pour aller voir.",
       "actionExport": "Exporter",
       "actionMonthlyReport": "Rapport mensuel",
+      "actionMonthlyReportBusy": "Génération…",
+      "actionBackfill12Months": "Backfill 12 mois",
+      "actionBackfill12MonthsTitle": "Génère les rapports manquants des 12 derniers mois (idempotent).",
+      "actionArchiveShow": "Voir l'archive",
+      "actionArchiveHide": "Masquer l'archive",
+      "reports": {
+        "messageGenerating": "Génération en cours…",
+        "messageBackfillRunning": "Backfill des 12 derniers mois en cours…",
+        "messageBackfillDone": "Backfill terminé — {enqueued, plural, =0 {aucun nouveau rapport} =1 {1 nouveau rapport} other {# nouveaux rapports}} en file, {skipped, plural, =0 {aucun déjà présent} =1 {1 déjà présent} other {# déjà présents}}.",
+        "messageBackfillError": "Erreur backfill : {error}",
+        "messageBackfillErrorGeneric": "Erreur backfill.",
+        "messageReady": "Rapport {month} prêt — téléchargement…",
+        "messageFailed": "Échec : {reason}",
+        "messageFailedGeneric": "Échec de la génération du rapport.",
+        "messagePendingTimeout": "Rapport encore en attente — réessaie dans quelques minutes.",
+        "messageGenerationError": "Erreur : {error}",
+        "messageGenerationErrorGeneric": "Erreur lors de la génération du rapport.",
+        "messageRegenerating": "Régénération du rapport {month} en cours…",
+        "messageRegenerated": "Rapport {month} régénéré — ancien ID {shortId}… remplacé.",
+        "messageRegenerateError": "Erreur régénération : {error}",
+        "messageRegenerateErrorGeneric": "Erreur régénération.",
+        "archive": {
+          "ariaLabel": "Archive des rapports mensuels",
+          "title": "Archive · derniers rapports",
+          "subtitle": "Un rapport par mois · le plus récent en premier",
+          "empty": "Aucun rapport pour l'instant. Clique « Rapport mensuel » ou « Backfill 12 mois ».",
+          "rgpdNoticeTitle": "Régénération & conformité RGPD",
+          "rgpdNoticeBody": "Chaque rapport est figé au moment de sa génération (Art. 5.2, principe d'exactitude et de traçabilité). Une régénération crée un nouveau document ; l'ancien est conservé dans le système et reste consultable via le journal d'audit. Toute action est tracée (qui, quand, depuis quelle IP).",
+          "statusReady": "Prêt",
+          "statusPending": "En cours…",
+          "statusFailed": "Échec",
+          "generatedAt": "Généré le {date}",
+          "errorPlaceholder": "Erreur",
+          "downloadPdf": "PDF",
+          "regenerate": "Régénérer",
+          "regenerateTitle": "Régénère le rapport avec le code et les données actuels. L'ancien sera conservé pour la traçabilité RGPD.",
+          "regenerateConfirm": "Régénérer le rapport de {month} ?\n\nUn nouveau PDF sera généré avec le code et les données actuels. L'ancien rapport sera marqué comme remplacé mais restera dans le système (conformité RGPD Art. 5.2 — traçabilité de chaque génération).\n\nCette action est tracée dans le journal d'audit."
+        }
+      },
       "filters": {
         "currencyAria": "Devise",
         "currencyAll": "Toutes devises (éq. EUR)",
         "tenantAria": "Tenant",
-        "tenantAll": "Tous les tenants"
+        "tenantAll": "Tous les tenants",
+        "tenantSelected": "tenant sélectionné"
       },
       "alertStrip": {
         "body": "{count, plural, =1 {1 tenant en alerte} other {# tenants en alerte}} — détracteurs croisés avec un signal de churn. À contacter cette semaine.",
@@ -1205,10 +1246,13 @@
       },
       "health": {
         "npsLabel": "NPS tenants",
+        "npsShort": "NPS",
         "npsInfo": "Indicateur retardé — le PMF est l'indicateur principal.",
         "npsUnit": "/ 100",
         "npsLegacy": "indicateur retardé · legacy",
+        "npsHistoric": "indicateur historique",
         "csatLabel": "CSAT support",
+        "csatLabelFull": "CSAT post-ticket",
         "csatInfo": "Post-ticket (1-5). Collecté en continu.",
         "csatUnit": "/ 5",
         "csatFreshLabel": "à jour · {days} j",
@@ -1216,7 +1260,100 @@
         "recontactInfo": "Détracteurs × signal comportemental — votre liste CSM.",
         "recontactUnit": "tenants",
         "recontactCta": "Voir la liste",
-        "surveyFreshAria": "Dernière enquête il y a {days} j"
+        "surveyFreshAria": "Dernière enquête il y a {days} j",
+        "sectionHint": "PMF · NPS · CSAT"
+      },
+      "freshness": {
+        "fresh": "à jour",
+        "soon": "bientôt périmé",
+        "stale": "périmé"
+      },
+      "cacheFlush": {
+        "successToast": "Cache vidé · {keysDeleted, plural, =0 {aucune entrée supprimée} =1 {1 entrée supprimée} other {# entrées supprimées}}",
+        "errorToast": "Le flush a échoué — réessayez dans une minute.",
+        "busy": "Flush en cours…",
+        "cta": "Forcer un rafraîchissement"
+      },
+      "viewLoadedAt": "Cette vue a été chargée à {timestamp}. Source : <code>/v1/superadmin/finance/summary</code>. Cache 5 min. Toute consultation est tracée dans <code>audit_logs</code>.",
+      "heroAlert": {
+        "bodyRich": "<b>{count, plural, =1 {1 tenant en alerte} other {# tenants en alerte}}</b> — détracteurs croisés avec un signal de churn. À contacter cette semaine.",
+        "cta": "Voir la liste →"
+      },
+      "mobilisationHero": {
+        "title": "Score de Mobilisation",
+        "titleInfo": "Indicateur de santé du fundraising — pas un score d'impact bénéficiaire.",
+        "outOf": "/ 100",
+        "deltaPlaceholder": "—",
+        "periodLabel": "vs période préc. · moy. pondérée volume",
+        "footnoteRich": "Santé du fundraising agrégée sur <b>{count} tenants</b>. Un score A en médico-social ≠ un A en culture — privilégier le <b>delta</b> à l'absolu."
+      },
+      "formulaHero": {
+        "title": "Composantes · moyenne plateforme",
+        "footnoteRich": "La décomposition est affichée par <b>transparence</b>. Chaque composante est plafonnée à 100 avant pondération."
+      },
+      "kpisExtra": {
+        "recurringSuffix": "/mois",
+        "recurringFoot": "{share}% du volume · pledges actifs",
+        "volumeFoot": "{count} dons · vs période préc.",
+        "stripeFoot": "~{rate}% du volume carte",
+        "revenueFoot": "take-rate {rate}%",
+        "revenueInfoTitle": "1,5% + 0,30€ par don cleared. Normalisé en EUR.",
+        "recurringInfoTitle": "Part du revenu issue de pledges actifs. Revenu prévisible.",
+        "stripeInfoTitle": "Rail Stripe uniquement. Déduit du compte de la NPO."
+      },
+      "chartLabels": {
+        "ariaLabel": "Évolution du volume et du revenu",
+        "volumeLabel": "Volume",
+        "revenueLabel": "Revenu"
+      },
+      "riskExtra": {
+        "concentrationLabelWithHhi": "Concentration (HHI)",
+        "concentrationInfoTitle": "HHI = somme des carrés des parts. < 0,15 = bien diversifié.",
+        "concentrationTopTenant": "Top tenant = {pct} %",
+        "concentrationBadgeWatch": "À surveiller",
+        "concentrationBadgeAlert": "Trop concentré",
+        "activeTenantsInfoTitle": "Au moins 1 don cleared sur la période.",
+        "activeTenantsSecondary": "{active}% actifs · {dormant} dormants",
+        "failureLabelFull": "Taux d'échec paiement",
+        "failureInfoTitle": "Stripe uniquement (Mollie non instrumenté).",
+        "failureFootnote": "Sur l'ensemble des tentatives Stripe sur la période."
+      },
+      "pmfExtra": {
+        "titleFull": "Product/Market Fit (Sean Ellis)",
+        "headlineRich": "« Très déçus » si Givernance disparaît. Seuil PMF = <b>40%</b>.",
+        "ariaLabel": "PMF: {pct}% très déçus",
+        "segmentSomewhat": "moyennement",
+        "segmentNot": "pas déçus",
+        "markerLabelShort": "40% seuil",
+        "legendVeryRich": "<b>Très déçus</b> : signal positif",
+        "noResponsesYet": "Pas encore de réponses PMF. Lance un envoi pour collecter."
+      },
+      "topTenantsCard": {
+        "title": "Top tenants · volume",
+        "subtitle": "Par volume de dons clearés sur la période",
+        "headerName": "Tenant · part",
+        "headerScore": "Score",
+        "headerVolume": "Volume",
+        "donationsCountSuffix": "{count, plural, =1 {1 don} other {# dons}}",
+        "empty": "Aucun tenant avec dons sur la période."
+      },
+      "refundCard": {
+        "subtitle": "Sain < 1% · alerte > 5%",
+        "tick0": "0%",
+        "tick1": "1%",
+        "tick2": "5%",
+        "tick3": "8%+",
+        "amountSuffix": "{amount} remboursés."
+      },
+      "currenciesCard": {
+        "subtitle": "Répartition du volume"
+      },
+      "histogramExtra": {
+        "label": "Répartition · {count} tenants",
+        "gameScore": "Score : {score} · {timeLeft}s",
+        "gameOver": "Game over — score final : {score}",
+        "footnoteFull": "Distribution sur {count} tenants. Tenants avec < 5 donateurs uniques exclus (k-anonymity).",
+        "barAriaItem": "{count} tenants {grade}"
       }
     }
   },

--- a/packages/web/src/models/superadmin-finance.ts
+++ b/packages/web/src/models/superadmin-finance.ts
@@ -148,3 +148,10 @@ export interface MonthlyReport {
 export interface MonthlyReportResponse {
   data: MonthlyReport;
 }
+
+export interface BackfillResponse {
+  data: {
+    enqueued: MonthlyReport[];
+    skipped: MonthlyReport[];
+  };
+}

--- a/packages/web/src/models/superadmin-finance.ts
+++ b/packages/web/src/models/superadmin-finance.ts
@@ -128,3 +128,23 @@ export interface SurveyLaunchResponse {
     launchedAt: string;
   };
 }
+
+// ─── Monthly platform finance report (issue #443) ──────────────────────────
+
+export type MonthlyReportStatus = "pending" | "ready" | "failed";
+
+export interface MonthlyReport {
+  id: string;
+  /** YYYY-MM */
+  month: string;
+  status: MonthlyReportStatus;
+  failureReason: string | null;
+  createdAt: string;
+  readyAt: string | null;
+  /** Path-relative URL of the streamed PDF (null until status='ready'). */
+  pdfUrl: string | null;
+}
+
+export interface MonthlyReportResponse {
+  data: MonthlyReport;
+}

--- a/packages/web/src/services/SuperAdminFinanceService.ts
+++ b/packages/web/src/services/SuperAdminFinanceService.ts
@@ -108,6 +108,15 @@ export const SuperAdminFinanceService = {
   },
 
   /**
+   * List the most recent monthly reports, one row per month (the API
+   * deduplicates and prefers `ready` over `pending`/`failed`).
+   */
+  async listReports(client: ApiClient): Promise<MonthlyReport[]> {
+    const response = await client.get<{ data: MonthlyReport[] }>("/v1/superadmin/finance/reports");
+    return response.data;
+  },
+
+  /**
    * Backfill — request reports for each of the last 12 fully-completed
    * months that doesn't yet have a live row. Idempotent; existing
    * pending/ready rows are reported as `skipped`. Rate-limited

--- a/packages/web/src/services/SuperAdminFinanceService.ts
+++ b/packages/web/src/services/SuperAdminFinanceService.ts
@@ -12,6 +12,7 @@
 
 import type { ApiClient } from "@/lib/api";
 import type {
+  BackfillResponse,
   FinancePeriod,
   FinanceSummary,
   FinanceSummaryResponse,
@@ -102,6 +103,20 @@ export const SuperAdminFinanceService = {
   async fetchReport(client: ApiClient, id: string): Promise<MonthlyReport> {
     const response = await client.get<MonthlyReportResponse>(
       `/v1/superadmin/finance/reports/${encodeURIComponent(id)}`,
+    );
+    return response.data;
+  },
+
+  /**
+   * Backfill — request reports for each of the last 12 fully-completed
+   * months that doesn't yet have a live row. Idempotent; existing
+   * pending/ready rows are reported as `skipped`. Rate-limited
+   * server-side (2/min/IP).
+   */
+  async backfillReports(client: ApiClient): Promise<BackfillResponse["data"]> {
+    const response = await client.post<BackfillResponse>(
+      "/v1/superadmin/finance/reports/backfill",
+      {},
     );
     return response.data;
   },

--- a/packages/web/src/services/SuperAdminFinanceService.ts
+++ b/packages/web/src/services/SuperAdminFinanceService.ts
@@ -15,6 +15,8 @@ import type {
   FinancePeriod,
   FinanceSummary,
   FinanceSummaryResponse,
+  MonthlyReport,
+  MonthlyReportResponse,
   SurveyLaunchResponse,
 } from "@/models/superadmin-finance";
 
@@ -75,6 +77,32 @@ export const SuperAdminFinanceService = {
     const response = await client.post<{
       data: { keysDeleted: number; pattern: string };
     }>("/v1/superadmin/finance/cache/flush", {});
+    return response.data;
+  },
+
+  /**
+   * Request generation of the monthly platform finance report PDF
+   * (issue #443). Idempotent on the target month — same-month replays
+   * return the existing pending/ready row. Pass an explicit `month`
+   * to re-run an older period; default is the most recent
+   * fully-completed calendar month (server-resolved).
+   */
+  async requestMonthlyReport(
+    client: ApiClient,
+    body: { month?: string } = {},
+  ): Promise<MonthlyReport> {
+    const response = await client.post<MonthlyReportResponse>(
+      "/v1/superadmin/finance/reports/monthly",
+      body,
+    );
+    return response.data;
+  },
+
+  /** Poll the report's status until `ready` or `failed`. */
+  async fetchReport(client: ApiClient, id: string): Promise<MonthlyReport> {
+    const response = await client.get<MonthlyReportResponse>(
+      `/v1/superadmin/finance/reports/${encodeURIComponent(id)}`,
+    );
     return response.data;
   },
 };

--- a/packages/web/src/services/SuperAdminFinanceService.ts
+++ b/packages/web/src/services/SuperAdminFinanceService.ts
@@ -117,6 +117,22 @@ export const SuperAdminFinanceService = {
   },
 
   /**
+   * Regenerate an existing report — marks the source row as
+   * superseded and enqueues a fresh PDF for the same month using
+   * the current SQL + renderer. The old row stays in the system
+   * for RGPD Art. 5.2 accountability.
+   */
+  async regenerateReport(
+    client: ApiClient,
+    id: string,
+  ): Promise<{ newReport: MonthlyReport; supersededReport: MonthlyReport }> {
+    const response = await client.post<{
+      data: { newReport: MonthlyReport; supersededReport: MonthlyReport };
+    }>(`/v1/superadmin/finance/reports/${encodeURIComponent(id)}/regenerate`, {});
+    return response.data;
+  },
+
+  /**
    * Backfill — request reports for each of the last 12 fully-completed
    * months that doesn't yet have a live row. Idempotent; existing
    * pending/ready rows are reported as `skipped`. Rate-limited

--- a/packages/web/src/tests/setup.tsx
+++ b/packages/web/src/tests/setup.tsx
@@ -45,8 +45,58 @@ vi.mock("next/link", () => ({
 
 vi.mock("next-intl", () => ({
   useLocale: () => "en",
-  useTranslations: (namespace?: string) => (key: string, values?: Record<string, unknown>) =>
-    interpolate(lookupMessage(namespace ? `${namespace}.${key}` : key), values),
+  useTranslations: (namespace?: string) => {
+    // Plain string interpolation — drops any function-typed `values`
+    // (used by `t.rich` for inline tag formatters like
+    // `b: (chunks) => <b>{chunks}</b>`) so a non-rich call doesn't
+    // crash trying to coerce a function to a string.
+    const scalarValues = (values?: Record<string, unknown>) => {
+      if (!values) return undefined;
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(values)) {
+        if (typeof v !== "function") out[k] = v;
+      }
+      return out;
+    };
+    const translate = (key: string, values?: Record<string, unknown>) =>
+      interpolate(lookupMessage(namespace ? `${namespace}.${key}` : key), scalarValues(values));
+    // `t.rich` returns a ReactNode in production — it invokes the
+    // formatter functions on the inner text between matching tags
+    // (e.g. `<b>foo</b>` → `b("foo")`). The shape here is a
+    // best-effort mock: invoke every function-valued formatter with
+    // the message string so the rendered tree contains the elements,
+    // then just return the string itself for any leftover plain
+    // values. Tests rarely assert against rich content directly; this
+    // is enough to prevent `t.rich is not a function` crashes during
+    // render.
+    const rich = (key: string, values?: Record<string, unknown>): React.ReactNode => {
+      const raw = interpolate(
+        lookupMessage(namespace ? `${namespace}.${key}` : key),
+        scalarValues(values),
+      );
+      if (!values) return raw;
+      const fragments: React.ReactNode[] = [];
+      let remaining = raw;
+      for (const [k, v] of Object.entries(values)) {
+        if (typeof v !== "function") continue;
+        const tagRegex = new RegExp(`<${k}>(.*?)</${k}>`, "g");
+        const matches = [...remaining.matchAll(tagRegex)];
+        if (matches.length === 0) continue;
+        let lastIndex = 0;
+        const formatter = v as (chunks: string) => React.ReactNode;
+        for (const match of matches) {
+          if (match.index === undefined) continue;
+          if (match.index > lastIndex) fragments.push(remaining.slice(lastIndex, match.index));
+          fragments.push(formatter(match[1] ?? ""));
+          lastIndex = match.index + match[0].length;
+        }
+        remaining = remaining.slice(lastIndex);
+      }
+      if (remaining) fragments.push(remaining);
+      return fragments.length > 0 ? fragments : raw;
+    };
+    return Object.assign(translate, { rich });
+  },
 }));
 
 vi.mock("@/components/ui/toast", () => ({

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -55,6 +55,15 @@ const EnvSchema = Type.Object({
    * exposes them off-server. ADR-023.
    */
   S3_BULK_IMPORT_BUCKET: Type.String({ minLength: 1, default: "bulk-imports" }),
+  /**
+   * S3 bucket for super-admin monthly finance reports (issue #443).
+   * **Private** — the PDF aggregates cross-tenant donation volume,
+   * platform revenue, Stripe fees and tenant-level Mobilisation Score.
+   * Served back through the API only (streaming-through-API per issue
+   * #214); never via presigned URL nor public-read. Key shape:
+   * `monthly/{YYYY-MM}/{report_id}.pdf`. ADR-023.
+   */
+  S3_REPORTS_BUCKET: Type.String({ minLength: 1, default: "reports" }),
   /** S3 region */
   S3_REGION: Type.String({ minLength: 1, default: "us-east-1" }),
   /**

--- a/packages/worker/src/lib/s3.ts
+++ b/packages/worker/src/lib/s3.ts
@@ -97,6 +97,21 @@ export async function streamArchiveToS3(
   return key;
 }
 
+/**
+ * Upload a platform monthly finance report PDF (issue #443) to the
+ * private reports bucket. Key shape: `monthly/{YYYY-MM}/{reportId}.pdf`
+ * — no tenant prefix because the report aggregates platform-wide
+ * cross-tenant data and is consumed by super-admins only.
+ */
+export async function uploadPlatformReportPdf(
+  month: string,
+  reportId: string,
+  doc: NodeJS.ReadableStream,
+): Promise<string> {
+  const key = `monthly/${month}/${reportId}.pdf`;
+  return streamPdfToS3(env.S3_REPORTS_BUCKET, key, doc);
+}
+
 /** Upload a postal-export ZIP to the campaigns bucket. */
 export async function uploadCampaignZip(
   tenantId: string,

--- a/packages/worker/src/processors/generate-monthly-finance-report.ts
+++ b/packages/worker/src/processors/generate-monthly-finance-report.ts
@@ -1,0 +1,109 @@
+/**
+ * Worker processor — generate the super-admin monthly finance report
+ * PDF (issue #443).
+ *
+ * Input: `{ reportId, month, traceparent? }`. The API already wrote
+ * the row with `status='pending'` and `kpi_snapshot` set; this
+ * processor:
+ *   1. Loads the row (under `systemDb` — platform-level table, no RLS).
+ *   2. Renders the PDF from `kpi_snapshot`.
+ *   3. Streams the PDF into `S3_REPORTS_BUCKET`.
+ *   4. UPDATEs the row to `status='ready'` + `pdf_s3_key` + `ready_at`.
+ *
+ * Failure path: a thrown error sets `status='failed'` + `failure_reason`
+ * before re-raising so BullMQ can apply its retry policy. The partial
+ * unique index is scoped to `('pending','ready')` so a `failed` row
+ * does not block a subsequent re-POST.
+ */
+
+import { platformFinanceReports } from "@givernance/shared/schema";
+import type { Job } from "bullmq";
+import { eq } from "drizzle-orm";
+// `db` is the owner pool (BYPASSRLS) — appropriate for a platform-level
+// table that has no `org_id` and explicitly REVOKEs grants from the
+// app role.
+import { db as systemDb } from "../lib/db.js";
+import { jobLogger } from "../lib/logger.js";
+import { uploadPlatformReportPdf } from "../lib/s3.js";
+import { extractTraceId } from "../lib/trace-context.js";
+import {
+  createPlatformReportPdfStream,
+  type ReportSnapshot,
+} from "../services/platform-report-pdf.js";
+
+interface JobData {
+  reportId: string;
+  month: string;
+  traceparent?: string;
+}
+
+export async function processGenerateMonthlyFinanceReport(job: Job<JobData>): Promise<void> {
+  const { reportId, month, traceparent } = job.data;
+
+  const log = jobLogger({
+    jobId: job.id,
+    traceId: extractTraceId(traceparent),
+  });
+  log.info({ reportId, month }, "Generating monthly platform finance report");
+  job.log(`Generating monthly platform finance report ${reportId} (month=${month})`);
+
+  const [row] = await systemDb
+    .select()
+    .from(platformFinanceReports)
+    .where(eq(platformFinanceReports.id, reportId))
+    .limit(1);
+
+  if (!row) {
+    throw new Error(`platform_finance_reports row ${reportId} not found`);
+  }
+
+  if (row.status === "ready") {
+    log.info({ reportId }, "Report already ready — idempotent no-op");
+    return;
+  }
+
+  if (!row.kpiSnapshot) {
+    // The API always writes the snapshot before enqueueing; a missing
+    // snapshot means the row was inserted by an out-of-band path (test
+    // bypass, manual SQL) and the worker has nothing to render.
+    await failRow(reportId, "kpi_snapshot is NULL — refusing to render an empty report");
+    throw new Error(`platform_finance_reports.kpi_snapshot is NULL for ${reportId}`);
+  }
+
+  try {
+    const snapshot = row.kpiSnapshot as ReportSnapshot;
+    const generatedAt = new Date();
+    const pdfStream = createPlatformReportPdfStream({
+      reportId,
+      month,
+      snapshot,
+      generatedAt,
+    });
+
+    const s3Key = await uploadPlatformReportPdf(month, reportId, pdfStream);
+
+    await systemDb
+      .update(platformFinanceReports)
+      .set({
+        status: "ready",
+        pdfS3Key: s3Key,
+        readyAt: generatedAt,
+        // Clear any previous failure reason from an earlier attempt.
+        failureReason: null,
+      })
+      .where(eq(platformFinanceReports.id, reportId));
+
+    log.info({ reportId, month, s3Key }, "Monthly finance report ready");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await failRow(reportId, message);
+    throw err;
+  }
+}
+
+async function failRow(reportId: string, reason: string): Promise<void> {
+  await systemDb
+    .update(platformFinanceReports)
+    .set({ status: "failed", failureReason: reason })
+    .where(eq(platformFinanceReports.id, reportId));
+}

--- a/packages/worker/src/services/platform-report-pdf.ts
+++ b/packages/worker/src/services/platform-report-pdf.ts
@@ -1,0 +1,627 @@
+/**
+ * PDF renderer for the super-admin monthly finance report (issue #443).
+ *
+ * Input: the frozen `kpi_snapshot` JSON the API built before enqueuing
+ * the job (full `SummaryServiceResult` payload). Output: a PDFKit
+ * Readable that `uploadPlatformReportPdf` streams directly into the
+ * private `reports` bucket.
+ *
+ * Layout follows the issue's 5-section spec:
+ *   1. Cover — month, tenant count, generation date, platform grade
+ *   2. KPIs — volume, revenue, MRR, Stripe fees, refunds, deltas
+ *   3. Top 10 tenants by volume with Mobilisation grade
+ *   4. Survey snapshot (PMF / NPS / CSAT) gated on k-anonymity
+ *   5. Footer — disclaimer + data source path
+ *
+ * Locale: French — the dashboard ships fr-FR, and the report is a
+ * direct PDF mirror of the dashboard. An i18n table for this PDF is
+ * deferred to a follow-up; one locale string lives at the top so a
+ * future translator only needs to edit one file.
+ */
+
+import PDFDocument from "pdfkit";
+
+// ─── Frozen snapshot shape ─────────────────────────────────────────────────
+//
+// Mirrors the `SummaryServiceResult` exported by
+// `packages/api/src/modules/superadmin/finance/service.ts`. Duplicated
+// here (not imported) because the worker cannot depend on @givernance/api.
+// The structural shape is the contract — kept in lockstep with the API
+// type by the `kpi_snapshot` integration test (issue #443).
+
+export interface ReportSnapshot {
+  period: {
+    from: string;
+    to: string;
+    label: string;
+    comparisonFrom: string;
+    comparisonTo: string;
+  };
+  kpis: {
+    volumeCents: number;
+    platformFeeCents: number;
+    stripeFeeCents: number | null;
+    donorCount: number;
+    refundedVolumeCents: number;
+    recurringMrrCents: number;
+    activeTenantsCount: number;
+    paymentFailureRate: number | null;
+    hhi: number;
+    deltas: {
+      volumePercent: number;
+      platformFeePercent: number;
+      stripeFeePercent: number | null;
+      donorCountPercent: number;
+      refundedVolumePercent: number;
+      recurringMrrPercent: number;
+    };
+  };
+  mobilisation: {
+    platformGrade: "A+" | "A" | "B" | "C" | "D" | null;
+    platformScore: number | null;
+    perTenant: Array<{
+      tenantId: string;
+      tenantName: string;
+      grade: "A+" | "A" | "B" | "C" | "D" | null;
+      score: number | null;
+      isAnonymised: boolean;
+    }>;
+  };
+  surveys: Array<{
+    kind: "pmf" | "nps" | "csat";
+    slug: string;
+    responseCount: number;
+    invitedCount: number;
+    pmfPercent: number | null;
+    npsScore: number | null;
+    csatScore: number | null;
+    isStatisticallySignificant: boolean;
+  }>;
+  perTenant: Array<{
+    tenantId: string;
+    tenantName: string;
+    volumeCents: number;
+    platformFeeCents: number;
+    donationCount: number;
+  }>;
+}
+
+export interface PlatformReportPdfInput {
+  reportId: string;
+  month: string;
+  snapshot: ReportSnapshot;
+  generatedAt: Date;
+}
+
+// ─── Brand palette — mirror packages/web/src/app/globals.css ──────────────
+const COLOR_PRIMARY = "#096447";
+const COLOR_ON_SURFACE = "#1c1b1a";
+const COLOR_ON_SURFACE_VARIANT = "#42403e";
+const COLOR_OUTLINE = "#72706e";
+const COLOR_OUTLINE_VARIANT = "#c3c1bc";
+const COLOR_SURFACE_CONTAINER = "#f2f0ec";
+const COLOR_ERROR = "#ba1a1a";
+
+// ─── Page geometry — A4 portrait, 50pt margins ─────────────────────────────
+const PAGE_WIDTH = 595.28;
+const PAGE_HEIGHT = 841.89;
+const MARGIN_LEFT = 50;
+const MARGIN_RIGHT = 50;
+const CONTENT_LEFT = MARGIN_LEFT;
+const CONTENT_RIGHT = PAGE_WIDTH - MARGIN_RIGHT;
+const CONTENT_WIDTH = CONTENT_RIGHT - CONTENT_LEFT;
+
+// KPI table columns (left edges).
+const KPI_COL_LABEL_X = CONTENT_LEFT;
+const KPI_COL_LABEL_W = 240;
+const KPI_COL_VALUE_X = CONTENT_LEFT + 260;
+const KPI_COL_VALUE_W = 130;
+const KPI_COL_DELTA_X = CONTENT_LEFT + 400;
+const KPI_COL_DELTA_W = CONTENT_RIGHT - (CONTENT_LEFT + 400);
+
+// Top-tenants table columns.
+//
+// Geometry (CONTENT_LEFT=50, CONTENT_RIGHT=~545, CONTENT_WIDTH=~495):
+//   NAME    [  50 → 280 ]  W=230  (left-aligned, ellipsised)
+//   VOLUME  [ 290 → 400 ]  W=110  (right-aligned, bold)
+//   DONS    [ 410 → 470 ]  W=60   (right-aligned, subdued)
+//   GRADE   [ 480 → 545 ]  W=65   (right-aligned, primary green)
+const T_COL_NAME_X = CONTENT_LEFT;
+const T_COL_NAME_W = 230;
+const T_COL_AMOUNT_X = CONTENT_LEFT + 240;
+const T_COL_AMOUNT_W = 110;
+const T_COL_COUNT_X = CONTENT_LEFT + 360;
+const T_COL_COUNT_W = 60;
+const T_COL_GRADE_X = CONTENT_LEFT + 430;
+const T_COL_GRADE_W = CONTENT_RIGHT - (CONTENT_LEFT + 430);
+
+// ─── Formatters — Helvetica-safe (no narrow NBSP that PDFKit renders as `/`) ─
+// `Intl.NumberFormat("fr-FR")` uses U+202F (narrow no-break space) as
+// the thousand separator since ICU 72. PDFKit's bundled Helvetica
+// can't render that codepoint and substitutes `/`, producing values
+// like `82 /280 €`. We format with regular ASCII spaces instead.
+
+function fmtThousands(n: number): string {
+  // Integer thousand separator with REGULAR space — matches FR
+  // convention visually but stays inside Helvetica's glyph set.
+  const rounded = Math.round(n);
+  const sign = rounded < 0 ? "-" : "";
+  return (
+    sign +
+    Math.abs(rounded)
+      .toString()
+      .replace(/\B(?=(\d{3})+(?!\d))/g, " ")
+  );
+}
+
+function fmtEur(cents: number): string {
+  return `${fmtThousands(cents / 100)} €`;
+}
+
+function fmtCount(n: number): string {
+  return fmtThousands(n);
+}
+
+function fmtDeltaPct(value: number | null): string {
+  if (value === null) return "n/a";
+  // `value` is already a percentage (e.g. 12.4 means +12.4%).
+  const sign = value > 0 ? "+" : "";
+  // FR decimal separator is comma; safe in Helvetica.
+  return `${sign}${value.toFixed(1).replace(".", ",")} %`;
+}
+
+function generationDateLabel(d: Date): string {
+  // `Intl.DateTimeFormat("fr-FR")` uses narrow NBSP too — build the
+  // label manually.
+  const months = [
+    "janv.",
+    "févr.",
+    "mars",
+    "avr.",
+    "mai",
+    "juin",
+    "juil.",
+    "août",
+    "sept.",
+    "oct.",
+    "nov.",
+    "déc.",
+  ];
+  const day = d.getUTCDate();
+  const month = months[d.getUTCMonth()];
+  const year = d.getUTCFullYear();
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${day} ${month} ${year} à ${hh}:${mm} UTC`;
+}
+
+type PdfDoc = InstanceType<typeof PDFDocument>;
+
+function deltaColor(value: number | null): string {
+  if (value === null) return COLOR_OUTLINE;
+  if (value > 0.05) return COLOR_PRIMARY;
+  if (value < -0.05) return COLOR_ERROR;
+  return COLOR_OUTLINE;
+}
+
+/** Horizontal divider line at the current y. */
+function divider(doc: PdfDoc, color = COLOR_OUTLINE_VARIANT): void {
+  const y = doc.y + 4;
+  doc.save();
+  doc.moveTo(CONTENT_LEFT, y).lineTo(CONTENT_RIGHT, y).lineWidth(0.5).strokeColor(color).stroke();
+  doc.restore();
+  doc.y = y + 8;
+}
+
+function sectionTitle(doc: PdfDoc, text: string): void {
+  doc.fillColor(COLOR_PRIMARY).font("Helvetica-Bold").fontSize(13);
+  doc.text(text, CONTENT_LEFT, doc.y, { width: CONTENT_WIDTH, align: "left" });
+  doc.font("Helvetica").fontSize(10).fillColor(COLOR_ON_SURFACE);
+  doc.moveDown(0.4);
+  divider(doc, COLOR_OUTLINE_VARIANT);
+}
+
+// ─── 1. Cover ────────────────────────────────────────────────────────────
+function renderCover(doc: PdfDoc, input: PlatformReportPdfInput): void {
+  const { snapshot, month, generatedAt, reportId } = input;
+
+  // Brand stripe at the top of the page (full-bleed, 6pt tall).
+  doc.save();
+  doc.rect(0, 0, PAGE_WIDTH, 6).fill(COLOR_PRIMARY);
+  doc.restore();
+
+  // Eyebrow.
+  doc.font("Helvetica").fontSize(9).fillColor(COLOR_OUTLINE);
+  doc.text("GIVERNANCE · FINANCE PLATEFORME", CONTENT_LEFT, MARGIN_LEFT, {
+    width: CONTENT_WIDTH,
+    align: "left",
+    characterSpacing: 1.2,
+  });
+
+  // Main title.
+  doc.moveDown(0.3);
+  doc.font("Helvetica-Bold").fontSize(26).fillColor(COLOR_ON_SURFACE);
+  doc.text("Rapport mensuel", CONTENT_LEFT, doc.y, {
+    width: CONTENT_WIDTH,
+    align: "left",
+  });
+
+  // Period.
+  doc.moveDown(0.2);
+  doc.font("Helvetica").fontSize(14).fillColor(COLOR_ON_SURFACE_VARIANT);
+  doc.text(`Période · ${month}`, CONTENT_LEFT, doc.y, {
+    width: CONTENT_WIDTH,
+    align: "left",
+  });
+
+  // Metadata strip.
+  doc.moveDown(0.6);
+  doc.fontSize(9).fillColor(COLOR_OUTLINE);
+  doc.text(`Généré le ${generationDateLabel(generatedAt)} · ID ${reportId}`, CONTENT_LEFT, doc.y, {
+    width: CONTENT_WIDTH,
+    align: "left",
+  });
+
+  doc.moveDown(1.4);
+
+  // Hero card — tenant count + platform grade in a tinted box.
+  const cardY = doc.y;
+  const cardH = 60;
+  doc.save();
+  doc.roundedRect(CONTENT_LEFT, cardY, CONTENT_WIDTH, cardH, 6).fill(COLOR_SURFACE_CONTAINER);
+  doc.restore();
+
+  const tenantCount = snapshot.kpis.activeTenantsCount;
+  const grade = snapshot.mobilisation.platformGrade ?? "—";
+  const score = snapshot.mobilisation.platformScore?.toFixed(0) ?? "—";
+
+  // Left half of the card — tenants.
+  doc.font("Helvetica").fontSize(9).fillColor(COLOR_OUTLINE);
+  doc.text("TENANTS ACTIFS", CONTENT_LEFT + 16, cardY + 12, { characterSpacing: 1.2 });
+  doc.font("Helvetica-Bold").fontSize(22).fillColor(COLOR_ON_SURFACE);
+  doc.text(fmtCount(tenantCount), CONTENT_LEFT + 16, cardY + 24);
+
+  // Right half of the card — Mobilisation score.
+  doc.font("Helvetica").fontSize(9).fillColor(COLOR_OUTLINE);
+  doc.text("SCORE MOBILISATION AGRÉGÉ", CONTENT_LEFT + CONTENT_WIDTH / 2 + 16, cardY + 12, {
+    characterSpacing: 1.2,
+  });
+  doc.font("Helvetica-Bold").fontSize(22).fillColor(COLOR_PRIMARY);
+  doc.text(`${grade}`, CONTENT_LEFT + CONTENT_WIDTH / 2 + 16, cardY + 24);
+  doc.font("Helvetica").fontSize(11).fillColor(COLOR_OUTLINE);
+  doc.text(`${score}/100`, CONTENT_LEFT + CONTENT_WIDTH / 2 + 50, cardY + 32);
+
+  doc.y = cardY + cardH + 18;
+}
+
+// ─── 2. KPIs ─────────────────────────────────────────────────────────────
+interface KpiRow {
+  label: string;
+  value: string;
+  delta: string;
+  deltaValue: number | null;
+  isCost?: boolean;
+}
+
+function buildKpiRows(snapshot: ReportSnapshot): KpiRow[] {
+  const k = snapshot.kpis;
+  return [
+    {
+      label: "Volume des dons",
+      value: fmtEur(k.volumeCents),
+      delta: fmtDeltaPct(k.deltas.volumePercent),
+      deltaValue: k.deltas.volumePercent,
+    },
+    {
+      label: "Revenu Givernance",
+      value: fmtEur(k.platformFeeCents),
+      delta: fmtDeltaPct(k.deltas.platformFeePercent),
+      deltaValue: k.deltas.platformFeePercent,
+    },
+    {
+      label: "Frais Stripe",
+      value: k.stripeFeeCents === null ? "n/a" : fmtEur(k.stripeFeeCents),
+      delta: fmtDeltaPct(k.deltas.stripeFeePercent),
+      deltaValue: k.deltas.stripeFeePercent,
+      isCost: true,
+    },
+    {
+      label: "MRR récurrent (instantané)",
+      value: fmtEur(k.recurringMrrCents),
+      delta: fmtDeltaPct(k.deltas.recurringMrrPercent),
+      deltaValue: k.deltas.recurringMrrPercent,
+    },
+    {
+      label: "Remboursements",
+      value: fmtEur(k.refundedVolumeCents),
+      delta: fmtDeltaPct(k.deltas.refundedVolumePercent),
+      deltaValue: k.deltas.refundedVolumePercent,
+      isCost: true,
+    },
+    {
+      label: "Donateurs uniques",
+      value: fmtCount(k.donorCount),
+      delta: fmtDeltaPct(k.deltas.donorCountPercent),
+      deltaValue: k.deltas.donorCountPercent,
+    },
+    {
+      label: "Taux d'échec paiement (Stripe)",
+      value:
+        k.paymentFailureRate === null
+          ? "n/a"
+          : `${k.paymentFailureRate.toFixed(1).replace(".", ",")} %`,
+      delta: "—",
+      deltaValue: null,
+    },
+    {
+      label: "Concentration HHI",
+      value: fmtThousands(k.hhi),
+      delta: "—",
+      deltaValue: null,
+    },
+  ];
+}
+
+function renderKpis(doc: PdfDoc, snapshot: ReportSnapshot): void {
+  sectionTitle(doc, "Indicateurs financiers");
+
+  const rows = buildKpiRows(snapshot);
+  const rowH = 22;
+  doc.font("Helvetica").fontSize(10);
+
+  for (let i = 0; i < rows.length; i += 1) {
+    const row = rows[i];
+    if (!row) continue;
+    const y = doc.y;
+
+    // Alternating zebra-stripe background for readability.
+    if (i % 2 === 0) {
+      doc.save();
+      doc.rect(CONTENT_LEFT, y - 4, CONTENT_WIDTH, rowH).fill(COLOR_SURFACE_CONTAINER);
+      doc.restore();
+    }
+
+    doc.fillColor(COLOR_ON_SURFACE_VARIANT).font("Helvetica");
+    doc.text(row.label, KPI_COL_LABEL_X + 6, y, { width: KPI_COL_LABEL_W, align: "left" });
+
+    doc.fillColor(COLOR_ON_SURFACE).font("Helvetica-Bold");
+    doc.text(row.value, KPI_COL_VALUE_X, y, { width: KPI_COL_VALUE_W, align: "right" });
+
+    // For cost-type KPIs, an INCREASE is bad — invert the delta color.
+    const baseColor = deltaColor(row.deltaValue);
+    const color =
+      row.isCost && row.deltaValue !== null && Math.abs(row.deltaValue) > 0.05
+        ? row.deltaValue > 0
+          ? COLOR_ERROR
+          : COLOR_PRIMARY
+        : baseColor;
+    doc.fillColor(color).font("Helvetica");
+    doc.text(row.delta, KPI_COL_DELTA_X, y, {
+      width: KPI_COL_DELTA_W - 6,
+      align: "right",
+    });
+
+    doc.y = y + rowH - 4;
+  }
+
+  doc.fillColor(COLOR_ON_SURFACE);
+  doc.moveDown(0.8);
+}
+
+// ─── 3. Top tenants ──────────────────────────────────────────────────────
+function renderTopTenants(doc: PdfDoc, snapshot: ReportSnapshot): void {
+  sectionTitle(doc, "Top 10 tenants par volume");
+
+  const tenantsByVolume = [...snapshot.perTenant]
+    .sort((a, b) => b.volumeCents - a.volumeCents)
+    .slice(0, 10);
+  const gradeByTenantId = new Map(
+    snapshot.mobilisation.perTenant.map((m) => [
+      m.tenantId,
+      m.isAnonymised ? "—" : (m.grade ?? "—"),
+    ]),
+  );
+
+  if (tenantsByVolume.length === 0) {
+    doc.font("Helvetica").fontSize(10).fillColor(COLOR_OUTLINE);
+    doc.text("Aucune donation cleared sur la période.", CONTENT_LEFT, doc.y, {
+      width: CONTENT_WIDTH,
+    });
+    doc.fillColor(COLOR_ON_SURFACE);
+    doc.moveDown(0.8);
+    return;
+  }
+
+  // Column headers.
+  doc.font("Helvetica").fontSize(8).fillColor(COLOR_OUTLINE);
+  const headerY = doc.y;
+  doc.text("TENANT", T_COL_NAME_X, headerY, {
+    width: T_COL_NAME_W,
+    align: "left",
+    characterSpacing: 1.2,
+  });
+  doc.text("VOLUME", T_COL_AMOUNT_X, headerY, {
+    width: T_COL_AMOUNT_W,
+    align: "right",
+    characterSpacing: 1.2,
+  });
+  doc.text("DONS", T_COL_COUNT_X, headerY, {
+    width: T_COL_COUNT_W,
+    align: "right",
+    characterSpacing: 1.2,
+  });
+  doc.text("GRADE", T_COL_GRADE_X, headerY, {
+    width: T_COL_GRADE_W,
+    align: "right",
+    characterSpacing: 1.2,
+  });
+  doc.y = headerY + 14;
+  divider(doc);
+
+  const rowH = 20;
+  doc.font("Helvetica").fontSize(10);
+  for (let i = 0; i < tenantsByVolume.length; i += 1) {
+    const t = tenantsByVolume[i];
+    if (!t) continue;
+    const y = doc.y;
+
+    if (i % 2 === 0) {
+      doc.save();
+      doc.rect(CONTENT_LEFT, y - 4, CONTENT_WIDTH, rowH).fill(COLOR_SURFACE_CONTAINER);
+      doc.restore();
+    }
+
+    doc.fillColor(COLOR_ON_SURFACE).font("Helvetica");
+    doc.text(t.tenantName, T_COL_NAME_X + 6, y, {
+      width: T_COL_NAME_W - 6,
+      align: "left",
+      ellipsis: true,
+    });
+    doc.font("Helvetica-Bold");
+    doc.text(fmtEur(t.volumeCents), T_COL_AMOUNT_X, y, {
+      width: T_COL_AMOUNT_W,
+      align: "right",
+    });
+    doc.font("Helvetica").fillColor(COLOR_ON_SURFACE_VARIANT);
+    doc.text(fmtCount(t.donationCount), T_COL_COUNT_X, y, {
+      width: T_COL_COUNT_W,
+      align: "right",
+    });
+    doc.fillColor(COLOR_PRIMARY).font("Helvetica-Bold");
+    doc.text(gradeByTenantId.get(t.tenantId) ?? "—", T_COL_GRADE_X, y, {
+      width: T_COL_GRADE_W - 6,
+      align: "right",
+    });
+
+    doc.y = y + rowH - 4;
+  }
+
+  doc.fillColor(COLOR_ON_SURFACE);
+  doc.moveDown(0.8);
+}
+
+// ─── 4. Surveys ──────────────────────────────────────────────────────────
+function surveyMetricLabel(s: ReportSnapshot["surveys"][number]): string {
+  if (s.kind === "pmf") {
+    const v = s.pmfPercent === null ? "n/a" : `${s.pmfPercent.toFixed(0)} %`;
+    return v;
+  }
+  if (s.kind === "nps") {
+    return s.npsScore === null ? "n/a" : s.npsScore.toFixed(0);
+  }
+  return s.csatScore === null ? "n/a" : `${s.csatScore.toFixed(1).replace(".", ",")} / 5`;
+}
+
+function renderSurveys(doc: PdfDoc, snapshot: ReportSnapshot): void {
+  sectionTitle(doc, "Satisfaction tenants");
+
+  if (snapshot.surveys.length === 0) {
+    doc.font("Helvetica").fontSize(10).fillColor(COLOR_OUTLINE);
+    doc.text("Aucun sondage activé.", CONTENT_LEFT, doc.y, { width: CONTENT_WIDTH });
+    doc.fillColor(COLOR_ON_SURFACE);
+    doc.moveDown(0.8);
+    return;
+  }
+
+  // One-line layout — all cells share a single y baseline so the slug
+  // can't bleed into the next row's chip.
+  //   KIND     [   0 →  60 ]  W=60   primary bold
+  //   SLUG     [  70 → 270 ]  W=200  subdued
+  //   VALUE    [ 280 → 410 ]  W=130  right-aligned bold
+  //   N=X/Y    [ 420 → end ]         right-aligned subdued
+  const S_KIND_X = CONTENT_LEFT + 6;
+  const S_KIND_W = 60;
+  const S_SLUG_X = CONTENT_LEFT + 70;
+  const S_SLUG_W = 200;
+  const S_VALUE_X = CONTENT_LEFT + 280;
+  const S_VALUE_W = 130;
+  const S_N_X = CONTENT_LEFT + 420;
+  const S_N_W = CONTENT_RIGHT - (CONTENT_LEFT + 420) - 6;
+  const rowH = 22;
+
+  for (let i = 0; i < snapshot.surveys.length; i += 1) {
+    const s = snapshot.surveys[i];
+    if (!s) continue;
+    const y = doc.y;
+
+    if (i % 2 === 0) {
+      doc.save();
+      doc.rect(CONTENT_LEFT, y - 4, CONTENT_WIDTH, rowH).fill(COLOR_SURFACE_CONTAINER);
+      doc.restore();
+    }
+
+    const cellY = y + 4;
+
+    doc.font("Helvetica-Bold").fontSize(11).fillColor(COLOR_PRIMARY);
+    doc.text(s.kind.toUpperCase(), S_KIND_X, cellY, { width: S_KIND_W, align: "left" });
+
+    doc.font("Helvetica").fontSize(8).fillColor(COLOR_OUTLINE);
+    doc.text(s.slug, S_SLUG_X, cellY + 3, {
+      width: S_SLUG_W,
+      align: "left",
+      ellipsis: true,
+    });
+
+    if (!s.isStatisticallySignificant) {
+      doc.font("Helvetica").fontSize(9).fillColor(COLOR_OUTLINE);
+      doc.text(
+        `anonymisé (n=${fmtCount(s.responseCount)} < seuil k-anonymity)`,
+        S_VALUE_X,
+        cellY + 3,
+        { width: CONTENT_RIGHT - S_VALUE_X - 6, align: "right" },
+      );
+    } else {
+      doc.font("Helvetica-Bold").fontSize(12).fillColor(COLOR_ON_SURFACE);
+      doc.text(surveyMetricLabel(s), S_VALUE_X, cellY, {
+        width: S_VALUE_W,
+        align: "right",
+      });
+      doc.font("Helvetica").fontSize(8).fillColor(COLOR_OUTLINE);
+      doc.text(`n=${fmtCount(s.responseCount)}/${fmtCount(s.invitedCount)}`, S_N_X, cellY + 3, {
+        width: S_N_W,
+        align: "right",
+      });
+    }
+
+    doc.y = y + rowH;
+  }
+
+  doc.fillColor(COLOR_ON_SURFACE);
+  doc.moveDown(1);
+}
+
+// ─── 5. Footer ───────────────────────────────────────────────────────────
+function renderFooter(doc: PdfDoc): void {
+  // Footer accent stripe at the very bottom + disclaimer above it.
+  const footerY = PAGE_HEIGHT - MARGIN_LEFT - 26;
+  doc.font("Helvetica").fontSize(7).fillColor(COLOR_OUTLINE);
+  doc.text(
+    "Source : /v1/superadmin/finance/summary · cache 5 min · audit_logs (resource_type=platform_finance_report). " +
+      "Ce rapport agrège des données cross-tenant via le pool BYPASSRLS systemDb et est destiné aux super-administrateurs Givernance uniquement.",
+    CONTENT_LEFT,
+    footerY,
+    { width: CONTENT_WIDTH, align: "left" },
+  );
+  doc.save();
+  doc.rect(0, PAGE_HEIGHT - 6, PAGE_WIDTH, 6).fill(COLOR_PRIMARY);
+  doc.restore();
+}
+
+/**
+ * Render the report as a PDFKit document. The caller pipes the
+ * returned stream straight into the S3 multipart upload — no
+ * intermediate buffering required.
+ */
+export function createPlatformReportPdfStream(input: PlatformReportPdfInput): PdfDoc {
+  const doc = new PDFDocument({ size: "A4", margin: 50 });
+  const { snapshot } = input;
+
+  renderCover(doc, input);
+  renderKpis(doc, snapshot);
+  renderTopTenants(doc, snapshot);
+  renderSurveys(doc, snapshot);
+  renderFooter(doc);
+
+  doc.end();
+  return doc;
+}

--- a/packages/worker/src/services/platform-report-pdf.ts
+++ b/packages/worker/src/services/platform-report-pdf.ts
@@ -365,8 +365,35 @@ function buildKpiRows(snapshot: ReportSnapshot): KpiRow[] {
 function renderKpis(doc: PdfDoc, snapshot: ReportSnapshot): void {
   sectionTitle(doc, "Indicateurs financiers");
 
+  // Column headers — same small-caps style as the tenants table.
+  doc.font("Helvetica").fontSize(8).fillColor(COLOR_OUTLINE);
+  const headerY = doc.y;
+  doc.text("INDICATEUR", KPI_COL_LABEL_X + 6, headerY, {
+    width: KPI_COL_LABEL_W,
+    align: "left",
+    characterSpacing: 1.2,
+  });
+  doc.text("MONTANT", KPI_COL_VALUE_X, headerY, {
+    width: KPI_COL_VALUE_W,
+    align: "right",
+    characterSpacing: 1.2,
+  });
+  doc.text("ÉVOLUTION", KPI_COL_DELTA_X, headerY, {
+    width: KPI_COL_DELTA_W - 6,
+    align: "right",
+    characterSpacing: 1.2,
+  });
+  doc.y = headerY + 14;
+  divider(doc);
+
   const rows = buildKpiRows(snapshot);
-  const rowH = 22;
+  // Row geometry: rect spans exactly [y, y+ROW_H]. Text is padded
+  // inside by ROW_PAD_Y so the baseline sits comfortably above
+  // mid-row. Advance doc.y by ROW_H exactly so the next row's rect
+  // tiles perfectly against the previous one — no overlap, no gap,
+  // no drift between text and its stripe.
+  const ROW_H = 24;
+  const ROW_PAD_Y = 7;
   doc.font("Helvetica").fontSize(10);
 
   for (let i = 0; i < rows.length; i += 1) {
@@ -374,18 +401,27 @@ function renderKpis(doc: PdfDoc, snapshot: ReportSnapshot): void {
     if (!row) continue;
     const y = doc.y;
 
-    // Alternating zebra-stripe background for readability.
     if (i % 2 === 0) {
       doc.save();
-      doc.rect(CONTENT_LEFT, y - 4, CONTENT_WIDTH, rowH).fill(COLOR_SURFACE_CONTAINER);
+      doc.rect(CONTENT_LEFT, y, CONTENT_WIDTH, ROW_H).fill(COLOR_SURFACE_CONTAINER);
       doc.restore();
     }
 
-    doc.fillColor(COLOR_ON_SURFACE_VARIANT).font("Helvetica");
-    doc.text(row.label, KPI_COL_LABEL_X + 6, y, { width: KPI_COL_LABEL_W, align: "left" });
+    const ty = y + ROW_PAD_Y;
 
-    doc.fillColor(COLOR_ON_SURFACE).font("Helvetica-Bold");
-    doc.text(row.value, KPI_COL_VALUE_X, y, { width: KPI_COL_VALUE_W, align: "right" });
+    doc.fillColor(COLOR_ON_SURFACE_VARIANT).font("Helvetica");
+    doc.text(row.label, KPI_COL_LABEL_X + 6, ty, { width: KPI_COL_LABEL_W, align: "left" });
+
+    // Cost KPIs (Frais Stripe, Remboursements) render as accounting
+    // negatives — value prefixed with `- ` and rendered in red — so
+    // an operator scanning the column instantly distinguishes
+    // money-out from money-in. Numeric n/a / non-cost / placeholder
+    // values stay neutral.
+    const isAccountingNegative = row.isCost && row.value !== "n/a" && row.value !== "—";
+    const displayValue = isAccountingNegative ? `- ${row.value}` : row.value;
+    const valueColor = isAccountingNegative ? COLOR_ERROR : COLOR_ON_SURFACE;
+    doc.fillColor(valueColor).font("Helvetica-Bold");
+    doc.text(displayValue, KPI_COL_VALUE_X, ty, { width: KPI_COL_VALUE_W, align: "right" });
 
     // For cost-type KPIs, an INCREASE is bad — invert the delta color.
     const baseColor = deltaColor(row.deltaValue);
@@ -396,12 +432,12 @@ function renderKpis(doc: PdfDoc, snapshot: ReportSnapshot): void {
           : COLOR_PRIMARY
         : baseColor;
     doc.fillColor(color).font("Helvetica");
-    doc.text(row.delta, KPI_COL_DELTA_X, y, {
+    doc.text(row.delta, KPI_COL_DELTA_X, ty, {
       width: KPI_COL_DELTA_W - 6,
       align: "right",
     });
 
-    doc.y = y + rowH - 4;
+    doc.y = y + ROW_H;
   }
 
   doc.fillColor(COLOR_ON_SURFACE);
@@ -458,7 +494,8 @@ function renderTopTenants(doc: PdfDoc, snapshot: ReportSnapshot): void {
   doc.y = headerY + 14;
   divider(doc);
 
-  const rowH = 20;
+  const ROW_H = 22;
+  const ROW_PAD_Y = 6;
   doc.font("Helvetica").fontSize(10);
   for (let i = 0; i < tenantsByVolume.length; i += 1) {
     const t = tenantsByVolume[i];
@@ -467,33 +504,35 @@ function renderTopTenants(doc: PdfDoc, snapshot: ReportSnapshot): void {
 
     if (i % 2 === 0) {
       doc.save();
-      doc.rect(CONTENT_LEFT, y - 4, CONTENT_WIDTH, rowH).fill(COLOR_SURFACE_CONTAINER);
+      doc.rect(CONTENT_LEFT, y, CONTENT_WIDTH, ROW_H).fill(COLOR_SURFACE_CONTAINER);
       doc.restore();
     }
 
+    const ty = y + ROW_PAD_Y;
+
     doc.fillColor(COLOR_ON_SURFACE).font("Helvetica");
-    doc.text(t.tenantName, T_COL_NAME_X + 6, y, {
+    doc.text(t.tenantName, T_COL_NAME_X + 6, ty, {
       width: T_COL_NAME_W - 6,
       align: "left",
       ellipsis: true,
     });
     doc.font("Helvetica-Bold");
-    doc.text(fmtEur(t.volumeCents), T_COL_AMOUNT_X, y, {
+    doc.text(fmtEur(t.volumeCents), T_COL_AMOUNT_X, ty, {
       width: T_COL_AMOUNT_W,
       align: "right",
     });
     doc.font("Helvetica").fillColor(COLOR_ON_SURFACE_VARIANT);
-    doc.text(fmtCount(t.donationCount), T_COL_COUNT_X, y, {
+    doc.text(fmtCount(t.donationCount), T_COL_COUNT_X, ty, {
       width: T_COL_COUNT_W,
       align: "right",
     });
     doc.fillColor(COLOR_PRIMARY).font("Helvetica-Bold");
-    doc.text(gradeByTenantId.get(t.tenantId) ?? "—", T_COL_GRADE_X, y, {
+    doc.text(gradeByTenantId.get(t.tenantId) ?? "—", T_COL_GRADE_X, ty, {
       width: T_COL_GRADE_W - 6,
       align: "right",
     });
 
-    doc.y = y + rowH - 4;
+    doc.y = y + ROW_H;
   }
 
   doc.fillColor(COLOR_ON_SURFACE);
@@ -537,7 +576,35 @@ function renderSurveys(doc: PdfDoc, snapshot: ReportSnapshot): void {
   const S_VALUE_W = 130;
   const S_N_X = CONTENT_LEFT + 420;
   const S_N_W = CONTENT_RIGHT - (CONTENT_LEFT + 420) - 6;
-  const rowH = 22;
+
+  // Column headers — same small-caps style as the other tables.
+  doc.font("Helvetica").fontSize(8).fillColor(COLOR_OUTLINE);
+  const headerY = doc.y;
+  doc.text("TYPE", S_KIND_X, headerY, {
+    width: S_KIND_W,
+    align: "left",
+    characterSpacing: 1.2,
+  });
+  doc.text("SLUG", S_SLUG_X, headerY, {
+    width: S_SLUG_W,
+    align: "left",
+    characterSpacing: 1.2,
+  });
+  doc.text("VALEUR", S_VALUE_X, headerY, {
+    width: S_VALUE_W,
+    align: "right",
+    characterSpacing: 1.2,
+  });
+  doc.text("RÉPONSES", S_N_X, headerY, {
+    width: S_N_W,
+    align: "right",
+    characterSpacing: 1.2,
+  });
+  doc.y = headerY + 14;
+  divider(doc);
+
+  const ROW_H = 26;
+  const ROW_PAD_Y = 7;
 
   for (let i = 0; i < snapshot.surveys.length; i += 1) {
     const s = snapshot.surveys[i];
@@ -546,11 +613,11 @@ function renderSurveys(doc: PdfDoc, snapshot: ReportSnapshot): void {
 
     if (i % 2 === 0) {
       doc.save();
-      doc.rect(CONTENT_LEFT, y - 4, CONTENT_WIDTH, rowH).fill(COLOR_SURFACE_CONTAINER);
+      doc.rect(CONTENT_LEFT, y, CONTENT_WIDTH, ROW_H).fill(COLOR_SURFACE_CONTAINER);
       doc.restore();
     }
 
-    const cellY = y + 4;
+    const cellY = y + ROW_PAD_Y;
 
     doc.font("Helvetica-Bold").fontSize(11).fillColor(COLOR_PRIMARY);
     doc.text(s.kind.toUpperCase(), S_KIND_X, cellY, { width: S_KIND_W, align: "left" });
@@ -583,7 +650,7 @@ function renderSurveys(doc: PdfDoc, snapshot: ReportSnapshot): void {
       });
     }
 
-    doc.y = y + rowH;
+    doc.y = y + ROW_H;
   }
 
   doc.fillColor(COLOR_ON_SURFACE);

--- a/packages/worker/src/services/platform-report-pdf.ts
+++ b/packages/worker/src/services/platform-report-pdf.ts
@@ -300,7 +300,28 @@ interface KpiRow {
   value: string;
   delta: string;
   deltaValue: number | null;
-  isCost?: boolean;
+  /**
+   * Render the value with a `- ` prefix (accounting "money-out"
+   * convention). Visually neutral — NOT a judgment call on whether
+   * the line is good or bad. Frais Stripe and Remboursements both
+   * sit on the cost side of the ledger and use this.
+   */
+  isAccountingNegative?: boolean;
+  /**
+   * Invert the delta colour: a POSITIVE evolution renders red, a
+   * negative one renders green. Only set this when an increase is
+   * unambiguously bad for the platform (Remboursements). Frais Stripe
+   * does NOT invert — Stripe fees grow with donation volume, so an
+   * increase usually mirrors the platform's own commission growth and
+   * is not a problem.
+   */
+  invertDelta?: boolean;
+  /**
+   * Raw cents amount (or null when the value is non-monetary / n/a).
+   * A zero value is neither money out nor money in — we skip the
+   * accounting `- ` prefix when `rawCents === 0`.
+   */
+  rawCents?: number | null;
 }
 
 function buildKpiRows(snapshot: ReportSnapshot): KpiRow[] {
@@ -323,7 +344,10 @@ function buildKpiRows(snapshot: ReportSnapshot): KpiRow[] {
       value: k.stripeFeeCents === null ? "n/a" : fmtEur(k.stripeFeeCents),
       delta: fmtDeltaPct(k.deltas.stripeFeePercent),
       deltaValue: k.deltas.stripeFeePercent,
-      isCost: true,
+      isAccountingNegative: true,
+      // No `invertDelta` — Stripe fees track donation volume, so an
+      // increase usually mirrors the platform's own commission growth.
+      rawCents: k.stripeFeeCents,
     },
     {
       label: "MRR récurrent (instantané)",
@@ -336,7 +360,10 @@ function buildKpiRows(snapshot: ReportSnapshot): KpiRow[] {
       value: fmtEur(k.refundedVolumeCents),
       delta: fmtDeltaPct(k.deltas.refundedVolumePercent),
       deltaValue: k.deltas.refundedVolumePercent,
-      isCost: true,
+      isAccountingNegative: true,
+      // Refunds going up IS a problem (lost revenue + donor friction).
+      invertDelta: true,
+      rawCents: k.refundedVolumeCents,
     },
     {
       label: "Donateurs uniques",
@@ -415,18 +442,31 @@ function renderKpis(doc: PdfDoc, snapshot: ReportSnapshot): void {
     // Cost KPIs (Frais Stripe, Remboursements) render as accounting
     // negatives — value prefixed with `- ` and rendered in red — so
     // an operator scanning the column instantly distinguishes
-    // money-out from money-in. Numeric n/a / non-cost / placeholder
-    // values stay neutral.
-    const isAccountingNegative = row.isCost && row.value !== "n/a" && row.value !== "—";
-    const displayValue = isAccountingNegative ? `- ${row.value}` : row.value;
-    const valueColor = isAccountingNegative ? COLOR_ERROR : COLOR_ON_SURFACE;
-    doc.fillColor(valueColor).font("Helvetica-Bold");
+    // Accounting view — render `- xxx €` for money-out lines (Frais
+    // Stripe, Remboursements). Visually NEUTRAL: no red colour, just
+    // the sign convention so an operator scanning the column tells
+    // money-out from money-in. Skip the prefix when the raw amount
+    // is exactly 0 (a zero cost is neither money out nor in).
+    const showAsNegative =
+      row.isAccountingNegative &&
+      row.value !== "n/a" &&
+      row.value !== "—" &&
+      row.rawCents !== null &&
+      row.rawCents !== undefined &&
+      row.rawCents !== 0;
+    const displayValue = showAsNegative ? `- ${row.value}` : row.value;
+    doc.fillColor(COLOR_ON_SURFACE).font("Helvetica-Bold");
     doc.text(displayValue, KPI_COL_VALUE_X, ty, { width: KPI_COL_VALUE_W, align: "right" });
 
-    // For cost-type KPIs, an INCREASE is bad — invert the delta color.
+    // Delta colour. Default semantics: up = green (good), down = red
+    // (bad). For KPIs flagged `invertDelta` (Remboursements only),
+    // the semantics flip — up = red, down = green. Frais Stripe does
+    // NOT invert because an increase usually correlates with donation
+    // volume growth (more donations = more Stripe fees = more
+    // platform commission), so red would be misleading.
     const baseColor = deltaColor(row.deltaValue);
     const color =
-      row.isCost && row.deltaValue !== null && Math.abs(row.deltaValue) > 0.05
+      row.invertDelta && row.deltaValue !== null && Math.abs(row.deltaValue) > 0.05
         ? row.deltaValue > 0
           ? COLOR_ERROR
           : COLOR_PRIMARY
@@ -663,8 +703,8 @@ function renderFooter(doc: PdfDoc): void {
   const footerY = PAGE_HEIGHT - MARGIN_LEFT - 26;
   doc.font("Helvetica").fontSize(7).fillColor(COLOR_OUTLINE);
   doc.text(
-    "Source : /v1/superadmin/finance/summary · cache 5 min · audit_logs (resource_type=platform_finance_report). " +
-      "Ce rapport agrège des données cross-tenant via le pool BYPASSRLS systemDb et est destiné aux super-administrateurs Givernance uniquement.",
+    "Document interne Givernance · Données consolidées de l'ensemble des organisations clientes, figées au moment de la génération. " +
+      "Réservé aux super-administrateurs. Chaque génération et chaque téléchargement sont enregistrés pour conformité (RGPD Art. 5.2).",
     CONTENT_LEFT,
     footerY,
     { width: CONTENT_WIDTH, align: "left" },

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -23,6 +23,7 @@ import { processConstituentCountRefresh } from "./processors/finance-constituent
 import { processSurveyRetention } from "./processors/finance-survey-retention.js";
 import { processSurveySend } from "./processors/finance-survey-send.js";
 import { processGdprErasure } from "./processors/gdpr-erasure.js";
+import { processGenerateMonthlyFinanceReport } from "./processors/generate-monthly-finance-report.js";
 import { processGenerateReceipt } from "./processors/generate-receipt.js";
 import { processKeycloakSyncOrgLogo } from "./processors/keycloak-sync-org-logo.js";
 import { processNotificationsEmailDigest } from "./processors/notifications-email-digest.js";
@@ -622,6 +623,25 @@ function startWorkers() {
     },
   );
 
+  // Issue #443 — Monthly platform finance report PDF generation.
+  // Concurrency 1 per process: each job runs a PDFKit render + a
+  // multipart S3 upload; the work is bound by S3 upload latency more
+  // than CPU. Scale by adding worker pods, not concurrency. The
+  // partial unique index on the live rows means at most one
+  // in-flight job per month anyway.
+  const platformReportsWorker = new Worker(
+    QUEUE_NAMES.PLATFORM_REPORTS,
+    (job) =>
+      processGenerateMonthlyFinanceReport(
+        job as Job<{ reportId: string; month: string; traceparent?: string }>,
+      ),
+    {
+      connection: createRedisConnection(),
+      concurrency: 1,
+      ...defaultJobOpts,
+    },
+  );
+
   const workers = [
     receiptsWorker,
     emailsWorker,
@@ -636,6 +656,7 @@ function startWorkers() {
     notificationsDigestWorker,
     bulkImportWorker,
     financeDashboardWorker,
+    platformReportsWorker,
   ];
 
   for (const w of workers) {


### PR DESCRIPTION
## Summary

Wires the **Rapport mensuel** button on `/admin/finance` end-to-end. The button was previously hidden per `feedback_no_anticipatory_ui`; this PR ships every layer the issue spec calls for and restores it.

- New `platform_finance_reports` table — partial unique index on `(month) WHERE status IN ('pending','ready')` for same-month idempotency. Frozen `kpi_snapshot` JSONB is the canonical record of the numbers the super-admin saw (GDPR Art. 5(2) accountability).
- API: `POST /v1/superadmin/finance/reports/monthly`, `GET /:id`, `GET /:id/pdf` (streamed-through-API per issue #214). Gated under the existing `ADMIN_FINANCE_DASHBOARD` flag.
- New BullMQ `PLATFORM_REPORTS` queue + worker processor; PDF render via PDFKit, multipart upload to the new private `S3_REPORTS_BUCKET` (ADR-023).
- Frontend button + 2 s polling loop (60-attempt ceiling = DLQ-candidate cutoff) + download trigger.
- Separate `generate` and `download` audit actions.
- [`docs/33-platform-finance-reports.md`](https://github.com/purposestack/givernance/blob/feat/platform-monthly-finance-report/docs/33-platform-finance-reports.md) — full flow + ERD + permissions matrix + GDPR posture.
- Integration tests (RBAC matrix, idempotency, audit trail, validation) + unit tests for calendar-boundary helpers.

close #443

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm test` passes the new `superadmin-monthly-report.test.ts` + `monthly-report.test.ts`
- [ ] `pnpm biome check .` returns 0 errors (warnings only — none new)
- [ ] **Manual**: with `admin.finance_dashboard` ON, super-admin → `/admin/finance` → click "Rapport mensuel" → toast "Génération en cours…" → PDF downloads with FR labels covering KPIs / top-10 tenants / surveys / footer
- [ ] **Manual idempotency**: click "Rapport mensuel" twice in the same month → only one `platform_finance_reports` row, second click returns 200 with the same id
- [ ] **Manual RBAC**: org_admin loading `/admin/finance` → button hidden (flag off via projection); direct POST → 404
- [ ] **Manual flag-off**: toggle the flag off in Back Office → button hidden + POST returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)