### PR TITLE
fix(surveys): never resurface an already-answered survey at login

### DIFF
--- a/packages/api/scripts/seed.ts
+++ b/packages/api/scripts/seed.ts
@@ -1534,6 +1534,13 @@ async function seedSurveyInvitationsForTenant(
       channel: i % 4 === 0 ? "in_app" : "email",
       invitedAt: new Date(invitedAtBase.getTime() + i * 60 * 60 * 1000),
       expiresAt: new Date(invitedAtBase.getTime() + (i + 30) * 24 * 60 * 60 * 1000),
+      // The first `responseCount` invitations get a seeded response below, so
+      // mark them opened at that response's submit time — mirroring the real
+      // respond flow (survey-respond.ts sets opened_at on submit). Without
+      // this, a responded invitation keeps opened_at = NULL and the in-app
+      // "pending" query resurfaces it at login even though a response already
+      // exists, so re-submitting 409s. Unanswered invitations stay NULL.
+      openedAt: i < s.responseCount ? new Date(invitedAtBase.getTime() + i * 2 * 60 * 60 * 1000) : null,
     }));
     const insertedInvitations = await systemDb
       .insert(surveyInvitations)

--- a/packages/api/src/modules/superadmin/finance/survey-pending.ts
+++ b/packages/api/src/modules/superadmin/finance/survey-pending.ts
@@ -16,8 +16,8 @@
 // The explicit eq(userId)+eq(orgId) above is the cross-tenant
 // isolation that RLS would otherwise enforce.
 
-import { surveyInvitations, surveys } from "@givernance/shared/schema";
-import { and, desc, eq, gt, inArray, isNull } from "drizzle-orm";
+import { surveyInvitations, surveyResponses, surveys } from "@givernance/shared/schema";
+import { and, desc, eq, gt, inArray, isNull, notExists } from "drizzle-orm";
 import { systemDb } from "../../../lib/db.js";
 
 /**
@@ -88,6 +88,27 @@ export async function listPendingInvitations(input: {
         isNull(surveyInvitations.dismissedAt),
         isNull(surveyInvitations.deletedAt),
         gt(surveyInvitations.expiresAt, now),
+        // Authoritative "done" signal: an invitation with a (live) response is
+        // never pending, regardless of `opened_at`. `opened_at IS NULL` above
+        // is a softer UX gate (the respond + dismiss flows both set it), but
+        // it can drift from reality — any path that records a response without
+        // also stamping `opened_at` (a seed fixture, a partial write, manual
+        // SQL) would otherwise resurface an already-answered survey at login
+        // and loop the user into a 409 on re-submit. Gating on the response's
+        // existence makes `pending` the exact inverse of the respond flow's
+        // `already_responded` check, so the two can't disagree.
+        notExists(
+          systemDb
+            .select({ id: surveyResponses.id })
+            .from(surveyResponses)
+            .where(
+              and(
+                eq(surveyResponses.invitationId, surveyInvitations.id),
+                eq(surveyResponses.orgId, surveyInvitations.orgId),
+                isNull(surveyResponses.deletedAt),
+              ),
+            ),
+        ),
         isNull(surveys.deletedAt),
         inArray(surveys.kind, ["pmf", "nps", "csat"]),
       ),

--- a/packages/api/src/tests/integration/superadmin-finance.test.ts
+++ b/packages/api/src/tests/integration/superadmin-finance.test.ts
@@ -1321,6 +1321,33 @@ describe("GET /v1/surveys/pending", () => {
     );
   });
 
+  it("excludes an invitation that already has a response even when opened_at is NULL (resilient to data drift)", async () => {
+    // The respond flow sets opened_at AND inserts a response in one tx, but a
+    // seed fixture / partial write / manual SQL can leave opened_at NULL while
+    // a response exists. The authoritative "done" signal is the response, not
+    // opened_at: 'pending' must still exclude it, or the user loops
+    // (prompt → respond → 409 already_responded → prompt …). opened_at stays
+    // NULL here — beforeEach reset it and we never call /respond.
+    await systemDb.execute(
+      sql`INSERT INTO survey_responses (invitation_id, org_id, response, submitted_at)
+          VALUES (${pmfInvitationForUserA}, ${ORG_A}, ${'{"category":"very_disappointed"}'}::jsonb, NOW())`,
+    );
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: "/v1/surveys/pending",
+        headers: authHeader(signToken(app)),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { data: Array<{ invitationId: string }> };
+      expect(body.data.map((r) => r.invitationId)).not.toContain(pmfInvitationForUserA);
+    } finally {
+      await systemDb.execute(
+        sql`DELETE FROM survey_responses WHERE invitation_id = ${pmfInvitationForUserA}`,
+      );
+    }
+  });
+
   it("includes email-channel invitations (modal is the unified response surface)", async () => {
     // Issue #444 follow-up — once the user lands logged-in (whether
     // via the email magic-link CTA or a normal login), the modal


### PR DESCRIPTION
## Problem
Testing impersonation on a freshly-seeded env, a PMF survey kept appearing at login for a user who had **already answered** it — responding returned **409 `already_responded`**, then the prompt came back: an infinite UX loop.

## Root cause — incoherent business rule
`GET /v1/surveys/pending` (`listPendingInvitations`) gated actionability on **`opened_at IS NULL`** (a soft UX signal), while the authoritative "this invitation is done" signal is the **existence of a `survey_responses` row** (1:1, unique constraint — exactly what the respond flow checks for `already_responded`). They can diverge: the real `respond` flow sets `opened_at` + inserts the response in one tx, but any path that records a response without stamping `opened_at` leaves the invitation `opened_at = NULL` → `pending` resurfaces it.

The dev **seed** does exactly that — it inserts `survey_responses` for the first N invitations but never sets their `opened_at`. So every fresh seed produced "already-answered" surveys that loop.

## Fix — resilient rule + consistent data
- **`survey-pending.ts`** — `pending` now also excludes any invitation with a live response (`NOT EXISTS`), so it is the **exact inverse** of the respond flow's `already_responded` check. They can't disagree, regardless of `opened_at`. Additive predicate → only excludes already-answered invitations, zero risk to the happy path. Handles the **existing anomalous data** with no re-seed.
- **`seed.ts`** — stamps `opened_at` on responded invitations (= their submit time), mirroring the real flow, so seeded data is self-consistent at the source.
- **test** — `pending` excludes a responded invitation **even when `opened_at` is NULL**.

## Verification
- `typecheck` ✓, `biome check .` ✓ (pre-push hook), survey `pending` integration tests **9 passed** incl. the new resilience case.

Unrelated to #479/#463 (survey feature + seed, untouched there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)