### PR TITLE
feat(design): align post-login UI with the marketing visual identity

### DIFF
--- a/docs/11-design-identity.md
+++ b/docs/11-design-identity.md
@@ -246,6 +246,20 @@ The pre-auth screens (login, signup, forgot/reset-password, invite-accept) and t
 
 Implemented in `packages/web/src/components/auth/auth-waves.tsx` + `auth-card.tsx` + the `(auth)` layout (SPA) and `infra/keycloak/themes/givernance/login/` (`template.ftl` markup + `givernance.css`). The previous interactive canvas icon-rain background was retired here.
 
+### 2.10 Post-login continuity — the cohesion conventions
+
+The authenticated app must read as **one continuous surface with the login card and the marketing hero**, not a stack of floating panels. The login card (§2.9) is the in-app gold standard. Seven north-star rules:
+
+1. **Flat surfaces.** Cards, panels, table containers, and tabs sit *in* the page — no drop shadow on a resting surface. Separation comes from a hairline, not elevation.
+2. **Teal-16% hairline is the surface-separation border.** `--color-border-brand` (`oklch(0.545 0.115 178 / 0.16)`) borders every card / panel / section / table container / resting overlay — the in-app equivalent of the marketing site's `--color-border`.
+3. **Warm-grey outline is reserved for form controls only.** `--color-outline-variant` (`#c3c1bc`) is the border for input / textarea / select-trigger / checkbox / radio. That is the *only* correct grey-hairline use — a control wants a firmer edge than a surface.
+4. **Soft shadow is reserved for genuinely-floating overlays.** One token, `--shadow-overlay`, on dropdown / popover / select-content / dialog / tooltip / toast / the mobile sidebar drawer. `--shadow-elevated` and `--shadow-modal` alias onto it; the old `--shadow-card` / `--shadow-kpi` grey rings are retired on resting surfaces.
+5. **Softened contrast.** The "violence" was never text contrast (which passes AA) — it was heavy shadows, the raw `rgba(30,27,22,0.5)` modal scrim (now `--color-overlay` = `rgba(28,27,25,0.32)`), and saturated full-bleed banner fills (now soft `--color-banner-warning-bg` / `--color-banner-danger-bg`). Text tokens are unchanged, so every AA ratio is preserved or improved.
+6. **Ember is a rare positive/brand accent only** (`bg-ember/15 text-ember-text`, the `accent` Badge variant). Never a status colour, never a default CTA — default actions stay teal `--color-primary`.
+7. **One interaction curve, one duration.** All hover/press feedback uses `transition-colors duration-normal ease-out` (150ms, `cubic-bezier(0.16, 1, 0.3, 1)`); focus is the instant `focus-visible:shadow-ring`. The global `prefers-reduced-motion` block neutralises it.
+
+**Two firm conventions for reviewers:** (1) `border-border-brand` for surfaces / `border-outline-variant` for inputs only; (2) `shadow-overlay` for floating overlays only — resting surfaces are flat. Applied across `components/ui/*`, `components/layout/*`, `components/shared/*`, and the operator screens under `app/(app)/**`. Donor-facing surfaces (`archetypes/**`, `app/(public)/**`, the donor donation form) keep their own per-template identities and are intentionally **out of scope**.
+
 ---
 
 ## 3. UI system & component design

--- a/docs/design/shared/tokens.css
+++ b/docs/design/shared/tokens.css
@@ -206,7 +206,7 @@
   --text-page-title:    3rem;       /* 48px — Sora, page greeting */
   --text-section-title: 1.5rem;     /* 24px — Sora */
   --text-kpi-value:     2.25rem;    /* 36px — Sora */
-  --text-kpi-label:     0.875rem;   /* 14px — Inter 500 */
+  --text-kpi-label:     0.875rem;   /* 14px — Manrope 500 */
 
   /* ── Line heights ── */
   --leading-none:    1;

--- a/packages/web/src/app/(app)/campaigns/page.tsx
+++ b/packages/web/src/app/(app)/campaigns/page.tsx
@@ -131,7 +131,7 @@ export default async function CampaignsPage({ searchParams }: CampaignsPageProps
           order={order}
         />
       ) : (
-        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+        <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
           <EmptyState icon={Megaphone} title={t("empty.title")} description={t("empty.seedHint")} />
         </div>
       )}

