### PR TITLE
fix(impersonation): recover platform-admin session on impersonation expiry (no more auth-error dead-end)

### DIFF
--- a/packages/web/src/components/layout/impersonation-banner.tsx
+++ b/packages/web/src/components/layout/impersonation-banner.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { setImpersonationActive } from "@/lib/api/client-browser";
 import type { ImpersonationInfo } from "@/lib/auth";
 import { getCsrfHeaderName, readCsrfTokenFromDocumentCookie } from "@/lib/auth/csrf";
 
@@ -80,6 +81,17 @@ export function ImpersonationBanner({ impersonation, userName }: ImpersonationBa
   // the practical UX is unchanged: the time appears within a frame of
   // hydration completing, just rendered exclusively on the client.
   const [remaining, setRemaining] = useState<string>("");
+
+  // Tell the browser API client whether this is an impersonation session so
+  // it can recover from a mid-session token expiry: a 401 on a client-side
+  // fetch then triggers a full navigation to /admin/impersonation, where the
+  // proxy restores the operator's platform-admin session. Kept independent
+  // of the countdown effect and above the `!impersonation` early-return so
+  // the flag also clears when impersonation ends.
+  useEffect(() => {
+    setImpersonationActive(!!impersonation);
+    return () => setImpersonationActive(false);
+  }, [impersonation]);
 
   useEffect(() => {
     if (!impersonation?.expiresAt) return;

--- a/packages/web/src/lib/api/client-browser.test.ts
+++ b/packages/web/src/lib/api/client-browser.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { createBrowserFetch } from "./client-browser";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBrowserFetch, setImpersonationActive } from "./client-browser";
 
 describe("createBrowserFetch", () => {
   afterEach(() => {
@@ -39,5 +39,64 @@ describe("createBrowserFetch", () => {
 
     const [, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit];
     expect(new Headers(init.headers).has("X-CSRF-Token")).toBe(false);
+  });
+});
+
+describe("createBrowserFetch — impersonation-expiry recovery", () => {
+  const originalLocation = window.location;
+  let assignMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // jsdom forbids spying on `window.location.assign` directly — replace the
+    // whole location object instead (see feedback_jsdom_location_assign_stub).
+    assignMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, assign: assignMock },
+    });
+    setImpersonationActive(false);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+    setImpersonationActive(false);
+  });
+
+  function fetchReturning(status: number) {
+    return vi.fn().mockResolvedValue(new Response(null, { status }));
+  }
+
+  it("navigates to /admin/impersonation on a 401 when impersonation is active", async () => {
+    setImpersonationActive(true);
+    const browserFetch = createBrowserFetch(fetchReturning(401) as typeof fetch);
+
+    const response = await browserFetch("https://example.test/v1/example");
+
+    expect(assignMock).toHaveBeenCalledWith("/admin/impersonation");
+    // The response is still returned so the caller's error handling runs.
+    expect(response.status).toBe(401);
+  });
+
+  it("does NOT navigate on a 401 when impersonation is inactive", async () => {
+    setImpersonationActive(false);
+    const browserFetch = createBrowserFetch(fetchReturning(401) as typeof fetch);
+
+    await browserFetch("https://example.test/v1/example");
+
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT navigate on a non-401 response even when impersonating", async () => {
+    setImpersonationActive(true);
+    const browserFetch = createBrowserFetch(fetchReturning(200) as typeof fetch);
+
+    await browserFetch("https://example.test/v1/example");
+
+    expect(assignMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/lib/api/client-browser.ts
+++ b/packages/web/src/lib/api/client-browser.ts
@@ -7,8 +7,36 @@ const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 /** Key for globalThis singleton — survives Next.js Fast Refresh in dev. */
 const GLOBAL_KEY = Symbol.for("givernance.browserApiClient");
 
+/** Where to land an operator whose impersonation session has expired. */
+const IMPERSONATION_RECOVERY_PATH = "/admin/impersonation";
+
+/**
+ * Whether the current browser session is an impersonation session.
+ * Set by the impersonation banner (the only client component that knows
+ * the SSR-resolved impersonation state) via `setImpersonationActive`.
+ */
+let impersonationActive = false;
+/** Guard against duplicate `assign` calls when concurrent requests 401. */
+let recoveryRedirecting = false;
+
+/**
+ * Mark the browser session as (not) an impersonation session.
+ *
+ * Wired from `ImpersonationBanner` so the browser fetch wrapper can tell,
+ * on a 401, whether to trigger impersonation-expiry recovery. When the
+ * impersonation token reaches its TTL mid-session on a client-side page,
+ * the API returns 401 and there is no full-page navigation to trigger the
+ * proxy's session-refresh path — leaving the operator dead-ended. The
+ * interceptor below forces a full navigation to `/admin/impersonation`,
+ * which the proxy uses to restore the operator's platform-admin session
+ * from their still-valid Keycloak refresh token.
+ */
+export function setImpersonationActive(active: boolean): void {
+  impersonationActive = active;
+}
+
 export function createBrowserFetch(fetchImpl: typeof fetch = fetch): typeof fetch {
-  return (input, init) => {
+  return async (input, init) => {
     const headers = new Headers(init?.headers);
     const method = (init?.method ?? "GET").toUpperCase();
 
@@ -30,11 +58,29 @@ export function createBrowserFetch(fetchImpl: typeof fetch = fetch): typeof fetc
       headers.delete("Content-Type");
     }
 
-    return fetchImpl(input, {
+    const response = await fetchImpl(input, {
       ...init,
       headers,
       credentials: "include",
     });
+
+    // Impersonation-expiry recovery: a 401 on a client-side fetch while the
+    // operator is impersonating means the short-lived impersonation token
+    // has expired. A full-page navigation hits the Next.js proxy, which
+    // restores the operator's platform-admin session from their still-valid
+    // Keycloak refresh token and lands them back on the session list. We
+    // still return the response so the caller's normal error handling runs.
+    if (
+      response.status === 401 &&
+      impersonationActive &&
+      !recoveryRedirecting &&
+      typeof window !== "undefined"
+    ) {
+      recoveryRedirecting = true;
+      window.location.assign(IMPERSONATION_RECOVERY_PATH);
+    }
+
+    return response;
   };
 }
 


### PR DESCRIPTION
## The bug

When a platform super-admin uses **impersonation** and the session reaches its TTL (30 min–1 h), the impersonation cookie `givernance_jwt` expires. If the operator is on a **client-side page** when this happens, the next client `fetch` gets a `401` from the API (`"Impersonation session ended or expired."`). The browser `ApiClient` throws an `ApiProblem`, the operator sees an authentication error, and there is **no way to recover** — no login link, no way to end the impersonation and get their platform-admin token back. They dead-end.

## Root cause

A recovery mechanism already exists, but it only fires on a **full-page navigation**: the Next.js proxy (`packages/web/src/proxy.ts`, `applyMaybeRefreshSession`) detects a request with no `givernance_jwt` but a still-valid `givernance_refresh_token` (the operator's Keycloak refresh token, which impersonation never overwrites) and refreshes the operator's Keycloak session, restoring the platform-admin. The DELETE end-session flow and the banner's "End session" button rely on this via `window.location.href`.

The gap: a **client-side** 401 never triggers a full navigation, so the proxy's refresh path never runs. Nothing intercepts the client 401.

## The fix (client-side only, no backend changes)

Add a global 401 interceptor to the **browser** API fetch wrapper:

- `setImpersonationActive(active)` exposes a module-level flag from `client-browser.ts`.
- `ImpersonationBanner` (the client component that already knows the SSR-resolved impersonation state) wires the flag in a `useEffect`, resetting it on cleanup / when impersonation ends.
- On a `401` **while the impersonation flag is true** (and `typeof window !== "undefined"`, guarded against duplicate redirects from concurrent 401s), the wrapper calls `window.location.assign("/admin/impersonation")`. The full navigation hits the proxy, which restores the operator's platform-admin session from the still-valid Keycloak refresh token and lands them back on the session list — exactly where they started.

Non-impersonation sessions keep their current behavior (a normal expired session is untouched). The response is still returned so the caller's existing error handling runs unchanged.

## Files changed

- `packages/web/src/lib/api/client-browser.ts` — `setImpersonationActive` flag bridge + 401 interceptor in the browser fetch wrapper.
- `packages/web/src/components/layout/impersonation-banner.tsx` — `useEffect` wiring `setImpersonationActive(!!impersonation)` with cleanup, above the `!impersonation` early-return.
- `packages/web/src/lib/api/client-browser.test.ts` — tests both directions (401 + impersonating → navigates; 401 + not impersonating → no navigation; non-401 + impersonating → no navigation).

## Manual acceptance checklist

- [ ] Impersonate a tenant user as super-admin; let the impersonation token expire (or revoke it); trigger any client-side fetch → browser navigates to `/admin/impersonation` and the operator is back as platform-admin.
- [ ] A normal (non-impersonation) session that 401s does NOT get redirected to `/admin/impersonation`.
- [ ] Ending impersonation via the banner button still works (unchanged).
- [ ] No duplicate navigation when several client fetches 401 at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)