### PR TITLE
fix(dependabot): use default-days cooldown for non-semver ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,21 @@ version: 2
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot-yml-file#groups
 #
 # `cooldown` blocks force every routine bump to soak in the wild before
-# Dependabot opens a PR — 14 days for majors (where breaking-change
-# blast-radius lives, e.g. archiver 7→8 going pure-ESM and breaking the
-# postal-export worker on the same day the version was tagged on npm),
-# 7 days for minor/patch (long enough to surface most regressions without
-# starving CVE coverage). Cooldown is per-ecosystem block — Dependabot's
-# parser does not honour YAML anchors, so the block is repeated by hand.
-# Cooldown applies to *version* updates only; Dependabot security updates
-# (CVE-driven) bypass cooldown entirely and ship same-day, which is the
-# whole point of the split.
+# Dependabot opens a PR — long enough to surface most regressions without
+# starving CVE coverage. Cooldown applies to *version* updates only; Dependabot
+# security updates (CVE-driven) bypass cooldown entirely and ship same-day,
+# which is the whole point of the split. Cooldown is per-ecosystem block —
+# Dependabot's parser does not honour YAML anchors, so the block is repeated by
+# hand.
+#
+# ⚠ The granular `semver-major-days` / `semver-minor-days` / `semver-patch-days`
+# keys are ONLY valid for semver ecosystems (npm). Dependabot's parser REJECTS
+# them for `github-actions`, `docker`, and `docker-compose` (tags/digests, not
+# semver) — the whole config fails to load if they appear there. Those
+# ecosystems use a single flat `default-days` instead. (npm keeps the granular
+# 14-day-major / 7-day-minor-patch split where breaking-change blast-radius
+# lives, e.g. archiver 7→8 going pure-ESM and breaking the postal-export worker
+# the day it was tagged on npm.)
 updates:
   - package-ecosystem: npm
     directory: /
@@ -38,9 +44,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
+      default-days: 7
     groups:
       actions:
         applies-to: version-updates
@@ -70,9 +74,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
+      default-days: 7
     ignore:
       - dependency-name: node
         update-types:
@@ -83,18 +85,14 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /packages/api
     schedule:
       interval: weekly
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
+      default-days: 7
     ignore:
       - dependency-name: node
         update-types:
@@ -105,9 +103,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
+      default-days: 7
     ignore:
       - dependency-name: node
         update-types:
@@ -126,9 +122,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
+      default-days: 7
     # Compliance-anchored dependencies (postgres, redis) are NOT ignored
     # here on purpose: Dependabot still opens major-bump PRs so the CVE
     # feed and upstream-release visibility stay intact. The


### PR DESCRIPTION
## Problem
GitHub rejects the entire `.github/dependabot.yml` on every push — so **Dependabot version updates are not running at all**:

> Your `.github/dependabot.yml` contained invalid details
> The property `#/updates/1/cooldown/semver-major-days` is not supported for the package ecosystem `github-actions`. […] `docker` […] `docker-compose`.

## Cause
The granular `cooldown.semver-{major,minor,patch}-days` keys are **only valid for semver ecosystems** (npm). `github-actions`, `docker`, and `docker-compose` version by tag/digest, not semver, so Dependabot's parser rejects those keys — and one invalid key fails the whole config. ([Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#configuration-options-for-dependabotyml))

## Fix
- `github-actions` + the 4 `docker` blocks + `docker-compose` → single flat `cooldown: { default-days: 7 }`.
- `npm` keeps the granular 14-day-major / 7-day-minor-patch split (it IS semver — and that block was never flagged).
- CVE-driven **security updates still bypass cooldown** entirely, so coverage is unchanged.
- Header comment documents the semver-vs-flat distinction so it doesn't regress.

Pre-existing config error (independent of the SeaweedFS/cron work); surfaced on a recent push. YAML validated; only npm retains `semver-*-days`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)