### PR TITLE
fix(campaigns): QR-bill postal preview picks reference type by IBAN kind (#495)

### DIFF
--- a/docs/25-swiss-qr-bill.md
+++ b/docs/25-swiss-qr-bill.md
@@ -269,6 +269,8 @@ Per-letter — never per-campaign — **a fresh reference is minted** keyed `(co
 
 > **EUR + QRR is illegal** under IG QR-bill v2.4 (euroSIC discontinuation): currency-vs-reference consistency is enforced server-side. CHF is the default for Swiss NPOs.
 
+> **The synchronous preview obeys this same matrix** (`POST /v1/campaigns/:id/postal-preview`). It resolves the reference type from the linked account's `iban_kind` + the campaign's `qr_reference_mode` exactly as the worker does, then mints a *never-registered* fixture of that type (QRR for a QR-IBAN, SCOR for a regular IBAN). Hardcoding a QRR fixture made the preview 500 for every regular-IBAN campaign — `swissqrbill` v4 rejects a QRR reference on a non-QR-IBAN with `QR-Reference requires the use of a QR-IBAN` (issue #495). The preview must stay in lockstep with the export here: the whole point of the preview is to show what Generate will print.
+
 The full rationale for these matrix decisions, including rejected alternatives (NON, per-campaign references, EUR+QRR), is in [ADR-027](./adrs/adr-027-swiss-qr-bill.md).
 
 ## 2. Domain model

--- a/packages/api/src/modules/campaigns/postal-routes.ts
+++ b/packages/api/src/modules/campaigns/postal-routes.ts
@@ -24,7 +24,7 @@ import {
   POSTAL_EXPORT_STATUS_VALUES,
   tenants,
 } from "@givernance/shared/schema";
-import { computeQrr } from "@givernance/shared/validators";
+import { computeQrr, computeScor } from "@givernance/shared/validators";
 import { Type } from "@sinclair/typebox";
 import archiver from "archiver";
 import { and, eq, isNull } from "drizzle-orm";
@@ -165,6 +165,36 @@ const MembersListQuery = Type.Intersect([
     order: Type.Optional(Type.Union([Type.Literal("asc"), Type.Literal("desc")])),
   }),
 ]);
+
+/**
+ * Resolve the QR-bill preview's fixture reference the same way the worker
+ * resolves the real reference TYPE for the export (`resolveReferenceType`
+ * in `worker/services/swiss-qr-bill.ts`, mirroring ADR-027's matrix):
+ * `auto` → QRR for a QR-IBAN, SCOR for a regular IBAN; an explicit campaign
+ * override wins. The preview MUST pick the same type the export will —
+ * `swissqrbill` v4 throws "QR-Reference requires the use of a QR-IBAN" when a
+ * QRR reference is paired with a regular IBAN, so hardcoding a QRR fixture
+ * 500'd every regular-IBAN campaign's preview while its export rendered fine
+ * (issue #495).
+ *
+ * Both branches go through the canonical Swiss check-digit helpers (rather
+ * than hand-rolled checksums) so a future tweak to either helper cannot
+ * silently desync the fixture from the validator. The fixture is never
+ * registered in `swiss_qr_references`, so a real bank scanning the preview
+ * rejects it (safe).
+ *   QRR  → 26-digit body + mod-10-recursive check digit.
+ *   SCOR → ISO 11649 `RF<check><payload>` creditor reference.
+ */
+function resolvePreviewReference(
+  qrReferenceMode: "auto" | "qrr" | "scor",
+  ibanKind: "iban" | "qr_iban",
+): string {
+  const effectiveType =
+    qrReferenceMode === "auto" ? (ibanKind === "qr_iban" ? "qrr" : "scor") : qrReferenceMode;
+  return effectiveType === "qrr"
+    ? computeQrr("21000000000000000000000000")
+    : computeScor("PREVIEWSAMPLE");
+}
 
 export async function postalCampaignRoutes(app: FastifyInstance) {
   // ─── Campaign ↔ constituent membership ──────────────────────────────
@@ -608,6 +638,7 @@ export async function postalCampaignRoutes(app: FastifyInstance) {
       const [bankAccount] = await systemDb
         .select({
           iban: bankAccounts.iban,
+          ibanKind: bankAccounts.ibanKind,
           holderName: bankAccounts.holderName,
           holderStreet: bankAccounts.holderStreet,
           holderBuildingNumber: bankAccounts.holderBuildingNumber,
@@ -638,15 +669,15 @@ export async function postalCampaignRoutes(app: FastifyInstance) {
           );
       }
 
-      // 27-digit fixture QRR with a valid mod-10 check digit — never
-      // registered in `swiss_qr_references` so a real bank scanning the
-      // preview will reject it (safe). Computed via the canonical Swiss
-      // "Modulo 10 recursive" helper rather than hand-rolling the check
-      // digit: a future tweak to the helper (or to the 26-char body
-      // sentinel below) cannot silently desync from the validator and
-      // produce an invalid fixture that the swissqrbill library would
-      // reject at render time.
-      const previewReference = computeQrr("21000000000000000000000000");
+      // Fixture reference matched to the resolved reference TYPE (QRR for a
+      // QR-IBAN, SCOR for a regular IBAN — see `resolvePreviewReference`).
+      // `swissqrbill` v4 throws on a QRR reference paired with a regular
+      // IBAN, so the preview MUST pick the same type the export will
+      // (issue #495).
+      const previewReference = resolvePreviewReference(
+        campaign.qrReferenceMode ?? "auto",
+        bankAccount.ibanKind,
+      );
 
       // ─── QR-bill only mode → single inline 2-page PDF. ─────────────
       if (runMode === "qr_bill_only") {

--- a/packages/api/src/tests/integration/postal-campaigns.test.ts
+++ b/packages/api/src/tests/integration/postal-campaigns.test.ts
@@ -751,6 +751,82 @@ describe("Postal preview", () => {
     });
     expect(res.statusCode).toBe(404);
   });
+
+  // Issue #495 — the QR-bill preview hardcoded a QRR fixture reference for
+  // every Swiss-linked campaign. `swissqrbill` v4 throws "QR-Reference
+  // requires the use of a QR-IBAN" when a QRR reference is paired with a
+  // *regular* IBAN, so the preview 500'd for every campaign whose linked
+  // account is a regular IBAN (the common case) even though the real
+  // export rendered fine (the worker resolves QRR-vs-SCOR from the IBAN
+  // kind). These two tests lock both branches: regular IBAN → SCOR
+  // fixture → renders; QR-IBAN → QRR fixture → renders.
+  const REGULAR_CH_IBAN = "CH9300762011623852957";
+  const QR_CH_IBAN = "CH4431999123000889012";
+  const QR_BILL_HOLDER = {
+    holderName: "Association Givernance Test (#495)",
+    holderStreet: "Rue de la Paix",
+    holderBuildingNumber: "12",
+    holderPostalCode: "1003",
+    holderTown: "Lausanne",
+    holderCountryCode: "CH",
+  };
+
+  async function createBankLinkedCampaign(iban: string): Promise<string> {
+    const token = signToken(app);
+    // Fresh slate — the partial unique (org_id, iban) WHERE deleted_at IS
+    // NULL would otherwise collide across re-runs on the persistent DB.
+    await db.execute(sql`DELETE FROM bank_accounts WHERE org_id = ${ORG_A} AND iban = ${iban}`);
+    const bank = await app.inject({
+      method: "POST",
+      url: "/v1/bank-accounts",
+      headers: authHeader(token),
+      payload: { ...QR_BILL_HOLDER, iban, bankName: "PostFinance", currency: "CHF" },
+    });
+    expect(bank.statusCode).toBe(201);
+    const bankAccountId = bank.json<{ data: { id: string } }>().data.id;
+
+    // No public page → qr_bill_only mode → single inline PDF (not a ZIP),
+    // so the assertion stays a clean `%PDF-` magic-header check.
+    const campaign = await createCampaign("QR-bill preview campaign", "nominative_postal", {
+      publishPage: false,
+    });
+    const linked = await app.inject({
+      method: "PATCH",
+      url: `/v1/campaigns/${campaign}`,
+      headers: authHeader(token),
+      payload: { bankAccountId },
+    });
+    expect(linked.statusCode).toBe(200);
+    return campaign;
+  }
+
+  it("preview renders a QR-bill PDF for a campaign linked to a REGULAR IBAN (SCOR, issue #495)", async () => {
+    const token = signToken(app);
+    const id = await createBankLinkedCampaign(REGULAR_CH_IBAN);
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/campaigns/${id}/postal-preview`,
+      headers: authHeader(token),
+      payload: { mode: "personalized" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/pdf");
+    expect(res.rawPayload.subarray(0, 5).toString("ascii")).toBe("%PDF-");
+  });
+
+  it("preview renders a QR-bill PDF for a campaign linked to a QR-IBAN (QRR)", async () => {
+    const token = signToken(app);
+    const id = await createBankLinkedCampaign(QR_CH_IBAN);
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/campaigns/${id}/postal-preview`,
+      headers: authHeader(token),
+      payload: { mode: "personalized" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/pdf");
+    expect(res.rawPayload.subarray(0, 5).toString("ascii")).toBe("%PDF-");
+  });
 });
 
 describe("QR tracking metrics", () => {


### PR DESCRIPTION
## Problem

On a campaign linked to a bank account, the postal-export **Aperçu** (preview) button returns `Preview failed (500)` (issue #495).

The synchronous preview endpoint (`POST /v1/campaigns/:id/postal-preview`) hardcoded a **QRR** fixture reference for every Swiss-linked campaign:

```ts
const previewReference = computeQrr("21000000000000000000000000");
```

But `swissqrbill` v4 enforces the Swiss spec: a **QRR reference requires a QR-IBAN** (IID 30000–31999). The reproduction throws:

```
ValidationError: QR-Reference requires the use of a QR-IBAN.
```

So the preview 500'd for **every campaign whose linked account is a regular IBAN** (the common case — staging's demo account `CH93…` is a regular IBAN, `iban_kind = 'iban'`) — even though the **real export rendered fine**, because the worker resolves QRR-vs-SCOR from the account's `iban_kind` (`resolveReferenceType`, ADR-027). Classic "preview lies about the print" drift.

No try/catch on the route → the `swissqrbill` throw surfaced as a bare 500.

## Fix

Resolve the preview's fixture reference **the same way the worker resolves the real reference type**: `auto` → QRR for a QR-IBAN, SCOR for a regular IBAN; an explicit campaign override wins. Extracted into a module-scope `resolvePreviewReference(qrReferenceMode, ibanKind)` helper.

- Both branches go through the canonical Swiss check-digit helpers (`computeQrr` / `computeScor`), so the fixture can't desync from the validator.
- The fixture is never registered in `swiss_qr_references`, so a real bank scanning the preview still rejects it (safe).

## Tests

Added integration coverage for **both** branches — the missing case that let this ship (the existing preview test only exercised standard mode with no bank account):

- regular IBAN → SCOR fixture → renders `application/pdf`
- QR-IBAN → QRR fixture → renders `application/pdf`

Verified the regular-IBAN test fails (500) against the pre-fix code and passes with the fix. Full `postal-campaigns.test.ts` suite: 53/53 green. `pnpm build` / `typecheck` / `biome check` clean.

## Docs

`docs/25-swiss-qr-bill.md` — noted that the preview obeys the same reference-type matrix as the export (lockstep), with the issue #495 context.

## Manual acceptance

- [x] On staging, open a campaign linked to a **regular** IBAN → click **Aperçu** → a watermarked QR-bill PDF (SCOR slip) opens instead of `Preview failed (500)`.
- [x] A campaign linked to a **QR-IBAN** still previews (QRR slip).
- [x] A campaign with a public page but **no** bank account still previews the standard letter.

close #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)