### PR TITLE
fix(ui): add `outline` Button variant for dialog dismiss actions

### DIFF
--- a/packages/web/src/components/surveys/survey-invitation-prompt.tsx
+++ b/packages/web/src/components/surveys/survey-invitation-prompt.tsx
@@ -231,19 +231,23 @@ export function SurveyInvitationPrompt({ locale }: { locale: "fr" | "en" }) {
         )}
 
         <DialogFooter>
-          {/* "Ignorer" settles the invitation server-side
+          {/* "Ne plus me demander" settles the invitation server-side
               (dismissed_at + opened_at = NOW) — the user opts out
               for this entire cycle and will only see this survey
-              again at the next cadence tick (90d for PMF/NPS). */}
-          <Button type="button" variant="ghost" onClick={handleDismiss} disabled={submitting}>
+              again at the next cadence tick (90d for PMF/NPS).
+              Lowest-emphasis of the three actions → `outline` (bordered
+              but unfilled) so it reads as a button on the white dialog
+              surface without competing with the neutral middle action. */}
+          <Button type="button" variant="outline" onClick={handleDismiss} disabled={submitting}>
             {t("dismiss")}
           </Button>
           {/* "Plus tard" is a session-local soft-close — no server
               call, just adds the invitation id to suppressedIds so
               the 60s poll doesn't re-pop it during this page
               session. Next login / page refresh surfaces it again,
-              matching what "plus tard" actually implies. */}
-          <Button type="button" variant="ghost" onClick={suppressLocally} disabled={submitting}>
+              matching what "plus tard" actually implies. Neutral middle
+              emphasis → `secondary` (filled) so it stays inviting. */}
+          <Button type="button" variant="secondary" onClick={suppressLocally} disabled={submitting}>
             {t("notNow")}
           </Button>
           <Button

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -16,6 +16,16 @@ const buttonVariants = cva(
       variant: {
         primary: "bg-primary text-on-primary hover:bg-primary-hover",
         secondary: "bg-surface-container-highest text-on-surface hover:bg-surface-dim",
+        // Canonical low-emphasis *cancel / dismiss* affordance for dialogs.
+        // Unlike `ghost` (fully transparent, no border — invisible on the
+        // white `surface-container-lowest` a DialogContent renders on), the
+        // 1px `outline-variant` border keeps it readable as a button against
+        // any surface. Use this — NOT `ghost` — for the negative action in a
+        // DialogFooter (Cancel / "Ne plus me demander"). Pair it with
+        // `secondary` for a neutral middle action and `primary` for the
+        // confirming action so the three tiers stay visually distinct.
+        outline:
+          "border border-outline-variant bg-transparent text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface",
         ghost:
           "bg-transparent text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface",
         destructive: "bg-error text-on-error hover:bg-error-hover",


### PR DESCRIPTION
## What

Adds an `outline` variant to the design-system `Button` and uses it for the survey invitation prompt's dismiss action.

`ghost` is fully transparent with no border, so on the white surface a `DialogContent` renders on, the dismiss/cancel action looks like plain text instead of a button. The new `outline` variant (1px `outline-variant` border, transparent fill) is the canonical low-emphasis dialog dismiss affordance.

Survey footer now reads as three visually distinct tiers:
- **"Ne plus me demander"** → `outline` (lowest emphasis)
- **"Plus tard"** → `secondary` (neutral middle, filled)
- confirm → `primary`

## Notes
- Two files: [`button.tsx`](packages/web/src/components/ui/button.tsx) (new variant + doc comment), [`survey-invitation-prompt.tsx`](packages/web/src/components/surveys/survey-invitation-prompt.tsx) (apply it).
- Tokens-only colours (`outline-variant`, `surface-container-low`, `on-surface-variant`) — white-label safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
