### PR TITLE
fix(campaigns): render pattern chips in the add-constituents filter summary

### DIFF
--- a/packages/web/src/app/(app)/campaigns/[id]/add-constituents/filter-mode.tsx
+++ b/packages/web/src/app/(app)/campaigns/[id]/add-constituents/filter-mode.tsx
@@ -24,13 +24,40 @@ interface FilterModeProps {
 }
 
 /**
+ * i18n key (under `constituents.filters.patterns.*`) for a BE pattern flag.
+ * `FilterChip` carries its own `constituents.filters` translator and resolves
+ * the key to the active locale, so we hand it the key path verbatim.
+ */
+const PATTERN_LABEL_KEY: Record<string, string> = {
+  LYBUNT: "patterns.lybunt",
+  SYBUNT: "patterns.sybunt",
+  RECURRING: "patterns.recurring",
+  LAPSED: "patterns.lapsed",
+  MAJOR_DONOR: "patterns.majorDonor",
+};
+
+/**
  * Build the chip list for the active-selection strip from a filter query.
- * Mirrors `FilterBuilder.getActiveFilters` so the summary shown here matches
- * the one inside the dialog.
+ * Two sources, mirroring `campaign-members-card.chipsFromQuery`:
+ *  - top-level conditions → condition chips,
+ *  - each `patterns[i]` flag → a `kind: "pattern"` chip (sparkle + localised
+ *    label) so a pattern-only preset (LYBUNT, RECURRING, …) doesn't render an
+ *    empty strip.
  */
 function getActiveFilters(query: FilterQuery | null) {
   if (!query) return [];
-  return query.conditions
+
+  const patternChips = (query.patterns ?? []).map((pattern) => ({
+    id: `pattern:${pattern}`,
+    kind: "pattern" as const,
+    label: PATTERN_LABEL_KEY[pattern] ?? pattern,
+    field: pattern,
+    operator: "eq",
+    value: pattern,
+    pattern,
+  }));
+
+  const conditionChips = query.conditions
     .filter(isFilterCondition)
     .filter(
       (c) =>
@@ -43,12 +70,15 @@ function getActiveFilters(query: FilterQuery | null) {
       const known = filterFields.find((f) => f.name === c.field);
       return {
         id: c.id,
+        kind: "condition" as const,
         label: known?.label ?? c.field,
         field: c.field,
         operator: c.operator,
         value: c.value,
       };
     });
+
+  return [...patternChips, ...conditionChips];
 }
 
 export function FilterMode({
@@ -65,7 +95,7 @@ export function FilterMode({
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const activeFilters = getActiveFilters(filterQuery);
-  const hasFilters = activeFilters.length > 0 || (filterQuery?.patterns?.length ?? 0) > 0;
+  const hasFilters = activeFilters.length > 0;
 
   const handleApply = async (query: FilterQuery) => {
     await onFilterChange(query);


### PR DESCRIPTION
## Context

Follow-up to #498 (which fixed the filters-never-load bug on the campaign **Add constituents** page, #494). That PR added an active-filters summary strip built from `query.conditions`.

## Problem

A **pattern-only** preset — LYBUNT, SYBUNT, RECURRING, LAPSED, MAJOR_DONOR — ships `conditions: []` + `patterns: [...]`. Because the summary only built chips from `conditions`, picking one of those presets rendered the **"Active filters" header above an empty chip row**.

## Fix

`getActiveFilters` in [`filter-mode.tsx`](packages/web/src/app/(app)/campaigns/[id]/add-constituents/filter-mode.tsx) now also emits a `kind: "pattern"` chip per pattern flag — mirroring `campaign-members-card.chipsFromQuery`. Each pattern chip gets the sparkle treatment and a label resolved from the existing `constituents.filters.patterns.*` messages (FilterChip carries its own translator, so we hand it the key path). `hasFilters` is simplified now that patterns are part of `activeFilters`.

No new strings, schema, or API surface — pure render fix on an existing flagged feature.

## Verification

- [x] `pnpm --filter @givernance/web typecheck` — clean
- [x] `pnpm biome check .` — exit 0
- [x] All five `patterns.*` label keys exist in en + fr

## Manual acceptance

- [x] New campaign → Add constituents → Advanced filters → pick a preset like **LYBUNT / Recurring donors** → a sparkle chip with the localized label appears (no empty strip)
- [x] A hand-built condition still renders its condition chip
- [x] A preset + a hand-built condition renders both

Relates to #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)