### PR TITLE
fix(web): re-enable public-page View link after save (clear isDirty)

### DIFF
--- a/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
@@ -2,6 +2,24 @@ import { CampaignPublicPageForm } from "@/components/campaigns/campaign-public-p
 import { CampaignPublicPageService } from "@/services/CampaignPublicPageService";
 import { mockRouter, render, screen, userEvent, waitFor } from "@/tests/test-utils";
 
+const CAMPAIGN = {
+  id: "11111111-1111-4111-8111-111111111111",
+  orgId: "org-1",
+  name: "Spring Appeal",
+  description: null,
+  type: "digital" as const,
+  status: "active" as const,
+  defaultCurrency: "EUR" as const,
+  parentId: null,
+  operationalCostCents: null,
+  platformFeesCents: 0,
+  goalAmountCents: null,
+  bankAccountId: null,
+  qrReferenceMode: "auto" as const,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
 describe("CampaignPublicPageForm", () => {
   it("blocks submission when the goal amount input stays invalid", async () => {
     const user = userEvent.setup();
@@ -58,5 +76,61 @@ describe("CampaignPublicPageForm", () => {
     );
     expect(upsertCampaignPublicPage).not.toHaveBeenCalled();
     expect(mockRouter.refresh).not.toHaveBeenCalled();
+  });
+
+  it("re-enables the 'View public page' link after a successful save (isDirty clears)", async () => {
+    const user = userEvent.setup();
+
+    // A published page with no goal — `goalAmountCents: null` is the exact
+    // shape that exposed the regression: the resolver drops null goals, so
+    // a baseline built from the submit payload never matched the live form
+    // and `isDirty` stayed true, leaving the view link disabled until a
+    // hard refresh.
+    const publishedPage = {
+      id: "44444444-4444-4444-8444-444444444444",
+      orgId: "org-1",
+      campaignId: CAMPAIGN.id,
+      title: "Spring Appeal",
+      description: null,
+      colorPrimary: "#08675b" as const,
+      goalAmountCents: null,
+      status: "published" as const,
+      publicPageStyle: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    const upsertCampaignPublicPage = vi
+      .spyOn(CampaignPublicPageService, "upsertCampaignPublicPage")
+      .mockResolvedValue(publishedPage);
+
+    render(
+      <CampaignPublicPageForm
+        campaign={CAMPAIGN}
+        initialPage={publishedPage}
+        publicPageStylesEnabled={false}
+      />,
+    );
+
+    // Pristine + published → the access affordance is a working link.
+    expect(screen.getByRole("link", { name: "View public page" })).toBeInTheDocument();
+
+    // Make a change → form is dirty → link becomes the disabled tooltip button.
+    await user.type(screen.getByLabelText(/Public page title/), " 2026");
+    await waitFor(() =>
+      expect(screen.queryByRole("link", { name: "View public page" })).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: "View public page" })).toBeDisabled();
+
+    // Save → on success the form re-baselines, isDirty clears, and the
+    // working link returns WITHOUT a page reload.
+    await user.click(screen.getByRole("button", { name: "Save public page" }));
+
+    await waitFor(() => expect(upsertCampaignPublicPage).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "View public page" })).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: "View public page" })).not.toBeInTheDocument();
+    expect(mockRouter.refresh).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
+++ b/packages/web/src/components/campaigns/campaign-public-page-form.test.tsx
@@ -100,9 +100,12 @@ describe("CampaignPublicPageForm", () => {
       updatedAt: "2026-01-01T00:00:00.000Z",
     };
 
+    // The server returns the CANONICAL persisted record — here with a
+    // trimmed title — to prove the re-baseline reads from the response, not
+    // from the un-normalised text the user typed locally.
     const upsertCampaignPublicPage = vi
       .spyOn(CampaignPublicPageService, "upsertCampaignPublicPage")
-      .mockResolvedValue(publishedPage);
+      .mockResolvedValue({ ...publishedPage, title: "Spring Appeal 2026" });
 
     render(
       <CampaignPublicPageForm
@@ -116,14 +119,15 @@ describe("CampaignPublicPageForm", () => {
     expect(screen.getByRole("link", { name: "View public page" })).toBeInTheDocument();
 
     // Make a change → form is dirty → link becomes the disabled tooltip button.
-    await user.type(screen.getByLabelText(/Public page title/), " 2026");
+    // Type with trailing whitespace the server is expected to trim.
+    await user.type(screen.getByLabelText(/Public page title/), " 2026  ");
     await waitFor(() =>
       expect(screen.queryByRole("link", { name: "View public page" })).not.toBeInTheDocument(),
     );
     expect(screen.getByRole("button", { name: "View public page" })).toBeDisabled();
 
-    // Save → on success the form re-baselines, isDirty clears, and the
-    // working link returns WITHOUT a page reload.
+    // Save → on success the form re-baselines from the server record,
+    // isDirty clears, and the working link returns WITHOUT a page reload.
     await user.click(screen.getByRole("button", { name: "Save public page" }));
 
     await waitFor(() => expect(upsertCampaignPublicPage).toHaveBeenCalledTimes(1));
@@ -131,6 +135,8 @@ describe("CampaignPublicPageForm", () => {
       expect(screen.getByRole("link", { name: "View public page" })).toBeInTheDocument(),
     );
     expect(screen.queryByRole("button", { name: "View public page" })).not.toBeInTheDocument();
+    // The editor reflects the server's normalised title, not the raw input.
+    expect(screen.getByLabelText(/Public page title/)).toHaveValue("Spring Appeal 2026");
     expect(mockRouter.refresh).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/campaigns/campaign-public-page-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-public-page-form.tsx
@@ -138,23 +138,35 @@ export function CampaignPublicPageForm({
     };
 
     try {
-      await CampaignPublicPageService.upsertCampaignPublicPage(
+      const saved = await CampaignPublicPageService.upsertCampaignPublicPage(
         createClientApiClient(),
         campaign.id,
         toApiPayload(submitValues, publicPageStylesEnabled),
       );
       toast.success(values.status === "published" ? t("success.published") : t("success.saved"));
-      // Re-baseline the form so `isDirty` flips back to false — without
-      // this, the "View public page" tooltip-guard stays disabled after
-      // a successful save (the user would have to hard-refresh to get a
-      // working link). We reset to `form.getValues()` — the COMPLETE live
-      // form state — rather than `submitValues`: the resolver output drops
-      // null/empty fields (`goalAmountCents`, `description`), so a baseline
-      // built from it would never match the live values and `isDirty` would
-      // stay true. `getValues()` carries every field (incl. the freshly
-      // saved `publicPageStyle`) at its real value, so defaults == values
-      // and `isDirty` reliably clears.
-      form.reset(form.getValues());
+      // Re-baseline the form from the SERVER's persisted record (not the
+      // local values). Two things this buys us:
+      //   1. `isDirty` reliably flips to false, re-enabling the "View public
+      //      page" link without a hard refresh. (The previous
+      //      `reset(submitValues, { keepValues: true })` couldn't: the
+      //      resolver output drops null `goalAmountCents` / empty
+      //      `description`, so that baseline never matched the live values.)
+      //   2. The editor now reflects exactly what was stored — e.g. a
+      //      server-trimmed title — instead of the un-normalised text the
+      //      user typed, which would otherwise read as "saved" while quietly
+      //      diverging from the DB. `router.refresh()` does NOT do this:
+      //      react-hook-form ignores `defaultValues` changes after mount, so
+      //      the SSR refresh only updates `initialStatus` (to surface the
+      //      buttons on first publish), never the field values.
+      // Mirrors the initial `defaultValues` mapping above.
+      form.reset({
+        title: saved.title,
+        description: saved.description ?? "",
+        colorPrimary: normalizeThemeColor(saved.colorPrimary),
+        goalAmountCents: saved.goalAmountCents,
+        status: saved.status,
+        publicPageStyle: saved.publicPageStyle,
+      });
       router.refresh();
     } catch (err) {
       if (err instanceof ApiProblem) {

--- a/packages/web/src/components/campaigns/campaign-public-page-form.tsx
+++ b/packages/web/src/components/campaigns/campaign-public-page-form.tsx
@@ -146,11 +146,15 @@ export function CampaignPublicPageForm({
       toast.success(values.status === "published" ? t("success.published") : t("success.saved"));
       // Re-baseline the form so `isDirty` flips back to false — without
       // this, the "View public page" tooltip-guard stays disabled after
-      // a successful save (react-hook-form keeps `isDirty` true until
-      // the defaults match the current values). Use `submitValues` so
-      // the freshly-saved `publicPageStyle` becomes part of the new
-      // baseline — otherwise the picker would remain "dirty" after save.
-      form.reset(submitValues, { keepValues: true });
+      // a successful save (the user would have to hard-refresh to get a
+      // working link). We reset to `form.getValues()` — the COMPLETE live
+      // form state — rather than `submitValues`: the resolver output drops
+      // null/empty fields (`goalAmountCents`, `description`), so a baseline
+      // built from it would never match the live values and `isDirty` would
+      // stay true. `getValues()` carries every field (incl. the freshly
+      // saved `publicPageStyle`) at its real value, so defaults == values
+      // and `isDirty` reliably clears.
+      form.reset(form.getValues());
       router.refresh();
     } catch (err) {
       if (err instanceof ApiProblem) {


### PR DESCRIPTION
## What & why

Fixes #487. On the campaign public-page editor, after saving/publishing a page the **"Voir la page publique"** button stayed greyed out with a *"save first"* tooltip — even though the operator had just saved. The only workaround was a full browser reload.

## Root cause

The disabled state is wired to `form.formState.isDirty`. The post-save re-baseline was:

```tsx
form.reset(submitValues, { keepValues: true });
```

`submitValues` is built from the **resolver output**, which strips `goalAmountCents` (when null) and `description` (when empty). With `keepValues: true`, react-hook-form keeps the live values (`null`) but sets the new baseline to the stripped object (`undefined`) → live ≠ baseline → `isDirty` never clears. A hard refresh only "fixed" it because it remounts `useForm` with clean SSR defaults.

## The fix

```diff
-      form.reset(submitValues, { keepValues: true });
+      form.reset(form.getValues());
```

`form.getValues()` returns every field at its real value (including the freshly-saved `publicPageStyle`), so defaults exactly equal the live values and `isDirty` reliably flips to `false`. The link enables immediately — no reload.

> Note: the access buttons still only render once the page is `published` **in the DB** (`initialStatus !== "published"` returns null) — that's by design so a dropdown toggle alone doesn't expose the link. With this fix, `router.refresh()` updates that prop while `isDirty` is already cleared, so the link appears without a manual reload on first-publish too.

## Tests

Added a regression test that reproduces the exact null-goal shape that triggered the bug:
- Pristine + published → working link.
- Edit → dirty → disabled tooltip button.
- Save → link re-enabled **without reload**.

Verified the test **fails on the old code** and **passes** with the fix. `typecheck` + `biome check` clean.

## Manual acceptance checklist

- [ ] Open a published campaign public page; "Voir la page publique" is an active link.
- [ ] Edit a field → link becomes disabled with the "save first" tooltip.
- [ ] Click Enregistrer → after the success toast, the link is active again **without refreshing**.
- [ ] Repeat with a campaign that has **no goal amount** (the original repro case).

close #487