--- a/packages/web/src/app/(app)/constituents/[id]/page.tsx
+++ b/packages/web/src/app/(app)/constituents/[id]/page.tsx
@@ -260,7 +260,7 @@ function ProfileCard({
   return (
     <section
       aria-label={labels.ariaLabel}
-      className="mb-6 flex flex-col gap-5 rounded-2xl bg-surface-container-lowest p-6 shadow-card md:flex-row md:items-start"
+      className="mb-6 flex flex-col gap-5 rounded-2xl bg-surface-container-lowest p-6 border border-border-brand md:flex-row md:items-start"
     >
       <div
         aria-hidden="true"
@@ -393,7 +393,7 @@ function AiSuggestionCard({
   return (
     <section
       aria-label={labels.ariaLabel}
-      className="mb-6 rounded-2xl border border-primary/20 bg-primary-50/40 p-5 shadow-card"
+      className="mb-6 rounded-2xl border border-primary/20 bg-primary-50/40 p-5"
     >
       <div className="flex items-center gap-2 text-primary">
         <Sparkles size={16} aria-hidden="true" />
@@ -438,7 +438,7 @@ function OverviewTab({
 
   return (
     <section
-      className="rounded-2xl bg-surface-container-lowest p-6 shadow-card"
+      className="rounded-2xl bg-surface-container-lowest p-6 border border-border-brand"
       aria-label={labels.ariaLabel}
     >
       <h2 className="font-heading text-xl text-on-surface">{labels.title}</h2>
@@ -485,7 +485,7 @@ function TimelineTab({
 }) {
   return (
     <section
-      className="rounded-2xl bg-surface-container-lowest p-6 shadow-card"
+      className="rounded-2xl bg-surface-container-lowest p-6 border border-border-brand"
       aria-label={labels.ariaLabel}
     >
       <h2 className="font-heading text-xl text-on-surface">{labels.title}</h2>

--- a/packages/web/src/app/(app)/constituents/page.tsx
+++ b/packages/web/src/app/(app)/constituents/page.tsx
@@ -161,7 +161,7 @@ export default async function ConstituentsPage({ searchParams }: ConstituentsPag
           order={order}
         />
       ) : (
-        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+        <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
           <EmptyState icon={Users} title={t("empty.title")} description={t("empty.seedHint")} />
         </div>
       )}

--- a/packages/web/src/app/(app)/dashboard/page.tsx
+++ b/packages/web/src/app/(app)/dashboard/page.tsx
@@ -138,7 +138,7 @@ export default async function DashboardPage() {
       </section>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.65fr)]">
-        <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+        <section className="rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6">
           <SectionHeader
             title={t("recentDonations.title")}
             actionHref="/donations"
@@ -161,7 +161,7 @@ export default async function DashboardPage() {
         </section>
 
         {canWrite ? (
-          <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+          <section className="rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6">
             <SectionHeader
               title={t("quickActions.title")}
               description={t("quickActions.description")}
@@ -176,7 +176,7 @@ export default async function DashboardPage() {
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.65fr)]">
-        <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+        <section className="rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6">
           <SectionHeader
             title={t("campaigns.title")}
             actionHref="/campaigns"
@@ -199,7 +199,7 @@ export default async function DashboardPage() {
         </section>
 
         <div className="space-y-6">
-          <section className="rounded-2xl border border-primary/20 bg-ai-bg p-5 shadow-card sm:p-6">
+          <section className="rounded-2xl border border-primary/20 bg-ai-bg p-5 sm:p-6">
             <div className="flex items-center gap-2 text-ai-text">
               <Lightbulb size={18} aria-hidden="true" />
               <h2 className="font-heading text-xl leading-tight">{t("aiSuggestion.title")}</h2>
@@ -207,7 +207,7 @@ export default async function DashboardPage() {
             <p className="mt-3 text-sm leading-relaxed text-on-surface">{t("aiSuggestion.body")}</p>
           </section>
 
-          <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+          <section className="rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6">
             <SectionHeader
               title={t("onboarding.title")}
               description={t("onboarding.description")}
@@ -326,7 +326,7 @@ function StatCard({
   };
 
   return (
-    <article className="min-h-36 rounded-2xl bg-surface-container-lowest p-5 shadow-card">
+    <article className="min-h-36 rounded-2xl bg-surface-container-lowest p-5 border border-border-brand">
       <div className="flex items-center justify-between">
         <p className="text-sm font-medium text-on-surface-variant">{label}</p>
         <div className="flex items-center gap-2">

--- a/packages/web/src/app/(app)/donations/page.tsx
+++ b/packages/web/src/app/(app)/donations/page.tsx
@@ -154,7 +154,7 @@ export default async function DonationsPage({ searchParams }: DonationsPageProps
           order={order}
         />
       ) : (
-        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+        <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
           <EmptyState icon={Gift} title={t("empty.title")} description={t("empty.seedHint")} />
         </div>
       )}

--- a/packages/web/src/app/(app)/settings/bank-accounts/bank-accounts-table.tsx
+++ b/packages/web/src/app/(app)/settings/bank-accounts/bank-accounts-table.tsx
@@ -75,7 +75,7 @@ export function BankAccountsTable({ bankAccounts, canManage }: BankAccountsTable
 
   return (
     <>
-      <div className="overflow-hidden rounded-2xl bg-surface-container-lowest shadow-card">
+      <div className="overflow-hidden rounded-2xl bg-surface-container-lowest border border-border-brand">
         <table className="w-full text-sm">
           <thead className="border-b border-outline-variant bg-surface-container">
             <tr>

--- a/packages/web/src/app/(app)/settings/bank-accounts/page.tsx
+++ b/packages/web/src/app/(app)/settings/bank-accounts/page.tsx
@@ -60,7 +60,7 @@ export default async function BankAccountsPage() {
       {hasAny ? (
         <BankAccountsTable bankAccounts={result.data} canManage={canManage} />
       ) : (
-        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+        <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
           <EmptyState
             icon={Banknote}
             title={t("empty.title")}

--- a/packages/web/src/app/(app)/settings/funds/page.tsx
+++ b/packages/web/src/app/(app)/settings/funds/page.tsx
@@ -96,7 +96,7 @@ export default async function FundsPage({ searchParams }: FundsPageProps) {
           order={order}
         />
       ) : (
-        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+        <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
           <EmptyState
             icon={PiggyBank}
             title={t("empty.title")}

--- a/packages/web/src/app/(app)/settings/members/page.tsx
+++ b/packages/web/src/app/(app)/settings/members/page.tsx
@@ -107,7 +107,7 @@ export default async function MembersPage({ searchParams }: MembersPageProps) {
         // Review D8 — single combined empty state for a fresh tenant
         // ("one screen, one CTA"). Once either list is non-empty the
         // page falls through to the two-section layout below.
-        <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+        <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
           <EmptyState
             icon={UserPlus}
             title={t("combinedEmpty.title")}
@@ -132,7 +132,7 @@ export default async function MembersPage({ searchParams }: MembersPageProps) {
                   currentUserKeycloakId={auth.userId}
                 />
               ) : (
-                <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+                <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
                   <EmptyState
                     icon={Users}
                     title={t("membersSection.empty.title")}
@@ -167,7 +167,7 @@ export default async function MembersPage({ searchParams }: MembersPageProps) {
                 canManageMembers={canManageMembers}
               />
             ) : (
-              <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+              <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
                 <EmptyState
                   icon={Users}
                   title={t("invitationsSection.empty.title")}

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -104,7 +104,18 @@
   --color-border-strong: var(--color-outline);
   --color-white: #ffffff;
   --color-black: #000000;
-  --color-overlay: rgba(30, 27, 22, 0.5);
+  /* Modal scrim. Softened from 0.5 → 0.32 (and onto the warm ink 28,27,25) so
+     dialogs veil the page rather than slab it in near-black — the "violent
+     contrast" the post-login cohesion pass set out to calm. Consumed as
+     `bg-overlay`; replaces the raw `rgba(30,27,22,0.5)` literals that used to
+     live inline in dialog.tsx / alert-dialog.tsx. */
+  --color-overlay: rgba(28, 27, 25, 0.32);
+  /* Soft full-bleed banner fills (impersonation + provisional-admin). Replace
+     the saturated --color-amber-light / --color-error-light fills; the AA text
+     tokens stay, so the lighter fill only raises the contrast ratio. The amber
+     value matches the proven `.stale-banner--soon` fill. */
+  --color-banner-warning-bg: rgba(134, 71, 0, 0.07);
+  --color-banner-danger-bg: rgba(186, 26, 26, 0.06);
 
   /* ── Legacy compat — mapped to Material You ── */
   --color-surface-alt: var(--color-surface-container-low);
@@ -308,8 +319,15 @@
   --shadow-2xl: 0 16px 48px rgba(0, 0, 0, 0.16);
   --shadow-card: 0 0 0 1px rgba(190, 201, 193, 0.1);
   --shadow-kpi: 0 0 0 1px rgba(190, 201, 193, 0.1);
-  --shadow-elevated: 0 2px 8px rgba(0, 0, 0, 0.08);
-  --shadow-modal: 0 8px 32px rgba(0, 0, 0, 0.12);
+  /* Single canonical floating-overlay shadow (warm ink, soft). Used by every
+     genuinely-floating surface — dropdown, popover, select content, dialog,
+     tooltip, toast, the mobile sidebar drawer. Resting surfaces (cards, tables,
+     panels) are FLAT with a teal hairline instead; see the post-login cohesion
+     pass. `--shadow-elevated` / `--shadow-modal` alias onto this so existing
+     call-sites converge without a sweep. */
+  --shadow-overlay: 0 8px 24px -8px rgba(28, 27, 25, 0.12), 0 2px 6px -2px rgba(28, 27, 25, 0.06);
+  --shadow-elevated: var(--shadow-overlay);
+  --shadow-modal: var(--shadow-overlay);
   --shadow-card-hover: 0 2px 8px rgba(0, 0, 0, 0.08);
   --shadow-button: 0 4px 16px rgba(8, 103, 91, 0.1);
   --shadow-ring: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-primary);
@@ -341,7 +359,7 @@
   --sidebar-collapsed: 64px;
   --topbar-height: 80px;
   --topbar-bg: rgba(252, 251, 249, 0.85); /* Ultra light translucent */
-  --topbar-border: rgba(148, 163, 184, 0.10); /* Cooler, lighter border */
+  --topbar-border: oklch(0.545 0.115 178 / 0.12); /* Teal hairline — sibling of --color-border-brand, matches the sidebar edge + card borders */
   --content-padding: 40px;
   --content-max: 1280px;
   --form-max: 800px;

--- a/packages/web/src/components/admin/new-tenant-form.tsx
+++ b/packages/web/src/components/admin/new-tenant-form.tsx
@@ -187,7 +187,7 @@ export function NewTenantForm() {
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
+        className="rounded-2xl bg-surface-container-lowest px-5 border border-border-brand sm:px-6"
         noValidate
       >
         <FormSection

--- a/packages/web/src/components/branding/logo-upload-card.tsx
+++ b/packages/web/src/components/branding/logo-upload-card.tsx
@@ -216,7 +216,9 @@ export function LogoUploadCard({
 
   const Wrapper = variant === "embedded" ? "div" : "section";
   const wrapperClass =
-    variant === "embedded" ? "" : "rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6";
+    variant === "embedded"
+      ? ""
+      : "rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6";
 
   return (
     <Wrapper className={wrapperClass}>

--- a/packages/web/src/components/campaigns/campaign-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-form.tsx
@@ -231,7 +231,7 @@ export function CampaignForm(props: CampaignFormProps) {
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
+        className="rounded-2xl bg-surface-container-lowest px-5 border border-border-brand sm:px-6"
         noValidate
       >
         <FormSection

--- a/packages/web/src/components/campaigns/campaign-public-page-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-public-page-form.tsx
@@ -173,7 +173,7 @@ export function CampaignPublicPageForm({
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
-          className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
+          className="rounded-2xl bg-surface-container-lowest px-5 border border-border-brand sm:px-6"
           noValidate
         >
           {publicPageStylesEnabled ? (
@@ -421,7 +421,7 @@ function CampaignPublicPagePreview({
   if (publicPageStyle !== null) {
     return (
       <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
-        <section className="rounded-2xl bg-surface-container-lowest p-3 shadow-card">
+        <section className="rounded-2xl bg-surface-container-lowest p-3 border border-border-brand">
           <div className="mb-3 flex items-center justify-between gap-3 px-2">
             <h2 className="font-heading text-base text-on-surface">{t("title")}</h2>
             <Badge variant={status === "published" ? "success" : "neutral"}>
@@ -495,7 +495,7 @@ function CampaignPublicPagePreview({
 
   return (
     <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
-      <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+      <section className="rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6">
         <div className="mb-4 flex items-center justify-between gap-3">
           <div>
             <h2 className="font-heading text-xl text-on-surface">{t("title")}</h2>
@@ -506,7 +506,7 @@ function CampaignPublicPagePreview({
           </Badge>
         </div>
 
-        <div className="overflow-hidden rounded-[28px] border border-outline-variant bg-surface shadow-card">
+        <div className="overflow-hidden rounded-[28px] border border-outline-variant bg-surface">
           <div
             className="px-5 py-5 sm:px-6"
             style={{

--- a/packages/web/src/components/constituents/bulk-import-history.tsx
+++ b/packages/web/src/components/constituents/bulk-import-history.tsx
@@ -64,7 +64,7 @@ function BulkImportHistoryBody() {
   }
 
   return (
-    <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+    <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
       <Table>
         <TableHeader>
           <TableRow>

--- a/packages/web/src/components/constituents/bulk-import-results.tsx
+++ b/packages/web/src/components/constituents/bulk-import-results.tsx
@@ -70,7 +70,7 @@ function BulkImportResultsBody({ jobId }: BulkImportResultsProps) {
         {filtered.length === 0 ? (
           <p className="py-6 text-center text-sm text-on-surface-variant">{t("empty")}</p>
         ) : (
-          <div className="rounded-2xl bg-surface-container-lowest shadow-card">
+          <div className="rounded-2xl bg-surface-container-lowest border border-border-brand">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/packages/web/src/components/constituents/constituent-form.tsx
+++ b/packages/web/src/components/constituents/constituent-form.tsx
@@ -191,7 +191,7 @@ export function ConstituentForm(props: ConstituentFormProps) {
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
-          className="rounded-2xl bg-surface-container-lowest px-6 shadow-card"
+          className="rounded-2xl bg-surface-container-lowest px-6 border border-border-brand"
           noValidate
         >
           <FormSection

--- a/packages/web/src/components/donations/donation-form.tsx
+++ b/packages/web/src/components/donations/donation-form.tsx
@@ -304,7 +304,7 @@ export function DonationForm(props: DonationFormProps) {
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
+        className="rounded-2xl bg-surface-container-lowest px-5 border border-border-brand sm:px-6"
         noValidate
       >
         <FormSection

--- a/packages/web/src/components/layout/impersonation-banner.tsx
+++ b/packages/web/src/components/layout/impersonation-banner.tsx
@@ -104,8 +104,8 @@ export function ImpersonationBanner({ impersonation, userName }: ImpersonationBa
   // for legacy single-mode tokens that don't carry `mode`.
   const isPure = impersonation.mode === "impersonation";
   const containerClass = isPure
-    ? "flex items-center justify-center gap-3 border-b border-error-border bg-error-light px-4 py-2 text-sm font-medium text-error-text"
-    : "flex items-center justify-center gap-3 border-b border-amber-border bg-amber-light px-4 py-2 text-sm font-medium text-amber-text";
+    ? "flex items-center justify-center gap-3 border-b border-error-border bg-[var(--color-banner-danger-bg)] px-4 py-2 text-sm font-medium text-error-text"
+    : "flex items-center justify-center gap-3 border-b border-amber-border bg-[var(--color-banner-warning-bg)] px-4 py-2 text-sm font-medium text-amber-text";
   const badgeClass = isPure
     ? "rounded bg-error-text/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-error-text"
     : "rounded bg-amber-dark/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-amber-dark";

--- a/packages/web/src/components/layout/provisional-admin-banner.tsx
+++ b/packages/web/src/components/layout/provisional-admin-banner.tsx
@@ -66,7 +66,7 @@ export function ProvisionalAdminBanner({ info }: Props) {
 
   return (
     <div
-      className="flex flex-wrap items-center justify-center gap-3 border-b border-amber-border bg-amber-light px-4 py-2 text-sm font-medium text-amber-text"
+      className="flex flex-wrap items-center justify-center gap-3 border-b border-amber-border bg-[var(--color-banner-warning-bg)] px-4 py-2 text-sm font-medium text-amber-text"
       role="status"
       aria-live="polite"
     >

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -197,8 +197,8 @@ export function Sidebar({
       {/* Sidebar */}
       <aside
         id="sidebar-nav"
-        className={`fixed top-0 left-0 z-[var(--z-modal)] flex h-screen w-[var(--sidebar-width)] flex-col overflow-y-auto overflow-x-hidden bg-surface-container-lowest transition-transform duration-slow ease-out md:z-[var(--z-sticky)] md:translate-x-0 ${
-          open ? "translate-x-0 shadow-2xl" : "-translate-x-full"
+        className={`fixed top-0 left-0 z-[var(--z-modal)] flex h-screen w-[var(--sidebar-width)] flex-col overflow-y-auto overflow-x-hidden border-r border-border-brand bg-surface-container-lowest transition-transform duration-slow ease-out md:z-[var(--z-sticky)] md:translate-x-0 ${
+          open ? "translate-x-0 shadow-overlay" : "-translate-x-full"
         }`}
         aria-label={t("mainNav")}
       >
@@ -230,7 +230,7 @@ export function Sidebar({
                   onClick={() => {
                     handleMobileClose();
                   }}
-                  className={`flex items-center gap-4 rounded-lg px-4 py-3 text-sm transition-colors duration-normal ease-out focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                  className={`flex items-center gap-4 rounded-[var(--radius-lg)] px-4 py-3 text-sm transition-colors duration-normal ease-out focus-visible:outline-none focus-visible:shadow-ring ${
                     isActive
                       ? "bg-surface-container font-medium text-primary"
                       : "text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface"
@@ -272,7 +272,7 @@ export function Sidebar({
                     key={item.href}
                     href={item.href}
                     onClick={handleMobileClose}
-                    className={`flex items-center gap-4 rounded-lg px-4 py-3 text-sm transition-colors duration-normal ease-out focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                    className={`flex items-center gap-4 rounded-[var(--radius-lg)] px-4 py-3 text-sm transition-colors duration-normal ease-out focus-visible:outline-none focus-visible:shadow-ring ${
                       isActive
                         ? "bg-surface-container font-medium text-primary"
                         : "text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface"

--- a/packages/web/src/components/layout/topbar.tsx
+++ b/packages/web/src/components/layout/topbar.tsx
@@ -133,7 +133,7 @@ export function Topbar({
       </button>
 
       <div className="flex min-w-0 items-center gap-2 text-sm">
-        <div className="flex items-center rounded-md bg-primary-fixed/30 px-3 py-1 text-on-primary-fixed-variant shadow-sm border border-primary-fixed/50">
+        <div className="flex items-center rounded-md bg-primary-fixed/30 px-3 py-1 text-on-primary-fixed-variant border border-primary-fixed/50">
           <span className="truncate font-medium">{title ?? t("breadcrumbDefault")}</span>
         </div>
       </div>
@@ -153,7 +153,7 @@ export function Topbar({
           onClick={onCommandPaletteOpen}
           aria-label={tPalette("openTrigger")}
           aria-haspopup="dialog"
-          className="relative mx-auto hidden h-10 max-w-[400px] flex-1 cursor-text items-center gap-2 rounded-pill border border-[var(--color-border-light)] bg-surface-container-lowest pl-3.5 pr-2.5 text-left text-sm text-text-muted hover:text-text focus-visible:outline-none focus-visible:border-primary focus-visible:shadow-ring md:flex"
+          className="relative mx-auto hidden h-10 max-w-[400px] flex-1 cursor-text items-center gap-2 rounded-pill border border-border-brand bg-surface-container-lowest pl-3.5 pr-2.5 text-left text-sm text-text-muted hover:text-text focus-visible:outline-none focus-visible:border-primary focus-visible:shadow-ring md:flex"
         >
           <Search size={16} aria-hidden="true" />
           <span className="flex-1 truncate">{tPalette("placeholder")}</span>

--- a/packages/web/src/components/profile/profile-language-form.tsx
+++ b/packages/web/src/components/profile/profile-language-form.tsx
@@ -87,7 +87,7 @@ export function ProfileLanguageForm({ initial }: ProfileLanguageFormProps) {
   }
 
   return (
-    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+    <section className="rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6">
       <div className="max-w-3xl">
         <h2 className="font-heading text-2xl leading-tight text-on-surface">{t("title")}</h2>
         <p className="mt-2 text-sm leading-6 text-on-surface-variant">{t("description")}</p>

--- a/packages/web/src/components/settings/bank-account-form.tsx
+++ b/packages/web/src/components/settings/bank-account-form.tsx
@@ -158,7 +158,7 @@ export function BankAccountForm(props: BankAccountFormProps) {
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
+        className="rounded-2xl bg-surface-container-lowest px-5 border border-border-brand sm:px-6"
         noValidate
       >
         <FormSection

--- a/packages/web/src/components/settings/fund-form.tsx
+++ b/packages/web/src/components/settings/fund-form.tsx
@@ -117,7 +117,7 @@ export function FundForm(props: FundFormProps) {
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="rounded-2xl bg-surface-container-lowest px-5 shadow-card sm:px-6"
+        className="rounded-2xl bg-surface-container-lowest px-5 border border-border-brand sm:px-6"
         noValidate
       >
         <FormSection

--- a/packages/web/src/components/settings/settings-navigation.tsx
+++ b/packages/web/src/components/settings/settings-navigation.tsx
@@ -67,7 +67,7 @@ export function SettingsNavigation({
 
   return (
     <nav aria-label={t("label")} className="overflow-x-auto">
-      <div className="inline-flex min-w-full gap-2 rounded-2xl bg-surface-container p-2 shadow-card">
+      <div className="inline-flex min-w-full gap-2 rounded-2xl bg-surface-container p-2 border border-border-brand">
         {items.map((item) => {
           const isActive = item.match(pathname);
           return (
@@ -78,7 +78,7 @@ export function SettingsNavigation({
               className={cn(
                 "inline-flex min-h-11 flex-1 items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition-colors sm:flex-none",
                 isActive
-                  ? "bg-surface-container-lowest text-on-surface shadow-card"
+                  ? "bg-surface-container-lowest text-primary"
                   : "text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface",
               )}
             >

--- a/packages/web/src/components/settings/settings-snapshot-panel.tsx
+++ b/packages/web/src/components/settings/settings-snapshot-panel.tsx
@@ -78,7 +78,7 @@ export function SettingsSnapshotPanel({ orgId, canExport }: SettingsSnapshotPane
   }
 
   return (
-    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+    <section className="rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
         <div className="max-w-3xl">
           <div className="inline-flex rounded-full bg-surface-container px-3 py-1 text-xs font-medium text-on-surface-variant">

--- a/packages/web/src/components/settings/stripe-connect-panel.tsx
+++ b/packages/web/src/components/settings/stripe-connect-panel.tsx
@@ -85,7 +85,7 @@ export function StripeConnectPanel({ canManageTenant }: StripeConnectPanelProps)
   }
 
   return (
-    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+    <section className="rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
         <div className="max-w-3xl">
           <div className="inline-flex items-center gap-2 rounded-full bg-surface-container px-3 py-1 text-xs font-medium text-on-surface-variant">

--- a/packages/web/src/components/settings/tenant-settings-form.tsx
+++ b/packages/web/src/components/settings/tenant-settings-form.tsx
@@ -158,7 +158,7 @@ export function TenantSettingsForm({
     mission !== initialMission;
 
   return (
-    <section className="rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6">
+    <section className="rounded-2xl bg-surface-container-lowest p-5 border border-border-brand sm:p-6">
       <div className="max-w-3xl">
         <h2 className="font-heading text-2xl leading-tight text-on-surface">{t("title")}</h2>
         <p className="mt-2 text-sm leading-6 text-on-surface-variant">{t("description")}</p>

--- a/packages/web/src/components/shared/filter-bar.tsx
+++ b/packages/web/src/components/shared/filter-bar.tsx
@@ -20,7 +20,7 @@ export function FilterBar({
     <div
       className={cn(
         "flex flex-wrap items-center gap-3",
-        "bg-surface-container-lowest border border-outline-variant rounded-[var(--radius-md)]",
+        "bg-surface-container-lowest border border-border-brand rounded-[var(--radius-md)]",
         "px-4 py-3",
         className,
       )}

--- a/packages/web/src/components/shared/form-section.tsx
+++ b/packages/web/src/components/shared/form-section.tsx
@@ -17,7 +17,7 @@ export function FormSection({
   return (
     <section
       className={cn(
-        "grid gap-6 border-b border-outline-variant py-8 last:border-b-0",
+        "grid gap-6 border-b border-border-brand py-8 last:border-b-0",
         "md:grid-cols-[minmax(0,240px)_minmax(0,1fr)]",
         className,
       )}

--- a/packages/web/src/components/ui/alert-dialog.tsx
+++ b/packages/web/src/components/ui/alert-dialog.tsx
@@ -20,7 +20,7 @@ export const AlertDialogOverlay = forwardRef<
   <AlertDialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[var(--z-modal)] bg-[rgba(30,27,22,0.5)]",
+      "fixed inset-0 z-[var(--z-modal)] bg-overlay",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
@@ -45,8 +45,8 @@ export const AlertDialogContent = forwardRef<
         // 2026-05-26 "la dialog box fait plate").
         "w-full max-w-lg p-8",
         "bg-surface-container-lowest text-on-surface",
-        "border border-outline-variant rounded-[var(--radius-lg)]",
-        "shadow-modal",
+        "border border-border-brand rounded-[var(--radius-lg)]",
+        "shadow-overlay",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "focus:outline-none",

--- a/packages/web/src/components/ui/alert.tsx
+++ b/packages/web/src/components/ui/alert.tsx
@@ -4,13 +4,14 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border p-4 [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  "relative w-full rounded-[var(--radius-lg)] border p-4 [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg~*]:pl-7",
   {
     variants: {
       variant: {
-        default: "bg-background text-foreground",
-        destructive:
-          "border-destructive/50 bg-destructive-container text-on-destructive-container dark:border-destructive [&>svg]:text-on-destructive-container",
+        default: "border-border-brand bg-surface-container-low text-on-surface",
+        destructive: "border-error-border bg-error-light text-error-text [&>svg]:text-error-text",
+        warning:
+          "border-amber-border bg-[var(--color-banner-warning-bg)] text-amber-text [&>svg]:text-amber-text",
       },
     },
     defaultVariants: {

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -17,6 +17,7 @@ const badgeVariants = cva(
         error: "bg-error-container text-on-error-container",
         info: "bg-secondary-fixed text-on-secondary-fixed-variant",
         neutral: "bg-surface-container-highest text-on-surface-variant",
+        accent: "bg-ember/15 text-ember-text",
       },
       shape: {
         pill: "rounded-[var(--radius-pill)]",

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -25,7 +25,7 @@ const buttonVariants = cva(
         // `secondary` for a neutral middle action and `primary` for the
         // confirming action so the three tiers stay visually distinct.
         outline:
-          "border border-outline-variant bg-transparent text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface",
+          "border border-border-brand bg-transparent text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface",
         ghost:
           "bg-transparent text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface",
         destructive: "bg-error text-on-error hover:bg-error-hover",

--- a/packages/web/src/components/ui/card.tsx
+++ b/packages/web/src/components/ui/card.tsx
@@ -5,7 +5,10 @@ import { cn } from "@/lib/utils";
 export function Card({ className, ...props }: HTMLAttributes<HTMLElement>) {
   return (
     <section
-      className={cn("rounded-2xl bg-surface-container-lowest p-5 shadow-card sm:p-6", className)}
+      className={cn(
+        "rounded-2xl border border-border-brand bg-surface-container-lowest p-5 sm:p-6",
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/web/src/components/ui/command.tsx
+++ b/packages/web/src/components/ui/command.tsx
@@ -32,7 +32,7 @@ Command.displayName = CommandPrimitive.displayName;
 export function CommandDialog({ children, ...props }: ComponentPropsWithoutRef<typeof Dialog>) {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-modal">
+      <DialogContent className="overflow-hidden p-0 shadow-overlay">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-on-surface-variant [&_[cmdk-input]]:h-12">
           {children}
         </Command>
@@ -45,10 +45,7 @@ export const CommandInput = forwardRef<
   ElementRef<typeof CommandPrimitive.Input>,
   ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div
-    className="flex items-center gap-2 border-b border-outline-variant px-3"
-    cmdk-input-wrapper=""
-  >
+  <div className="flex items-center gap-2 border-b border-border-brand px-3" cmdk-input-wrapper="">
     <Search size={16} className="shrink-0 text-on-surface-variant opacity-60" aria-hidden="true" />
     <CommandPrimitive.Input
       ref={ref}

--- a/packages/web/src/components/ui/data-table.tsx
+++ b/packages/web/src/components/ui/data-table.tsx
@@ -176,12 +176,12 @@ export function DataTable<TData>({
       // `aria-busy` on the table together cover sighted and SR users.
       data-pending={isPending || undefined}
       className={cn(
-        "overflow-hidden rounded-2xl bg-surface-container-lowest shadow-card transition-opacity duration-normal",
+        "overflow-hidden rounded-2xl border border-border-brand bg-surface-container-lowest transition-opacity duration-normal",
         "data-[pending=true]:pointer-events-none data-[pending=true]:opacity-60",
         className,
       )}
     >
-      <div className="flex flex-col gap-3 border-b border-outline-variant px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-3 border-b border-border-brand px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="text-sm text-on-surface-variant">
           {/*
            * Review D6 — when the table has no `pagination` prop, suppress
@@ -210,7 +210,7 @@ export function DataTable<TData>({
             type="button"
             onClick={() => setDensity("comfortable")}
             className={cn(
-              "flex h-8 w-8 items-center justify-center rounded-md transition-colors duration-normal ease-out",
+              "flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] transition-colors duration-normal ease-out",
               "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
               density === "comfortable"
                 ? "bg-surface-container text-on-surface"
@@ -226,7 +226,7 @@ export function DataTable<TData>({
             type="button"
             onClick={() => setDensity("compact")}
             className={cn(
-              "flex h-8 w-8 items-center justify-center rounded-md transition-colors duration-normal ease-out",
+              "flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] transition-colors duration-normal ease-out",
               "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
               density === "compact"
                 ? "bg-surface-container text-on-surface"
@@ -259,7 +259,7 @@ export function DataTable<TData>({
                   key={row.id}
                   onClick={onRowClick ? () => onRowClick(row) : undefined}
                   className={cn(
-                    "border-t border-outline-variant transition-colors duration-normal ease-out hover:bg-surface-container-low",
+                    "border-t border-border-brand transition-colors duration-normal ease-out hover:bg-surface-container-low",
                     onRowClick && "cursor-pointer",
                   )}
                 >
@@ -294,7 +294,7 @@ export function DataTable<TData>({
       </div>
 
       {hasRows && pagination && onPageChange ? (
-        <div className="flex flex-col gap-3 border-t border-outline-variant px-5 py-3 text-sm text-on-surface-variant sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-3 border-t border-border-brand px-5 py-3 text-sm text-on-surface-variant sm:flex-row sm:items-center sm:justify-between">
           <span>
             {t("pageOf", { page: pagination.page, totalPages: Math.max(pagination.totalPages, 1) })}
           </span>

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -23,7 +23,7 @@ export const DialogOverlay = forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[var(--z-modal)] bg-[rgba(30,27,22,0.5)]",
+      "fixed inset-0 z-[var(--z-modal)] bg-overlay",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
@@ -45,8 +45,8 @@ export const DialogContent = forwardRef<
         "fixed left-1/2 top-1/2 z-[var(--z-modal)] -translate-x-1/2 -translate-y-1/2",
         "w-full max-w-lg p-6",
         "bg-surface-container-lowest text-on-surface",
-        "border border-outline-variant rounded-[var(--radius-lg)]",
-        "shadow-modal",
+        "border border-border-brand rounded-[var(--radius-lg)]",
+        "shadow-overlay",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "focus:outline-none",

--- a/packages/web/src/components/ui/dropdown-menu.tsx
+++ b/packages/web/src/components/ui/dropdown-menu.tsx
@@ -19,7 +19,7 @@ export const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 export const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
 const itemBase =
-  "relative flex min-h-10 cursor-default select-none items-center gap-2 rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium outline-none transition-colors focus:bg-surface-container data-[disabled]:pointer-events-none data-[disabled]:opacity-50";
+  "relative flex min-h-10 cursor-default select-none items-center gap-2 rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium outline-none transition-colors duration-normal ease-out focus:bg-surface-container data-[disabled]:pointer-events-none data-[disabled]:opacity-50";
 
 export const DropdownMenuSubTrigger = forwardRef<
   ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
@@ -45,7 +45,7 @@ export const DropdownMenuSubContent = forwardRef<
     className={cn(
       "z-[var(--z-popover)] min-w-[12rem] overflow-hidden p-1.5",
       "bg-surface-container-lowest text-on-surface",
-      "border border-outline-variant rounded-[var(--radius-md)] shadow-elevated",
+      "border border-border-brand rounded-[var(--radius-md)] shadow-overlay",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
@@ -66,7 +66,7 @@ export const DropdownMenuContent = forwardRef<
       className={cn(
         "z-[var(--z-popover)] min-w-[12rem] overflow-hidden p-1.5",
         "bg-surface-container-lowest text-on-surface",
-        "border border-outline-variant rounded-[var(--radius-md)] shadow-elevated",
+        "border border-border-brand rounded-[var(--radius-md)] shadow-overlay",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         className,
@@ -146,7 +146,7 @@ export const DropdownMenuSeparator = forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1.5 my-1.5 h-px bg-outline-variant", className)}
+    className={cn("-mx-1.5 my-1.5 h-px bg-border-brand", className)}
     {...props}
   />
 ));

--- a/packages/web/src/components/ui/popover.tsx
+++ b/packages/web/src/components/ui/popover.tsx
@@ -21,8 +21,8 @@ export const PopoverContent = forwardRef<
       className={cn(
         "z-[var(--z-popover)] w-72 p-4",
         "bg-surface-container-lowest text-on-surface",
-        "border border-outline-variant rounded-[var(--radius-md)]",
-        "shadow-elevated outline-none",
+        "border border-border-brand rounded-[var(--radius-md)]",
+        "shadow-overlay outline-none",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         className,

--- a/packages/web/src/components/ui/progress.tsx
+++ b/packages/web/src/components/ui/progress.tsx
@@ -20,7 +20,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
         {...props}
       >
         <div
-          className="h-full bg-primary transition-all duration-300 ease-out"
+          className="h-full bg-primary transition-[width] duration-slow ease-out"
           style={{ width: `${percentage}%` }}
         />
       </div>

--- a/packages/web/src/components/ui/radio-group.tsx
+++ b/packages/web/src/components/ui/radio-group.tsx
@@ -22,7 +22,7 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square h-4 w-4 rounded-full border border-outline text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square h-4 w-4 rounded-full border border-outline-variant text-primary transition-colors duration-normal ease-out focus-visible:outline-none focus-visible:shadow-ring disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/packages/web/src/components/ui/select.tsx
+++ b/packages/web/src/components/ui/select.tsx
@@ -82,8 +82,8 @@ export const SelectContent = forwardRef<
         // hiding the options. (Issue #153 follow-up.)
         "relative z-[var(--z-popover)] max-h-96 min-w-[8rem] overflow-hidden",
         "bg-surface-container-lowest text-on-surface",
-        "border border-outline-variant rounded-[var(--radius-md)]",
-        "shadow-elevated",
+        "border border-border-brand rounded-[var(--radius-md)]",
+        "shadow-overlay",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         position === "popper" &&
@@ -129,7 +129,7 @@ export const SelectItem = forwardRef<
     className={cn(
       "relative flex w-full cursor-default select-none items-center",
       "py-1.5 pl-8 pr-2 text-sm rounded-[var(--radius-sm)]",
-      "outline-none",
+      "outline-none transition-colors duration-normal ease-out",
       "focus:bg-surface-container text-on-surface",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
@@ -152,7 +152,7 @@ export const SelectSeparator = forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-outline-variant", className)}
+    className={cn("-mx-1 my-1 h-px bg-border-brand", className)}
     {...props}
   />
 ));

--- a/packages/web/src/components/ui/table.tsx
+++ b/packages/web/src/components/ui/table.tsx
@@ -42,7 +42,7 @@ export function TableRow({ className, ...props }: HTMLAttributes<HTMLTableRowEle
   return (
     <tr
       className={cn(
-        "border-t border-outline-variant/70 align-middle transition-colors hover:bg-surface-container-low/50",
+        "border-t border-border-brand align-middle transition-colors duration-normal ease-out hover:bg-surface-container-low/50",
         className,
       )}
       {...props}

--- a/packages/web/src/components/ui/tabs.tsx
+++ b/packages/web/src/components/ui/tabs.tsx
@@ -36,7 +36,7 @@ export const TabsTrigger = forwardRef<
       "rounded-[var(--radius-sm)] transition-colors duration-normal ease-out",
       "focus-visible:outline-none focus-visible:shadow-ring",
       "disabled:pointer-events-none disabled:opacity-50",
-      "data-[state=active]:bg-surface-container-lowest data-[state=active]:text-on-surface data-[state=active]:shadow-xs",
+      "data-[state=active]:bg-surface-container-lowest data-[state=active]:text-primary data-[state=active]:font-semibold",
       className,
     )}
     {...props}

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -13,7 +13,7 @@ export function Toaster({ position = "bottom-right", ...props }: ToasterProps) {
       toastOptions={{
         classNames: {
           toast:
-            "group toast !bg-surface-container-lowest !text-on-surface !border !border-outline-variant !rounded-[var(--radius-md)] !shadow-elevated !font-body",
+            "group toast !bg-surface-container-lowest !text-on-surface !border !border-border-brand !rounded-[var(--radius-md)] !shadow-overlay !font-body",
           title: "!font-medium !text-on-surface",
           description: "!text-on-surface-variant",
           actionButton: "!bg-primary !text-on-primary",

--- a/packages/web/src/components/ui/tooltip.tsx
+++ b/packages/web/src/components/ui/tooltip.tsx
@@ -21,7 +21,7 @@ export const TooltipContent = forwardRef<
         "z-[var(--z-tooltip)] overflow-hidden",
         "px-2.5 py-1.5 text-xs",
         "bg-inverse-surface text-inverse-on-surface",
-        "rounded-[var(--radius-sm)] shadow-elevated",
+        "rounded-[var(--radius-sm)] shadow-overlay",
         "data-[state=delayed-open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0",
         className,


### PR DESCRIPTION
## What this is

A **visual-identity cohesion pass** on the **post-login** app. The marketing rebrand (teal + coral ember, Sora/Manrope/IBM Plex Mono, three-cube logo) and the **login/auth pages** were already aligned; once logged in, though, screens felt **disparate** — inconsistent cards/borders/shadows/radii, occasionally **harsh contrast**, inconsistent menus, and inconsistent hover/transition behaviour. This makes the whole authenticated app read as **one continuous surface with the login card and the marketing hero**.

**Pure `className` + token changes — no logic, no structural changes.** 50 files, +129/−93. A design team (ui-designer lead + parallel frontend agents) drove it from an audit + spec; the conventions are recorded in `docs/11-design-identity.md` §2.10.

## The design language (the login card is the gold standard)

| Rule | What it means |
|---|---|
| **Flat surfaces** | Cards / panels / tables / tabs sit *in* the page — no shadow on a resting surface. |
| **Teal-16% hairline = surface border** | `border-border-brand` (`oklch(0.545 0.115 178 / 0.16)`) separates every card/panel/section/table — the in-app twin of the marketing `--color-border`. |
| **Grey outline = inputs only** | `border-outline-variant` (`#c3c1bc`) stays on input/textarea/select/checkbox/radio only. |
| **One soft shadow, overlays only** | `--shadow-overlay` on dropdown/popover/select/dialog/tooltip/toast/mobile-drawer. `--shadow-elevated`/`--shadow-modal` alias onto it; the `--shadow-card` grey ring is retired on surfaces. |
| **Softened contrast** | Modal scrim `--color-overlay` 0.5 → **0.32** (warm ink); saturated banner fills → soft `--color-banner-*-bg`. **No text token changed → every AA ratio is preserved or improved.** |
| **Ember = rare accent** | `bg-ember/15 text-ember-text` (new `accent` Badge variant) — never a status colour or default CTA. |
| **One motion curve** | `transition-colors duration-normal ease-out` (150ms) for hover/press; instant `focus-visible:shadow-ring`. Frozen under `prefers-reduced-motion`. |

## Changes by layer

**A — central tokens (`globals.css`)**: softened scrim; new `--shadow-overlay` + aliases; soft banner-fill tokens; teal `--topbar-border`.

**B — shared primitives (`components/ui/*`)**: `card`, `table`/`data-table` → flat + teal hairline. `tabs` → drop active `shadow-xs`, emphasise with `text-primary`. `dialog`/`alert-dialog` → `bg-overlay` scrim (removes the raw `rgba(30,27,22,0.5)` literals) + teal hairline + `shadow-overlay`. `dropdown`/`popover`/`select`/`tooltip`/`toast`/`command` → teal hairline + `shadow-overlay`. `radio-group` → focus ring now matches `checkbox` (was an undefined `ring-ring`/`ring-offset` idiom). **`alert` → fixed a latent bug** (its `destructive` variant referenced tokens that don't exist) + added a `warning` variant. `button` outline edge → teal hairline. `badge` → `accent` variant. `progress` → `transition-[width] duration-slow`.

**C — shell + banners**: `sidebar` right hairline + consistent `shadow-ring` focus + de-literal'd radii; `topbar` breadcrumb de-shadowed + Cmd+K hairline; impersonation + provisional banners get soft fills.

**D — shared/forms**: `form-section` + `filter-bar` hairlines.

**E — screens**: flattened **~38 hard-coded `shadow-card` surfaces** across the operator app (dashboard, constituents, donations, campaigns, settings/*, and their forms) to the teal hairline. AI/assistant panels kept their `border-primary/20` (just dropped the shadow); the settings segmented control emphasises the active item with `text-primary` instead of elevation.

**F — docs**: `docs/11-design-identity.md` §2.10 records the conventions; fixed a stale `Inter`→`Manrope` comment in `docs/design/shared/tokens.css`.

## Deliberately out of scope (untouched)

- **Donor-facing surfaces** — `packages/web/src/archetypes/**`, `app/(public)/**`, and the donor donation form keep their own deliberate per-template identities (per the rebrand scope-guard).
- **`docs/design/` mockup gallery** — already correct in source (verified: the logo SVG is the cube, identical to `main`; no stale brand-green/phoenix anywhere). An old logo seen locally was a stale working copy / browser cache, not the repo.

## Verification

- ✅ `pnpm biome check .` — 0 errors
- ✅ `pnpm typecheck` — all 6 packages
- ✅ `pnpm --filter @givernance/web build` — clean, all new utilities (`border-border-brand`, `shadow-overlay`, `bg-overlay`, `text-error-text`/`text-amber-text`, `accent`, `duration-slow`) resolve
- ✅ Web tests — **278 passed / 0 failed**
- No test asserted on the changed classes; no donor surface touched (verified by grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
