### PR TITLE
test(ci): run integration suite under both Postgres roles (#455)

### DIFF
--- a/.claude/agents/mvp-engineer.md
+++ b/.claude/agents/mvp-engineer.md
@@ -163,7 +163,7 @@ export function createDonationReceiptWorker(connection: Redis) {
 3. **Design the service layer first** — write the function signatures with types before the implementation
 4. **Implement routes.ts** referencing the service, with full TypeBox schemas for every input/output
 5. **Write the integration test** alongside the route (not after)
-6. **Run `pnpm typecheck` and `pnpm lint`** before declaring done
+6. **Run `pnpm typecheck` and `pnpm lint`** before declaring done — and run the suite under the `givernance_app` role (`DATABASE_URL_APP_TEST=postgresql://givernance_app:givernance_app_dev@localhost:5432/givernance_test pnpm test`) so a missed `withTenantContext` fails locally, not in the `api-tests-app` CI gate (issue #455)
 7. **Never skip the outbox** for mutations that trigger async work — insert domain_event in the same transaction
 
 ## Output format
@@ -184,6 +184,9 @@ export function createDonationReceiptWorker(connection: Redis) {
 | Offset pagination | Cursor-based pagination always |
 | Hard deletes on user data | Set `deleted_at`, filter in queries |
 | Skipping RLS context | Always `SET LOCAL` before any tenant query |
+| Tenant-scoped read on the bare `db` pool | Wrap in `withTenantContext(orgId, …)` — else it returns 0 rows under `givernance_app` |
+| Cross-tenant / platform-table read on the tenant pool | Use `systemDb` (owner) with a justifying comment — the tenant pool 500s on REVOKE'd tables and can't see other tenants |
+| Importing `db` from `lib/db.js` in a test file | Import from `tests/helpers/db.js` (owner pool) so harness setup survives the `app` test job (issue #455) |
 | Synchronous receipt generation | Emit domain event → BullMQ job → async processing |
 | Duplicating types between packages | Single source of truth in `@givernance/shared` |
 | Missing outbox entry | Every async side effect must go through outbox, never fire-and-forget |

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -100,6 +100,18 @@ describe('GET /constituents', () => {
 
 Integration tests connect only to the `givernance_test` database (app schema, owned by `givernance`). Keycloak is not spun up in CI today. When a Keycloak-dependent e2e test lands, it **must** use a separate `givernance_keycloak_test` database + `keycloak` role — never reuse `givernance_test` or any other co-located schema. Same rule as prod: any new tool that needs Postgres storage gets its own logical DB and its own owner role. Co-locating a third-party service's schema with app tables is rejected at review time. See [ADR-017](../../docs/15-infra-adr.md#adr-017-one-logical-database-per-tool--isolate-keycloak-from-the-application-db).
 
+## Tests run under BOTH Postgres roles — the `app` job is the RLS gate (issue #455)
+
+CI runs the integration suite **twice**: `api-tests-owner` (the `givernance` owner role, BYPASSRLS) and `api-tests-app` (the `givernance_app` NOBYPASSRLS role). **The `app` job is the must-pass gate.** Locally, a bare `pnpm test` runs as the owner role (ergonomic); set `DATABASE_URL_APP_TEST=postgresql://givernance_app:givernance_app_dev@localhost:5432/givernance_test` to reproduce the `app` job before pushing.
+
+Why two roles: when every test ran only as the BYPASSRLS owner, a route that forgot `withTenantContext` (returns 0 rows / 404 under RLS) or that used the tenant pool on a REVOKE'd platform table (permission denied / 500 under `givernance_app`) passed CI green and broke only in dev/staging/prod. The `app` job turns both into RED.
+
+**Route ↔ harness split (do not break it):**
+- **Import `db` / `withTenantContext` in test files from `../helpers/db.js`** (or `../../tests/helpers/db.js` for co-located module tests) — never from `../../lib/db.js`. The helper re-exports the **owner pool**, so fixture setup + cross-tenant seeding + verification reads never trip RLS regardless of which role the *route* pool uses.
+- **The route under test** uses `db` from `lib/db.ts`, which the `app` job points at `givernance_app`. That's the pool whose RLS behaviour you're validating.
+
+**Mandatory for every new test that exercises a tenant-scoped route:** it must pass under `api-tests-app` without bypassing RLS. If a new test only goes green under the owner role, you've found a real route bug (a missing `withTenantContext`, or a wrong `db`-vs-`systemDb` choice on a platform table) — fix the route, not the test. Write at least one assertion that would flip RED if `withTenantContext` were dropped from the route, so the coverage actually exercises the RLS path rather than coincidentally passing.
+
 ## RLS multi-tenancy tests (mandatory for every module)
 
 Every module must have an explicit RLS isolation test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,61 @@ on:
     branches: [main]
 
 jobs:
+  # Static gate: lint, types, i18n parity, build. No database — fast feedback
+  # that's independent of which Postgres role the tests run under.
   check:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Reads the pnpm version from `packageManager` in package.json.
+      # v4 of pnpm/action-setup refuses to run when both `with.version`
+      # and `packageManager` are set, so we keep a single source of truth.
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Biome lint
+        run: pnpm biome check .
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      # ADR-015 (i18n): fail CI if any locale drifts from the source `fr` in
+      # either the web (next-intl) or API (RFC 9457 / email) message tree.
+      - name: Check translation key parity
+        run: pnpm check:translations
+
+      - name: Build
+        run: pnpm build
+
+  # Integration tests, run under BOTH Postgres roles (issue #455):
+  #
+  #   • api-tests-owner — the `db` pool falls back to DATABASE_URL (the
+  #     `givernance` owner role, BYPASSRLS). Ergonomic baseline; matches local
+  #     `pnpm test`.
+  #   • api-tests-app   — DATABASE_URL_APP_TEST points the `db` pool at
+  #     `givernance_app` (NOBYPASSRLS, created by migration 0005). Every route
+  #     query goes through RLS, so a route that forgot `withTenantContext`, or
+  #     that used the tenant pool on a REVOKE'd platform table, fails RED here
+  #     instead of silently passing under the owner role. This is the must-pass
+  #     tenant-isolation gate.
+  #
+  # `fail-fast: false` so a failure under one role still reports the other —
+  # you want to see whether a break is role-specific (an RLS bug) or universal.
+  api-tests:
+    name: api-tests-${{ matrix.role }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        role: [owner, app]
 
     # ADR-017 (one logical DB per tool): CI today only spins up the app DB
     # (`givernance_test`). When Keycloak-dependent e2e tests land, add a
@@ -47,9 +100,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Reads the pnpm version from `packageManager` in package.json.
-      # v4 of pnpm/action-setup refuses to run when both `with.version`
-      # and `packageManager` are set, so we keep a single source of truth.
       - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
@@ -60,22 +110,22 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Biome lint
-        run: pnpm biome check .
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      # ADR-015 (i18n): fail CI if any locale drifts from the source `fr` in
-      # either the web (next-intl) or API (RFC 9457 / email) message tree.
-      - name: Check translation key parity
-        run: pnpm check:translations
-
       - name: Build
         run: pnpm build
 
+      # `givernance_app` (NOBYPASSRLS) is created by migration 0005 with the
+      # baked-in dev password. Migrations run as the owner role (DATABASE_URL).
       - name: Run database migrations
         run: pnpm db:migrate
+
+      # App role only: point the route-path pool at `givernance_app` so RLS is
+      # enforced. `tests/setup.ts` maps DATABASE_URL_APP_TEST → DATABASE_URL_APP
+      # before env validation. The owner leg leaves this unset → BYPASSRLS.
+      - name: Enable app-role (RLS-enforced) pool
+        if: matrix.role == 'app'
+        run: >-
+          echo "DATABASE_URL_APP_TEST=postgresql://givernance_app:givernance_app_dev@localhost:5432/givernance_test"
+          >> "$GITHUB_ENV"
 
       - name: Test
         run: pnpm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,21 @@ Apply this in `gh pr create` / `gh pr edit` bodies, in commit messages that clos
 - [ ] No new `systemDb` use without a comment justifying the cross-tenant intent.
 - [ ] If the query is inside a worker processor, the `withWorkerContext(orgId, …)` wrapper is present AND the inner query carries the explicit `eq(orgId, …)`.
 
+#### Tests run under BOTH roles — the `app` job is the RLS gate (issue #455)
+
+**Integration tests run twice in CI: `api-tests-owner` (BYPASSRLS owner role, ergonomic baseline + local default) and `api-tests-app` (the `givernance_app` NOBYPASSRLS role). The `app` job is the must-pass tenant-isolation gate.** Before this, every test ran only as the owner role, so a route that forgot `withTenantContext` — or that used the tenant pool on a REVOKE'd platform table — passed CI green and broke only in dev/staging/prod. Issue #455 was filed after this bit twice in a single epic (the `survey-pending` 500 + `survey-respond` 404 in PR #454); the `app` job reproduces both as RED.
+
+**The route ↔ harness split is load-bearing — do not break it:**
+- **Route / production code** under test uses `db` from [`packages/api/src/lib/db.ts`](packages/api/src/lib/db.ts). In the `app` job this pool connects as `givernance_app`, so RLS is enforced exactly as in prod.
+- **Test-harness code** (fixture setup + cross-tenant seeding + verification reads) imports `db` from [`packages/api/src/tests/helpers/db.js`](packages/api/src/tests/helpers/db.ts), which re-exports the **owner pool**. Harness ops legitimately span tenants without an `app.current_organization_id` in scope — that's what the owner role is for — so they never spuriously fail under the `app` job. **Never import `db` from `lib/db.js` in a test file; always import from `tests/helpers/db.js`.** (`withTenantContext` is re-exported there too, for harness reads that genuinely want to exercise RLS.)
+
+**New-rule for every new test file that exercises a tenant-scoped route:** it MUST pass under `api-tests-app` without bypassing RLS. Concretely — the route it tests must set tenant context (`withTenantContext` / `withWorkerContext`) for tenant-scoped queries, or use `systemDb` (with a justifying comment) for legitimate cross-tenant / platform-table reads. If a brand-new test only passes under the owner role, that is a real route bug, not a test-harness quirk — fix the route, not the test.
+
+**Reviewer checklist (dual-role testing):**
+- [ ] Test files import `db` / `withTenantContext` from `../helpers/db.js` (or `../../tests/helpers/db.js` for co-located module tests), never from `lib/db.js`.
+- [ ] Any new tenant-scoped route is covered by a test that would 404/500 under `api-tests-app` if `withTenantContext` were dropped (i.e. the coverage actually exercises the RLS path).
+- [ ] Cross-tenant / platform-table reads in a route use `systemDb` with a comment; tenant-scoped reads use `withTenantContext`.
+
 ### 🛑 No secrets in Keycloak Organization attributes (issue #114)
 
 **Never put secrets, API keys, billing tokens, or any sensitive data into a Keycloak Organization's `attributes` map.** The `organization` client scope (attached as default to `givernance-web` and as optional to `admin-cli`) carries an `oidc-organization-membership-mapper` configured with `addOrganizationAttributes=true`, which emits every organization attribute into every access, ID, and introspection token for members of that org. Any secret stashed there will leak to the browser and every downstream service that sees the JWT.

--- a/packages/api/src/lib/flags/flag-service.ts
+++ b/packages/api/src/lib/flags/flag-service.ts
@@ -132,10 +132,21 @@ async function loadTenantFromDb(
   conn: NodePgDatabase<Record<string, never>>,
   orgId: string,
 ): Promise<Record<string, boolean>> {
-  const rows = await conn
-    .select({ flagKey: tenantFlagOverrides.flagKey, value: tenantFlagOverrides.value })
-    .from(tenantFlagOverrides)
-    .where(eq(tenantFlagOverrides.tenantId, orgId));
+  // `tenant_flag_overrides` has FORCE RLS (policy
+  // `tenant_id = app_current_organization_id()`). The evaluator runs on the
+  // `givernance_app` (NOBYPASSRLS) pool, so we MUST set the RLS GUC inside the
+  // read transaction — otherwise the policy filters every row and the
+  // evaluator silently falls back to the platform default for every flag
+  // (issue #455). We set the GUC on the passed `conn` rather than calling
+  // `withTenantContext` so the test-seam (`deps.db`) is still honoured; an
+  // owner-pool conn simply ignores the (harmless) GUC.
+  const rows = await conn.transaction(async (tx) => {
+    await tx.execute(sql`SELECT set_config('app.current_organization_id', ${orgId}, true)`);
+    return tx
+      .select({ flagKey: tenantFlagOverrides.flagKey, value: tenantFlagOverrides.value })
+      .from(tenantFlagOverrides)
+      .where(eq(tenantFlagOverrides.tenantId, orgId));
+  });
   const map: Record<string, boolean> = {};
   for (const row of rows) {
     map[row.flagKey] = row.value;

--- a/packages/api/src/modules/branding/branding.test.ts
+++ b/packages/api/src/modules/branding/branding.test.ts
@@ -17,7 +17,6 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -27,6 +26,7 @@ import {
   signToken,
   signTokenB,
 } from "../../tests/helpers/auth.js";
+import { db } from "../../tests/helpers/db.js";
 
 // CI has no MinIO service; the branding upload path does a real PutObject.
 // Stub the bucket-write helper so the route succeeds without the network

--- a/packages/api/src/modules/finance/exchange-rate-service.test.ts
+++ b/packages/api/src/modules/finance/exchange-rate-service.test.ts
@@ -2,7 +2,7 @@ import { clearExchangeRateApiCache } from "@givernance/shared";
 import { exchangeRates } from "@givernance/shared/schema";
 import { and, eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { db, withTenantContext } from "../../lib/db.js";
+import { db, withTenantContext } from "../../tests/helpers/db.js";
 import { ExchangeRateService } from "./exchange-rate-service.js";
 
 const ORG_ID = "00000000-0000-0000-0000-000000000125";

--- a/packages/api/src/modules/payments/service.test.ts
+++ b/packages/api/src/modules/payments/service.test.ts
@@ -22,8 +22,8 @@
 import { tenants } from "@givernance/shared/schema";
 import { eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { db } from "../../lib/db.js";
 import { ORG_A } from "../../tests/helpers/auth.js";
+import { db } from "../../tests/helpers/db.js";
 
 const { mockAccountsCreate, mockAccountsUpdate, mockAccountLinksCreate } = vi.hoisted(() => ({
   mockAccountsCreate: vi.fn(),

--- a/packages/api/src/modules/signup/service.ts
+++ b/packages/api/src/modules/signup/service.ts
@@ -191,7 +191,14 @@ export async function signup(input: SignupInput): Promise<SignupResult> {
   // Existing-user short-circuit: if the email already belongs to a user in
   // any tenant, surface `email_in_use` rather than creating a duplicate
   // provisional row that would 23505 at Keycloak-bind time (DATA-2).
-  const [existingUser] = await db
+  //
+  // Owner pool (`systemDb`): this is an UNAUTHENTICATED cross-tenant check
+  // ("is this email used by ANY tenant?") with no `app.current_organization_id`
+  // in scope. `users` has FORCE RLS, so the tenant pool (`givernance_app`)
+  // would silently return zero rows and miss the duplicate — the bug class
+  // issue #455 exists to catch. Same rationale as the domain checks below
+  // (lines using `systemDb`).
+  const [existingUser] = await systemDb
     .select({ id: users.id })
     .from(users)
     .where(sql`lower(${users.email}) = ${normalisedEmail}`)
@@ -202,8 +209,13 @@ export async function signup(input: SignupInput): Promise<SignupResult> {
 
   // Domain-already-claimed check (enterprise tenants). Skipped for personal-
   // email domains.
+  //
+  // Owner pool (`systemDb`): same unauthenticated cross-tenant rationale as
+  // the existing-user check above — `tenant_domains` has FORCE RLS, so the
+  // tenant pool would return zero rows and let a competing org sign up on an
+  // already-claimed domain (issue #455).
   if (!isPersonalEmailDomain(parsedEmail.domain)) {
-    const [claimedDomain] = await db
+    const [claimedDomain] = await systemDb
       .select({ orgId: tenantDomains.orgId })
       .from(tenantDomains)
       .where(and(eq(tenantDomains.domain, parsedEmail.domain), eq(tenantDomains.state, "verified")))

--- a/packages/api/src/modules/tenant-admin/service.ts
+++ b/packages/api/src/modules/tenant-admin/service.ts
@@ -39,7 +39,7 @@ import {
 } from "@givernance/shared/schema";
 import { validateTenantSlug } from "@givernance/shared/validators";
 import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
-import { db, withTenantContext } from "../../lib/db.js";
+import { db, systemDb, withTenantContext } from "../../lib/db.js";
 import { isUniqueViolation } from "../../lib/db-errors.js";
 import {
   createSystemTxtResolver,
@@ -209,7 +209,14 @@ export async function claimDomain(input: DomainClaimInput): Promise<DomainClaimR
 
   // Pre-check global domain uniqueness among active rows (the partial unique
   // index is the real enforcer; this preempt returns a friendlier error).
-  const [conflict] = await db
+  //
+  // Owner pool (`systemDb`): this is a CROSS-TENANT uniqueness check — "is
+  // this domain claimed by ANY tenant?" — so it deliberately reaches outside
+  // the caller's tenant. `tenant_domains` has FORCE RLS, so the tenant pool
+  // (`givernance_app`) would only ever see the caller's own rows and silently
+  // skip the friendly conflict error for a domain claimed by a different org
+  // (issue #455). The partial unique index still backstops the actual write.
+  const [conflict] = await systemDb
     .select({ id: tenantDomains.id })
     .from(tenantDomains)
     .where(and(eq(tenantDomains.domain, parsed.domain), sql`${tenantDomains.state} <> 'revoked'`))
@@ -323,16 +330,24 @@ async function loadVerifiableClaim(
     }
   | { ok: false; error: "not_found" | "already_verified" }
 > {
-  const [claim] = await db
-    .select({
-      id: tenantDomains.id,
-      orgId: tenantDomains.orgId,
-      state: tenantDomains.state,
-      dnsTxtValue: tenantDomains.dnsTxtValue,
-    })
-    .from(tenantDomains)
-    .where(and(eq(tenantDomains.orgId, orgId), eq(tenantDomains.domain, domain)))
-    .limit(1);
+  // Tenant-scoped read against the FORCE-RLS `tenant_domains` table — wrap in
+  // `withTenantContext(orgId)` so the policy
+  // `org_id = app_current_organization_id()` matches under the
+  // `givernance_app` pool. Without the GUC the verify path reads zero rows and
+  // returns `not_found` for a claim the caller legitimately owns (issue #455);
+  // matches the `withTenantContext` wrapper `revokeDomain` already uses.
+  const [claim] = await withTenantContext(orgId, async (tx) =>
+    tx
+      .select({
+        id: tenantDomains.id,
+        orgId: tenantDomains.orgId,
+        state: tenantDomains.state,
+        dnsTxtValue: tenantDomains.dnsTxtValue,
+      })
+      .from(tenantDomains)
+      .where(and(eq(tenantDomains.orgId, orgId), eq(tenantDomains.domain, domain)))
+      .limit(1),
+  );
   if (!claim) return { ok: false, error: "not_found" };
   if (claim.state === "verified") return { ok: false, error: "already_verified" };
   if (claim.state === "revoked") return { ok: false, error: "not_found" };

--- a/packages/api/src/tests/helpers/auth.ts
+++ b/packages/api/src/tests/helpers/auth.ts
@@ -3,7 +3,7 @@
 import { createSign } from "node:crypto";
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { db } from "../../lib/db.js";
+import { systemDb as db } from "../../lib/db.js";
 
 export const ORG_A = "00000000-0000-0000-0000-000000000001";
 export const ORG_B = "00000000-0000-0000-0000-000000000002";

--- a/packages/api/src/tests/helpers/db.ts
+++ b/packages/api/src/tests/helpers/db.ts
@@ -1,0 +1,29 @@
+/**
+ * Test-harness database handle (issue #455).
+ *
+ * Integration tests run under two roles in CI (job `api-tests-owner` and the
+ * must-pass `api-tests-app`). In the `app` job the route-path pool (`db` in
+ * `lib/db.ts`) connects as `givernance_app` (NOBYPASSRLS) so any route that
+ * forgot `withTenantContext`, or that wrongly used the tenant pool on a
+ * REVOKE'd platform table, fails RED instead of silently passing under the
+ * BYPASSRLS owner role.
+ *
+ * Test *harness* code (fixture setup, cross-tenant seeding, and verification
+ * reads) is a different thing from the code under test: it legitimately needs
+ * to read and write any tenant's rows without an `app.current_organization_id`
+ * in scope — that is exactly what the owner role is for. So the harness always
+ * uses the OWNER pool, regardless of which role the route-path pool uses.
+ *
+ * Test files therefore import `db` from THIS module (`../helpers/db.js`), not
+ * from `../../lib/db.js`. The `db` exported here is the owner-role handle
+ * (`systemDb`). Route code under test is unaffected — it keeps importing the
+ * app-role `db` from `lib/db.ts`, which is the pool the `app` job swaps to
+ * `givernance_app`. `withTenantContext` is re-exported unchanged: it runs on
+ * the route-path pool and sets the GUC, so harness reads that genuinely want
+ * to exercise RLS (e.g. cross-tenant isolation assertions) still can.
+ *
+ * Net effect: harness operations never spuriously fail under the app role,
+ * while real route-level RLS / grant bugs surface as test failures.
+ */
+
+export { systemDb as db, systemDb, withTenantContext } from "../../lib/db.js";

--- a/packages/api/src/tests/integration/bank-accounts.test.ts
+++ b/packages/api/src/tests/integration/bank-accounts.test.ts
@@ -11,7 +11,6 @@ import { bankAccounts, campaigns } from "@givernance/shared/schema";
 import { and, eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -21,6 +20,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/bulk-import.test.ts
+++ b/packages/api/src/tests/integration/bulk-import.test.ts
@@ -37,7 +37,6 @@ import {
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { db, withTenantContext } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
@@ -49,6 +48,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db, withTenantContext } from "../helpers/db.js";
 
 // ─── In-memory S3 mock (vi.hoisted so it's defined before vi.mock) ──────────
 //

--- a/packages/api/src/tests/integration/campaigns-bank-account-link.test.ts
+++ b/packages/api/src/tests/integration/campaigns-bank-account-link.test.ts
@@ -16,7 +16,6 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -26,6 +25,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/campaigns.test.ts
+++ b/packages/api/src/tests/integration/campaigns.test.ts
@@ -1,7 +1,6 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -11,6 +10,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 const CAMPAIGN_STATS_ORG = "00000000-0000-0000-0000-000000000127";

--- a/packages/api/src/tests/integration/constituents.test.ts
+++ b/packages/api/src/tests/integration/constituents.test.ts
@@ -2,7 +2,6 @@ import { donations } from "@givernance/shared/schema";
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db, withTenantContext } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -12,6 +11,7 @@ import {
   signTokenB,
   USER_A,
 } from "../helpers/auth.js";
+import { db, withTenantContext } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/dashboard-stats.test.ts
+++ b/packages/api/src/tests/integration/dashboard-stats.test.ts
@@ -1,10 +1,10 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { getDashboardStats, monthRanges } from "../../modules/dashboard/service.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, seedTenantUser, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 const DASHBOARD_ORG = "00000000-0000-0000-0000-000000000125";

--- a/packages/api/src/tests/integration/domain-disputes.test.ts
+++ b/packages/api/src/tests/integration/domain-disputes.test.ts
@@ -1,9 +1,9 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import { signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/donations.test.ts
+++ b/packages/api/src/tests/integration/donations.test.ts
@@ -2,7 +2,6 @@ import { funds } from "@givernance/shared/schema";
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { db, withTenantContext } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -12,6 +11,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db, withTenantContext } from "../helpers/db.js";
 
 // Stub the Stripe SDK so the refund route doesn't hit real Stripe. Only
 // `getStripe()` is mocked — the rest of the service runs unmodified.

--- a/packages/api/src/tests/integration/feature-flags-phase2.test.ts
+++ b/packages/api/src/tests/integration/feature-flags-phase2.test.ts
@@ -35,7 +35,6 @@ import { featureFlags, tenantFlagOverrides } from "@givernance/shared/schema";
 import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
@@ -47,6 +46,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/feature-flags.test.ts
+++ b/packages/api/src/tests/integration/feature-flags.test.ts
@@ -20,11 +20,11 @@ import { auditLogs, featureFlags } from "@givernance/shared/schema";
 import { and, desc, eq, gte, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, ORG_A, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/filters.test.ts
+++ b/packages/api/src/tests/integration/filters.test.ts
@@ -13,7 +13,6 @@ import {
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db, withTenantContext } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import type { FilterQuery } from "../../modules/constituents/filters/types.js";
@@ -26,6 +25,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db, withTenantContext } from "../helpers/db.js";
 
 // Test data interfaces
 interface TestConstituent {

--- a/packages/api/src/tests/integration/funds.test.ts
+++ b/packages/api/src/tests/integration/funds.test.ts
@@ -1,7 +1,6 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -11,6 +10,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/idempotency-rbac.test.ts
+++ b/packages/api/src/tests/integration/idempotency-rbac.test.ts
@@ -26,10 +26,10 @@ import { campaigns, donations, pledges } from "@givernance/shared/schema";
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db, withTenantContext } from "../../lib/db.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, signToken } from "../helpers/auth.js";
+import { db, withTenantContext } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/impersonation.test.ts
+++ b/packages/api/src/tests/integration/impersonation.test.ts
@@ -11,7 +11,6 @@ import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { env } from "../../env.js";
-import { db } from "../../lib/db.js";
 import {
   IMPERSONATION_DENIED_LOCKOUT_THRESHOLD,
   IMPERSONATION_MAX_STARTS_PER_24H,
@@ -27,6 +26,7 @@ import {
   USER_A,
   USER_B,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 const SUPER_ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000000ad";
 const TARGET_USER_APP_ID = "00000000-0000-0000-0000-0000000aaaaa";

--- a/packages/api/src/tests/integration/issue-56-hardening.test.ts
+++ b/packages/api/src/tests/integration/issue-56-hardening.test.ts
@@ -27,7 +27,6 @@ import {
 import { and, eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db, withTenantContext } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -37,6 +36,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db, withTenantContext } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/list-sort.test.ts
+++ b/packages/api/src/tests/integration/list-sort.test.ts
@@ -26,9 +26,9 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, seedTenantUser, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 /**
  * RFC 9457 problem `type` URI used by this app for HTTP 400. Pinned to

--- a/packages/api/src/tests/integration/locale-resolution.test.ts
+++ b/packages/api/src/tests/integration/locale-resolution.test.ts
@@ -20,7 +20,7 @@ import { localeFromCountry, SUPPORTED_LOCALES } from "@givernance/shared/i18n";
 import { outboxEvents, tenants, users } from "@givernance/shared/schema";
 import { eq, inArray, sql } from "drizzle-orm";
 import { afterAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
+import { db } from "../helpers/db.js";
 import { expectQueryToReject } from "../helpers/db-errors.js";
 
 const trackedTenants = new Set<string>();

--- a/packages/api/src/tests/integration/notifications.test.ts
+++ b/packages/api/src/tests/integration/notifications.test.ts
@@ -21,7 +21,6 @@ import { featureFlags, notifications } from "@givernance/shared/schema";
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { createServer } from "../../server.js";
 import {
@@ -34,6 +33,7 @@ import {
   USER_A_ROW_ID,
   USER_B_ROW_ID,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 const FLAG_KEY = FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER;
 

--- a/packages/api/src/tests/integration/onboarding-runtime.test.ts
+++ b/packages/api/src/tests/integration/onboarding-runtime.test.ts
@@ -27,7 +27,6 @@ import {
 import { eq, inArray, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import type { TxtResolver } from "../../lib/dns.js";
 import type { KeycloakAdminClient } from "../../lib/keycloak-admin.js";
 import { KeycloakAdminError } from "../../lib/keycloak-admin.js";
@@ -48,6 +47,7 @@ import {
 } from "../../modules/tenant-admin/service.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, ORG_A, ORG_B, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/payments.test.ts
+++ b/packages/api/src/tests/integration/payments.test.ts
@@ -3,9 +3,9 @@ import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import type Stripe from "stripe";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, signToken, signTokenB } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 // vi.hoisted runs before vi.mock hoisting — ensures mocks are defined before use
 const {

--- a/packages/api/src/tests/integration/platform-admins.test.ts
+++ b/packages/api/src/tests/integration/platform-admins.test.ts
@@ -18,11 +18,11 @@ import { randomUUID } from "node:crypto";
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { db, systemDb } from "../../lib/db.js";
 import { _setKeycloakAdminSingleton, type KeycloakAdminClient } from "../../lib/keycloak-admin.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
 import { authHeader, signToken } from "../helpers/auth.js";
+import { db, systemDb } from "../helpers/db.js";
 
 const PLATFORM_TENANT_ID = "00000000-0000-0000-0000-0000000000a1";
 const SUPER_ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000000ad";

--- a/packages/api/src/tests/integration/postal-campaigns.test.ts
+++ b/packages/api/src/tests/integration/postal-campaigns.test.ts
@@ -12,7 +12,6 @@ import { featureFlags } from "@givernance/shared/schema";
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
@@ -24,6 +23,7 @@ import {
   seedTenantUser,
   signToken,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 let campaignId: string;

--- a/packages/api/src/tests/integration/profile-locale.test.ts
+++ b/packages/api/src/tests/integration/profile-locale.test.ts
@@ -15,9 +15,9 @@ import { auditLogs, tenants, users } from "@givernance/shared/schema";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import { authHeader, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/public-donations.test.ts
+++ b/packages/api/src/tests/integration/public-donations.test.ts
@@ -1,9 +1,9 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, ORG_A, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 const PRIMARY_THEME_COLOR = "#096447";
 const SECONDARY_THEME_COLOR = "#006C48";

--- a/packages/api/src/tests/integration/public-page-styles.test.ts
+++ b/packages/api/src/tests/integration/public-page-styles.test.ts
@@ -45,7 +45,6 @@ import { featureFlags } from "@givernance/shared/schema";
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { createServer } from "../../server.js";
 import {
@@ -56,6 +55,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/receipts.test.ts
+++ b/packages/api/src/tests/integration/receipts.test.ts
@@ -3,9 +3,9 @@ import { receipts } from "@givernance/shared/schema";
 import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { withTenantContext } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, ORG_A, signToken, signTokenB } from "../helpers/auth.js";
+import { withTenantContext } from "../helpers/db.js";
 
 // Stub S3 fetch so the streaming download tests don't depend on a real
 // MinIO object existing at the receipt's s3_path. The 403/404 paths

--- a/packages/api/src/tests/integration/reports.test.ts
+++ b/packages/api/src/tests/integration/reports.test.ts
@@ -1,7 +1,6 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -10,6 +9,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 const REPORTS_ORG = "00000000-0000-0000-0000-000000000124";

--- a/packages/api/src/tests/integration/schema-parity.test.ts
+++ b/packages/api/src/tests/integration/schema-parity.test.ts
@@ -32,7 +32,7 @@
 
 import { sql } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { systemDb } from "../../lib/db.js";
+import { systemDb } from "../helpers/db.js";
 
 interface IndexProbe {
   table: string;

--- a/packages/api/src/tests/integration/search.test.ts
+++ b/packages/api/src/tests/integration/search.test.ts
@@ -22,7 +22,6 @@ import { campaigns, constituents, donations, featureFlags } from "@givernance/sh
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { createServer } from "../../server.js";
 import {
@@ -33,6 +32,7 @@ import {
   signToken,
   signTokenB,
 } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 const FLAG_KEY = FEATURE_FLAG_KEYS.PRODUCTIVITY_COMMAND_PALETTE;
 

--- a/packages/api/src/tests/integration/signup.test.ts
+++ b/packages/api/src/tests/integration/signup.test.ts
@@ -28,7 +28,6 @@ import { resendSignupVerification } from "@givernance/shared/signup";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { db, systemDb } from "../../lib/db.js";
 import {
   _resetKeycloakAdminSingleton,
   _setKeycloakAdminSingleton,
@@ -37,6 +36,7 @@ import {
 import { redis } from "../../lib/redis.js";
 import { cleanupUnverifiedTenants, log as signupLog } from "../../modules/signup/service.js";
 import { createServer } from "../../server.js";
+import { db, systemDb } from "../helpers/db.js";
 
 // F3 — route the in-process "enqueue" back through the same shared
 // `resendSignupVerification` helper the worker uses so DB state remains

--- a/packages/api/src/tests/integration/super-admin-first-admin-invite.test.ts
+++ b/packages/api/src/tests/integration/super-admin-first-admin-invite.test.ts
@@ -10,10 +10,10 @@ import { auditLogs, invitations, outboxEvents, tenants, users } from "@givernanc
 import { inArray, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
 import { authHeader, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/superadmin-finance.test.ts
+++ b/packages/api/src/tests/integration/superadmin-finance.test.ts
@@ -23,7 +23,6 @@ import { featureFlags } from "@givernance/shared/schema";
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db, systemDb } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
@@ -37,6 +36,7 @@ import {
   USER_A_ROW_ID,
   USER_B_ROW_ID,
 } from "../helpers/auth.js";
+import { db, systemDb } from "../helpers/db.js";
 
 const FLAG_KEY = FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD;
 const SUPER_ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000437ad";

--- a/packages/api/src/tests/integration/superadmin-monthly-report.test.ts
+++ b/packages/api/src/tests/integration/superadmin-monthly-report.test.ts
@@ -23,12 +23,12 @@ import { auditLogs, featureFlags, platformFinanceReports } from "@givernance/sha
 import { and, desc, eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { db, systemDb } from "../../lib/db.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import { previousMonth } from "../../modules/superadmin/finance/monthly-report.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, signToken } from "../helpers/auth.js";
+import { db, systemDb } from "../helpers/db.js";
 
 const FLAG_KEY = FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD;
 const SUPER_ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000443ad";

--- a/packages/api/src/tests/integration/team-invitations.test.ts
+++ b/packages/api/src/tests/integration/team-invitations.test.ts
@@ -12,7 +12,6 @@ import { auditLogs, invitations, outboxEvents, tenants, users } from "@givernanc
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { db } from "../../lib/db.js";
 import {
   _resetKeycloakAdminSingleton,
   _setKeycloakAdminSingleton,
@@ -24,6 +23,7 @@ import { redis } from "../../lib/redis.js";
 import { isUserBlocklisted } from "../../modules/session/service.js";
 import { createServer } from "../../server.js";
 import { authHeader, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/tenant-admin.test.ts
+++ b/packages/api/src/tests/integration/tenant-admin.test.ts
@@ -3,9 +3,9 @@ import { auditLogs, tenants } from "@givernance/shared/schema";
 import { eq, inArray, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import { authHeader, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/integration/tenant-onboarding-schema.test.ts
+++ b/packages/api/src/tests/integration/tenant-onboarding-schema.test.ts
@@ -25,8 +25,8 @@ import { tenantAdminDisputes, tenantDomains, tenants, users } from "@givernance/
 import { validateTenantSlug } from "@givernance/shared/validators";
 import { and, eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db, withTenantContext } from "../../lib/db.js";
 import { ensureTestTenants } from "../helpers/auth.js";
+import { db, withTenantContext } from "../helpers/db.js";
 import { expectQueryToReject } from "../helpers/db-errors.js";
 
 // Dedicated tenants for this suite so shared fixtures (ORG_A, ORG_B) aren't

--- a/packages/api/src/tests/integration/tenant-snapshot.test.ts
+++ b/packages/api/src/tests/integration/tenant-snapshot.test.ts
@@ -1,9 +1,9 @@
 import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { db } from "../../lib/db.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, signToken, signTokenB } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 const SNAPSHOT_ORG = "00000000-0000-0000-0000-000000000123";

--- a/packages/api/src/tests/integration/user-edit.test.ts
+++ b/packages/api/src/tests/integration/user-edit.test.ts
@@ -22,7 +22,6 @@ import { auditLogs, tenants, users } from "@givernance/shared/schema";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { db } from "../../lib/db.js";
 import {
   _resetKeycloakAdminSingleton,
   _setKeycloakAdminSingleton,
@@ -30,6 +29,7 @@ import {
 } from "../../lib/keycloak-admin.js";
 import { createServer } from "../../server.js";
 import { authHeader, signToken } from "../helpers/auth.js";
+import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 

--- a/packages/api/src/tests/setup.ts
+++ b/packages/api/src/tests/setup.ts
@@ -8,9 +8,36 @@ import { createServer } from "node:http";
 
 process.env.DATABASE_URL ??=
   "postgresql://givernance:givernance_dev@localhost:5432/givernance_test";
-// DATABASE_URL_APP intentionally NOT set in tests — falls back to DATABASE_URL (owner role).
-// The givernance_app role is created by migration 0005 and applied in real environments;
-// tests use the owner role so they can set up fixtures without RLS restrictions.
+
+// Dual-role test execution (issue #455).
+//
+// The route-path pool (`db` in `lib/db.ts`) connects as
+// `env.DATABASE_URL_APP ?? env.DATABASE_URL`. CI runs the integration suite
+// under BOTH roles:
+//
+//   • `api-tests-owner` — DATABASE_URL_APP_TEST unset → `db` falls back to
+//     DATABASE_URL (the `givernance` owner role, BYPASSRLS). Ergonomic: fixture
+//     setup can write platform tables freely. This is also the local-dev
+//     default, so a bare `pnpm test` keeps working with zero extra config.
+//
+//   • `api-tests-app` — DATABASE_URL_APP_TEST points at the `givernance_app`
+//     role (NOBYPASSRLS, created by migration 0005). Every route query then
+//     goes through RLS, so any route that forgot `withTenantContext` — or that
+//     wrongly used the tenant pool on a REVOKE'd platform table — fails RED
+//     instead of silently passing. This is the must-pass gate.
+//
+// We map DATABASE_URL_APP_TEST → DATABASE_URL_APP here (before `env.ts` reads
+// process.env) rather than setting DATABASE_URL_APP directly in CI so the two
+// concerns stay separable: the *test* role swap never risks leaking into a
+// real DATABASE_URL_APP a developer may have exported for another purpose.
+//
+// Test *harness* code (fixtures + verification reads) deliberately stays on the
+// owner role regardless of this swap — it imports `db` from
+// `tests/helpers/db.js` (which re-exports the owner pool), so seeding any
+// tenant's rows never trips RLS. See that file's header for the rationale.
+if (process.env.DATABASE_URL_APP_TEST) {
+  process.env.DATABASE_URL_APP = process.env.DATABASE_URL_APP_TEST;
+}
 process.env.REDIS_URL ??= "redis://localhost:6379";
 process.env.S3_ENDPOINT ??= "http://localhost:9000";
 process.env.S3_ACCESS_KEY_ID ??= "minioadmin";


### PR DESCRIPTION
## Why

Integration tests only ever ran as the `givernance` **owner role (BYPASSRLS)**. Side effect: any route that forgot `withTenantContext` — or that used the tenant pool on a REVOKE'd platform table — passed every test but **broke in dev/staging/prod the moment `givernance_app` was actually in use.** This bit twice in Epic #444 alone (the `survey-pending` 500 + `survey-respond` 404), and is the same family of root cause as the #430 staging cross-tenant leak.

This PR makes CI run the integration suite **under both roles**, turning that whole bug class from "ships green, breaks in prod" into "fails RED in CI". Closes #455.

## What

**CI** — `ci.yml` splits the static gate from a matrixed test job:
- **`check`** — biome / typecheck / i18n parity / build (role-independent, runs once).
- **`api-tests-owner`** — owner role (BYPASSRLS). Ergonomic baseline; matches local `pnpm test`.
- **`api-tests-app`** — `givernance_app` (NOBYPASSRLS, created by migration 0005). Every route query goes through RLS. **Must-pass tenant-isolation gate.**

**Test infra** — the route ↔ harness split:
- New [`tests/helpers/db.ts`](packages/api/src/tests/helpers/db.ts) re-exports the **owner pool** as `db`. Every test file now imports `db` / `withTenantContext` from there, never from `lib/db.ts`. Harness setup + verification reads stay on the owner role (legitimately cross-tenant), while the **route under test** uses the app-role pool — so real RLS bugs surface without fixture setup spuriously failing.
- [`tests/setup.ts`](packages/api/src/tests/setup.ts) maps `DATABASE_URL_APP_TEST` → `DATABASE_URL_APP` before env validation. Unset locally → owner fallback (zero-config `pnpm test` still works).

**Real production bugs the `app` job immediately surfaced (all fixed in this PR):**

| File | Bug | Fix |
|---|---|---|
| [`signup/service.ts`](packages/api/src/modules/signup/service.ts) | Unauthenticated preflight read RLS-protected `users` + `tenant_domains` via the tenant pool → 0 rows → duplicate email / already-claimed domain not detected (201 instead of 409). | `systemDb` (matches the sibling checks already in the file). |
| [`flags/flag-service.ts`](packages/api/src/lib/flags/flag-service.ts) | Override evaluator read FORCE-RLS `tenant_flag_overrides` with no tenant GUC → 0 rows → every tenant silently fell back to the platform default. | Set the RLS GUC on the read txn. |
| [`tenant-admin/service.ts`](packages/api/src/modules/tenant-admin/service.ts) | Domain-claim conflict pre-check (cross-tenant) + verify-claim lookup (tenant-scoped) both on the bare tenant pool → friendly-conflict skipped / verify returns `not_found`. | `systemDb` for the cross-tenant check; `withTenantContext` for the tenant-scoped lookup. |

**Docs** — CLAUDE.md "RLS is the safety net" gains a dual-role-testing sub-rule; `qa-engineer.md` + `mvp-engineer.md` updated with the import path + role expectations.

## Regression proof (acceptance criterion)

Reverting [`survey-pending.ts`](packages/api/src/modules/superadmin/finance/survey-pending.ts) to its pre-PR-#454 `db` (tenant-pool) form:
- **`api-tests-owner`** → 6 pending tests **GREEN** (CI's old blind spot).
- **`api-tests-app`** → same 6 tests **RED** (500 — permission denied on the REVOKE'd `surveys` join).

## Verification

- [x] `pnpm biome check .` clean (8 pre-existing warnings in untouched files only).
- [x] `pnpm typecheck`, `pnpm build` pass.
- [x] Full suite **owner role**: 59/59 files pass.
- [x] Full suite **app role** (`DATABASE_URL_APP_TEST=…givernance_app…`): 59/59 files pass.
- [x] Root `pnpm test` (api + web + worker + shared + relay): all pass.
- [x] Branch matches the harness-swap design: 262 spurious app-role failures → 9 real route bugs → 0 after fixes.

## Out of scope (explicit)

The issue's *optional* follow-up — a Biome custom lint flagging `db.select/insert/update` outside `withTenantContext` — is **not** included: the `app` CI job is now the enforcing mechanism, and a static rule can't distinguish a legitimate `systemDb` platform read from a forgotten context. Left as a possible future hardening, not deferred work this PR owes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
