### PR TITLE
fix(deploy): remove invalid Kamal deploy_timeout key that aborts every deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,17 @@ Valid uses for Organization attributes: non-sensitive identifiers (`org_id`, slu
 
 Reference: [`packages/api/src/modules/superadmin/finance/routes.ts`](packages/api/src/modules/superadmin/finance/routes.ts) (route), [`packages/api/src/tests/integration/superadmin-finance.test.ts`](packages/api/src/tests/integration/superadmin-finance.test.ts) (test pattern), [`packages/web/src/services/SuperAdminFinanceService.ts`](packages/web/src/services/SuperAdminFinanceService.ts) (client wiring).
 
+### 🛑 Kamal config keys must be valid for the PINNED Kamal version
+
+**Never add or rename a key in `config/deploy-*.yml` without confirming it exists in the Kamal version pinned in [`Gemfile.lock`](Gemfile.lock).** Kamal validates the ENTIRE config at parse time: a single unknown key aborts **every** `kamal deploy` / `kamal setup` before any container moves — and the error names only the offending key, never the fix, so it reads like an unrelated outage and blocks PRs whose only crime was triggering a deploy.
+
+**Why this is a hard rule**: on 2026-06-06 a `deploy_timeout: 120` was added to `accessories.keycloak.proxy` — a key that exists in Kamal's docs / newer releases but **not** in the pinned 2.11. Every staging deploy then failed for days with `ConfigurationError: accessories/keycloak/proxy: unknown key: deploy_timeout`, silently, including unrelated merges. The YAML was valid; the **schema** wasn't.
+
+**Before touching a Kamal config key:**
+- Verify it against the installed gem, not a blog post / newer-version docs / an LLM suggestion: `grep -rn "<key>" "$(bundle show kamal)/lib/kamal/configuration/"`, or read the release notes for the **exact** pinned version. Proxy/accessory keys differ across Kamal majors *and* minors.
+- A config-only change still needs a real or dry-run `kamal deploy` (or `kamal config`) to catch parse errors — `actionlint` and YAML-lint will pass on a valid-YAML-but-invalid-schema file.
+- The same applies to any tool whose config is schema-validated at load (Drizzle, Biome, Vitest, GitHub Actions reusable-workflow inputs): pin-aware key validation, not "looks plausible".
+
 ---
 
 ## 🛑 DEV PROCESS (CRITICAL FOR CI)

--- a/config/deploy-staging.yml
+++ b/config/deploy-staging.yml
@@ -356,16 +356,24 @@ accessories:
       ssl: true
       app_port: 8080
       # Keycloak re-imports the realm JSON + runs Liquibase migrations on every
-      # boot (KC_IMPORT_STRATEGY=OVERWRITE_EXISTING below), so the master-realm
-      # well-known endpoint can take well over kamal-proxy's default 30s
-      # deploy-timeout to answer on a cold boot. When it does, `kamal accessory
-      # boot` (which `kamal-proxy remove`s then re-`deploy`s the route) times out
-      # registering the route — leaving auth.staging.givernance.org un-routed
-      # (kamal-proxy 404 + TLS SNI `internal error`) even though the container
-      # comes up healthy seconds later. Incident 2026-06-05, deploy aa8f8f01.
-      # Give the registration room to outlast the realm import. Recovery +
-      # rationale: docs/runbooks/keycloak-proxy-route-recovery.md.
-      deploy_timeout: 120
+      # boot (KC_IMPORT_STRATEGY=OVERWRITE_EXISTING below). On the 2026-06-05
+      # incident (deploy aa8f8f01) the master-realm well-known endpoint took
+      # longer than kamal-proxy's default 30s deploy-timeout to answer, so
+      # `kamal accessory boot` timed out re-registering the `auth.*` route.
+      #
+      # A `deploy_timeout: 120` was added here (commit f27e4934) to widen that
+      # window — but `deploy_timeout` is NOT a valid Kamal 2.11 accessory-proxy
+      # key: it aborts EVERY `kamal deploy` at config-parse time with
+      # `ConfigurationError: accessories/keycloak/proxy: unknown key:
+      # deploy_timeout`. So the "fix" silently broke all deploys. Removed.
+      #
+      # The cold boot only blew past 30s because the in-process monthly-report
+      # cron was busy-looping a CPU core (PR #479), inflating Quarkus
+      # augmentation from ~12-15s to 27s. With that root cause fixed, the
+      # default 30s has comfortable margin again. If a longer proxy wait is ever
+      # genuinely needed, use a mechanism the pinned Kamal version actually
+      # accepts (validate against the gem) — not this key. Recovery runbook:
+      # docs/runbooks/keycloak-proxy-route-recovery.md.
       healthcheck:
         path: /realms/master/.well-known/openid-configuration
     env:

--- a/docs/runbooks/keycloak-proxy-route-recovery.md
+++ b/docs/runbooks/keycloak-proxy-route-recovery.md
@@ -93,21 +93,34 @@ login at `auth.staging…/realms/givernance/protocol/openid-connect/auth?…` wi
 
 ## 3. Durable fix (shipped)
 
-Two changes prevent recurrence:
+> ⚠️ **Correction (2026-06-06):** the original durable fix added a
+> `deploy_timeout: 120` to `accessories.keycloak.proxy`. **`deploy_timeout` is
+> NOT a valid Kamal 2.11 accessory-proxy key** — it aborts EVERY `kamal deploy`
+> at config-parse time (`ConfigurationError: accessories/keycloak/proxy:
+> unknown key: deploy_timeout`), so it silently broke all deploys instead of
+> fixing anything. The key has been **removed**.
 
-1. **`deploy_timeout: 120`** on the `accessories.keycloak.proxy` block in
-   `config/deploy-staging.yml` — gives the route registration room to outlast the
-   realm import (root-cause fix).
+What actually prevents recurrence:
+
+1. **Root-cause fix (PR #479)** — the cold Keycloak boot only blew past
+   kamal-proxy's 30s deploy-timeout because the in-process monthly-report cron
+   was busy-looping a CPU core (a 32-bit `setTimeout` overflow), inflating
+   Quarkus augmentation from ~12-15s to 27s. Moving that cron to a BullMQ
+   repeatable job removed the CPU loop, so the default 30s has comfortable
+   margin again.
 2. **Self-healing step** in `.github/actions/reboot-kamal-accessory/action.yml` —
    after boot, if a proxied accessory's route is missing, it reboots once more via
    kamal (config-driven). No-op on the happy path; only touches accessories with a
    `proxy:` block (never postgres/redis).
 
-When `deploy-prod.yml` lands, mirror `deploy_timeout` on the prod Keycloak proxy
-block (see `docs/runbooks/launch-prod.md`).
+If a longer proxy deploy-wait is ever genuinely needed (e.g. prod), use a
+mechanism the pinned Kamal version actually accepts — validate the key against
+the installed `kamal` gem first. Do **not** re-add `deploy_timeout` to a proxy
+block. When `deploy-prod.yml` lands, do not mirror the (removed) key.
 
 ## 4. Post-mortem log
 
 | Date | Trigger | Symptom | Resolution | Notes |
 |---|---|---|---|---|
-| 2026-06-05 | Deploy `aa8f8f01` (teal-rebrand auth theme) rebooted Keycloak | `auth.staging` 404 + TLS SNI error; route absent from kamal-proxy; KC healthy internally | Manual `kamal-proxy deploy` re-register (§2) | Root-cause fix (`deploy_timeout` + self-heal) shipped same day |
+| 2026-06-05 | Deploy `aa8f8f01` (teal-rebrand auth theme) rebooted Keycloak | `auth.staging` 404 + TLS SNI error; route absent from kamal-proxy; KC healthy internally | Manual `kamal-proxy deploy` re-register (§2) | Same-day "fix" added `deploy_timeout: 120` + self-heal |
+| 2026-06-06 | Every `kamal deploy` aborting | `ConfigurationError: accessories/keycloak/proxy: unknown key: deploy_timeout` | Removed the invalid key; real root cause was the cron CPU-loop (PR #479) | `deploy_timeout` is not a Kamal 2.11 proxy key — it never took effect |


### PR DESCRIPTION
## Problem (deploys broken for everyone)
Every `kamal deploy` was aborting at config-parse time:
\`\`\`
ERROR (Kamal::ConfigurationError): accessories/keycloak/proxy: unknown key: deploy_timeout
\`\`\`
This has failed **all recent deploys** (not caused by #479 — merging #479 just triggered another deploy that hit the pre-existing broken config).

## Root cause
The 2026-06-05 route-registration incident's "durable fix" (commit f27e4934) added `deploy_timeout: 120` to `accessories.keycloak.proxy`. **`deploy_timeout` is not a valid key in the pinned Kamal 2.11** — Kamal validates the whole config at parse time, so the invalid key aborts every deploy *before any container moves*. The YAML is valid; the schema isn't. The "fix" silently broke deploys instead of fixing anything (it never took effect).

The cold Keycloak boot only blew past kamal-proxy's 30s deploy-timeout because the in-process monthly-report cron was **busy-looping a CPU core** (32-bit `setTimeout` overflow), inflating Quarkus augmentation from ~12-15s to 27s. **PR #479 fixed that root cause** (BullMQ repeatable job), so the default 30s has margin again — the timeout bump isn't needed.

## Fix
- Remove the invalid `deploy_timeout: 120` key from `config/deploy-staging.yml` (keep an explanatory comment + the self-heal reboot step).
- Correct `docs/runbooks/keycloak-proxy-route-recovery.md` (it documented the broken key as the durable fix + told prod to mirror it).
- **CLAUDE.md hard rule**: validate Kamal config keys against the pinned `Gemfile.lock` version before adding them — a config-only change still needs a real/dry-run `kamal deploy` because actionlint/YAML-lint pass on valid-YAML-but-invalid-schema.

## Verification
YAML parses; no `deploy_timeout` key remains (only the explanatory comment). `biome check .` green (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)