### PR TITLE
chore(flags): retire 5 validated feature flags, keep enabled path (#493)

### DIFF
--- a/docs/18-feature-flags.md
+++ b/docs/18-feature-flags.md
@@ -8,16 +8,18 @@
 
 Phase 1 (PR #352) shipped the global-flag subset; Phase 2 (PR #366 / Epic #365) added tenant overrides, scope-based gating, and the public-projection filter. The table below is the live status as of PR #366 (status banner at the top of [`.claude/agents/feature-flag-engineer.md`](../.claude/agents/feature-flag-engineer.md) carries the same summary for agent briefings):
 
+> **Retired flags (issue #493).** Five validated flags were retired — their features are now permanently part of the product, with the gating code deleted (no `requireFlag`, no worker `isFlagEnabled`, no SSR `xEnabled`) and their seed rows dropped by migration `0082`: `admin.feature_flags_phase2`, `admin.finance_dashboard`, `admin.impersonation_replicate`, `communication.notifications_center`, `productivity.command_palette`. The per-organisation flag-administration tooling that `admin.feature_flags_phase2` once gated **stays** — only its own gate was removed; the remaining flags still use it. See § 8 "Flag Lifecycle → REMOVED". The flags still in active rollout are `communication.bulk_email`, `donation.public_page_styles`, `constituents.bulk_import`, `advanced_filters`, `campaign.postal_merged_pdf`.
+
 | Surface | Status | Notes |
 |---|---|---|
 | `feature_flags` table | ✅ shipped (`0047` + `0051`) | Phase 2 added `scope` (enum platform/tenant), `tenant_override_allowed` boolean, `public` boolean. Partial index on `WHERE public = TRUE` for the hot projection path. |
 | `tenant_flag_overrides` table | ✅ shipped (`0051`) | Per-org overrides. RLS forced via `tenant_id = app_current_organization_id()`. `UNIQUE (tenant_id, flag_key)`. `reason` free-text + `set_by SET NULL ON DELETE`. `expires_at` reserved (UI deferred). |
-| `FEATURE_FLAG_REGISTRY` const (`packages/shared/src/constants/feature-flags.ts`) | ✅ shipped | Typed `FeatureFlagKey` union; entries now declare `scope` + `tenantOverrideAllowed` + `public`. Keys: `communication.bulk_email`, `admin.feature_flags_phase2`, `constituents.bulk_import` (the first key shipped with `scope='tenant'` AND `tenant_override_allowed=true`, driving the first real row on the org-admin `/settings/feature-flags` page — Epic #373, PR #385). |
+| `FEATURE_FLAG_REGISTRY` const (`packages/shared/src/constants/feature-flags.ts`) | ✅ shipped | Typed `FeatureFlagKey` union; entries declare `scope` + `tenantOverrideAllowed` + `public`. Live keys after issue #493: `communication.bulk_email`, `donation.public_page_styles`, `constituents.bulk_import`, `advanced_filters`, `campaign.postal_merged_pdf` (all `scope='tenant'`). `constituents.bulk_import` was the first key with `tenant_override_allowed=true`, driving the first real row on the org-admin `/settings/feature-flags` page — Epic #373, PR #385. |
 | `flagService.isEnabled(key, ctx?)` + Redis cache | ✅ shipped (Phase 2) | `ctx.orgId` activates tenant overrides for `scope='tenant'` flags. Caches: `flags:global:v2` (Map<key, {enabled, scope}>) + per-tenant `flags:tenant:{orgId}:v1`. TTL 60 s. v2 because Phase-1 shape was `Record<key, boolean>` and the evaluator now needs `scope`. |
 | Precedence algorithm | ✅ shipped (Phase 2) | unknown key → false; `scope='platform'` → platform default (overrides ignored even if rows exist); `scope='tenant'` + orgId → override row if present else default; `scope='tenant'` + no orgId → default (worker / platform path). Section 5 below is the live spec. |
 | `requireFlag(key)` preHandler | ✅ shipped | 404 on disabled, runs FIRST in the preHandler chain so a scanner can't enumerate role requirements. Now passes `request.auth.orgId` so tenant-scoped flags evaluate against the caller's org (backward-compatible: public/unauthenticated routes get a null orgId and fall back to platform default, identical to the Phase-1 no-context call). |
 | Worker-side `isFlagEnabled(key)` | ✅ shipped | `packages/worker/src/lib/flags.ts` — defence-in-depth at job pickup. Workers operate without an `orgId` context (platform path) — fine for `scope='platform'` flags, which are the only thing workers gate on today. |
-| `GET /v1/admin/feature-flags` | ✅ shipped | Super-admin global view. Response now carries `overrideStats` per row (count of tenants overriding to true / false) when `admin.feature_flags_phase2` is on — null otherwise so the JSON shape stays stable across flag flips. |
+| `GET /v1/admin/feature-flags` | ✅ shipped | Super-admin global view. Response carries `overrideStats` per row (count of tenants overriding to true / false) for tenant-scoped flags; `null` for platform-scoped flags that never carry overrides so the JSON shape stays stable. |
 | `PATCH /v1/admin/feature-flags/:key` | ✅ shipped | Super-admin platform-default flip. Unchanged from Phase 1. |
 | `GET /v1/admin/tenants/:tenantId/feature-flags` | ✅ shipped (Phase 2) | Super-admin tenant-detail tab. Returns each flag with platform default + effective value + override row (if any). `scope='platform'` flags surface as read-only context. |
 | `PUT /v1/admin/tenants/:tenantId/feature-flags/:key` | ✅ shipped (Phase 2) | Super-admin upsert override. 404 on missing flag (anti-disclosure), 422 on `scope='platform'` attempt (operator picked the wrong tool). Idempotent — re-PUT with same payload refreshes `set_by` / `reason` / `updated_at`. |
@@ -26,7 +28,7 @@ Phase 1 (PR #352) shipped the global-flag subset; Phase 2 (PR #366 / Epic #365) 
 | `PATCH /v1/org/feature-flags/:key` | ✅ shipped (Phase 2) | Org-admin self-service toggle. 404 (anti-disclosure) for every rejection — platform-scoped flags, admin-gated flags, missing keys all look identical to the caller. |
 | `GET /v1/feature-flags` (public projection) | ✅ shipped (Phase 2) | Now filtered by `public=true` — unreleased flag names no longer leak via DevTools. Evaluator overlays the caller's tenant overrides on each value. Resolves the public-projection caveat from prior § 0. |
 | Audit trail | ✅ shipped | The existing `audit-plugin` (`packages/api/src/plugins/audit.ts`) auto-records every mutating request including the new override CRUD. `action` (e.g. `PUT:/v1/admin/tenants/:tenantId/feature-flags/:key`), `org_id`, `actor_id`, `resource_type`, `resource_id`, impersonation context — all captured. Satisfies § 4.3 with zero new audit code. |
-| `admin.feature_flags_phase2` self-flag | ✅ shipped (Phase 2) | All Phase-2 endpoints + UI surfaces are gated by this flag — kill-switch for the whole Epic. Off-state: every new endpoint 404s, new UI surfaces absent. `scope='platform'` so tenants can't opt themselves in; `public=true` so the org-admin SSR layout can decide to render the sidebar entry. |
+| `admin.feature_flags_phase2` self-flag | ♻️ retired (issue #493) | The Phase-2 tooling is now always reachable; only the self-flag gate was removed. The override endpoints, the per-tenant "Feature flags" tab, the org-admin `/settings/feature-flags` page, and `overrideStats` all stay — the remaining flags rely on them. Seed row dropped by migration `0082`. |
 | Back Office page `/admin/feature-flags` | ✅ shipped Phase 1; 🚧 Phase 2 tenant-override column lands on PR #366 | Existing toggle UI for platform defaults. Tenant-override count column + drill-down side-panel land on this PR. |
 | Super-admin "Feature flags" tab on `/admin/tenants/[id]` | 🚧 in progress (PR #366) | Lands on this PR. |
 | Org-admin `/settings/feature-flags` page | 🚧 in progress (PR #366) | Lands on this PR. |
@@ -63,38 +65,31 @@ Why DB-stored text (vs i18n-keyed): the registry is small (<10 keys foreseeable)
 
 If the Back Office page is unavailable and a flag needs to come down NOW, see `docs/runbooks/feature-flag-rollback.md` — the canonical procedure is `UPDATE feature_flags SET enabled = false WHERE key = ?;` + `redis-cli DEL flags:global`.
 
-### How to verify Phase 2 surfaces locally
+### How to verify the per-organisation override surfaces locally
 
-Because every Phase-2 surface is gated by `admin.feature_flags_phase2` (off by default — the kill-switch pattern), a fresh local checkout shows **no visible change** until that flag is flipped on. Symptoms of "I don't see anything": (a) the new "Feature flags" tab is absent from `/admin/tenants/[id]`, (b) the `/settings/feature-flags` route returns 404, (c) the Feature flags entry is missing from the org-admin settings nav strip.
+The flag-administration tooling is always reachable (the `admin.feature_flags_phase2` self-flag that once gated it was retired in issue #493). On a fresh local checkout the surfaces are present immediately: the **Feature flags** tab on `/admin/tenants/[id]`, the `/settings/feature-flags` org-admin page, and the Feature flags entry in the org-admin settings nav strip.
 
-To see the Phase-2 UI end-to-end:
+To see the override UI end-to-end:
 
-1. **Apply migration 0051** on the local DB:
+1. **Apply migrations** on the local DB:
    ```bash
    DATABASE_URL="postgresql://givernance:givernance_dev@localhost:5432/givernance" \
      pnpm --filter @givernance/api run db:migrate
    ```
 
-2. **Verify the seed**:
+2. **Verify the seed** (the retired keys are gone after migration `0082`):
    ```bash
    psql "postgresql://givernance:givernance_dev@localhost:5432/givernance" \
      -c "SELECT key, enabled, scope, tenant_override_allowed, public FROM feature_flags;"
    ```
-   Three rows are expected: `communication.bulk_email` (scope=tenant, override=false), `admin.feature_flags_phase2` (scope=platform), and `constituents.bulk_import` (scope=tenant, override=true) — all `enabled=false` at first deploy.
+   The live keys are `communication.bulk_email`, `donation.public_page_styles`, `constituents.bulk_import`, `advanced_filters`, `campaign.postal_merged_pdf` — all `scope='tenant'`, all `enabled=false` at first deploy.
 
-3. **Flip the self-flag on**. Either toggle it from the Back Office (`/admin/feature-flags`), or via SQL:
-   ```bash
-   psql "postgresql://givernance:givernance_dev@localhost:5432/givernance" \
-     -c "UPDATE feature_flags SET enabled=true WHERE key='admin.feature_flags_phase2';"
-   redis-cli DEL flags:global:v2      # bypass the 60 s TTL
-   ```
+3. **Reload + observe**:
+   - **Super-admin** `/admin/feature-flags` — `Per-organisation` scope badges per row + plain-language scope hint; "Organisations overriding the default" line renders (zeros until overrides exist).
+   - **Super-admin** `/admin/tenants/[id]` — the **Feature flags** tab to the right of Audit.
+   - **Org-admin** `/settings/feature-flags` — page renders with a row for `constituents.bulk_import` (scope='tenant', override-allowed). Toggling it on activates the "Bulk import" button on the constituents page.
 
-4. **Reload + observe**:
-   - **Super-admin** `/admin/feature-flags` — `Platform-wide` / `Per-organisation` scope badges per row + plain-language scope hint; "Organisations overriding the default" line renders (zeros until overrides exist).
-   - **Super-admin** `/admin/tenants/[id]` — new **Feature flags** tab to the right of Audit. `scope='platform'` flags render read-only with a "use the global page" hint.
-   - **Org-admin** `/settings/feature-flags` — page renders with a row for `constituents.bulk_import` (scope='tenant', override-allowed) — the first registry entry of that shape. Toggling it on activates the "Bulk import" button on the constituents page.
-
-5. **To see the real override controls** (the per-tenant toggle on the super-admin tenant tab + the toggle row on the org-admin page), insert a demo flag that's actually tenant-overridable. This is **local-only**; do not seed it in a shipped migration:
+4. **To see the real override controls** (the per-tenant toggle on the super-admin tenant tab + the toggle row on the org-admin page), insert a demo flag that's actually tenant-overridable. This is **local-only**; do not seed it in a shipped migration:
    ```bash
    psql "postgresql://givernance:givernance_dev@localhost:5432/givernance" <<'SQL'
    INSERT INTO feature_flags (key, enabled, label, description, scope, tenant_override_allowed, public)
@@ -390,6 +385,8 @@ PROPOSED → ACTIVE (off) → TEST_TENANT → GA_ROLLOUT → GA (on by default) 
 - ✅ QA test suite includes both "flag on" and "flag off" paths
 - ✅ No open HIGH issues in the feature's spike doc
 - ✅ Security Architect sign-off if the feature handles PII or payments
+
+**`REMOVED` — worked example (issue #493).** Once a flag has been GA + on everywhere long enough to be permanent, the gate is dead code. Retirement is a single PR that: (1) deletes every `requireFlag` / worker `isFlagEnabled` / SSR `xEnabled` consumer, keeping only the enabled code path; (2) removes the `FEATURE_FLAG_KEYS` + `FEATURE_FLAG_REGISTRY` entries (the shrinking `FeatureFlagKey` union makes the compiler list every orphaned reference); (3) ships a new migration that `DELETE`s the `tenant_flag_overrides` rows **before** the `feature_flags` rows (FK order) — original seed migrations stay immutable; (4) updates the parity + off-state tests so they pass with the rows gone. Issue #493 retired `admin.feature_flags_phase2`, `admin.finance_dashboard`, `admin.impersonation_replicate`, `communication.notifications_center`, and `productivity.command_palette` this way (migration `0082`). Note the special case: `admin.feature_flags_phase2` gated the per-org flag *tooling itself*, so its retirement removed **only its own gate** — the tooling stays, because the surviving flags still need it.
 
 ## 9. Flag Administration API
 

--- a/docs/19-impersonation.md
+++ b/docs/19-impersonation.md
@@ -26,7 +26,7 @@ Both modes carry the RFC 8693 `act` claim — the RFC's "delegation" / "imperson
 
 **Why both must coexist**: a one-mode design forces a tradeoff between "operator can do support work" and "operator can safely browse a user's account without changing anything". Delegation answers the first; pure impersonation answers the second. Conflating them is what the RFC 8693 spec writers explicitly warned against (§4.1).
 
-**Dev-speed surface (issue #428)**: a one-click **Replicate** row-action on the Back Office past-sessions list re-enters the same target with the same mode + reason, reusing the existing 5-min MFA-fresh window (no new security mechanism — see § 4.1). Gated by `admin.impersonation_replicate` (default off, `scope='platform'`); with the flag off the list is identical to what shipped with issue #24.
+**Dev-speed surface (issue #428)**: a one-click **Replicate** row-action ships unconditionally on the Back Office past-sessions list — it re-enters the same target with the same mode + reason, reusing the existing 5-min MFA-fresh window (no new security mechanism — see § 4.1). It originally shipped behind `admin.impersonation_replicate`; that flag was retired in issue #493 (migration 0082).
 
 ## 1. Goals
 
@@ -152,9 +152,9 @@ Once a session is `ENDED` / `REVOKED` / `EXPIRED`, the same investigation often 
 
 **Reason marker**: the FE appends `" (replicated)"` to the original reason before POSTing, idempotently (no double-append on chained replicates) and skipped when the result would exceed the 2000-char cap. Audit-log readers see distinct rows under `impersonation.started` with the marker visible in the captured reason; SOC dashboards correlate replicate chains by `(impersonator_keycloak_id, target_keycloak_id)` ordered by `created_at`.
 
-**Flag gate**: `admin.impersonation_replicate` (default off, `scope='platform'`, `tenant_override_allowed=false`, `public=true`). SSR-fetched on the list page; with the flag off the column ends with only the View button and the Replicate component is never mounted. Migration `0059_admin_impersonation_replicate_flag` seeds the row. Emergency rollback: `docs/runbooks/feature-flag-rollback.md`.
+**No flag gate**: the Replicate column always renders on past sessions for super-admins. A disabled marker still shows in place of the button when the target was hard-deleted (see "Off-boarded target" below) — that behaviour is unchanged. The action originally shipped behind `admin.impersonation_replicate` (seeded by migration `0059_admin_impersonation_replicate_flag`, which stays immutable); that flag was retired in issue #493 (migration 0082).
 
-**Off-boarded target**: if the past target's `users.id` has been hard-deleted (`targetUserId` null in the DTO), the Replicate button is hidden for that row even with the flag on. The operator can still inspect the past session via View, but cannot re-enter it (the start endpoint requires a live `users.id` — see `resolveTarget()` in `impersonation-service.ts`).
+**Off-boarded target**: if the past target's `users.id` has been hard-deleted (`targetUserId` null in the DTO), the Replicate button is hidden for that row. The operator can still inspect the past session via View, but cannot re-enter it (the start endpoint requires a live `users.id` — see `resolveTarget()` in `impersonation-service.ts`).
 
 ```mermaid
 sequenceDiagram

--- a/docs/27-notifications.md
+++ b/docs/27-notifications.md
@@ -3,7 +3,7 @@
 > Related: [`docs/14-screen-inventory.md`](14-screen-inventory.md) GLO-004, [`docs/17-log-management.md`](17-log-management.md), [`docs/18-feature-flags.md`](18-feature-flags.md), [`docs/adrs/adr-031-notifications-delivery-and-fanout.md`](adrs/adr-031-notifications-delivery-and-fanout.md), [`diagrams/notifications-flow.mmd`](../diagrams/notifications-flow.mmd), [Epic #363](https://github.com/purposestack/givernance/issues/363).
 >
 > Migration that ships the schema: [`packages/api/migrations/0055_notifications_center.sql`](../packages/api/migrations/0055_notifications_center.sql).
-> Feature flag: `communication.notifications_center` (default off, scope `tenant`).
+> Feature flag: retired in issue #493 (migration 0082) — the notification centre is now always on. See [`docs/18-feature-flags.md`](18-feature-flags.md) for the flag lifecycle.
 
 ## 0. Why this exists — at a glance
 
@@ -45,13 +45,8 @@ sequenceDiagram
   Relay->>DB: SELECT pending outbox_events FOR UPDATE SKIP LOCKED
   Relay->>Worker: enqueue { type: "donation.created", payload }
   Worker->>Worker: fanoutNotifications(event)
-  Worker->>Worker: flag check: communication.notifications_center?
-  alt flag off
-    Worker-->>Worker: skip — log debug
-  else flag on
-    Worker->>DB: SELECT users WHERE role='org_admin'<br/>+ honour notification_preferences (in_app)
-    Worker->>DB: INSERT notifications (one per recipient)
-  end
+  Worker->>DB: SELECT users WHERE role='org_admin'<br/>+ honour notification_preferences (in_app)
+  Worker->>DB: INSERT notifications (one per recipient)
   Worker->>Worker: routeDomainEvent → existing receipt PDF job
   Bell->>API: EventSource /v1/notifications/stream
   API->>DB: SELECT new rows WHERE created_at > cursor (polling loop)
@@ -62,13 +57,15 @@ sequenceDiagram
   API->>DB: UPDATE read_at = NOW()
 ```
 
-### Off-state behaviour (flag off)
+### Surface availability
 
-- Topbar has no bell icon at all (off-state QA per `feedback_feature_flag_first`).
-- `/v1/notifications*` + `/v1/notification-preferences*` routes return 404 (anti-disclosure — same posture as `/v1/constituents/bulk-email`).
-- `/profile/notifications` returns 404 (the page itself re-checks the flag SSR).
-- Outbox-fanout worker silently no-ops on every event.
-- Email-digest BullMQ tick reads the flag, sees off, returns.
+The notification centre is always on (the `communication.notifications_center` flag was retired in issue #493, migration 0082). Concretely:
+
+- The topbar bell renders for every authenticated tenant user. Super-admins don't see it — they have no tenant-scoped chrome — but that's a role distinction, not a flag.
+- `/v1/notifications*` + `/v1/notification-preferences*` routes require only `requireAuth`.
+- `/profile/notifications` is reachable by any authenticated tenant role.
+- The outbox-fanout worker fans out unconditionally on every event.
+- The email-digest BullMQ tick runs on its schedule for every tenant.
 
 ## 2. Architecture overview
 
@@ -118,7 +115,6 @@ flowchart LR
 |---|---|---|
 | Schema (Drizzle) | `packages/shared/src/schema/notifications.ts` | `notifications`, `notification_preferences` |
 | Type registry | `packages/shared/src/constants/notifications.ts` | `NOTIFICATION_TYPE_VALUES`, `NOTIFICATION_TYPE_REGISTRY` |
-| Feature flag | `packages/shared/src/constants/feature-flags.ts` | `COMMUNICATION_NOTIFICATIONS_CENTER` |
 | Migration | `packages/api/migrations/0055_notifications_center.sql` | seed + table + RLS |
 | Fanout producer | `packages/worker/src/processors/notifications-fanout.ts` | `fanoutNotifications`, `planFanout` |
 | Worker wiring | `packages/worker/src/worker.ts` | `processDomainEvent` calls fanout first |
@@ -227,20 +223,18 @@ The same discipline applies to other FK columns pointing at `users.id` across th
 
 ## 4. Permissions matrix
 
-| Endpoint | Method | Flag | Guard | Notes |
-|---|---|---|---|---|
-| `/v1/notifications` | GET | `communication.notifications_center` | `requireAuth` | Lists caller's own rows. RLS isolates tenant; service filters `user_id = currentUserId`. |
-| `/v1/notifications/unread-count` | GET | `communication.notifications_center` | `requireAuth` | Caller-scoped count. |
-| `/v1/notifications/:id/read` | PATCH | `communication.notifications_center` | `requireAuth` | Caller-scoped — 404 if not owned. Idempotent. |
-| `/v1/notifications/read-all` | POST | `communication.notifications_center` | `requireAuth` | Idempotent — returns count of rows touched. |
-| `/v1/notifications/mark-read-by-link` | POST | `communication.notifications_center` | `requireAuth` | Body `{ linkUrl }`. Marks every panel-visible unread row matching the link as read. Auto-fired by the bell hook on every pathname change. |
-| `/v1/notifications/:id` | DELETE | `communication.notifications_center` | `requireAuth` | Soft-delete (sets `deleted_at`). |
-| `/v1/notifications/stream` | GET | `communication.notifications_center` | `requireAuth` | SSE. Heartbeat every 25 s. Resumes from `Last-Event-ID`. |
-| `/v1/notification-preferences` | GET | `communication.notifications_center` | `requireAuth` | Returns the closed set (every registered type), defaults merged in. |
-| `/v1/notification-preferences/:type` | PATCH | `communication.notifications_center` | `requireAuth` | Upsert (idempotent). Body `{ inApp, emailDigest }`. |
-| `/profile/notifications` | GET | `communication.notifications_center` | requireAuth (SSR) | 404 if flag off. |
-
-Flag gate runs FIRST per the canonical `[requireFlag, requireRole]` pattern from `docs/18-feature-flags.md` § 6.1 — a scanner can't enumerate gated routes by their auth requirement.
+| Endpoint | Method | Guard | Notes |
+|---|---|---|---|
+| `/v1/notifications` | GET | `requireAuth` | Lists caller's own rows. RLS isolates tenant; service filters `user_id = currentUserId`. |
+| `/v1/notifications/unread-count` | GET | `requireAuth` | Caller-scoped count. |
+| `/v1/notifications/:id/read` | PATCH | `requireAuth` | Caller-scoped — 404 if not owned. Idempotent. |
+| `/v1/notifications/read-all` | POST | `requireAuth` | Idempotent — returns count of rows touched. |
+| `/v1/notifications/mark-read-by-link` | POST | `requireAuth` | Body `{ linkUrl }`. Marks every panel-visible unread row matching the link as read. Auto-fired by the bell hook on every pathname change. |
+| `/v1/notifications/:id` | DELETE | `requireAuth` | Soft-delete (sets `deleted_at`). |
+| `/v1/notifications/stream` | GET | `requireAuth` | SSE. Heartbeat every 25 s. Resumes from `Last-Event-ID`. |
+| `/v1/notification-preferences` | GET | `requireAuth` | Returns the closed set (every registered type), defaults merged in. |
+| `/v1/notification-preferences/:type` | PATCH | `requireAuth` | Upsert (idempotent). Body `{ inApp, emailDigest }`. |
+| `/profile/notifications` | GET | requireAuth (SSR) | The preferences page — reachable by any authenticated tenant role. |
 
 ## 5. GDPR posture
 
@@ -257,9 +251,9 @@ The notification surface is per-user data; GDPR Articles 5, 15, 17 apply.
 
 The Epic ships in one PR:
 
-1. **Step 0 — feature flag**: register `communication.notifications_center` in the shared registry; seed via migration. Every new route + worker job pickup + web surface gates on it.
+1. **Step 0 — feature flag (retired)**: the centre originally shipped behind `communication.notifications_center` (every route, worker job pickup, and web surface gated on it). That flag was retired in issue #493 (migration 0082); the surface is now permanently on.
 2. **Phase 1 — schema + outbox subscriber + REST API**: migration 0055 creates the two tables + RLS + indices. Worker's `fanoutNotifications` runs alongside `routeDomainEvent` for every outbox event. API exposes list / unread-count / mark-read / mark-all-read / soft-delete.
-3. **Phase 2 — topbar bell + panel**: `NotificationsBell` mounts when the SSR-resolved flag is on; `NotificationsPanel` matches the GLO-004 mockup (filter chips, accent bars, mark-all-read, click-through). Polling fallback at 30 s.
+3. **Phase 2 — topbar bell + panel**: `NotificationsBell` mounts for every authenticated tenant user; `NotificationsPanel` matches the GLO-004 mockup (filter chips, accent bars, mark-all-read, click-through). Polling fallback at 30 s.
 4. **Phase 3 — preferences page**: `/profile/notifications` (every authenticated role; not `/settings/*` which is org-admin only). Optimistic upsert.
 5. **Phase 4 — SSE delivery**: `/v1/notifications/stream` (`text/event-stream`). EventSource client swaps polling for SSE; falls back automatically on error. `Last-Event-ID` resume.
 6. **Phase 5 — email digest (opt-in)**: BullMQ recurring job at 09:00 UTC daily. Reads each tenant's opted-in users + their unread rows since the cursor, sends one digest per recipient via `defaultEmailSender`. Templates are minimal text/HTML — per-user locale + per-tenant DKIM are explicit follow-ups (see § 7).
@@ -282,7 +276,7 @@ The Epic explicitly does NOT ship:
 
 ## 8. Acceptance — per Epic #363
 
-- [x] `communication.notifications_center` flag registered + seeded; every new route protected with `requireFlag(...)` as the first preHandler; every dependent UI surface and worker job pickup gated; off-state QA done.
+- [x] `communication.notifications_center` flag registered + seeded; every new route protected with `requireFlag(...)` as the first preHandler; every dependent UI surface and worker job pickup gated; off-state QA done. *(Flag retired in issue #493 / migration 0082 — the surface is now permanently on.)*
 - [x] Spike ADR merged ([`docs/adrs/adr-031`](adrs/adr-031-notifications-delivery-and-fanout.md)).
 - [x] `notifications` table + RLS shipped, with passing isolation tests.
 - [x] At least 5 event producers wired (donation, invitation × 2, branding activation, postal export, bulk email).

--- a/docs/29-global-search.md
+++ b/docs/29-global-search.md
@@ -1,6 +1,6 @@
 # 29 — Global search / Command palette (GLO-001)
 
-> Related: [`docs/14-screen-inventory.md`](14-screen-inventory.md) (GLO-001 spec), [`docs/11-design-identity.md`](11-design-identity.md) (Cmd+K as navigation contract), [`docs/18-feature-flags.md`](18-feature-flags.md) (flag pattern), [`docs/27-notifications.md`](27-notifications.md) (parallel global surface — bell vs. palette), [Mockup `docs/design/global/command-palette.html`](design/global/command-palette.html). Schema lives in migration [`0062_search_indexes.sql`](../packages/api/migrations/0062_search_indexes.sql); flag seed in [`0061_command_palette_feature_flag.sql`](../packages/api/migrations/0061_command_palette_feature_flag.sql).
+> Related: [`docs/14-screen-inventory.md`](14-screen-inventory.md) (GLO-001 spec), [`docs/11-design-identity.md`](11-design-identity.md) (Cmd+K as navigation contract), [`docs/18-feature-flags.md`](18-feature-flags.md) (flag pattern), [`docs/27-notifications.md`](27-notifications.md) (parallel global surface — bell vs. palette), [Mockup `docs/design/global/command-palette.html`](design/global/command-palette.html). Schema lives in migration [`0062_search_indexes.sql`](../packages/api/migrations/0062_search_indexes.sql). The flag seed in [`0061_command_palette_feature_flag.sql`](../packages/api/migrations/0061_command_palette_feature_flag.sql) is superseded by the issue #493 flag retirement (migration 0082) — the palette is now always on for tenant users.
 
 ## 0. Why this exists — at a glance
 
@@ -14,7 +14,7 @@ Givernance's MVP shipped with **entity-scoped** search — every list page has i
 
 It's the keyboard-first navigation layer that operators trained by Linear, Notion, and the Stripe Dashboard already expect. Without it, every entity-scoped search input is a separate place to look — and Salesforce's "global search" is one of the few NPSP features users actually praise.
 
-The surface is **gated behind `productivity.command_palette` (default off)**. With the flag off, the overlay, the topbar button, the global keyboard listener, and the `GET /v1/search` route are all completely absent — no inert placeholder anywhere. The full flag rationale + rollback drill is in [§5](#5-feature-flag-productivitycommand_palette).
+The palette is **always available to tenant users** — pressing `Cmd+K` / `Ctrl+K` opens it on any authenticated page. Super-admins don't get it because it searches tenant-scoped data (constituents / campaigns / donations) that has no meaning outside a tenant context — a role distinction, not a flag. The surface originally shipped behind `productivity.command_palette` (default off); that flag was retired in issue #493 — see [§5](#5-flag-retirement-issue-493).
 
 ## 1. User flow — operator searches across entities
 
@@ -37,7 +37,7 @@ sequenceDiagram
 
     Note over Palette: debounce 200 ms<br/>previous in-flight req aborted
     Palette->>+API: GET /v1/search?q=Marie<br/>Bearer JWT (HTTP-only cookie)
-    Note over API: 1. requireFlag(productivity.command_palette)<br/>   → 404 if off (anti-disclosure)<br/>2. requireAuth — extract orgId<br/>3. rate limit: 60/min/user
+    Note over API: 1. requireAuth — extract orgId<br/>2. rate limit: 60/min/user
     API->>+DB: withTenantContext(orgId, ...)<br/>3 parallel queries:<br/>• constituents (FTS + trigram + ILIKE)<br/>• campaigns   (FTS + trigram + ILIKE)<br/>• donations   (JOIN constituents, ref ILIKE)
     DB-->>-API: rows ranked by ts_rank + similarity,<br/>capped at 5 per group
     API-->>-Palette: { data: { query, groups } }
@@ -54,7 +54,6 @@ sequenceDiagram
 - Network error → palette stays open, shows the generic `t("commandPalette.error")` ("Could not run the search. Try again in a moment."); `aria-live="assertive"` + `role="alert"` announce it to assistive tech. The next valid keystroke supersedes the failed request.
 - 429 (rate-limit) → surfaced as the **same** generic error banner (no distinct toast) — we deliberately keep one error path rather than expose the rate-limit as a separate UX, because a sustained burst hitting the cap is usually a runaway typing loop, not a state the operator can fix differently.
 - Unauthenticated request mid-session (cookie expired between renders) → the global axios-style 401 handler in [`packages/web/src/lib/api/client.ts`](../packages/web/src/lib/api/client.ts) already routes through the auth refresh path; the palette catches the resulting rejection and surfaces the generic error until the next debounced refetch succeeds.
-- Flag off mid-session (operator just got demoted) → SSR-fetched flag list was stale, the topbar button vanishes on next nav, the API returns 404; the palette is never re-opened. No UI is left half-broken because the entire surface is conditional on `commandPaletteEnabled`.
 
 ## 2. Domain model — no new tables
 
@@ -173,7 +172,7 @@ The raw user input never reaches the SQL string. It's bound as a single `text` p
 ### 3.6 Frontend architecture
 
 - The **CommandPalette** component lives in [`packages/web/src/components/command-palette/command-palette.tsx`](../packages/web/src/components/command-palette/command-palette.tsx).
-- Mounted once inside **AppShell** (conditional on `commandPaletteEnabled`); open/close state is owned by AppShell so the global keyboard listener + the topbar trigger button both share one source of truth.
+- Mounted once inside **AppShell** for every authenticated tenant user; open/close state is owned by AppShell so the global keyboard listener + the topbar trigger button both share one source of truth.
 - Built on the existing `cmdk` wrapper in [`packages/web/src/components/ui/command.tsx`](../packages/web/src/components/ui/command.tsx) + Radix `Dialog`.
 - Server-side filtering — `shouldFilter={false}` on the `Command` root so cmdk doesn't re-filter server results client-side (which would override the server's relevance ordering and drop hits whose `title` doesn't contain the literal query).
 - 200 ms debounce on input changes. In-flight requests are aborted via `AbortController` when a fresher keystroke supersedes them — eliminates the out-of-order-response race.
@@ -183,36 +182,23 @@ The raw user input never reaches the SQL string. It's bound as a single `text` p
 
 | Endpoint / surface | Auth | RBAC | Notes |
 |---|---|---|---|
-| `GET /v1/search?q=…` | Authenticated tenant user (any role) | None beyond auth | Flag-gated 404 when `productivity.command_palette=off`. Rate limit: 60 req/min/user. RLS-scoped to the JWT's `org_id`. |
-| Topbar Cmd+K trigger button | Authenticated tenant user | None | Hidden entirely when the flag is off (off-state QA). |
-| Global Cmd+K / Ctrl+K listener | Authenticated tenant user | None | Listener is NOT mounted when the flag is off — pressing the shortcut is a no-op. |
-| Command palette overlay | Authenticated tenant user | None for the search results; quick-create rows require `org_admin` or `user` (viewers see only the search + Go-to rows). | Component is not loaded at all when the flag is off. |
+| `GET /v1/search?q=…` | Authenticated tenant user (any role) | None beyond auth | `requireAuth` + rate limit: 60 req/min/user. RLS-scoped to the JWT's `org_id`. |
+| Topbar Cmd+K trigger button | Authenticated tenant user | None | Always rendered for tenant users. |
+| Global Cmd+K / Ctrl+K listener | Authenticated tenant user | None | Always mounted for tenant users. |
+| Command palette overlay | Authenticated tenant user | None for the search results; quick-create rows require `org_admin` or `user` (viewers see only the search + Go-to rows). | Always available to tenant users. |
 | "New constituent" / "Record a donation" / "New campaign" rows | Authenticated tenant user | `org_admin` OR `user` (the `requireWrite` boundary) | Reused existing entity-create flows — no new endpoints. |
 
 Search results respect each entity's existing RLS: a viewer sees the same hits as an org_admin within the tenant (the palette is a navigation aid, not a permissioned data surface), and tenant isolation prevents any cross-tenant leakage.
 
-## 5. Feature flag — `productivity.command_palette`
+## 5. Flag retirement (issue #493)
 
-| Field | Value |
-|---|---|
-| Key | `productivity.command_palette` |
-| Default | `false` |
-| Scope | `tenant` |
-| Tenant override allowed | `true` (org-admin self-serves from `/settings/feature-flags`) |
-| Public projection | `true` (the topbar trigger + global listener need to know at page-load) |
-| Registry | [`packages/shared/src/constants/feature-flags.ts`](../packages/shared/src/constants/feature-flags.ts) |
-| Seed migration | [`0061_command_palette_feature_flag.sql`](../packages/api/migrations/0061_command_palette_feature_flag.sql) |
-| Gated surfaces | `GET /v1/search` route, topbar trigger button, global Cmd+K listener, the CommandPalette component (never imported when off via the conditional in AppShell) |
-| Off-state QA | With the flag off: the trigger button is **absent** (not greyed out), the Cmd+K keypress is a **no-op** (listener not mounted), and the API returns **404** (not 403). |
-| Emergency rollback | See [`docs/runbooks/feature-flag-rollback.md`](runbooks/feature-flag-rollback.md). One `UPDATE feature_flags SET enabled=false WHERE key='productivity.command_palette';` + `redis-cli DEL flags:global`. |
-
-The public-projection caveat in CLAUDE.md applies — the key name is intentionally descriptive (`productivity.command_palette`) and not teasing an unannounced surprise, so its presence in `GET /v1/feature-flags` for every authenticated tenant user is acceptable.
+The command palette originally shipped behind the `productivity.command_palette` feature flag (default off, tenant scope), with a phased rollout and the standard off-state guarantees. That flag was **retired in issue #493** (migration 0082 drops the seed row): the palette now ships unconditionally for every tenant user — the `GET /v1/search` route is guarded by `requireAuth` alone, and the topbar trigger, the global Cmd+K / Ctrl+K listener, and the `CommandPalette` component all mount for tenant users without any flag check. The original rollout rationale and the off-state QA matrix are preserved in git history (and in this doc's earlier revisions).
 
 ## 6. Privacy / GDPR posture
 
 - **No new PII storage**: search reads from existing tables only. The `constituents.deleted_at` soft-delete filter is applied; deleted donor records are invisible to the palette.
 - **Audit trail**: read-only search hits do **not** generate audit rows — every authenticated tenant user can already list constituents / campaigns / donations, and the audit log already records the *resulting* navigation (e.g. opening a constituent detail page emits the existing read audit, unchanged).
-- **Logs**: the `requireFlag` guard logs `flag.route_gated` when a disabled tenant hits the route (existing pattern, low cardinality — path is the route TEMPLATE, not the raw URL). The search handler emits the standard request log line via Fastify's pino — **the raw query string `q` is not redacted** because it doesn't carry PII by design (an operator's typed substring of a donor's name is far less sensitive than what the constituent detail page itself emits to the same log channel). If a future tenant requests stricter posture, redacting `q` to a hash is a single-line change in [`packages/shared/src/constants/log-redact-paths.ts`](../packages/shared/src/constants/log-redact-paths.ts).
+- **Logs**: the search handler emits the standard request log line via Fastify's pino — **the raw query string `q` is not redacted** because it doesn't carry PII by design (an operator's typed substring of a donor's name is far less sensitive than what the constituent detail page itself emits to the same log channel). If a future tenant requests stricter posture, redacting `q` to a hash is a single-line change in [`packages/shared/src/constants/log-redact-paths.ts`](../packages/shared/src/constants/log-redact-paths.ts).
 - **Erasure**: a constituent erasure cascade already removes their `donations`. After erasure, the palette returns zero hits for any query that previously matched — no separate index to rebuild because the expression indices reference the live row.
 
 ## 7. Out of scope (deferred)
@@ -241,4 +227,4 @@ When a new tenant-scoped table joins the searchable graph (e.g. grants, programs
 5. Add translations under `appShell.commandPalette.groups.*` in `en.json` and `fr.json`.
 6. Add RLS-isolation + happy-path tests in [`packages/api/src/tests/integration/search.test.ts`](../packages/api/src/tests/integration/search.test.ts).
 
-The flag stays the same — adding a new entity is not "a new feature", it's an extension of an already-shipped surface.
+No flag is involved — adding a new entity is not "a new feature", it's an extension of an already-shipped, always-on surface.

--- a/docs/33-platform-finance-reports.md
+++ b/docs/33-platform-finance-reports.md
@@ -3,7 +3,7 @@
 > Related: [`docs/14-screen-inventory.md`](14-screen-inventory.md) (super-admin Finance), [`docs/31-tenant-mobilization-score.md`](31-tenant-mobilization-score.md), [`docs/32-survey-infrastructure.md`](32-survey-infrastructure.md), [`docs/15-infra-adr.md`](15-infra-adr.md) (ADR-023 bucket topology), [Epic #434](https://github.com/purposestack/givernance/issues/434), [Issue #443](https://github.com/purposestack/givernance/issues/443).
 >
 > Migration that ships the schema: [`packages/api/migrations/0079_platform_finance_reports.sql`](../packages/api/migrations/0079_platform_finance_reports.sql).
-> Feature flag: gated under the existing `admin.finance_dashboard` (default off; same flag as the rest of Epic #434).
+> Feature flag: retired in issue #493 (migration 0082) — these routes are now reachable by super-admins unconditionally.
 > S3 bucket: `S3_REPORTS_BUCKET` (private, ADR-023).
 
 ## 0. Why this exists — at a glance
@@ -94,7 +94,7 @@ erDiagram
 
 | Concern | Owner | Notes |
 |---|---|---|
-| Route handlers | [`packages/api/src/modules/superadmin/finance/routes.ts`](../packages/api/src/modules/superadmin/finance/routes.ts) | Three new routes (POST, GET, GET pdf). Guard chain `requireFlag(ADMIN_FINANCE_DASHBOARD) → requireSuperAdmin` — flag first so a scanner gets 404 without enumerating the role requirement. |
+| Route handlers | [`packages/api/src/modules/superadmin/finance/routes.ts`](../packages/api/src/modules/superadmin/finance/routes.ts) | Three new routes (POST, GET, GET pdf). Guard: `requireSuperAdmin`. |
 | Service / idempotency | [`packages/api/src/modules/superadmin/finance/monthly-report.ts`](../packages/api/src/modules/superadmin/finance/monthly-report.ts) | Month resolution, snapshot build, INSERT, enqueue. Same-month race collapses to the existing row via the partial unique index (catch + re-SELECT). |
 | Snapshot source | [`packages/api/src/modules/superadmin/finance/service.ts`](../packages/api/src/modules/superadmin/finance/service.ts) (`buildFinanceSummary`) | Same SQL as the live dashboard. The 5-min Redis cache covers the typical "view dashboard → click Generate" flow. |
 | Worker processor | [`packages/worker/src/processors/generate-monthly-finance-report.ts`](../packages/worker/src/processors/generate-monthly-finance-report.ts) | Reads snapshot from row, renders PDF, uploads, flips status. |
@@ -116,7 +116,7 @@ erDiagram
 | `GET /v1/superadmin/finance/reports/:id` | 200 / 404 | 404 | 401 |
 | `GET /v1/superadmin/finance/reports/:id/pdf` | 200 stream / 409 / 404 | 404 | 401 |
 
-Every route's `preHandler` is `requireFlag(ADMIN_FINANCE_DASHBOARD) → requireSuperAdmin` (order matters — flag-off returns 404 without revealing the role requirement, consistent with the rest of Epic #434).
+Every route's `preHandler` is `requireSuperAdmin`.
 
 ## 5. Privacy / GDPR posture
 
@@ -136,7 +136,7 @@ Two non-manual paths feed into the same `requestMonthlyReport()` flow:
 
 **Multi-replica safety** — the cron and the boot-time backfill BOTH check `findLiveByMonth` before INSERTing; concurrent replicas race the partial unique index, and the loser catches the violation + replays the existing row. No coordination service required.
 
-**Flag gating** — both the boot-time backfill and the cron's fire-time fire re-check `ADMIN_FINANCE_DASHBOARD` and no-op when off, so a paused rollout doesn't churn Postgres.
+**Flag gating (retired)** — the boot-time backfill and the cron's fire-time fire originally re-checked `ADMIN_FINANCE_DASHBOARD` and no-op'd when off, so a paused rollout didn't churn Postgres. That flag was retired in issue #493 (migration 0082); both paths now run unconditionally.
 
 **Tests** — `disableSchedulers: true` on `createServer` opts is the test-only opt-out so integration suites don't enqueue spurious jobs. Production callers always get the scheduler.
 

--- a/packages/api/migrations/0082_retire_validated_feature_flags.sql
+++ b/packages/api/migrations/0082_retire_validated_feature_flags.sql
@@ -1,0 +1,47 @@
+-- Migration: 0082_retire_validated_feature_flags (issue #493)
+--
+-- Retires five feature flags whose features have been validated in
+-- production and are now permanently part of the product. The gating
+-- code (requireFlag preHandlers, worker isFlagEnabled early-returns,
+-- SSR xEnabled plumbing) is removed in the same PR; this migration
+-- drops the now-orphaned seed rows so the registry ↔ DB parity test
+-- (`packages/api/src/tests/integration/feature-flags.test.ts`) stays
+-- green after the registry entries are gone.
+--
+-- Retired keys:
+--   admin.feature_flags_phase2          (gate only — the admin tooling stays)
+--   admin.finance_dashboard
+--   admin.impersonation_replicate
+--   communication.notifications_center
+--   productivity.command_palette
+--
+-- NOTE on admin.feature_flags_phase2: only its OWN gate is retired. The
+-- per-org flag-administration tooling it used to gate (override
+-- endpoints, /settings/feature-flags, the per-tenant tab, overrideStats)
+-- stays — the remaining flags still rely on it.
+--
+-- FK order: `tenant_flag_overrides.flag_key` REFERENCES `feature_flags(key)`
+-- ON DELETE CASCADE, so deleting the flag rows would cascade anyway. We
+-- delete the override rows first explicitly so the intent is auditable and
+-- the migration does not depend on the cascade staying in place.
+--
+-- The original seed migrations (0051, 0055, 0059, 0061, 0075, 0078) are
+-- immutable and stay untouched — this is an additive retirement migration.
+
+DELETE FROM tenant_flag_overrides
+WHERE flag_key IN (
+  'admin.feature_flags_phase2',
+  'admin.finance_dashboard',
+  'admin.impersonation_replicate',
+  'communication.notifications_center',
+  'productivity.command_palette'
+);
+
+DELETE FROM feature_flags
+WHERE key IN (
+  'admin.feature_flags_phase2',
+  'admin.finance_dashboard',
+  'admin.impersonation_replicate',
+  'communication.notifications_center',
+  'productivity.command_palette'
+);

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1948180000000,
       "tag": "0081_postal_export_merged_pdf",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1958180000000,
+      "tag": "0082_retire_validated_feature_flags",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/modules/admin/feature-flags-routes.ts
+++ b/packages/api/src/modules/admin/feature-flags-routes.ts
@@ -1,13 +1,11 @@
 /**
  * Feature-flag routes (issue #326 / PR #352, expanded by Epic #365 PR #366).
  *
- * Surface map (every new Phase-2 route is gated by
- * `ADMIN_FEATURE_FLAGS_PHASE2` as the FIRST preHandler — before
- * role guards — so an off-state 404 leaks no role info per the
- * Feature-flag-first rule in CLAUDE.md):
+ * Surface map (each route is guarded by its role guard —
+ * `requireSuperAdmin` / `requireOrgAdmin` / `requireAuth`):
  *
  *   GET    /v1/feature-flags                                — public projection (public=true only)
- *   GET    /v1/admin/feature-flags                          — super-admin list (+ overrideStats when phase2 on)
+ *   GET    /v1/admin/feature-flags                          — super-admin list (+ overrideStats)
  *   PATCH  /v1/admin/feature-flags/:key                     — super-admin platform-default flip
  *   GET    /v1/admin/tenants/:tenantId/feature-flags        — super-admin tenant-detail tab
  *   PUT    /v1/admin/tenants/:tenantId/feature-flags/:key   — super-admin upsert override
@@ -27,13 +25,11 @@
  * Platform-default flips still call `flagService.invalidate()`.
  */
 
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { tenants } from "@givernance/shared/schema";
 import { Type } from "@sinclair/typebox";
 import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { db } from "../../lib/db.js";
-import { requireFlag } from "../../lib/flags/flag-guard.js";
 import { flagService } from "../../lib/flags/flag-service.js";
 import { requireAuth, requireOrgAdmin, requireSuperAdmin } from "../../lib/guards.js";
 import {
@@ -85,10 +81,9 @@ const FlagRowSchema = Type.Object({
   createdAt: Type.String(),
   updatedAt: Type.String(),
   /**
-   * Present only when the caller is super-admin AND the
-   * `admin.feature_flags_phase2` flag is on. Null otherwise — the
-   * field stays in the schema so the frontend doesn't have to branch
-   * on undefined vs. missing.
+   * Per-tenant override counts. Null for platform-scoped flags that
+   * never carry overrides; the field stays in the schema so the
+   * frontend doesn't have to branch on undefined vs. missing.
    */
   overrideStats: Type.Union([Type.Null(), OverrideStatsSchema]),
 });
@@ -160,12 +155,11 @@ const PublicFlagRowSchema = Type.Object({
 });
 
 /**
- * Resolve `overrideStats` for a given flag key against the current
- * Phase-2 self-flag state. Used by both `GET /admin/feature-flags`
- * (list) and `PATCH /admin/feature-flags/:key` (single-row update)
- * so the response shape stays identical across endpoints — without
- * this, the PATCH used to return `overrideStats: null` and the FE
- * would optimistically replace the row, losing the
+ * Resolve `overrideStats` for a given flag key. Used by both
+ * `GET /admin/feature-flags` (list) and `PATCH /admin/feature-flags/:key`
+ * (single-row update) so the response shape stays identical across
+ * endpoints — without this, the PATCH used to return `overrideStats: null`
+ * and the FE would optimistically replace the row, losing the
  * "Manage per organisation" button until the page reloaded.
  *
  * Accepts a pre-fetched stats map when the caller already has one
@@ -174,10 +168,8 @@ const PublicFlagRowSchema = Type.Object({
  */
 async function resolveOverrideStatsFor(
   flagKey: string,
-  phase2On: boolean,
   statsByKey?: Map<string, { enabledCount: number; disabledCount: number }>,
-): Promise<{ enabledCount: number; disabledCount: number } | null> {
-  if (!phase2On) return null;
+): Promise<{ enabledCount: number; disabledCount: number }> {
   if (statsByKey) {
     return statsByKey.get(flagKey) ?? { enabledCount: 0, disabledCount: 0 };
   }
@@ -237,24 +229,19 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
         },
       },
     },
-    async (request) => {
+    async () => {
       const rows = await flagService.list();
-      const phase2On = await flagService.isEnabled(FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2, {
-        orgId: request.auth?.orgId ?? null,
-      });
-      const statsByKey = phase2On
-        ? new Map(
-            (await flagService.overrideStats()).map((s) => [
-              s.flagKey,
-              { enabledCount: s.enabledCount, disabledCount: s.disabledCount },
-            ]),
-          )
-        : undefined;
+      const statsByKey = new Map(
+        (await flagService.overrideStats()).map((s) => [
+          s.flagKey,
+          { enabledCount: s.enabledCount, disabledCount: s.disabledCount },
+        ]),
+      );
       return {
         data: await Promise.all(
           rows.map(async (row) => ({
             ...row,
-            overrideStats: await resolveOverrideStatsFor(row.key, phase2On, statsByKey),
+            overrideStats: await resolveOverrideStatsFor(row.key, statsByKey),
           })),
         ),
       };
@@ -310,10 +297,7 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
       // Same shape as `GET /admin/feature-flags` so the FE can
       // optimistically replace the row without losing the
       // override-stats badges + the Manage button.
-      const phase2On = await flagService.isEnabled(FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2, {
-        orgId: request.auth?.orgId ?? null,
-      });
-      const overrideStats = await resolveOverrideStatsFor(key, phase2On);
+      const overrideStats = await resolveOverrideStatsFor(key);
       return { data: { ...result.row, overrideStats } };
     },
   );
@@ -336,7 +320,7 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
   app.get(
     "/admin/feature-flags/:key/tenants",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Admin"],
         params: FlagKeyParams,
@@ -367,7 +351,7 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
   app.get(
     "/admin/tenants/:tenantId/feature-flags",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Admin"],
         params: TenantParams,
@@ -421,7 +405,7 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
   app.put(
     "/admin/tenants/:tenantId/feature-flags/:key",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
       schema: {
         tags: ["Admin"],
@@ -506,7 +490,7 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
   app.delete(
     "/admin/tenants/:tenantId/feature-flags/:key",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
       schema: {
         tags: ["Admin"],
@@ -557,7 +541,7 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
   app.get(
     "/org/feature-flags",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2), requireOrgAdmin],
+      preHandler: requireOrgAdmin,
       schema: {
         tags: ["Org"],
         response: {
@@ -607,7 +591,7 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
   app.patch(
     "/org/feature-flags/:key",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2), requireOrgAdmin],
+      preHandler: requireOrgAdmin,
       config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
       schema: {
         tags: ["Org"],
@@ -685,7 +669,7 @@ export async function featureFlagsRoutes(app: FastifyInstance) {
   app.delete(
     "/org/feature-flags/:key",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2), requireOrgAdmin],
+      preHandler: requireOrgAdmin,
       config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
       schema: {
         tags: ["Org"],

--- a/packages/api/src/modules/notifications/routes.ts
+++ b/packages/api/src/modules/notifications/routes.ts
@@ -1,10 +1,6 @@
 /**
  * Notification centre routes (Epic #363, GLO-004).
  *
- * Every route is gated by `requireFlag(COMMUNICATION_NOTIFICATIONS_CENTER)`
- * as the FIRST preHandler — a disabled tenant gets a 404, indistinguishable
- * from a typo'd URL. Auth runs second.
- *
  * RBAC: every authenticated tenant member sees their OWN notifications and
  * their OWN preferences. No role restriction beyond auth — viewers,
  * users, and org_admins all get the panel. The service layer enforces
@@ -25,14 +21,9 @@
  * Givernance module). RFC 9457 problem+json on every error path.
  */
 
-import {
-  FEATURE_FLAG_KEYS,
-  NOTIFICATION_TYPE_VALUES,
-  type NotificationType,
-} from "@givernance/shared/constants";
+import { NOTIFICATION_TYPE_VALUES, type NotificationType } from "@givernance/shared/constants";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
-import { requireFlag } from "../../lib/flags/flag-guard.js";
 import { requireAuth } from "../../lib/guards.js";
 import {
   DataResponse,
@@ -110,12 +101,10 @@ const PreferenceParams = Type.Object({
 // ─── Routes ─────────────────────────────────────────────────────────
 
 export async function notificationRoutes(app: FastifyInstance) {
-  // Flag gate FIRST so an unauthenticated scanner cannot enumerate
-  // gated routes by their auth requirement. See `requireFlag` JSDoc.
   app.get(
     "/notifications",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Notifications"],
         querystring: NotificationListQuery,
@@ -145,7 +134,7 @@ export async function notificationRoutes(app: FastifyInstance) {
   app.get(
     "/notifications/unread-count",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Notifications"],
         response: { 200: UnreadCountResponse, ...ErrorResponses },
@@ -165,7 +154,7 @@ export async function notificationRoutes(app: FastifyInstance) {
   app.patch(
     "/notifications/:id/read",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Notifications"],
         params: IdParams,
@@ -193,7 +182,7 @@ export async function notificationRoutes(app: FastifyInstance) {
   app.post(
     "/notifications/read-all",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Notifications"],
         response: {
@@ -226,7 +215,7 @@ export async function notificationRoutes(app: FastifyInstance) {
   app.post(
     "/notifications/mark-read-by-link",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Notifications"],
         body: Type.Object({
@@ -260,7 +249,7 @@ export async function notificationRoutes(app: FastifyInstance) {
   app.delete(
     "/notifications/:id",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Notifications"],
         params: IdParams,
@@ -294,7 +283,7 @@ export async function notificationRoutes(app: FastifyInstance) {
   app.get(
     "/notifications/stream",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      preHandler: requireAuth,
       // Rate-limit the SSE handshake (not the long-lived stream
       // itself — `@fastify/rate-limit` only sees the initial request).
       // 5 opens / minute / IP is plenty for the ordinary "swap polling
@@ -392,24 +381,6 @@ export async function notificationRoutes(app: FastifyInstance) {
           signal: controller.signal,
           intervalMs: 5_000,
           since: Number.isNaN(since?.getTime() ?? NaN) ? undefined : since,
-          // Re-validate authorisation every polling tick — the flag
-          // may have been flipped off mid-stream, or the user's
-          // active-row check (ADR-021) may have failed. Either way
-          // we tear the stream down within one interval. (Security H2.)
-          isStillAuthorised: async () => {
-            try {
-              const stillEnabled = await request.flagService.isEnabled(
-                FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER,
-                { orgId },
-              );
-              return stillEnabled;
-            } catch {
-              // If the flag service is unhealthy mid-stream we err on
-              // the side of closing — a stalled flag check is worse
-              // than a dropped stream the client will auto-reconnect.
-              return false;
-            }
-          },
         });
         for await (const row of stream) {
           const payload = JSON.stringify(serializeNotification(row));
@@ -435,7 +406,7 @@ export async function notificationRoutes(app: FastifyInstance) {
   app.get(
     "/notification-preferences",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Notifications"],
         response: { 200: PreferenceListResponse, ...ErrorResponses },
@@ -454,7 +425,7 @@ export async function notificationRoutes(app: FastifyInstance) {
   app.patch(
     "/notification-preferences/:type",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Notifications"],
         params: PreferenceParams,

--- a/packages/api/src/modules/search/routes.ts
+++ b/packages/api/src/modules/search/routes.ts
@@ -5,12 +5,10 @@
  * constituents, donations, and campaigns. Backs the `Cmd+K` palette in
  * the web app.
  *
- * preHandler order: `requireFlag` is FIRST so a tenant with the flag
- * off gets 404 (indistinguishable from a typo'd URL), then `requireAuth`
- * resolves the JWT. RBAC: every authenticated tenant member can search;
- * RLS in the service layer enforces tenant scope, and viewers see the
- * same set as users / admins (the palette is a navigation aid, not a
- * permissioned data surface).
+ * RBAC: every authenticated tenant member can search; RLS in the service
+ * layer enforces tenant scope, and viewers see the same set as users /
+ * admins (the palette is a navigation aid, not a permissioned data
+ * surface).
  *
  * Rate limit: 60 requests/minute/user. The frontend debounces input by
  * 200 ms, so a sustained keystroke burst lands around 5 req/s — the
@@ -19,10 +17,8 @@
  * fast typists.)
  */
 
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { Type } from "@sinclair/typebox";
 import type { FastifyInstance } from "fastify";
-import { requireFlag } from "../../lib/flags/flag-guard.js";
 import { requireAuth } from "../../lib/guards.js";
 import {
   ErrorResponses,
@@ -67,10 +63,7 @@ export async function searchRoutes(app: FastifyInstance) {
   app.get(
     "/search",
     {
-      // Flag-gate FIRST so a disabled tenant looks identical to a typo'd
-      // URL (404). Auth runs second. (Doc 18 §6.1, mirrors notifications
-      // and bulk-email routes.)
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.PRODUCTIVITY_COMMAND_PALETTE), requireAuth],
+      preHandler: requireAuth,
       // 60 req/min/user: matches the debounce-friendly cadence the
       // frontend can produce (5 req/s sustained at the upper bound) and
       // is comfortably above any realistic human typing speed. The
@@ -78,10 +71,7 @@ export async function searchRoutes(app: FastifyInstance) {
       config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
       // Quiet the per-keystroke 200s so a sustained typing burst
       // doesn't flood stdout (and Loki) with the raw `q` substring.
-      // Errors (4xx / 5xx) still emit at warn+. The flag-gate denial
-      // path emits its own structured `flag.route_gated` log line at
-      // info via `requireFlag` (kept) — that one is bounded by route
-      // template, not the user's query.
+      // Errors (4xx / 5xx) still emit at warn+.
       logLevel: "warn",
       schema: {
         tags: ["Search"],

--- a/packages/api/src/modules/superadmin/finance/routes.ts
+++ b/packages/api/src/modules/superadmin/finance/routes.ts
@@ -6,19 +6,15 @@
 //   POST /v1/superadmin/surveys/:slug/schedule
 //   POST /v1/surveys/:invitationId/respond     (tenant user; NOT super-admin)
 //
-// Every super-admin route's preHandler chain is:
-//   requireFlag(ADMIN_FINANCE_DASHBOARD) → requireSuperAdmin
-// ORDER MATTERS: flag-first so a non-flagged probe gets 404 without
-// revealing the role requirement.
+// Every super-admin route is guarded by requireSuperAdmin; the tenant-
+// facing survey routes use requireAuth.
 
 import { createHash } from "node:crypto";
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { auditLogs, platformAdmins, tenants } from "@givernance/shared/schema";
 import { Type } from "@sinclair/typebox";
 import { and, eq, isNull } from "drizzle-orm";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { systemDb } from "../../../lib/db.js";
-import { requireFlag } from "../../../lib/flags/flag-guard.js";
 import { requireAuth, requireSuperAdmin } from "../../../lib/guards.js";
 import { redis } from "../../../lib/redis.js";
 import { fetchPlatformReportObject } from "../../../lib/s3.js";
@@ -234,7 +230,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.get(
     "/superadmin/finance/summary",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Finance"],
         querystring: SummaryQuery,
@@ -322,7 +318,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.get(
     "/superadmin/finance/summary.csv",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Finance"],
         querystring: SummaryQuery,
@@ -389,7 +385,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.post(
     "/superadmin/surveys/:slug/launch",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Surveys"],
         params: SurveySlugParams,
@@ -487,7 +483,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.post(
     "/superadmin/surveys/:slug/schedule",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Surveys"],
         params: SurveySlugParams,
@@ -530,7 +526,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.post(
     "/surveys/:invitationId/respond",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Surveys"],
         params: InvitationIdParams,
@@ -619,7 +615,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.get(
     "/surveys/pending",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Surveys"],
         response: {
@@ -671,7 +667,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.post(
     "/surveys/:invitationId/dismiss",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireAuth],
+      preHandler: requireAuth,
       schema: {
         tags: ["Surveys"],
         params: InvitationIdParams,
@@ -717,9 +713,8 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   //
   // Security posture (per issue #449 callout — "ne doit pas être une
   // faille"):
-  //  - preHandler chain identical to other superadmin routes: requireFlag
-  //    fires BEFORE requireSuperAdmin so a flag-off probe gets 404
-  //    without revealing the route.
+  //  - preHandler chain identical to other superadmin routes:
+  //    requireSuperAdmin gates access.
   //  - No request body / query / header. The Redis SCAN pattern is
   //    hardcoded server-side; a compromised super-admin can NOT extend
   //    the pattern to flush arbitrary keys (e.g. `*` to nuke the entire
@@ -739,7 +734,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.post(
     "/superadmin/finance/cache/flush",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Finance"],
         response: {
@@ -780,7 +775,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.post(
     "/superadmin/finance/reports/monthly",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Finance"],
         body: MonthlyReportBody,
@@ -868,7 +863,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.get(
     "/superadmin/finance/reports",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Finance"],
         response: {
@@ -907,7 +902,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.post(
     "/superadmin/finance/reports/:id/regenerate",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Finance"],
         params: ReportIdParams,
@@ -1000,7 +995,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.get(
     "/superadmin/finance/reports/:id",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Finance"],
         params: ReportIdParams,
@@ -1041,7 +1036,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.get(
     "/superadmin/finance/reports/:id/pdf",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Finance"],
         params: ReportIdParams,
@@ -1119,7 +1114,7 @@ export async function superadminFinanceRoutes(app: FastifyInstance) {
   app.post(
     "/superadmin/finance/reports/backfill",
     {
-      preHandler: [requireFlag(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD), requireSuperAdmin],
+      preHandler: requireSuperAdmin,
       schema: {
         tags: ["Superadmin", "Finance"],
         response: {

--- a/packages/api/src/tests/integration/feature-flags-phase2.test.ts
+++ b/packages/api/src/tests/integration/feature-flags-phase2.test.ts
@@ -1,29 +1,34 @@
 /**
- * Feature-flag Phase 2 integration tests (Epic #365 / PR #366).
+ * Feature-flag per-organisation override integration tests
+ * (Epic #365 / PR #366). The `admin.feature_flags_phase2` gate that
+ * once fronted these surfaces was retired in issue #493; the tooling
+ * (override endpoints, org-admin self-service, overrideStats) stays
+ * and is always reachable.
  *
- * Covers the surfaces introduced by Phase 2:
+ * Covers:
  *
  *   1. Public projection — `GET /v1/feature-flags` filters by
  *      `public=true` and overlays the caller's tenant overrides.
  *   2. Super-admin tenant overrides — GET / PUT / DELETE under
  *      `/v1/admin/tenants/:tenantId/feature-flags`.
- *   3. `overrideStats` field on `GET /v1/admin/feature-flags` when
- *      `admin.feature_flags_phase2` is on (null otherwise).
+ *   3. `overrideStats` field on `GET /v1/admin/feature-flags`.
  *   4. Org-admin self-service — `/v1/org/feature-flags` GET + PATCH.
- *   5. Off-state QA — every Phase-2 endpoint 404s when the
- *      self-flag is off.
  *
- * Test fixtures (set up in beforeAll, torn down in afterAll):
+ * Test fixtures (set up in beforeAll, torn down in afterAll) — all
+ * test-only flags NOT in FEATURE_FLAG_REGISTRY (the parity test in
+ * feature-flags.test.ts iterates the registry, so unregistered DB
+ * rows don't break it):
  *
- *   - `admin.feature_flags_phase2` flipped on for the duration of
- *     the suite (so the Phase-2 surfaces are reachable).
- *   - A test-only flag `test.scope_tenant_demo` with
- *     `scope='tenant', tenant_override_allowed=true, public=true`.
- *     The day-one production registry has zero `scope='tenant'`
- *     flags so the positive paths need a fixture flag.
- *   - A test-only flag `test.scope_tenant_admin_only` with
- *     `scope='tenant', tenant_override_allowed=false, public=false`.
- *     Used to assert that org-admin is correctly excluded.
+ *   - `test.scope_tenant_demo` with `scope='tenant',
+ *     tenant_override_allowed=true, public=true`. Drives the positive
+ *     override paths.
+ *   - `test.scope_tenant_admin_only` with `scope='tenant',
+ *     tenant_override_allowed=false, public=false`. Used to assert
+ *     that org-admin is correctly excluded.
+ *   - `test.scope_platform_demo` with `scope='platform', public=true,
+ *     enabled=true`. Drives the platform-scoped rejection paths
+ *     (PUT 422, org-admin 404) and the precedence matrix — no
+ *     production platform-scoped flag survives after issue #493.
  *
  * `audit_log` emission is exercised by the existing audit-plugin
  * tests; here we focus on flag semantics. The plugin auto-records
@@ -50,7 +55,7 @@ import { db } from "../helpers/db.js";
 
 let app: FastifyInstance;
 
-const PHASE2_KEY = "admin.feature_flags_phase2";
+const PLATFORM_DEMO_KEY = "test.scope_platform_demo";
 const TENANT_DEMO_KEY = "test.scope_tenant_demo";
 const TENANT_ADMIN_ONLY_KEY = "test.scope_tenant_admin_only";
 
@@ -66,13 +71,10 @@ beforeAll(async () => {
   await app.ready();
   await ensureTestTenants();
 
-  // Enable the Phase 2 self-flag so the new endpoints are reachable.
-  await db.update(featureFlags).set({ enabled: true }).where(eq(featureFlags.key, PHASE2_KEY));
-
-  // Seed the two test fixture flags. These are NOT in
-  // FEATURE_FLAG_REGISTRY — the parity test in feature-flags.test.ts
-  // iterates the registry, so unregistered DB rows don't break it.
-  // They live in the DB only for this suite's positive paths.
+  // Seed the test fixture flags. These are NOT in FEATURE_FLAG_REGISTRY
+  // — the parity test in feature-flags.test.ts iterates the registry, so
+  // unregistered DB rows don't break it. They live in the DB only for
+  // this suite's positive paths.
   await db
     .insert(featureFlags)
     .values([
@@ -81,7 +83,7 @@ beforeAll(async () => {
         enabled: false,
         label: "Test fixture — tenant-overridable",
         description:
-          "Test fixture used by feature-flags-phase2 integration tests. Not part of the production registry; safe to ignore in operator UI.",
+          "Test fixture used by the feature-flag override integration tests. Not part of the production registry; safe to ignore in operator UI.",
         scope: "tenant",
         tenantOverrideAllowed: true,
         public: true,
@@ -91,10 +93,20 @@ beforeAll(async () => {
         enabled: false,
         label: "Test fixture — super-admin-gated",
         description:
-          "Test fixture used by feature-flags-phase2 integration tests. Tenant-scoped but only super-admin can flip the override per tenant.",
+          "Test fixture used by the feature-flag override integration tests. Tenant-scoped but only super-admin can flip the override per tenant.",
         scope: "tenant",
         tenantOverrideAllowed: false,
         public: false,
+      },
+      {
+        key: PLATFORM_DEMO_KEY,
+        enabled: true,
+        label: "Test fixture — platform-scoped",
+        description:
+          "Test fixture used by the feature-flag override integration tests. Platform-scoped: tenant overrides are rejected and ignored by the evaluator.",
+        scope: "platform",
+        tenantOverrideAllowed: false,
+        public: true,
       },
     ])
     .onConflictDoNothing();
@@ -104,13 +116,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   // Wipe everything this suite added so other suites see a clean DB.
-  await db.delete(tenantFlagOverrides).where(eq(tenantFlagOverrides.flagKey, TENANT_DEMO_KEY));
-  await db
-    .delete(tenantFlagOverrides)
-    .where(eq(tenantFlagOverrides.flagKey, TENANT_ADMIN_ONLY_KEY));
-  await db.delete(featureFlags).where(eq(featureFlags.key, TENANT_DEMO_KEY));
-  await db.delete(featureFlags).where(eq(featureFlags.key, TENANT_ADMIN_ONLY_KEY));
-  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, PHASE2_KEY));
+  for (const key of [TENANT_DEMO_KEY, TENANT_ADMIN_ONLY_KEY, PLATFORM_DEMO_KEY]) {
+    await db.delete(tenantFlagOverrides).where(eq(tenantFlagOverrides.flagKey, key));
+    await db.delete(featureFlags).where(eq(featureFlags.key, key));
+  }
   await flagService.invalidate();
   await flagService.invalidateTenant(ORG_A);
   await flagService.invalidateTenant(ORG_B);
@@ -293,7 +302,7 @@ describe("PUT /v1/admin/tenants/:tenantId/feature-flags/:key (Phase 2)", () => {
     const token = superAdminToken();
     const res = await app.inject({
       method: "PUT",
-      url: `/v1/admin/tenants/${ORG_A}/feature-flags/${PHASE2_KEY}`,
+      url: `/v1/admin/tenants/${ORG_A}/feature-flags/${PLATFORM_DEMO_KEY}`,
       headers: authHeader(token),
       payload: { value: true },
     });
@@ -356,7 +365,7 @@ describe("DELETE /v1/admin/tenants/:tenantId/feature-flags/:key (Phase 2)", () =
 // ─── 5. GET /admin/feature-flags — overrideStats field ─────────────────────
 
 describe("GET /v1/admin/feature-flags — overrideStats (Phase 2)", () => {
-  it("rows carry overrideStats with counts when phase2 is on", async () => {
+  it("rows carry overrideStats with counts", async () => {
     const token = superAdminToken();
     // ORG_A overrides ON, ORG_B overrides OFF — stats should report 1/1.
     await app.inject({
@@ -439,7 +448,7 @@ describe("GET /v1/org/feature-flags (Phase 2)", () => {
     const keys = body.data.map((r) => r.key);
     expect(keys).toContain(TENANT_DEMO_KEY);
     expect(keys).not.toContain(TENANT_ADMIN_ONLY_KEY); // tenant_override_allowed=false
-    expect(keys).not.toContain(PHASE2_KEY); // scope=platform
+    expect(keys).not.toContain(PLATFORM_DEMO_KEY); // scope=platform
   });
 
   it("non-org_admin gets 403 (RBAC denial — anti-disclosure 404 would be wrong here because requireOrgAdmin uses 403)", async () => {
@@ -494,7 +503,7 @@ describe("PATCH /v1/org/feature-flags/:key (Phase 2)", () => {
     const token = signToken(app);
     const res = await app.inject({
       method: "PATCH",
-      url: `/v1/org/feature-flags/${PHASE2_KEY}`,
+      url: `/v1/org/feature-flags/${PLATFORM_DEMO_KEY}`,
       headers: authHeader(token),
       payload: { value: true },
     });
@@ -522,81 +531,6 @@ describe("PATCH /v1/org/feature-flags/:key (Phase 2)", () => {
   });
 });
 
-// ─── 7. Off-state QA — every Phase-2 endpoint 404s when self-flag is off ───
-
-describe("Phase-2 self-flag off-state QA", () => {
-  // This block flips the self-flag OFF then back ON so all the
-  // Phase-2 endpoints can be exercised in their disabled posture.
-  beforeAll(async () => {
-    await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, PHASE2_KEY));
-    await flagService.invalidate();
-  });
-  afterAll(async () => {
-    await db.update(featureFlags).set({ enabled: true }).where(eq(featureFlags.key, PHASE2_KEY));
-    await flagService.invalidate();
-  });
-
-  it("GET /admin/tenants/:tenantId/feature-flags → 404", async () => {
-    const res = await app.inject({
-      method: "GET",
-      url: `/v1/admin/tenants/${ORG_A}/feature-flags`,
-      headers: authHeader(superAdminToken()),
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it("PUT /admin/tenants/:tenantId/feature-flags/:key → 404", async () => {
-    const res = await app.inject({
-      method: "PUT",
-      url: `/v1/admin/tenants/${ORG_A}/feature-flags/${TENANT_DEMO_KEY}`,
-      headers: authHeader(superAdminToken()),
-      payload: { value: true },
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it("DELETE /admin/tenants/:tenantId/feature-flags/:key → 404", async () => {
-    const res = await app.inject({
-      method: "DELETE",
-      url: `/v1/admin/tenants/${ORG_A}/feature-flags/${TENANT_DEMO_KEY}`,
-      headers: authHeader(superAdminToken()),
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it("GET /org/feature-flags → 404", async () => {
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/org/feature-flags",
-      headers: authHeader(signToken(app)),
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it("PATCH /org/feature-flags/:key → 404", async () => {
-    const res = await app.inject({
-      method: "PATCH",
-      url: `/v1/org/feature-flags/${TENANT_DEMO_KEY}`,
-      headers: authHeader(signToken(app)),
-      payload: { value: true },
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it("/admin/feature-flags response has overrideStats=null when phase2 is off", async () => {
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/admin/feature-flags",
-      headers: authHeader(superAdminToken()),
-    });
-    expect(res.statusCode).toBe(200);
-    const body = res.json<{ data: Array<{ overrideStats: unknown }> }>();
-    for (const row of body.data) {
-      expect(row.overrideStats).toBeNull();
-    }
-  });
-});
-
 // ─── 8. Precedence matrix unit-test through the route surface ───────────────
 
 describe("Evaluator precedence matrix (Phase 2)", () => {
@@ -607,23 +541,26 @@ describe("Evaluator precedence matrix (Phase 2)", () => {
     // still ignore it.
     await db.insert(tenantFlagOverrides).values({
       tenantId: ORG_A,
-      flagKey: PHASE2_KEY, // scope='platform'
+      flagKey: PLATFORM_DEMO_KEY, // scope='platform'
       value: false, // override would turn it OFF
       reason: "precedence-test",
     });
     await flagService.invalidateTenant(ORG_A);
 
-    // PHASE2_KEY platform default is `enabled=true` for this suite
+    // PLATFORM_DEMO_KEY platform default is `enabled=true` for this suite
     // (set in beforeAll). The evaluator should return TRUE despite
     // the false override.
-    const enabled = await flagService.isEnabled(PHASE2_KEY, { orgId: ORG_A });
+    const enabled = await flagService.isEnabled(PLATFORM_DEMO_KEY, { orgId: ORG_A });
     expect(enabled).toBe(true);
 
     // Clean up the artificially-injected row.
     await db
       .delete(tenantFlagOverrides)
       .where(
-        and(eq(tenantFlagOverrides.tenantId, ORG_A), eq(tenantFlagOverrides.flagKey, PHASE2_KEY)),
+        and(
+          eq(tenantFlagOverrides.tenantId, ORG_A),
+          eq(tenantFlagOverrides.flagKey, PLATFORM_DEMO_KEY),
+        ),
       );
     await flagService.invalidateTenant(ORG_A);
   });
@@ -820,7 +757,7 @@ describe("DELETE /v1/org/feature-flags/:key (Phase 2)", () => {
     const token = signToken(app);
     const res = await app.inject({
       method: "DELETE",
-      url: `/v1/org/feature-flags/${PHASE2_KEY}`,
+      url: `/v1/org/feature-flags/${PLATFORM_DEMO_KEY}`,
       headers: authHeader(token),
     });
     expect(res.statusCode).toBe(404);

--- a/packages/api/src/tests/integration/notifications.test.ts
+++ b/packages/api/src/tests/integration/notifications.test.ts
@@ -2,26 +2,20 @@
  * Notification centre integration tests (Epic #363, GLO-004).
  *
  * Coverage matrix:
- *   1. Off-state flag — every gated route returns 404 when the flag is
- *      off (anti-disclosure). 404 fires BEFORE auth.
- *   2. On-state flag — list + mark-read + mark-all-read happy paths,
- *      RFC 9457 problem+json on 404.
- *   3. RLS isolation — Tenant A can never see Tenant B's notifications
+ *   1. List + mark-read + mark-all-read happy paths, RFC 9457
+ *      problem+json on 404.
+ *   2. RLS isolation — Tenant A can never see Tenant B's notifications
  *      (cross-tenant cursor probe + cross-tenant mark-read attempt).
- *   4. Recipient isolation — within the SAME tenant, user A can't read
+ *   3. Recipient isolation — within the SAME tenant, user A can't read
  *      user B's notifications.
- *   5. Preferences — list returns the closed type set with defaults
+ *   4. Preferences — list returns the closed type set with defaults
  *      merged; PATCH upserts; unknown type returns 404.
- *   6. Registry parity — DB row matches FEATURE_FLAG_REGISTRY for the
- *      new flag (drift guard).
  */
 
-import { FEATURE_FLAG_KEYS, FEATURE_FLAG_REGISTRY } from "@givernance/shared/constants";
-import { featureFlags, notifications } from "@givernance/shared/schema";
+import { notifications } from "@givernance/shared/schema";
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { flagService } from "../../lib/flags/flag-service.js";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -35,8 +29,6 @@ import {
 } from "../helpers/auth.js";
 import { db } from "../helpers/db.js";
 
-const FLAG_KEY = FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER;
-
 let app: FastifyInstance;
 
 beforeAll(async () => {
@@ -46,30 +38,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
   await app.close();
 });
 
 beforeEach(async () => {
-  // Reset DB state — no notifications, no preferences, flag off.
+  // Reset DB state — no notifications, no preferences.
   await db.execute(sql`DELETE FROM notification_preferences`);
   await db.execute(sql`DELETE FROM notifications`);
-  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
-});
-
-afterEach(async () => {
-  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
 });
 
 // ─── Helpers ──────────────────────────────────────────────────────────
-
-async function setFlag(enabled: boolean): Promise<void> {
-  await db.update(featureFlags).set({ enabled }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
-}
 
 async function seedNotification(opts: {
   orgId: string;
@@ -125,93 +103,9 @@ async function seedSecondUserInTenantA(): Promise<string> {
   return USER_A2;
 }
 
-// ─── 1. Off-state flag — every gated route is 404 ─────────────────────
+// ─── 1. Happy paths + RFC 9457 ─────────────────────────────────────────
 
-describe("Notifications — off-state flag (anti-disclosure)", () => {
-  // Parametrise over every gated route so a refactor that drops the
-  // `requireFlag` preHandler is caught here, not in production.
-  const gatedRoutes: Array<{
-    method: "GET" | "POST" | "PATCH" | "DELETE";
-    url: string;
-    payload?: unknown;
-  }> = [
-    { method: "GET", url: "/v1/notifications" },
-    { method: "GET", url: "/v1/notifications/unread-count" },
-    // SSE endpoint — `app.inject` resolves the response before any
-    // streaming, so this exercises the flag gate (QA H1).
-    { method: "GET", url: "/v1/notifications/stream" },
-    {
-      method: "PATCH",
-      url: "/v1/notifications/00000000-0000-0000-0000-000000000001/read",
-    },
-    { method: "POST", url: "/v1/notifications/read-all" },
-    {
-      method: "POST",
-      url: "/v1/notifications/mark-read-by-link",
-      payload: { linkUrl: "/donations/00000000-0000-0000-0000-000000000aaa" },
-    },
-    {
-      method: "DELETE",
-      url: "/v1/notifications/00000000-0000-0000-0000-000000000001",
-    },
-    { method: "GET", url: "/v1/notification-preferences" },
-    {
-      method: "PATCH",
-      url: "/v1/notification-preferences/donation.received",
-      payload: { inApp: true, emailDigest: false },
-    },
-  ];
-
-  for (const route of gatedRoutes) {
-    it(`returns 404 on ${route.method} ${route.url} when flag is off`, async () => {
-      const token = signToken(app);
-      const res = await app.inject({
-        method: route.method,
-        url: route.url,
-        headers: authHeader(token),
-        payload: route.payload as Record<string, unknown> | undefined,
-      });
-      expect(res.statusCode).toBe(404);
-    });
-
-    it(`unauthenticated ${route.method} ${route.url} also returns 404 (no auth-vs-flag disclosure)`, async () => {
-      const res = await app.inject({
-        method: route.method,
-        url: route.url,
-        payload: route.payload as Record<string, unknown> | undefined,
-      });
-      // requireFlag is first preHandler — runs before auth, so
-      // unauthenticated callers hit the gate 404 (not 401).
-      expect(res.statusCode).toBe(404);
-    });
-  }
-
-  // Pin RFC 9457 body shape on at least one off-state 404 per
-  // `feedback_lock_rfc9457_body_in_tests`. The flag gate returns a
-  // problem+json body via `problemDetail()` — assert the well-known
-  // members rather than a plain-string body.
-  it("off-state 404 body conforms to RFC 9457 (status + title members)", async () => {
-    const token = signToken(app);
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/notifications",
-      headers: authHeader(token),
-    });
-    expect(res.statusCode).toBe(404);
-    const body = res.json<{ status?: number; title?: string }>();
-    expect(body.status).toBe(404);
-    expect(typeof body.title).toBe("string");
-    expect(body.title?.length ?? 0).toBeGreaterThan(0);
-  });
-});
-
-// ─── 2. On-state flag — happy paths + RFC 9457 ─────────────────────────
-
-describe("Notifications — list + mark + delete (flag on)", () => {
-  beforeEach(async () => {
-    await setFlag(true);
-  });
-
+describe("Notifications — list + mark + delete", () => {
   it("GET /v1/notifications returns caller's own rows", async () => {
     const id1 = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
     const id2 = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
@@ -427,10 +321,6 @@ describe("Notifications — list + mark + delete (flag on)", () => {
 // ─── 3. RLS / cross-tenant + cross-user isolation ──────────────────────
 
 describe("Notifications — isolation (RLS + recipient)", () => {
-  beforeEach(async () => {
-    await setFlag(true);
-  });
-
   it("Tenant A user can NEVER see Tenant B notifications via list", async () => {
     const tenantBId = await seedNotification({ orgId: ORG_B, userId: USER_B_ROW_ID });
 
@@ -576,10 +466,6 @@ describe("Notifications — isolation (RLS + recipient)", () => {
 // level flag that carries the write-time decision.
 
 describe("Notifications — panel_visible (digest-only rows)", () => {
-  beforeEach(async () => {
-    await setFlag(true);
-  });
-
   it("GET /v1/notifications excludes panel_visible = false rows", async () => {
     const visible = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
     const digestOnly = await seedNotification({
@@ -677,10 +563,6 @@ describe("Notifications — panel_visible (digest-only rows)", () => {
 // on every pathname change.
 
 describe("Notifications — mark-read-by-link", () => {
-  beforeEach(async () => {
-    await setFlag(true);
-  });
-
   it("marks every panel-visible unread notification pointing at the link as read", async () => {
     const one = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
     const two = await seedNotification({ orgId: ORG_A, userId: USER_A_ROW_ID });
@@ -803,10 +685,6 @@ describe("Notifications — mark-read-by-link", () => {
 // ─── 4. Preferences ────────────────────────────────────────────────────
 
 describe("Notifications — preferences", () => {
-  beforeEach(async () => {
-    await setFlag(true);
-  });
-
   it("GET /v1/notification-preferences returns the closed set with defaults merged", async () => {
     const token = signToken(app);
     const res = await app.inject({
@@ -871,38 +749,5 @@ describe("Notifications — preferences", () => {
       payload: { inApp: true, emailDigest: true },
     });
     expect(res.statusCode).toBe(400);
-  });
-});
-
-// ─── 5. Registry parity — DB row matches FEATURE_FLAG_REGISTRY ─────────
-
-describe("Notifications — feature-flag registry parity", () => {
-  it("FEATURE_FLAG_REGISTRY has the notifications-center entry", () => {
-    const entry = FEATURE_FLAG_REGISTRY.find((e) => e.key === FLAG_KEY);
-    expect(entry).toBeDefined();
-    expect(entry?.defaultEnabled).toBe(false);
-    expect(entry?.scope).toBe("tenant");
-    expect(entry?.tenantOverrideAllowed).toBe(false);
-    expect(entry?.public).toBe(true);
-  });
-
-  it("DB seed row matches the registry label / description / scope / public", async () => {
-    const [row] = await db
-      .select({
-        label: featureFlags.label,
-        description: featureFlags.description,
-        scope: featureFlags.scope,
-        tenantOverrideAllowed: featureFlags.tenantOverrideAllowed,
-        public: featureFlags.public,
-      })
-      .from(featureFlags)
-      .where(eq(featureFlags.key, FLAG_KEY));
-    expect(row).toBeDefined();
-    const entry = FEATURE_FLAG_REGISTRY.find((e) => e.key === FLAG_KEY)!;
-    expect(row?.label).toBe(entry.label);
-    expect(row?.description).toBe(entry.description);
-    expect(row?.scope).toBe(entry.scope);
-    expect(row?.tenantOverrideAllowed).toBe(entry.tenantOverrideAllowed);
-    expect(row?.public).toBe(entry.public);
   });
 });

--- a/packages/api/src/tests/integration/search.test.ts
+++ b/packages/api/src/tests/integration/search.test.ts
@@ -2,27 +2,19 @@
  * Global search integration tests (Epic #364, GLO-001).
  *
  * Coverage matrix:
- *   1. Off-state flag — `GET /v1/search` returns 404 when the flag is
- *      off, INCLUDING for unauthenticated callers (flag gate fires
- *      before auth — anti-disclosure).
- *   2. On-state flag — happy path returns grouped hits with the
+ *   1. Happy path returns grouped hits with the
  *      `{ data: { query, groups } }` envelope.
- *   3. RLS isolation — Tenant A's records never appear in Tenant B's
+ *   2. RLS isolation — Tenant A's records never appear in Tenant B's
  *      search results, even when the literal query matches both.
- *   4. Query-injection safety — pg-flavoured payloads (NUL byte, SQL
+ *   3. Query-injection safety — pg-flavoured payloads (NUL byte, SQL
  *      meta-characters, `to_tsquery` operators) don't crash and don't
  *      escape the parameter binder.
- *   5. Schema parity — the `productivity.command_palette` row matches
- *      `FEATURE_FLAG_REGISTRY` (drift guard).
- *   6. RFC 9457 body shape on the off-state 404.
  */
 
-import { FEATURE_FLAG_KEYS, FEATURE_FLAG_REGISTRY } from "@givernance/shared/constants";
-import { campaigns, constituents, donations, featureFlags } from "@givernance/shared/schema";
-import { eq, sql } from "drizzle-orm";
+import { campaigns, constituents, donations } from "@givernance/shared/schema";
+import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { flagService } from "../../lib/flags/flag-service.js";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createServer } from "../../server.js";
 import {
   authHeader,
@@ -34,8 +26,6 @@ import {
 } from "../helpers/auth.js";
 import { db } from "../helpers/db.js";
 
-const FLAG_KEY = FEATURE_FLAG_KEYS.PRODUCTIVITY_COMMAND_PALETTE;
-
 let app: FastifyInstance;
 
 beforeAll(async () => {
@@ -45,8 +35,6 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
   await app.close();
 });
 
@@ -61,19 +49,7 @@ beforeEach(async () => {
     DELETE FROM constituents
     WHERE first_name LIKE 'SEARCH-TEST-%' OR last_name LIKE 'SEARCH-TEST-%'
   `);
-  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
 });
-
-afterEach(async () => {
-  await db.update(featureFlags).set({ enabled: false }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
-});
-
-async function setFlag(enabled: boolean): Promise<void> {
-  await db.update(featureFlags).set({ enabled }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
-}
 
 async function seedConstituent(
   orgId: string,
@@ -133,43 +109,10 @@ async function seedDonation(
   return id;
 }
 
-// ─── 1. Off-state flag (anti-disclosure) ─────────────────────────────
-
-describe("Search — off-state flag (anti-disclosure)", () => {
-  it("returns 404 on GET /v1/search when flag is off (authenticated)", async () => {
-    const token = signToken(app);
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/search?q=marie",
-      headers: authHeader(token),
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it("unauthenticated GET /v1/search also returns 404 (gate before auth)", async () => {
-    const res = await app.inject({ method: "GET", url: "/v1/search?q=marie" });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it("off-state 404 body conforms to RFC 9457 (status + title members)", async () => {
-    const token = signToken(app);
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/search?q=marie",
-      headers: authHeader(token),
-    });
-    expect(res.statusCode).toBe(404);
-    const body = res.json<{ status?: number; title?: string }>();
-    expect(body.status).toBe(404);
-    expect(body.title).toBe("Not Found");
-  });
-});
-
-// ─── 2. Happy path ───────────────────────────────────────────────────
+// ─── 1. Happy path ───────────────────────────────────────────────────
 
 describe("Search — happy path", () => {
   beforeEach(async () => {
-    await setFlag(true);
     // Use highly-unique fixture names so other test suites' constituents
     // (e.g. constituents.test.ts seeds "Marie" rows of its own) don't
     // crowd this query past the PER_GROUP_LIMIT=5 cap.
@@ -342,11 +285,10 @@ describe("Search — happy path", () => {
   });
 });
 
-// ─── 3. RLS isolation ────────────────────────────────────────────────
+// ─── 2. RLS isolation ────────────────────────────────────────────────
 
 describe("Search — RLS isolation across tenants", () => {
   it("Tenant B cannot see Tenant A constituents matching the same query", async () => {
-    await setFlag(true);
     // Both tenants own a "SEARCH-TEST-Camille". RLS must not leak A's
     // row to B and vice versa.
     await seedConstituent(ORG_A, "SEARCH-TEST-Camille", "AlphaOnly");
@@ -369,7 +311,6 @@ describe("Search — RLS isolation across tenants", () => {
   });
 
   it("Tenant A's campaigns are not visible to Tenant B", async () => {
-    await setFlag(true);
     await seedCampaign(ORG_A, "SEARCH-TEST-AlphaSecretCampaign");
 
     const tokenB = signTokenB(app);
@@ -384,11 +325,10 @@ describe("Search — RLS isolation across tenants", () => {
   });
 });
 
-// ─── 4. Query-injection safety ───────────────────────────────────────
+// ─── 3. Query-injection safety ───────────────────────────────────────
 
 describe("Search — query-injection safety", () => {
   beforeEach(async () => {
-    await setFlag(true);
     await seedConstituent(ORG_A, "SEARCH-TEST-Probe-Marie", "Fontaine");
   });
 
@@ -438,26 +378,5 @@ describe("Search — query-injection safety", () => {
       SELECT COUNT(*)::text AS count FROM constituents WHERE first_name = 'SEARCH-TEST-Probe-Marie'
     `);
     expect(Number(survived.rows[0]?.count ?? "0")).toBeGreaterThanOrEqual(1);
-  });
-});
-
-// ─── 5. Registry parity ──────────────────────────────────────────────
-
-describe("Search — feature-flag registry parity", () => {
-  it("DB row for productivity.command_palette matches FEATURE_FLAG_REGISTRY", async () => {
-    const row = await db.query.featureFlags.findFirst({
-      where: eq(featureFlags.key, FLAG_KEY),
-    });
-    expect(row).toBeDefined();
-
-    const expected = FEATURE_FLAG_REGISTRY.find((r) => r.key === FLAG_KEY);
-    expect(expected).toBeDefined();
-    if (!row || !expected) return;
-
-    expect(row.label).toBe(expected.label);
-    expect(row.description).toBe(expected.description);
-    expect(row.scope).toBe(expected.scope);
-    expect(row.tenantOverrideAllowed).toBe(expected.tenantOverrideAllowed);
-    expect(row.public).toBe(expected.public);
   });
 });

--- a/packages/api/src/tests/integration/superadmin-finance.test.ts
+++ b/packages/api/src/tests/integration/superadmin-finance.test.ts
@@ -4,7 +4,6 @@
  * Coverage:
  *   - RBAC matrix per route: super_admin → 200/202; org_admin / user /
  *     viewer → 404 (anti-disclosure); unauthenticated → 401.
- *   - Flag off → 404 on every gated route.
  *   - Custom-range fuzz: missing bounds, `from > to`, oversize window,
  *     `1900-01-01` clamping, `'; DROP TABLE` SQLi attempt.
  *   - Idempotent launch: replay with same key → cached 202.
@@ -18,12 +17,9 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
-import { featureFlags } from "@givernance/shared/schema";
-import { eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { flagService } from "../../lib/flags/flag-service.js";
 import { redis } from "../../lib/redis.js";
 import { createServer } from "../../server.js";
 import {
@@ -36,9 +32,8 @@ import {
   USER_A_ROW_ID,
   USER_B_ROW_ID,
 } from "../helpers/auth.js";
-import { db, systemDb } from "../helpers/db.js";
+import { systemDb } from "../helpers/db.js";
 
-const FLAG_KEY = FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD;
 const SUPER_ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000437ad";
 const SUPER_ADMIN_PLATFORM_ROW_ID = "00000000-0000-0000-0000-0000000437a1";
 const PLATFORM_TENANT_ID = "00000000-0000-0000-0000-0000000000a1";
@@ -59,11 +54,6 @@ function superAdminToken() {
     role: undefined,
     email: "super-finance@example.org",
   });
-}
-
-async function setFlag(enabled: boolean): Promise<void> {
-  await db.update(featureFlags).set({ enabled }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
 }
 
 async function clearRedisCache(): Promise<void> {
@@ -139,8 +129,6 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await clearRedisCache();
-  // Default ON for most tests — flag-off coverage explicitly toggles back.
-  await setFlag(true);
   // Clean state per test.
   await systemDb.execute(sql`DELETE FROM survey_launches WHERE survey_id = ${pmfSurveyId}`);
   await systemDb.execute(
@@ -169,10 +157,6 @@ beforeEach(async () => {
     WHERE survey_id = ${pmfSurveyId}
       AND id NOT IN (${pmfInvitationForUserA}, ${pmfInvitationForUserB})
   `);
-});
-
-afterEach(async () => {
-  await setFlag(false);
 });
 
 // ─── GET /v1/superadmin/finance/summary ─────────────────────────────────
@@ -235,21 +219,6 @@ describe("GET /v1/superadmin/finance/summary", () => {
         type: "https://httpproblems.com/http-status/401",
         title: "Unauthorized",
         status: 401,
-      });
-    });
-
-    it("flag off → 404 (gated route invisible)", async () => {
-      await setFlag(false);
-      const res = await app.inject({
-        method: "GET",
-        url: "/v1/superadmin/finance/summary?period=30d",
-        headers: authHeader(superAdminToken()),
-      });
-      expect(res.statusCode).toBe(404);
-      expect(res.json()).toMatchObject({
-        type: "https://httpproblems.com/http-status/404",
-        title: "Not Found",
-        status: 404,
       });
     });
   });
@@ -482,16 +451,6 @@ describe("GET /v1/superadmin/finance/summary.csv", () => {
         url: "/v1/superadmin/finance/summary.csv?period=30d",
       });
       expect(res.statusCode).toBe(401);
-    });
-
-    it("flag off → 404", async () => {
-      await setFlag(false);
-      const res = await app.inject({
-        method: "GET",
-        url: "/v1/superadmin/finance/summary.csv?period=30d",
-        headers: authHeader(superAdminToken()),
-      });
-      expect(res.statusCode).toBe(404);
     });
   });
 
@@ -834,17 +793,6 @@ describe("POST /v1/superadmin/surveys/:slug/launch", () => {
     expect(res.statusCode).toBe(404);
   });
 
-  it("flag off → 404", async () => {
-    await setFlag(false);
-    const res = await app.inject({
-      method: "POST",
-      url: `/v1/superadmin/surveys/${PMF_SLUG}/launch`,
-      headers: { ...authHeader(superAdminToken()), "idempotency-key": randomUUID() },
-      payload: { channel: "email" },
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
   it("non-v4 UUID Idempotency-Key → 400 (v3/v5 must fail closed)", async () => {
     // RFC-4122 v3 (MD5-namespaced): the third group starts with '3', not '4'.
     const v3Key = "12345678-1234-3456-8123-1234567890ab";
@@ -1056,17 +1004,6 @@ describe("POST /v1/surveys/:invitationId/respond", () => {
     });
     expect(res.statusCode).toBe(401);
   });
-
-  it("flag off → 404", async () => {
-    await setFlag(false);
-    const res = await app.inject({
-      method: "POST",
-      url: `/v1/surveys/${pmfInvitationForUserA}/respond`,
-      headers: authHeader(signToken(app, { sub: USER_A })),
-      payload: { response: { category: "very_disappointed" } },
-    });
-    expect(res.statusCode).toBe(404);
-  });
 });
 
 describe("POST /v1/superadmin/finance/cache/flush (#449)", () => {
@@ -1148,16 +1085,6 @@ describe("POST /v1/superadmin/finance/cache/flush (#449)", () => {
     });
   });
 
-  it("flag off → 404", async () => {
-    await setFlag(false);
-    const res = await app.inject({
-      method: "POST",
-      url: "/v1/superadmin/finance/cache/flush",
-      headers: authHeader(superAdminToken()),
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
   it("idempotent: flushing twice keeps decoy keys intact and returns 0 the second time", async () => {
     await app.inject({
       method: "POST",
@@ -1224,16 +1151,6 @@ describe("GET /v1/surveys/pending", () => {
     expect(body.data[0]?.invitationId).toBe(pmfInvitationForUserA);
     expect(body.data[0]?.surveyKind).toBe("pmf");
     expect(body.data[0]?.questionFr).toBe("PMF FR");
-  });
-
-  it("flag-off → 404 (anti-disclosure)", async () => {
-    await setFlag(false);
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/surveys/pending",
-      headers: authHeader(signToken(app)),
-    });
-    expect(res.statusCode).toBe(404);
   });
 
   it("super_admin → empty list (no tenant user row)", async () => {
@@ -1412,16 +1329,6 @@ describe("POST /v1/surveys/:invitationId/dismiss", () => {
       method: "POST",
       // User A trying to dismiss User B's invitation.
       url: `/v1/surveys/${pmfInvitationForUserB}/dismiss`,
-      headers: authHeader(signToken(app)),
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it("flag-off → 404", async () => {
-    await setFlag(false);
-    const res = await app.inject({
-      method: "POST",
-      url: `/v1/surveys/${pmfInvitationForUserA}/dismiss`,
       headers: authHeader(signToken(app)),
     });
     expect(res.statusCode).toBe(404);

--- a/packages/api/src/tests/integration/superadmin-monthly-report.test.ts
+++ b/packages/api/src/tests/integration/superadmin-monthly-report.test.ts
@@ -4,7 +4,6 @@
  * Coverage:
  *   - RBAC matrix on POST/GET routes (super_admin → 202/200/404;
  *     org_admin / user / viewer → 404; unauthenticated → 401).
- *   - Flag off → 404 on every gated route.
  *   - Idempotency: two POSTs for the same target month return the
  *     same `id`, only the first emits status=202 (fresh enqueue).
  *   - Audit trail: every POST writes a `platform_finance_report`
@@ -18,19 +17,16 @@
  *     elsewhere).
  */
 
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
-import { auditLogs, featureFlags, platformFinanceReports } from "@givernance/shared/schema";
+import { auditLogs, platformFinanceReports } from "@givernance/shared/schema";
 import { and, desc, eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { flagService } from "../../lib/flags/flag-service.js";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { redis } from "../../lib/redis.js";
 import { previousMonth } from "../../modules/superadmin/finance/monthly-report.js";
 import { createServer } from "../../server.js";
 import { authHeader, ensureTestTenants, signToken } from "../helpers/auth.js";
-import { db, systemDb } from "../helpers/db.js";
+import { systemDb } from "../helpers/db.js";
 
-const FLAG_KEY = FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD;
 const SUPER_ADMIN_KEYCLOAK_ID = "00000000-0000-0000-0000-0000000443ad";
 const SUPER_ADMIN_PLATFORM_ROW_ID = "00000000-0000-0000-0000-0000000443a1";
 const PLATFORM_TENANT_ID = "00000000-0000-0000-0000-0000000000a1";
@@ -44,11 +40,6 @@ function superAdminToken() {
     role: undefined,
     email: "super-report@example.org",
   });
-}
-
-async function setFlag(enabled: boolean): Promise<void> {
-  await db.update(featureFlags).set({ enabled }).where(eq(featureFlags.key, FLAG_KEY));
-  await flagService.invalidate();
 }
 
 async function clearReportsAndAudit(): Promise<void> {
@@ -85,11 +76,6 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await clearReportsAndAudit();
-  await setFlag(true);
-});
-
-afterEach(async () => {
-  await setFlag(false);
 });
 
 // ─── helpers ──────────────────────────────────────────────────────────────
@@ -172,17 +158,6 @@ describe("POST /v1/superadmin/finance/reports/monthly", () => {
         title: "Unauthorized",
         status: 401,
       });
-    });
-
-    it("flag off → 404 (gated route invisible)", async () => {
-      await setFlag(false);
-      const res = await app.inject({
-        method: "POST",
-        url: "/v1/superadmin/finance/reports/monthly",
-        headers: authHeader(superAdminToken()),
-        payload: {},
-      });
-      expect(res.statusCode).toBe(404);
     });
   });
 
@@ -348,17 +323,6 @@ describe("POST /v1/superadmin/finance/reports/backfill", () => {
   // each describe-it consumes at most one slot and use a distinct
   // x-forwarded-for header per test where two consecutive calls are
   // unavoidable.
-  it("flag off → 404 (gated)", async () => {
-    await setFlag(false);
-    const res = await app.inject({
-      method: "POST",
-      url: "/v1/superadmin/finance/reports/backfill",
-      headers: { ...authHeader(superAdminToken()), "x-forwarded-for": "10.0.0.1" },
-      payload: {},
-    });
-    expect(res.statusCode).toBe(404);
-  });
-
   it("org_admin → 404 (anti-disclosure)", async () => {
     const res = await app.inject({
       method: "POST",

--- a/packages/shared/src/constants/feature-flags.ts
+++ b/packages/shared/src/constants/feature-flags.ts
@@ -106,80 +106,6 @@ export const FEATURE_FLAG_KEYS = {
   DONATION_PUBLIC_PAGE_STYLES: "donation.public_page_styles",
 
   /**
-   * Gates the in-app notification centre (Epic #363, GLO-004).
-   *
-   * The Epic ships the bell icon + side-panel + per-user preferences
-   * page + outbox-fanout producer + SSE stream + email-digest worker.
-   * With the flag OFF the topbar has no bell at all, the gated routes
-   * (`/v1/notifications/*`, `/v1/notification-preferences*`) return
-   * 404 not 403, the outbox-fanout worker silently no-ops, and the
-   * digest worker skips its tick. End result: a tenant with the flag
-   * off is indistinguishable from one before the Epic shipped.
-   *
-   * `scope='tenant'`: every NPO is independent. A noisy fundraising
-   * team that wants notifications shouldn't force a quiet operational
-   * team to turn them on too.
-   *
-   * `tenant_override_allowed=false` for the initial rollout: super-
-   * admin keeps the gate per tenant until the UX is verified end-to-
-   * end on staging. Flips to `true` in a follow-up once preferences
-   * + SSE prove stable (no policy reason to keep org-admins out
-   * beyond "let's see how the panel lands first").
-   *
-   * `public=true`: the appShell layout SSR-fetches `/v1/feature-flags`
-   * to decide whether to render the bell icon in the topbar AND
-   * whether to mount the polling/SSE client. A private value would
-   * unconditionally hide the entry and defeat the Epic.
-   *
-   * Surfaces gated by this key:
-   *   - API: GET / POST / PATCH / DELETE on `/v1/notifications*`
-   *   - API: GET / PATCH on `/v1/notification-preferences*`
-   *   - API: GET /v1/notifications/stream (SSE)
-   *   - Worker: outbox-event fanout into notification rows silently
-   *     no-ops (defence in depth — second wall behind the API gate).
-   *   - Worker: weekly email-digest BullMQ tick skips if off.
-   *   - Web: bell icon + panel + filter chips + `/settings/notifications`
-   *     page + sidebar entry + polling/SSE client all hidden.
-   *
-   * Emergency rollback: see `docs/runbooks/feature-flag-rollback.md`
-   * if the Back Office is unavailable.
-   */
-  COMMUNICATION_NOTIFICATIONS_CENTER: "communication.notifications_center",
-
-  /**
-   * Gates the Feature flags Phase 2 work itself (Epic #365 / PR #366).
-   *
-   * Even flag-administration tooling gets a flag — the new tenant-
-   * override endpoints, the "Feature flags" tab on the tenant detail
-   * page, and the org-admin `/settings/feature-flags` page are all
-   * net-new user-facing surfaces and deserve the same kill-switch
-   * pattern as every other feature.
-   *
-   * `scope='platform'`: only Givernance staff decide when the
-   * Phase 2 surface ships; tenants can't opt themselves in.
-   *
-   * `public=true`: the org-admin layout reads `/v1/feature-flags`
-   * via SSR to decide whether to render the "Feature flags" sidebar
-   * entry. A private value here would unconditionally hide the
-   * entry, defeating the Epic.
-   *
-   * The evaluator's precedence change (deprecated → platform-locked
-   * → tenant override → default) and the `tenant_flag_overrides`
-   * table itself land UN-flagged because they're internal mechanics
-   * with no user-observable behaviour change while no overrides
-   * exist, and gating the evaluator on a flag is circular.
-   *
-   * Surfaces gated by this key:
-   *   - API: GET/PUT/DELETE /v1/admin/tenants/:id/feature-flags*
-   *   - API: GET /v1/org/feature-flags + PATCH /v1/org/feature-flags/:key
-   *   - API: `overrideStats` field on GET /v1/admin/feature-flags
-   *   - Web: "Feature flags" tab on /admin/tenants/[id]
-   *   - Web: /settings/feature-flags page + sidebar entry
-   *   - Web: tenant-override count column on /admin/feature-flags
-   */
-  ADMIN_FEATURE_FLAGS_PHASE2: "admin.feature_flags_phase2",
-
-  /**
    * Gates the bulk-import-constituents feature (Epic #373, PR #385).
    *
    * Off by default until we've watched a few real-world imports go
@@ -204,97 +130,6 @@ export const FEATURE_FLAG_KEYS = {
   CONSTITUENTS_BULK_IMPORT: "constituents.bulk_import",
 
   /**
-   * Gates the one-click "Replicate" row-action on the Back Office
-   * impersonation list (issue #428).
-   *
-   * The Epic adds a Replicate button next to every past-session row.
-   * Click → re-POST `/v1/admin/impersonation` with the original
-   * target / mode / reason. If the operator's MFA step-up is still
-   * fresh (Keycloak `auth_time` ≤ 5 min, the existing
-   * `STEP_UP_AUTH_TIME_WINDOW_SECONDS` window), the new session
-   * starts in a single click; otherwise the same stash + bounce-through
-   * `/admin/impersonation/new` machinery the start-form already uses
-   * picks the request up after the MFA round-trip. With the flag OFF
-   * the past-sessions list looks identical to what it shipped — no
-   * extra column, no extra DOM, no extra keybinding.
-   *
-   * `scope='platform'`: this is a dev-/staff-speed feature, not a
-   * tenant-facing capability. Only Givernance staff (super-admins)
-   * see the button at all; the gate is global, not per-tenant.
-   *
-   * `tenant_override_allowed=false`: tenants have no business with
-   * this flag — it sits behind `super_admin` anyway.
-   *
-   * `public=true`: the Back Office list page SSR-fetches
-   * `/v1/feature-flags` to decide whether to render the Replicate
-   * cell. A private projection would unconditionally hide the
-   * surface and defeat the Epic.
-   *
-   * Surfaces gated by this key:
-   *   - Web: Replicate column on the past-sessions table at
-   *     `/admin/impersonation`.
-   *
-   * No backend route or schema is gated — Replicate is a pure client
-   * wrapper over the existing `POST /v1/admin/impersonation`. The
-   * five-step flag pattern still applies (registry + seed migration +
-   * parity test + SSR gate + off-state QA) but step 3 (`requireFlag`
-   * preHandler) and step 4 (worker `isFlagEnabled`) don't have a
-   * surface here.
-   *
-   * Emergency rollback: see `docs/runbooks/feature-flag-rollback.md`
-   * if the Back Office is unavailable.
-   */
-  ADMIN_IMPERSONATION_REPLICATE: "admin.impersonation_replicate",
-
-  /**
-   * Gates the global search / command palette feature (Epic #364, GLO-001).
-   *
-   * Adds a `Cmd+K` / `Ctrl+K` keyboard binding that opens a `cmdk` overlay
-   * with grouped, RLS-scoped cross-entity search across constituents,
-   * donations, and campaigns, plus static "go to …" navigation commands and
-   * RBAC-aware quick-create actions (new constituent, new donation,
-   * new campaign).
-   *
-   * `scope='tenant'`: every NPO is independent. A tenant on Postgres FTS
-   * is the entire feature today, but if Givernance later swaps to an
-   * external search engine (Meilisearch / Typesense, hosted EU on
-   * Scaleway), the per-tenant gate is the rollout knob — we can pilot
-   * the new backend with a single tenant override before flipping the
-   * platform default.
-   *
-   * `tenant_override_allowed=true`: there is no platform-level
-   * precondition (no DKIM-style external dependency); each org-admin can
-   * self-serve the toggle from `/settings/feature-flags` once we're past
-   * the initial rollout.
-   *
-   * `public=true`: the topbar's `Cmd+K` button + keyboard binding +
-   * SSR-rendered overlay shell all need to know the effective value at
-   * page-load time. A private projection would unconditionally hide the
-   * surface and defeat the Epic.
-   *
-   * Surfaces gated by this key:
-   *   - API: GET /v1/search (`requireFlag` is the FIRST preHandler — a
-   *     disabled tenant gets 404, indistinguishable from a typo'd URL,
-   *     so a scanner can't enumerate the feature).
-   *   - Web: the topbar `Cmd+K` button is completely absent when the
-   *     flag is off (no greyed-out placeholder).
-   *   - Web: the global `Cmd+K` / `Ctrl+K` keydown listener is NOT
-   *     mounted when the flag is off (off-state QA: pressing the
-   *     shortcut does nothing).
-   *   - Web: the command palette overlay component is not loaded at
-   *     all when the flag is off.
-   *
-   * Public-projection caveat: per the CLAUDE.md feature-flag-first
-   * rule, the key name `productivity.command_palette` is intentionally
-   * descriptive and not teasing an unannounced surprise, so its
-   * presence in `/v1/feature-flags` for every authenticated tenant
-   * user is acceptable.
-   *
-   * Emergency rollback: see `docs/runbooks/feature-flag-rollback.md`.
-   */
-  PRODUCTIVITY_COMMAND_PALETTE: "productivity.command_palette",
-
-  /**
    * Advanced constituent filtering with complex queries and pattern detection
    * (issue #422). Enables DSL-based filtering with aggregations, patterns
    * (LYBUNT, SYBUNT, recurring, lapsed, major donors), and campaign targeting.
@@ -307,54 +142,6 @@ export const FEATURE_FLAG_KEYS = {
    * filter controls in the constituents module.
    */
   ADVANCED_FILTERS: "advanced_filters",
-
-  /**
-   * Gates the super-admin platform finance + tenant-health dashboard
-   * (Epic #434, route `/admin/finance`).
-   *
-   * The epic ships the entire super-admin operational nerve-centre:
-   * real-time finance signals (volume, Revenu Givernance, MRR, frais
-   * Stripe), portfolio risk (HHI concentration, active-tenants ratio,
-   * payment-failure rate), Mobilisation Score per tenant (A+ → D), and
-   * Tenant Health via the in-house survey infrastructure (PMF Sean
-   * Ellis, NPS, CSAT) with the data-freshness pattern that surfaces
-   * stale survey data with inline refresh actions.
-   *
-   * Default-off until the dashboard's numbers have been validated
-   * against ground-truth on at least one live tenant. The KPIs
-   * aggregate cross-tenant data through `systemDb` (the only legitimate
-   * super-admin BYPASSRLS path); an off-by-one in the SQL is invisible
-   * to QA until real money is in the table, so the safe rollout is to
-   * deploy the schema + worker + API + page behind a flag and flip it
-   * per super-admin session for validation before the platform-wide
-   * enable.
-   *
-   * `scope='platform'`: the dashboard is super-admin-only by product
-   * design. Tenants have no per-tenant override semantics here — they
-   * never see this surface at all.
-   *
-   * `tenant_override_allowed=false`: follows from `scope='platform'`.
-   *
-   * `public=true`: the super-admin appShell SSR-fetches
-   * `/v1/feature-flags` to decide whether to render the "Finance
-   * plateforme" sidebar entry. A private projection would
-   * unconditionally hide the nav entry and defeat the epic.
-   *
-   * Surfaces gated by this key:
-   *   - API: GET /v1/superadmin/finance/summary (`requireFlag` is the
-   *     FIRST preHandler — disabled returns 404 so a scanner can't
-   *     enumerate role requirements).
-   *   - API: POST /v1/superadmin/surveys/:slug/launch (email|in_app)
-   *     + POST /v1/superadmin/surveys/:slug/schedule.
-   *   - Worker: Stripe BalanceTransaction enrichment job no-ops when
-   *     the flag is off; the daily constituent-count refresh job
-   *     no-ops too.
-   *   - Web: "Finance plateforme" sidebar entry hidden; `/admin/finance`
-   *     route returns 404.
-   *
-   * Emergency rollback: see `docs/runbooks/feature-flag-rollback.md`.
-   */
-  ADMIN_FINANCE_DASHBOARD: "admin.finance_dashboard",
 
   /**
    * Gates the merged single multi-page PDF option for postal exports
@@ -462,51 +249,11 @@ export const FEATURE_FLAG_REGISTRY: ReadonlyArray<{
     public: true,
   },
   {
-    key: FEATURE_FLAG_KEYS.ADMIN_FEATURE_FLAGS_PHASE2,
-    defaultEnabled: false,
-    label: "Per-organisation feature flag controls",
-    description:
-      "Lets Givernance staff turn features on or off for one organisation at a time, and lets each organisation's admin manage their own feature settings from the Settings menu. Off by default until the new pages have been verified end-to-end.",
-    scope: "platform",
-    tenantOverrideAllowed: false,
-    public: true,
-  },
-  {
-    key: FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER,
-    defaultEnabled: false,
-    label: "In-app notification centre",
-    description:
-      "Adds a bell icon to the top bar with a panel that lists what happened in your organisation — new donations, postal-export downloads, team invitations, and more. Each member can choose which alerts they want from the Settings menu. Off by default until Givernance staff confirm the bell, panel, and per-member preferences for your organisation.",
-    scope: "tenant",
-    tenantOverrideAllowed: false,
-    public: true,
-  },
-  {
     key: FEATURE_FLAG_KEYS.CONSTITUENTS_BULK_IMPORT,
     defaultEnabled: false,
     label: "Bulk import constituents from CSV / Excel",
     description:
       "Lets operators upload a CSV or Excel file (max 10 MB) to create constituents in bulk, with duplicate detection and a per-row progress view. Off by default while we monitor the first real-world imports — flip it on from this page when you're ready.",
-    scope: "tenant",
-    tenantOverrideAllowed: true,
-    public: true,
-  },
-  {
-    key: FEATURE_FLAG_KEYS.ADMIN_IMPERSONATION_REPLICATE,
-    defaultEnabled: false,
-    label: "One-click Replicate on the Back Office support sessions list",
-    description:
-      "Adds a Replicate action next to each past support session on the Back Office, so support staff can re-enter the same session in one click without retyping the target and reason. The same security checks still apply on every replicate.",
-    scope: "platform",
-    tenantOverrideAllowed: false,
-    public: true,
-  },
-  {
-    key: FEATURE_FLAG_KEYS.PRODUCTIVITY_COMMAND_PALETTE,
-    defaultEnabled: false,
-    label: "Keyboard quick search (Cmd+K / Ctrl+K)",
-    description:
-      "Adds a quick search panel that opens with Cmd+K (Mac) or Ctrl+K (Windows / Linux) from any page. Type to find a constituent, donation, or campaign, jump to a section, or start a new record. Off by default while we monitor performance and search quality — flip it on from this page when you're ready.",
     scope: "tenant",
     tenantOverrideAllowed: true,
     public: true,
@@ -519,16 +266,6 @@ export const FEATURE_FLAG_REGISTRY: ReadonlyArray<{
       "Enables powerful filtering capabilities with complex queries, aggregations, and pattern detection (LYBUNT, SYBUNT, recurring donors, lapsed donors, major donors). Performance-intensive feature that requires database indexes. Enable gradually to monitor impact.",
     scope: "tenant",
     tenantOverrideAllowed: true,
-    public: true,
-  },
-  {
-    key: FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD,
-    defaultEnabled: false,
-    label: "Admin · Platform finance dashboard",
-    description:
-      "Cross-tenant super-admin dashboard aggregating donation volume, revenue, Stripe fees, and tenant health signals (Mobilisation Score + PMF/NPS/CSAT). Off by default until live tenant numbers are validated against ground truth.",
-    scope: "platform",
-    tenantOverrideAllowed: false,
     public: true,
   },
   {

--- a/packages/shared/src/finance/reporting/monthly-report.ts
+++ b/packages/shared/src/finance/reporting/monthly-report.ts
@@ -26,10 +26,8 @@
 // passes its owner-pool `db` + its own PLATFORM_REPORTS queue closure.
 //
 // PLATFORM-LEVEL: every query goes through the injected owner `db`
-// (the table has no org_id, no RLS). The API route guard chain
-// `requireFlag(ADMIN_FINANCE_DASHBOARD) → requireSuperAdmin` is
-// enforced in routes.ts (flag first so a scanner gets 404 without
-// revealing the role requirement); the worker gates on the same flag.
+// (the table has no org_id, no RLS). The API route guard
+// `requireSuperAdmin` is enforced in routes.ts.
 
 import { platformFinanceReports } from "@givernance/shared/schema";
 import { and, eq, inArray, sql } from "drizzle-orm";

--- a/packages/shared/src/jobs/index.ts
+++ b/packages/shared/src/jobs/index.ts
@@ -207,10 +207,6 @@ export interface GenerateMonthlyFinanceReportJob {
  *    sends, and re-schedules cyclical surveys.
  *  - SURVEY_RETENTION (weekly, Sunday 04:00 UTC) — soft-deletes
  *    `survey_responses` older than 24 months (docs/31).
- *
- * All three respect the `admin.finance_dashboard` feature flag — a
- * no-op (early return) when the flag is off so a paused rollout
- * doesn't churn Postgres for nothing.
  */
 export const FINANCE_DASHBOARD_JOBS = {
   CONSTITUENT_COUNT_REFRESH: "finance.constituent_count_refresh",
@@ -358,9 +354,8 @@ export const NOTIFICATIONS_DIGEST_JOBS = {
  *
  *  - MONTHLY_AUTO_TRIGGER — cron-fired on the 1st of each month at
  *    03:30 UTC, and once at worker startup for the boot-time backfill.
- *    The processor checks the `admin.finance_dashboard` flag, resolves
- *    the previous calendar month, idempotently inserts a pending row
- *    (with kpi_snapshot), and enqueues GENERATE_PDF.
+ *    The processor resolves the previous calendar month, idempotently
+ *    inserts a pending row (with kpi_snapshot), and enqueues GENERATE_PDF.
  *  - GENERATE_PDF — one job per `platform_finance_reports` row;
  *    renders the PDF from the pre-built kpi_snapshot and uploads to S3.
  */

--- a/packages/web/src/app/(admin)/admin/feature-flags/[key]/page.tsx
+++ b/packages/web/src/app/(admin)/admin/feature-flags/[key]/page.tsx
@@ -4,7 +4,6 @@ import { getTranslations } from "next-intl/server";
 
 import { PerFlagTenants } from "@/components/admin/per-flag-tenants";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 import {
   type FeatureFlagRow,
   FeatureFlagsService,
@@ -19,17 +18,12 @@ export const dynamic = "force-dynamic";
  * `/admin/feature-flags` — lets the operator manage "5 enabled across
  * 45 tenants" without navigating the per-tenant detail page 45 times.
  *
- * Gated by `admin.feature_flags_phase2` (off-state: 404, same posture
- * as the rest of the Epic). Also 404s when the flag key is unknown —
- * that's a hand-typed URL, not a navigable mistake.
+ * 404s when the flag key is unknown — that's a hand-typed URL, not a
+ * navigable mistake.
  */
 export default async function PerFlagTenantsPage({ params }: { params: Promise<{ key: string }> }) {
   const t = await getTranslations("admin.featureFlags.perFlagTenants");
   const { key } = await params;
-
-  if (!(await isFeatureFlagsPhase2Enabled())) {
-    notFound();
-  }
 
   const api = await createServerApiClient();
 

--- a/packages/web/src/app/(admin)/admin/finance/__tests__/page.test.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/__tests__/page.test.tsx
@@ -1,11 +1,12 @@
 /**
  * Smoke tests for the super-admin finance page (issue #206).
  *
- * Covers the two flag-gate code paths:
- *   1. Flag-off → `notFound()` (per the off-state QA rule).
- *   2. Flag-on with seed data → dashboard renders with the page title.
- *   3. Flag-on with no data → empty-state copy renders without
- *      throwing (charts must not crash on a zero-volume window).
+ * The page is gated only by the `(admin)` layout's super_admin check —
+ * there is no per-feature flag any more (retired in issue #493).
+ * Remaining coverage:
+ *   1. Seed data → dashboard renders with the page title.
+ *   2. No data → empty-state copy renders without throwing (charts must
+ *      not crash on a zero-volume window).
  */
 
 import { render, screen, waitFor } from "@testing-library/react";
@@ -13,25 +14,12 @@ import { vi } from "vitest";
 
 import type { FinanceSummary } from "@/models/superadmin-finance";
 
-const notFoundMock = vi.fn(() => {
-  throw new Error("__NEXT_NOT_FOUND__");
-});
-
-const isFinanceDashboardEnabledMock = vi.fn<() => Promise<boolean>>();
 const fetchSummaryMock = vi.fn<(client: unknown, params: unknown) => Promise<FinanceSummary>>();
-
-vi.mock("next/navigation", () => ({
-  notFound: () => notFoundMock(),
-}));
 
 vi.mock("next-intl/server", () => ({
   getTranslations: async () => (key: string, values?: Record<string, string | number>) =>
     values ? `${key} ${JSON.stringify(values)}` : key,
   getLocale: async () => "en",
-}));
-
-vi.mock("@/lib/feature-flags/server", () => ({
-  isFinanceDashboardEnabled: () => isFinanceDashboardEnabledMock(),
 }));
 
 vi.mock("@/lib/api/client-server", () => ({
@@ -173,17 +161,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("/admin/finance — flag gate", () => {
-  it("calls notFound() when the admin.finance_dashboard flag is off", async () => {
-    isFinanceDashboardEnabledMock.mockResolvedValue(false);
-    const { default: FinancePage } = await import("../page");
-    await expect(FinancePage()).rejects.toThrow("__NEXT_NOT_FOUND__");
-    expect(notFoundMock).toHaveBeenCalledTimes(1);
-    expect(fetchSummaryMock).not.toHaveBeenCalled();
-  });
-
-  it("renders the dashboard when the flag is on and the summary fetch succeeds", async () => {
-    isFinanceDashboardEnabledMock.mockResolvedValue(true);
+describe("/admin/finance — dashboard render", () => {
+  it("renders the dashboard when the summary fetch succeeds", async () => {
     fetchSummaryMock.mockResolvedValue(buildSummary());
     const { default: FinancePage } = await import("../page");
     const tree = await FinancePage();
@@ -199,7 +178,6 @@ describe("/admin/finance — flag gate", () => {
   });
 
   it("Export button click builds the CSV URL with current filters + triggers anchor download (#442)", async () => {
-    isFinanceDashboardEnabledMock.mockResolvedValue(true);
     fetchSummaryMock.mockResolvedValue(buildSummary());
     const { default: FinancePage } = await import("../page");
     const tree = await FinancePage();
@@ -235,7 +213,6 @@ describe("/admin/finance — flag gate", () => {
 
 describe("/admin/finance — empty state", () => {
   it("renders the friendly empty-state copy when the period has no data", async () => {
-    isFinanceDashboardEnabledMock.mockResolvedValue(true);
     fetchSummaryMock.mockResolvedValue(emptySummary());
     const { default: FinancePage } = await import("../page");
     const tree = await FinancePage();

--- a/packages/web/src/app/(admin)/admin/finance/page.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/page.tsx
@@ -1,10 +1,8 @@
 /**
  * Super-admin platform finance dashboard (Epic #434 · issue #206).
  *
- * Route: /admin/finance — gated by:
- *   1. `(admin)` layout: requires `super_admin` realm role (else 404).
- *   2. This page: requires `admin.finance_dashboard` feature flag on
- *      (else notFound() — never 403, per feedback_authenticated_unauthorized_uses_404).
+ * Route: /admin/finance — gated by the `(admin)` layout, which requires
+ * the `super_admin` realm role (else 404).
  *
  * The page is the i18n boundary: all translated strings are resolved
  * here and passed as `labels` props to the presentational components
@@ -16,10 +14,7 @@
  * `FinanceDashboard` via the existing ApiClient.
  */
 
-import { notFound } from "next/navigation";
-
 import { createServerApiClient } from "@/lib/api/client-server";
-import { isFinanceDashboardEnabled } from "@/lib/feature-flags/server";
 import type { FinanceSummary } from "@/models/superadmin-finance";
 import { SuperAdminFinanceService } from "@/services/SuperAdminFinanceService";
 
@@ -28,13 +23,6 @@ import { FinanceDashboard } from "./finance-dashboard";
 export const dynamic = "force-dynamic";
 
 export default async function FinancePage() {
-  // Flag-gate FIRST — non-flagged probe gets 404 without revealing
-  // anything (the super_admin role check has already passed in the
-  // layout, but we keep this 404 so off-state QA is uniform).
-  if (!(await isFinanceDashboardEnabled())) {
-    notFound();
-  }
-
   // i18n (labels) is built inside the client component — the labels
   // shape carries function fields (`foot(count, period)`, `footnote`,
   // `format.shortDate`, …) that RSC cannot serialise across the

--- a/packages/web/src/app/(admin)/admin/impersonation/page.tsx
+++ b/packages/web/src/app/(admin)/admin/impersonation/page.tsx
@@ -5,7 +5,6 @@ import { EndImpersonationSessionButton } from "@/components/admin/end-impersonat
 import { ReplicateImpersonationSessionButton } from "@/components/admin/replicate-impersonation-session-button";
 import { Button } from "@/components/ui/button";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { isImpersonationReplicateEnabled } from "@/lib/feature-flags/server";
 import { cn } from "@/lib/utils";
 import {
   ImpersonationService,
@@ -63,14 +62,9 @@ export default async function ImpersonationListPage({ searchParams }: Impersonat
   const [params, client] = await Promise.all([searchParams, createServerApiClient()]);
   const modeFilter = parseModeFilter(params.mode);
 
-  // Two independent SSR fetches — kick off in parallel so the page
-  // doesn't block on serial round-trips. `?all=true` returns historical
-  // sessions too (newest-first); the flag fetch decides whether the
+  // `?all=true` returns historical sessions too (newest-first); the
   // past-rows table renders the Replicate row-action (issue #428).
-  const [sessionsRes, replicateEnabled] = await Promise.all([
-    ImpersonationService.listSessions(client, { all: true, limit: 200 }),
-    isImpersonationReplicateEnabled(),
-  ]);
+  const sessionsRes = await ImpersonationService.listSessions(client, { all: true, limit: 200 });
   const { data } = sessionsRes;
 
   const active = data.filter((s) => deriveStatus(s) === "active");
@@ -121,7 +115,7 @@ export default async function ImpersonationListPage({ searchParams }: Impersonat
             }
           />
         ) : (
-          <SessionTable rows={past} rowActions={replicateEnabled ? "replicate" : "none"} />
+          <SessionTable rows={past} rowActions="replicate" />
         )}
       </section>
     </main>
@@ -249,10 +243,9 @@ function UserCell({
 /**
  * Per-section row action mode. `end` = active row with the End-Session
  * button. `replicate` = past row with the Replicate row-action (issue
- * #428, gated on `admin.impersonation_replicate`). `none` = past row
- * with the flag off, only the View button renders.
+ * #428).
  */
-type RowActions = "end" | "replicate" | "none";
+type RowActions = "end" | "replicate";
 
 async function SessionTable({
   rows,
@@ -370,14 +363,11 @@ async function SessionRow({
           </Button>
           {rowActions === "end" && <EndImpersonationSessionButton sessionId={session.id} />}
           {/*
-            Replicate variants when `rowActions === "replicate"` (flag
-            ON; off-state QA invariant: flag OFF means this branch is
-            never reached and the column ends with only the View button):
+            Replicate variants when `rowActions === "replicate"`:
               - `targetUserId !== null` → render the active button.
               - `targetUserId === null` → render a disabled marker
                 explaining *why* Replicate is unavailable (off-boarded
-                target). Pre-fix the row was visually identical to a
-                flag-off row, which read as "Replicate is gone" rather
+                target) so it doesn't read as "Replicate is gone" rather
                 than "the target this session ran against has been
                 hard-deleted" — SOC + ops feedback, PR #429 review.
            */}

--- a/packages/web/src/app/(admin)/admin/tenants/[id]/page.tsx
+++ b/packages/web/src/app/(admin)/admin/tenants/[id]/page.tsx
@@ -23,7 +23,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { FeatureFlagsService, isFlagEnabled } from "@/services/FeatureFlagsService";
+import { FeatureFlagsService } from "@/services/FeatureFlagsService";
 import type { AdminTenantDetailResponse } from "@/services/TenantAdminService";
 
 export const dynamic = "force-dynamic";
@@ -79,23 +79,15 @@ export default async function TenantDetailPage({
   const { tenant, domains, users, recentAudit, firstAdminInvitation } = detail;
 
   /**
-   * Feature-flags tab content — Epic #365 / PR #366. Gated by the
-   * `admin.feature_flags_phase2` self-flag so the surface is fully
-   * absent (no tab trigger, no fetch) when the Epic is off.
-   *
-   * SSR-fetches both the platform flag projection (to learn if the
-   * self-flag is on) and the per-tenant flag view in parallel.
-   * `Promise.allSettled` so a transient API blip on either doesn't
-   * 500 the whole tenant detail page — the tab degrades to absent
-   * with a console-only error.
+   * Feature-flags tab content — Epic #365 / PR #366. SSR-fetches the
+   * per-tenant flag view. Wrapped in try/catch so a transient API blip
+   * doesn't 500 the whole tenant detail page — the tab degrades to
+   * absent with a console-only error.
    */
   let featureFlagsTab: React.ReactNode | null = null;
   try {
-    const publicFlags = await FeatureFlagsService.listPublic(api);
-    if (isFlagEnabled(publicFlags, "admin.feature_flags_phase2")) {
-      const tenantFlags = await FeatureFlagsService.listForTenant(api, tenant.id);
-      featureFlagsTab = <TenantFeatureFlags tenantId={tenant.id} initialRows={tenantFlags} />;
-    }
+    const tenantFlags = await FeatureFlagsService.listForTenant(api, tenant.id);
+    featureFlagsTab = <TenantFeatureFlags tenantId={tenant.id} initialRows={tenantFlags} />;
   } catch {
     // Non-fatal — the rest of the tenant detail page still renders.
     featureFlagsTab = null;

--- a/packages/web/src/app/(admin)/layout.tsx
+++ b/packages/web/src/app/(admin)/layout.tsx
@@ -3,7 +3,6 @@ import { AppShell } from "@/components/layout";
 import { Toaster } from "@/components/ui/toast";
 import { AuthProvider } from "@/lib/auth";
 import { requireAuth } from "@/lib/auth/guards";
-import { isFinanceDashboardEnabled } from "@/lib/feature-flags/server";
 
 /**
  * Back-office layout — guarded by `super_admin` realm role.
@@ -17,18 +16,9 @@ export default async function AdminLayout({ children }: { children: React.ReactN
     notFound();
   }
 
-  // Resolve the finance-dashboard flag SSR so the sidebar entry never
-  // pops in after hydration (off-state QA per `feedback_feature_flag_first`).
-  const financeDashboardEnabled = await isFinanceDashboardEnabled();
-
   return (
     <AuthProvider>
-      <AppShell
-        impersonation={auth.impersonation}
-        impersonationUserName={undefined}
-        isSuperAdmin
-        financeDashboardEnabled={financeDashboardEnabled}
-      >
+      <AppShell impersonation={auth.impersonation} impersonationUserName={undefined} isSuperAdmin>
         {children}
       </AppShell>
       <Toaster />

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -1,4 +1,3 @@
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { getLocale } from "next-intl/server";
 import { cache } from "react";
 import { AppShell } from "@/components/layout";
@@ -9,7 +8,6 @@ import { createServerApiClient } from "@/lib/api/client-server";
 import { AuthProvider } from "@/lib/auth";
 import { requireAuth } from "@/lib/auth/guards";
 import type { OrgLogo } from "@/models/branding";
-import { FeatureFlagsService, isFlagEnabled } from "@/services/FeatureFlagsService";
 
 /**
  * Authenticated app layout — wraps all protected routes with:
@@ -80,22 +78,6 @@ const fetchOrgLogo = cache(async (orgId: string | undefined): Promise<OrgLogo | 
   }
 });
 
-/**
- * Resolve the tenant-public feature-flag projection server-side so the
- * topbar can render the notifications bell (Epic #363) on first paint
- * without a hydration flash. Soft-fails to an empty list — every
- * downstream `isFlagEnabled` call falls back to `false` (doc 18 §5)
- * which is the safe default for a brand-new feature.
- */
-const fetchPublicFlags = cache(async () => {
-  try {
-    const api = await createServerApiClient();
-    return await FeatureFlagsService.listPublic(api);
-  } catch {
-    return [];
-  }
-});
-
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const auth = await requireAuth();
   const isSuperAdmin = auth.roles.includes("super_admin");
@@ -103,30 +85,10 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 
   const userName = auth.firstName ? `${auth.firstName} ${auth.lastName ?? ""}`.trim() : auth.email;
 
-  const [{ me, membershipCount }, orgLogo, publicFlags] = await Promise.all([
+  const [{ me, membershipCount }, orgLogo] = await Promise.all([
     fetchMeWithMembership(),
     fetchOrgLogo(auth.orgId),
-    fetchPublicFlags(),
   ]);
-
-  const notificationsEnabled = isFlagEnabled(
-    publicFlags,
-    FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER,
-  );
-  const commandPaletteEnabled = isFlagEnabled(
-    publicFlags,
-    FEATURE_FLAG_KEYS.PRODUCTIVITY_COMMAND_PALETTE,
-  );
-  // Super-admin sidebar item "Platform finance" must stay visible across
-  // every authenticated route — not just `/admin/*`. Without this, a
-  // super-admin browsing to /dashboard or /constituents loses the
-  // navigation handle back to the platform finance view (and any other
-  // super-admin entry the sidebar adds). The (admin) layout resolves
-  // the same flag; this mirror keeps the (app) layout in lockstep.
-  const financeDashboardEnabled = isFlagEnabled(
-    publicFlags,
-    FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD,
-  );
 
   // Broken state: a non-super-admin reached the authenticated layout but
   // we couldn't resolve their tenant memberships. Two failure modes:
@@ -187,12 +149,9 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         orgId={auth.orgId}
         canManageBranding={canManageBranding}
         orgLogo={orgLogo}
-        notificationsEnabled={!isSuperAdmin && notificationsEnabled}
-        commandPaletteEnabled={!isSuperAdmin && commandPaletteEnabled}
-        financeDashboardEnabled={financeDashboardEnabled}
       >
         {children}
-        {!isSuperAdmin && financeDashboardEnabled && <SurveyInvitationPrompt locale={locale} />}
+        {!isSuperAdmin && <SurveyInvitationPrompt locale={locale} />}
       </AppShell>
       <Toaster />
     </AuthProvider>

--- a/packages/web/src/app/(app)/profile/notifications/page.tsx
+++ b/packages/web/src/app/(app)/profile/notifications/page.tsx
@@ -1,12 +1,9 @@
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
-import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
 import { NotificationPreferencesForm } from "@/components/notifications/notification-preferences-form";
 import { PageHeader } from "@/components/shared/page-header";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
-import { FeatureFlagsService, isFlagEnabled } from "@/services/FeatureFlagsService";
 import { NotificationsService } from "@/services/NotificationsService";
 
 /**
@@ -20,21 +17,10 @@ import { NotificationsService } from "@/services/NotificationsService";
  *     be reachable by every authenticated role (GLO-004 spec: "Rôles
  *     autorisés: Tous les rôles authentifiés").
  *   - `/profile/*` already houses personal preferences (locale).
- *
- * Off-state QA per `feedback_feature_flag_first`: the page returns
- * 404 (not 403, not a blank screen) when
- * `communication.notifications_center` is off for the tenant. The
- * topbar bell, panel, and footer-link to this page are all hidden in
- * that case — there's no other way to land here than typing the URL.
  */
 export default async function NotificationPreferencesPage() {
   await requireAuth();
   const api = await createServerApiClient();
-
-  const publicFlags = await FeatureFlagsService.listPublic(api).catch(() => []);
-  if (!isFlagEnabled(publicFlags, FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER)) {
-    notFound();
-  }
 
   const t = await getTranslations("notifications.preferencesPage");
   const initial = await NotificationsService.listPreferences(api);

--- a/packages/web/src/app/(app)/settings/bank-accounts/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/settings/bank-accounts/[id]/edit/page.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from "@/components/shared/page-header";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 import type { BankAccount } from "@/models/bank-account";
 import { BankAccountService } from "@/services/BankAccountService";
 
@@ -35,7 +34,6 @@ export default async function EditBankAccountPage({ params }: EditBankAccountPag
   const t = await getTranslations("settings.bankAccounts");
   const tSettings = await getTranslations("settings");
   const tForm = await getTranslations("settings.bankAccounts.form");
-  const showFeatureFlags = await isFeatureFlagsPhase2Enabled();
 
   return (
     <>
@@ -50,7 +48,7 @@ export default async function EditBankAccountPage({ params }: EditBankAccountPag
           { label: tForm("breadcrumbEdit") },
         ]}
       />
-      <SettingsNavigation showFeatureFlags={showFeatureFlags} />
+      <SettingsNavigation />
       <BankAccountForm
         mode="edit"
         bankAccount={bankAccount}

--- a/packages/web/src/app/(app)/settings/bank-accounts/new/page.tsx
+++ b/packages/web/src/app/(app)/settings/bank-accounts/new/page.tsx
@@ -4,14 +4,12 @@ import { BankAccountForm } from "@/components/settings/bank-account-form";
 import { SettingsNavigation } from "@/components/settings/settings-navigation";
 import { PageHeader } from "@/components/shared/page-header";
 import { requireAuth } from "@/lib/auth/guards";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 
 export default async function NewBankAccountPage() {
   const auth = await requireAuth();
   const t = await getTranslations("settings.bankAccounts");
   const tSettings = await getTranslations("settings");
   const tForm = await getTranslations("settings.bankAccounts.form");
-  const showFeatureFlags = await isFeatureFlagsPhase2Enabled();
 
   return (
     <>
@@ -25,7 +23,7 @@ export default async function NewBankAccountPage() {
           { label: tForm("breadcrumbNew") },
         ]}
       />
-      <SettingsNavigation showFeatureFlags={showFeatureFlags} />
+      <SettingsNavigation />
       <BankAccountForm mode="create" canManage={auth.roles.includes("org_admin")} />
     </>
   );

--- a/packages/web/src/app/(app)/settings/bank-accounts/page.tsx
+++ b/packages/web/src/app/(app)/settings/bank-accounts/page.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from "@/components/shared/page-header";
 import { Button } from "@/components/ui/button";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 import { BankAccountService } from "@/services/BankAccountService";
 
 import { BankAccountsTable } from "./bank-accounts-table";
@@ -30,7 +29,6 @@ export default async function BankAccountsPage() {
   });
 
   const hasAny = result.pagination.total > 0;
-  const showFeatureFlags = await isFeatureFlagsPhase2Enabled();
 
   return (
     <>
@@ -55,7 +53,7 @@ export default async function BankAccountsPage() {
           ) : null
         }
       />
-      <SettingsNavigation showFeatureFlags={showFeatureFlags} />
+      <SettingsNavigation />
 
       {hasAny ? (
         <BankAccountsTable bankAccounts={result.data} canManage={canManage} />

--- a/packages/web/src/app/(app)/settings/feature-flags/page.tsx
+++ b/packages/web/src/app/(app)/settings/feature-flags/page.tsx
@@ -1,5 +1,4 @@
 import { AlertTriangle } from "lucide-react";
-import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
 import { OrgFeatureFlagsList } from "@/components/settings/org-feature-flags-list";
@@ -7,7 +6,6 @@ import { SettingsNavigation } from "@/components/settings/settings-navigation";
 import { EmptyState } from "@/components/shared/empty-state";
 import { PageHeader } from "@/components/shared/page-header";
 import { createServerApiClient } from "@/lib/api/client-server";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 import { FeatureFlagsService, type TenantFlagViewRow } from "@/services/FeatureFlagsService";
 
 export const dynamic = "force-dynamic";
@@ -19,21 +17,10 @@ export const dynamic = "force-dynamic";
  * on their own org. The API server filters to `scope='tenant' AND
  * tenant_override_allowed=true`, so the day-one registry returns
  * zero rows — we render an explanatory empty state.
- *
- * Off-state QA (admin.feature_flags_phase2 = off): we read the
- * public-projection flag SSR-side and call `notFound()` when the
- * Epic is disabled. This keeps the route off the discoverable
- * surface while the feature is in dark-launch on prod — matches the
- * Feature-flag-first rule's "surface completely absent" requirement.
  */
 export default async function OrgFeatureFlagsPage() {
   const t = await getTranslations("settings.featureFlags");
   const api = await createServerApiClient();
-
-  // SSR gate — `notFound()` when the Phase-2 self-flag is off.
-  if (!(await isFeatureFlagsPhase2Enabled())) {
-    notFound();
-  }
 
   let rows: TenantFlagViewRow[] = [];
   let fetchFailed = false;
@@ -46,7 +33,7 @@ export default async function OrgFeatureFlagsPage() {
   return (
     <div className="space-y-8">
       <PageHeader title={t("title")} description={t("subtitle")} />
-      <SettingsNavigation showFeatureFlags />
+      <SettingsNavigation />
 
       {fetchFailed ? (
         <div

--- a/packages/web/src/app/(app)/settings/funds/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/settings/funds/[id]/edit/page.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from "@/components/shared/page-header";
 import { ApiProblem } from "@/lib/api";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 import type { Fund } from "@/models/fund";
 import { FundService } from "@/services/FundService";
 
@@ -37,7 +36,6 @@ export default async function EditFundPage({ params }: EditFundPageProps) {
   const t = await getTranslations("settings.funds");
   const tSettings = await getTranslations("settings");
   const tForm = await getTranslations("settings.funds.form");
-  const showFeatureFlags = await isFeatureFlagsPhase2Enabled();
 
   return (
     <>
@@ -52,7 +50,7 @@ export default async function EditFundPage({ params }: EditFundPageProps) {
           { label: tForm("breadcrumbEdit") },
         ]}
       />
-      <SettingsNavigation showFeatureFlags={showFeatureFlags} />
+      <SettingsNavigation />
       <FundForm mode="edit" fund={fund} canManageFunds={auth.roles.includes("org_admin")} />
     </>
   );

--- a/packages/web/src/app/(app)/settings/funds/new/page.tsx
+++ b/packages/web/src/app/(app)/settings/funds/new/page.tsx
@@ -4,14 +4,12 @@ import { FundForm } from "@/components/settings/fund-form";
 import { SettingsNavigation } from "@/components/settings/settings-navigation";
 import { PageHeader } from "@/components/shared/page-header";
 import { requireAuth } from "@/lib/auth/guards";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 
 export default async function NewFundPage() {
   const auth = await requireAuth();
   const t = await getTranslations("settings.funds");
   const tSettings = await getTranslations("settings");
   const tForm = await getTranslations("settings.funds.form");
-  const showFeatureFlags = await isFeatureFlagsPhase2Enabled();
 
   return (
     <>
@@ -25,7 +23,7 @@ export default async function NewFundPage() {
           { label: tForm("breadcrumbNew") },
         ]}
       />
-      <SettingsNavigation showFeatureFlags={showFeatureFlags} />
+      <SettingsNavigation />
       <FundForm mode="create" canManageFunds={auth.roles.includes("org_admin")} />
     </>
   );

--- a/packages/web/src/app/(app)/settings/funds/page.tsx
+++ b/packages/web/src/app/(app)/settings/funds/page.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from "@/components/shared/page-header";
 import { Button } from "@/components/ui/button";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 import type { FundSortField, FundSortOrder } from "@/models/fund";
 import { FundService } from "@/services/FundService";
 
@@ -60,7 +59,6 @@ export default async function FundsPage({ searchParams }: FundsPageProps) {
   const result = await FundService.listFunds(client, { page, perPage, sort, order });
 
   const hasAny = result.pagination.total > 0;
-  const showFeatureFlags = await isFeatureFlagsPhase2Enabled();
 
   return (
     <>
@@ -85,7 +83,7 @@ export default async function FundsPage({ searchParams }: FundsPageProps) {
           ) : null
         }
       />
-      <SettingsNavigation showFeatureFlags={showFeatureFlags} />
+      <SettingsNavigation />
 
       {hasAny ? (
         <FundsTable

--- a/packages/web/src/app/(app)/settings/members/page.tsx
+++ b/packages/web/src/app/(app)/settings/members/page.tsx
@@ -5,7 +5,6 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { PageHeader } from "@/components/shared/page-header";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 import { InvitationService } from "@/services/InvitationService";
 import { MemberService } from "@/services/MemberService";
 import { UserService } from "@/services/UserService";
@@ -77,8 +76,6 @@ export default async function MembersPage({ searchParams }: MembersPageProps) {
   const invitationCount = invitationsResult.pagination.total;
   const memberCount = members?.pagination.total ?? 0;
   const bothEmpty = invitationCount === 0 && memberCount === 0;
-  // Phase 2 (Epic #365): only surface the Feature flags nav entry when the self-flag is on.
-  const showFeatureFlags = await isFeatureFlagsPhase2Enabled();
 
   return (
     <>
@@ -101,7 +98,7 @@ export default async function MembersPage({ searchParams }: MembersPageProps) {
           ) : null
         }
       />
-      <SettingsNavigation showFeatureFlags={showFeatureFlags} />
+      <SettingsNavigation />
 
       {bothEmpty && canManageMembers ? (
         // Review D8 — single combined empty state for a fresh tenant

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -6,7 +6,6 @@ import { TenantSettingsForm } from "@/components/settings/tenant-settings-form";
 import { PageHeader } from "@/components/shared/page-header";
 import { createServerApiClient } from "@/lib/api/client-server";
 import { requireAuth } from "@/lib/auth/guards";
-import { isFeatureFlagsPhase2Enabled } from "@/lib/feature-flags/server";
 
 /**
  * Settings page — protected, requires authentication.
@@ -44,9 +43,6 @@ export default async function SettingsPage() {
   }
 
   const canManageBranding = auth.roles.includes("org_admin");
-  // Phase 2 (Epic #365): only surface the Feature flags nav entry when
-  // the self-flag is on. Fail-closed (off) on projection errors.
-  const showFeatureFlags = await isFeatureFlagsPhase2Enabled();
 
   return (
     <div className="space-y-8">
@@ -55,7 +51,7 @@ export default async function SettingsPage() {
         description={t("subtitle")}
         breadcrumbs={[{ label: t("breadcrumbRoot"), href: "/dashboard" }, { label: t("title") }]}
       />
-      <SettingsNavigation showFeatureFlags={showFeatureFlags} />
+      <SettingsNavigation />
       <TenantSettingsForm
         orgId={auth.orgId}
         canManageTenant={auth.roles.includes("org_admin")}

--- a/packages/web/src/components/admin/feature-flags-table.test.tsx
+++ b/packages/web/src/components/admin/feature-flags-table.test.tsx
@@ -35,10 +35,10 @@ const baseRow = {
   updatedBy: null,
   createdAt: "2026-05-10T10:00:00.000Z",
   updatedAt: "2026-05-10T10:00:00.000Z",
-  // Phase 1 shape — Phase 2's overrideStats is null when the
-  // `admin.feature_flags_phase2` self-flag is off. The existing
-  // test fixtures exercise the row layout in the off-state of
-  // Phase 2 (Phase-2-on coverage lives in the API integration tests).
+  // overrideStats is null for platform-scoped flags that never carry
+  // per-tenant overrides — the badge gracefully vanishes for those rows.
+  // This fixture therefore exercises the no-badge render path
+  // (per-tenant override coverage lives in the API integration tests).
   overrideStats: null,
 };
 

--- a/packages/web/src/components/admin/feature-flags-table.tsx
+++ b/packages/web/src/components/admin/feature-flags-table.tsx
@@ -19,9 +19,9 @@ import { type FeatureFlagRow, FeatureFlagsService } from "@/services/FeatureFlag
  * platform default?" at a glance.
  *
  * The override-stats badge renders only when `row.overrideStats`
- * is non-null — the API returns `null` when the Phase-2 self-flag
- * (`admin.feature_flags_phase2`) is off, so the column gracefully
- * vanishes in the kill-switch case without an empty UI element.
+ * is non-null — the API returns `null` for platform-scoped flags that
+ * never carry per-tenant overrides, so the badge gracefully vanishes
+ * for those rows without an empty UI element.
  */
 interface FeatureFlagsTableProps {
   rows: FeatureFlagRow[];

--- a/packages/web/src/components/admin/tenant-detail-tabs.tsx
+++ b/packages/web/src/components/admin/tenant-detail-tabs.tsx
@@ -11,11 +11,9 @@ interface TenantDetailTabsProps {
   users: ReactNode;
   audit: ReactNode;
   /**
-   * Feature-flags tab content. Phase 2 (Epic #365) addition. The
-   * super-admin tenant detail page passes `null` when the
-   * `admin.feature_flags_phase2` self-flag is off so the tab is
-   * absent end-to-end (matches the off-state QA requirement that
-   * the whole surface disappears, not just the tab body).
+   * Feature-flags tab content (Epic #365). The super-admin tenant
+   * detail page passes `null` when the per-tenant flag fetch fails so
+   * the tab degrades to absent rather than 500-ing the whole page.
    */
   featureFlags?: ReactNode | null;
 }

--- a/packages/web/src/components/layout/app-shell.test.tsx
+++ b/packages/web/src/components/layout/app-shell.test.tsx
@@ -2,8 +2,14 @@
  * AppShell tests — focused on the global Cmd+K listener wiring added by
  * Epic #364 (GLO-001). The shell composes Sidebar / Topbar / Banners /
  * CommandPalette; this suite only asserts behaviours the shell itself
- * owns (the keydown listener + off-state mounting). The downstream
+ * owns (the keydown listener + conditional mounting). The downstream
  * components have their own tests.
+ *
+ * The tenant chrome (command palette + bell) is derived from
+ * `isSuperAdmin`: tenant users (`isSuperAdmin={false}`) get the palette,
+ * super-admins (`isSuperAdmin={true}`) do not — they live in
+ * `platform_admins` with no org_id (ADR-022), so a tenant-scoped search
+ * surface is meaningless for them.
  *
  * Mocks every collaborator that fetches or routes so the test exercises
  * just the AppShell wiring.
@@ -67,36 +73,36 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function renderShell(props: { commandPaletteEnabled: boolean }) {
+function renderShell(props: { isSuperAdmin: boolean }) {
   return render(
     <AppShell
       impersonation={undefined}
       impersonationUserName={undefined}
-      commandPaletteEnabled={props.commandPaletteEnabled}
+      isSuperAdmin={props.isSuperAdmin}
     >
       <main data-testid="children">child</main>
     </AppShell>,
   );
 }
 
-describe("AppShell — command palette off-state", () => {
-  it("does not render the CommandPalette component when the flag is off", () => {
-    renderShell({ commandPaletteEnabled: false });
+describe("AppShell — command palette absent for super-admin", () => {
+  it("does not render the CommandPalette component for a super-admin", () => {
+    renderShell({ isSuperAdmin: true });
     expect(screen.queryByTestId("cmdk-palette")).toBeNull();
     expect(mockCommandPalette).not.toHaveBeenCalled();
   });
 
-  it("Cmd+K is a no-op when the flag is off (listener not mounted)", () => {
-    renderShell({ commandPaletteEnabled: false });
+  it("Cmd+K is a no-op for a super-admin (listener not mounted)", () => {
+    renderShell({ isSuperAdmin: true });
     fireKeydown({ key: "k", metaKey: true });
     expect(screen.queryByTestId("cmdk-palette")).toBeNull();
     expect(mockCommandPalette).not.toHaveBeenCalled();
   });
 });
 
-describe("AppShell — command palette on-state", () => {
-  it("renders the CommandPalette component (closed) when the flag is on", () => {
-    renderShell({ commandPaletteEnabled: true });
+describe("AppShell — command palette present for tenant users", () => {
+  it("renders the CommandPalette component (closed) for a tenant user", () => {
+    renderShell({ isSuperAdmin: false });
     // Mount = the mock was called once with open=false; the sentinel
     // is absent because open=false.
     expect(mockCommandPalette).toHaveBeenCalledWith(expect.objectContaining({ open: false }));
@@ -104,31 +110,31 @@ describe("AppShell — command palette on-state", () => {
   });
 
   it("opens the palette when Meta+K is pressed", () => {
-    renderShell({ commandPaletteEnabled: true });
+    renderShell({ isSuperAdmin: false });
     fireKeydown({ key: "k", metaKey: true });
     expect(screen.getByTestId("cmdk-palette")).toBeDefined();
   });
 
   it("opens the palette when Ctrl+K is pressed (non-Mac)", () => {
-    renderShell({ commandPaletteEnabled: true });
+    renderShell({ isSuperAdmin: false });
     fireKeydown({ key: "k", ctrlKey: true });
     expect(screen.getByTestId("cmdk-palette")).toBeDefined();
   });
 
   it("does NOT open on Meta+Shift+K (devtools chord)", () => {
-    renderShell({ commandPaletteEnabled: true });
+    renderShell({ isSuperAdmin: false });
     fireKeydown({ key: "k", metaKey: true, shiftKey: true });
     expect(screen.queryByTestId("cmdk-palette")).toBeNull();
   });
 
   it("does NOT open on Alt+K alone", () => {
-    renderShell({ commandPaletteEnabled: true });
+    renderShell({ isSuperAdmin: false });
     fireKeydown({ key: "k", altKey: true });
     expect(screen.queryByTestId("cmdk-palette")).toBeNull();
   });
 
   it("toggles closed when Meta+K is pressed a second time", () => {
-    renderShell({ commandPaletteEnabled: true });
+    renderShell({ isSuperAdmin: false });
     fireKeydown({ key: "k", metaKey: true });
     expect(screen.getByTestId("cmdk-palette")).toBeDefined();
     fireKeydown({ key: "k", metaKey: true });

--- a/packages/web/src/components/layout/app-shell.tsx
+++ b/packages/web/src/components/layout/app-shell.tsx
@@ -25,16 +25,12 @@ interface AppShellProps {
   /**
    * SSR-resolved super-admin flag — lets the sidebar's "Back office" section
    * render on the server instead of popping in after `/v1/users/me` hydrates.
+   * Also decides whether the tenant-scoped topbar chrome (notifications
+   * bell, command palette) renders: super-admins live in `platform_admins`
+   * with no org_id (ADR-022), so those surfaces are meaningless for them.
    * FE-1 (PR #135 review).
    */
   isSuperAdmin?: boolean;
-  /**
-   * SSR-resolved value of `admin.finance_dashboard` (Epic #434). When
-   * `true` AND the viewer is super-admin, the sidebar renders the
-   * "Platform finance" entry. Defaults to `false` — off-state QA per
-   * `feedback_feature_flag_first`.
-   */
-  financeDashboardEnabled?: boolean;
   /**
    * Active tenant id — used to scope the "Add your logo" banner's per-org
    * dismissal key (Epic #286). Optional: when missing (super-admin), the
@@ -43,21 +39,6 @@ interface AppShellProps {
   orgId?: string;
   /** Whether the current user can act on the "Add your logo" CTA (Epic #286). */
   canManageBranding?: boolean;
-  /**
-   * Whether the `communication.notifications_center` feature flag is
-   * on for this tenant (Epic #363). Resolved SSR so the bell icon
-   * doesn't flash in/out on hydration. Defaults to `false` — off-state
-   * QA per `feedback_feature_flag_first`.
-   */
-  notificationsEnabled?: boolean;
-  /**
-   * Whether the `productivity.command_palette` feature flag is on for
-   * this tenant (Epic #364). Resolved SSR so the global Cmd+K
-   * listener + topbar button don't flash in/out on hydration. When
-   * `false`, the listener is never mounted and the overlay is never
-   * rendered — off-state QA per `feedback_feature_flag_first`.
-   */
-  commandPaletteEnabled?: boolean;
   /**
    * Server-resolved org logo (Epic #286 / PR #287 review, major 4).
    * Threaded down to `Sidebar` and `AddLogoBanner` so they don't each
@@ -88,17 +69,20 @@ export function AppShell({
   impersonationUserName,
   provisionalAdmin,
   membershipCount,
-  isSuperAdmin,
-  financeDashboardEnabled = false,
+  isSuperAdmin = false,
   orgId,
   canManageBranding = false,
   orgLogo = null,
-  notificationsEnabled = false,
-  commandPaletteEnabled = false,
 }: AppShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
+
+  // Tenant-scoped topbar chrome (notifications bell + command palette)
+  // renders for tenant users only. Super-admins live in `platform_admins`
+  // with no org_id (ADR-022), so there's nothing tenant-scoped to notify
+  // them about or search across.
+  const showTenantChrome = !isSuperAdmin;
 
   const handleMenuToggle = useCallback(() => {
     setSidebarOpen((prev) => !prev);
@@ -127,16 +111,15 @@ export function AppShell({
     };
   }, [sidebarOpen]);
 
-  // Global Cmd+K / Ctrl+K binding (Epic #364, GLO-001). Mounted ONLY
-  // when the flag is on so an off-state user pressing the shortcut
-  // does nothing — off-state QA per `feedback_feature_flag_first`.
+  // Global Cmd+K / Ctrl+K binding (Epic #364, GLO-001). Mounted only for
+  // tenant users — a super-admin has nothing tenant-scoped to search.
   // Guards against firing inside a text field or with modifier
   // combinations the OS already owns (Cmd+K is normally free; Ctrl+K
   // shadows a browser address-bar shortcut in Firefox, which we accept
   // — the palette is the higher-value surface for an authenticated
   // app).
   useEffect(() => {
-    if (!commandPaletteEnabled) return;
+    if (!showTenantChrome) return;
     function handleKeyDown(e: KeyboardEvent) {
       const isShortcut = (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key === "k";
       if (!isShortcut) return;
@@ -145,7 +128,7 @@ export function AppShell({
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [commandPaletteEnabled]);
+  }, [showTenantChrome]);
 
   return (
     <div className="flex min-h-screen">
@@ -154,7 +137,6 @@ export function AppShell({
         onClose={handleSidebarClose}
         membershipCount={membershipCount}
         isSuperAdmin={isSuperAdmin}
-        financeDashboardEnabled={financeDashboardEnabled}
         orgLogo={orgLogo}
       />
 
@@ -166,8 +148,8 @@ export function AppShell({
           onMenuToggle={handleMenuToggle}
           sidebarOpen={sidebarOpen}
           hamburgerRef={hamburgerRef}
-          notificationsEnabled={notificationsEnabled}
-          commandPaletteEnabled={commandPaletteEnabled}
+          notificationsEnabled={showTenantChrome}
+          commandPaletteEnabled={showTenantChrome}
           onCommandPaletteOpen={handleCommandPaletteOpen}
         />
 
@@ -179,7 +161,7 @@ export function AppShell({
         </main>
       </div>
 
-      {commandPaletteEnabled ? (
+      {showTenantChrome ? (
         <CommandPalette open={commandPaletteOpen} onClose={handleCommandPaletteClose} />
       ) : null}
     </div>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -81,9 +81,9 @@ const ADMIN_NAV_ITEMS: AdminNavItem[] = [
 ];
 
 /**
- * Flag-gated admin nav entries (Epic #434). Rendered only when the
- * matching flag prop is on at SSR time — keeps the off-state surface
- * completely absent per `feedback_feature_flag_first`.
+ * Platform-finance admin nav entry (Epic #434). Rendered first in the
+ * super-admin "Back office" section so the daily-use dashboard leads
+ * the list.
  */
 const FINANCE_ADMIN_NAV_ITEM: AdminNavItem = {
   href: "/admin/finance",
@@ -103,13 +103,6 @@ interface SidebarProps {
    */
   isSuperAdmin?: boolean;
   /**
-   * SSR-resolved value of `admin.finance_dashboard` (Epic #434). When
-   * `true` AND the viewer is super-admin, render the "Platform finance"
-   * nav entry. When `false` the entry is completely absent (no aria
-   * trace) — off-state QA per `feedback_feature_flag_first`.
-   */
-  financeDashboardEnabled?: boolean;
-  /**
    * Server-resolved org logo (Epic #286 / PR #287 review, major 4).
    * Replaces the per-mount client-side fetch — both eliminates the
    * initial-letter flash and stops 1 GET per navigation. `null` =
@@ -128,7 +121,6 @@ export function Sidebar({
   onClose,
   membershipCount,
   isSuperAdmin: isSuperAdminProp,
-  financeDashboardEnabled = false,
   orgLogo = null,
 }: SidebarProps) {
   const pathname = usePathname();
@@ -260,9 +252,8 @@ export function Sidebar({
                 // Finance plateforme is the daily-use dashboard for
                 // super-admins — render it first so the surface follows
                 // the admin-dashboard convention (overview → entities
-                // → operations → config). Flag-gated so the slot is
-                // absent when the rollout is paused.
-                ...(financeDashboardEnabled ? [FINANCE_ADMIN_NAV_ITEM] : []),
+                // → operations → config).
+                FINANCE_ADMIN_NAV_ITEM,
                 ...ADMIN_NAV_ITEMS,
               ].map((item) => {
                 const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);

--- a/packages/web/src/components/layout/topbar.tsx
+++ b/packages/web/src/components/layout/topbar.tsx
@@ -29,17 +29,15 @@ interface TopbarProps {
   sidebarOpen: boolean;
   hamburgerRef: RefObject<HTMLButtonElement | null>;
   /**
-   * Whether the `communication.notifications_center` flag is on for this
-   * tenant (Epic #363). When `false` the bell button is completely
-   * absent — off-state QA per `feedback_feature_flag_first`.
-   * Resolved server-side in `(app)/layout.tsx` so the bell doesn't
-   * flash in then out on hydration.
+   * Whether to render the notifications bell (Epic #363). True for
+   * tenant users, false for super-admins (no tenant-scoped events).
+   * Resolved by `AppShell` from the super-admin flag.
    */
   notificationsEnabled?: boolean;
   /**
-   * Whether the `productivity.command_palette` flag is on for this
-   * tenant (Epic #364). When `false`, the Cmd+K trigger button is
-   * completely absent — off-state QA per `feedback_feature_flag_first`.
+   * Whether to render the Cmd+K command-palette trigger (Epic #364).
+   * True for tenant users, false for super-admins (nothing tenant-
+   * scoped to search). Resolved by `AppShell` from the super-admin flag.
    */
   commandPaletteEnabled?: boolean;
   /**
@@ -139,13 +137,12 @@ export function Topbar({
       </div>
 
       {/*
-        Cmd+K trigger button (Epic #364, GLO-001). When the flag is off,
-        the surface is COMPLETELY absent (off-state QA per
-        `feedback_feature_flag_first`) — no inert placeholder input.
-        When on, this button opens the command palette via the
-        AppShell-owned state. Visual mimics the mockup's input look
-        (pill, search icon left, ⌘K badge right) but it's a button so
-        pointer + keyboard activation both go through one path.
+        Cmd+K trigger button (Epic #364, GLO-001). Rendered for tenant
+        users only (super-admins have nothing tenant-scoped to search).
+        Opens the command palette via the AppShell-owned state. Visual
+        mimics the mockup's input look (pill, search icon left, ⌘K badge
+        right) but it's a button so pointer + keyboard activation both go
+        through one path.
       */}
       {commandPaletteEnabled && onCommandPaletteOpen ? (
         <button
@@ -165,9 +162,8 @@ export function Topbar({
 
       <div className="ml-auto flex items-center gap-3">
         {/*
-          NotificationsBell is feature-flag-gated (Epic #363). When the
-          flag is off the button is completely absent — off-state QA per
-          `feedback_feature_flag_first` / docs/18 § 5.
+          NotificationsBell renders for tenant users only (Epic #363);
+          super-admins receive no tenant-scoped events.
         */}
         {notificationsEnabled ? <NotificationsBell /> : null}
 

--- a/packages/web/src/components/notifications/notifications-bell.tsx
+++ b/packages/web/src/components/notifications/notifications-bell.tsx
@@ -6,10 +6,8 @@
  * Renders the bell button + the dynamic unread badge. Owns the panel
  * open/close state and forwards the live data to `NotificationsPanel`.
  *
- * Mounted ONLY when the `communication.notifications_center` flag is
- * on for this tenant — the wrapper in `topbar.tsx` short-circuits
- * before this component is even loaded by Next.js (off-state QA per
- * `feedback_feature_flag_first`).
+ * Mounted for tenant users only — the wrapper in `topbar.tsx`
+ * short-circuits for super-admins (no tenant-scoped events).
  */
 
 import type { NotificationFilterKey } from "@givernance/shared/constants";

--- a/packages/web/src/components/settings/settings-navigation.tsx
+++ b/packages/web/src/components/settings/settings-navigation.tsx
@@ -35,35 +35,23 @@ const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
     key: "bankAccounts",
     match: (pathname: string) => pathname.startsWith("/settings/bank-accounts"),
   },
+  {
+    href: "/settings/feature-flags",
+    key: "featureFlags",
+    match: (pathname: string) => pathname.startsWith("/settings/feature-flags"),
+  },
 ];
 
-const FEATURE_FLAGS_NAV_ITEM: SettingsNavItem = {
-  href: "/settings/feature-flags",
-  key: "featureFlags",
-  match: (pathname: string) => pathname.startsWith("/settings/feature-flags"),
-};
-
 /**
- * Settings-area nav strip.
- *
- * Phase 2 (Epic #365) adds an optional "Feature flags" entry — the
- * parent server component decides whether to surface it by reading
- * the `admin.feature_flags_phase2` flag SSR-side and passing
- * `showFeatureFlags`. We render the entry conditionally rather than
- * always-on so a non-org_admin user (or an org where the flag is
- * off) never sees a dead-end link.
+ * Settings-area nav strip. The "Feature flags" entry (Epic #365) points
+ * at the org-admin self-service page; the settings area is org-admin
+ * gated at the route level, so the entry is always surfaced here.
  */
-export function SettingsNavigation({
-  showFeatureFlags = false,
-}: {
-  showFeatureFlags?: boolean;
-} = {}) {
+export function SettingsNavigation() {
   const pathname = usePathname();
   const t = useTranslations("settings.navigation");
 
-  const items = showFeatureFlags
-    ? [...SETTINGS_NAV_ITEMS, FEATURE_FLAGS_NAV_ITEM]
-    : SETTINGS_NAV_ITEMS;
+  const items = SETTINGS_NAV_ITEMS;
 
   return (
     <nav aria-label={t("label")} className="overflow-x-auto">

--- a/packages/web/src/lib/feature-flags/server.ts
+++ b/packages/web/src/lib/feature-flags/server.ts
@@ -1,44 +1,17 @@
 /**
- * Server-side helpers for SSR-resolving Phase-2 feature-flag state
- * (Epic #365 / PR #366).
+ * Server-side helpers for SSR-resolving tenant feature-flag state.
  *
  * The public projection (`/v1/feature-flags`) is the cheapest way to
- * decide whether a given Phase-2 surface should render. Used by:
- *   - Settings sub-pages (decide whether `SettingsNavigation`
- *     surfaces the Feature flags entry).
- *   - The org-admin Feature flags page itself (SSR-gate via
- *     `notFound()` when the Epic is off).
- *   - The super-admin tenant detail page (decide whether the
- *     Feature flags tab is rendered).
- *
- * Fail-closed: if the projection is unreachable, the caller treats
- * the surface as off rather than risk a dead-end render.
+ * decide whether a flag-gated surface should render. Fail-closed: if
+ * the projection is unreachable, the caller treats the surface as off
+ * rather than risk a dead-end render.
  */
 
 import { createServerApiClient } from "@/lib/api/client-server";
 import { FeatureFlagsService, isFlagEnabled } from "@/services/FeatureFlagsService";
 
-const PHASE2_KEY = "admin.feature_flags_phase2";
 const PUBLIC_PAGE_STYLES_KEY = "donation.public_page_styles";
-const IMPERSONATION_REPLICATE_KEY = "admin.impersonation_replicate";
-const FINANCE_DASHBOARD_KEY = "admin.finance_dashboard";
 const POSTAL_MERGED_PDF_KEY = "campaign.postal_merged_pdf";
-
-/**
- * Returns `true` iff `admin.feature_flags_phase2` is on for the
- * current caller. Never throws — a failure to fetch the projection
- * is treated as "off" so the new surfaces stay invisible during a
- * partial outage rather than render in an ambiguous state.
- */
-export async function isFeatureFlagsPhase2Enabled(): Promise<boolean> {
-  try {
-    const api = await createServerApiClient();
-    const flags = await FeatureFlagsService.listPublic(api);
-    return isFlagEnabled(flags, PHASE2_KEY);
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Returns `true` iff `donation.public_page_styles` is on for the
@@ -53,41 +26,6 @@ export async function isPublicPageStylesEnabled(): Promise<boolean> {
     const api = await createServerApiClient();
     const flags = await FeatureFlagsService.listPublic(api);
     return isFlagEnabled(flags, PUBLIC_PAGE_STYLES_KEY);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Returns `true` iff `admin.impersonation_replicate` is on for the
- * caller. Drives whether the Back Office impersonation list renders
- * the Replicate row-action (issue #428). Fail-closed on projection
- * errors — better to hide the button than render one that points
- * at an off feature.
- */
-export async function isImpersonationReplicateEnabled(): Promise<boolean> {
-  try {
-    const api = await createServerApiClient();
-    const flags = await FeatureFlagsService.listPublic(api);
-    return isFlagEnabled(flags, IMPERSONATION_REPLICATE_KEY);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Returns `true` iff `admin.finance_dashboard` is on for the current
- * caller (Epic #434, issue #206). Gates:
- *   - The `/admin/finance` super-admin page (returns notFound() when off).
- *   - The "Finance plateforme" sidebar entry.
- * Fail-closed on projection errors — better to hide the dashboard
- * than render it pointing at a 404 backend.
- */
-export async function isFinanceDashboardEnabled(): Promise<boolean> {
-  try {
-    const api = await createServerApiClient();
-    const flags = await FeatureFlagsService.listPublic(api);
-    return isFlagEnabled(flags, FINANCE_DASHBOARD_KEY);
   } catch {
     return false;
   }

--- a/packages/worker/scripts/trigger-notification-digest.ts
+++ b/packages/worker/scripts/trigger-notification-digest.ts
@@ -23,7 +23,6 @@
  *     row (toggle from /profile/notifications or via SQL).
  *   - User has an unread `notifications` row whose `type` matches the
  *     preference row.
- *   - `communication.notifications_center` flag is on for the tenant.
  */
 
 import { Queue } from "bullmq";

--- a/packages/worker/src/processors/finance-constituent-count-refresh.ts
+++ b/packages/worker/src/processors/finance-constituent-count-refresh.ts
@@ -16,22 +16,14 @@
  * revisit with a single GROUP BY + UPDATE FROM aggregate.
  */
 
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { constituents, tenants } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { db } from "../lib/db.js";
-import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
 
 export async function processConstituentCountRefresh(job: Job): Promise<void> {
   const log = jobLogger({ jobId: job.id, tenantId: "system" });
-
-  const flagOn = await isFlagEnabled(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD);
-  if (!flagOn) {
-    log.info("admin.finance_dashboard flag is off, skipping constituent count refresh");
-    return;
-  }
 
   // CROSS-TENANT INTENTIONAL: platform-wide cron sweep — every tenant's
   // count refresh happens in one job tick. Owner-pool (`db`) is used

--- a/packages/worker/src/processors/finance-survey-retention.ts
+++ b/packages/worker/src/processors/finance-survey-retention.ts
@@ -24,14 +24,12 @@
  * we stopped retaining" failure mode that has no other tell.
  */
 
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { auditLogs, surveyResponses } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
 import { count, inArray, sql } from "drizzle-orm";
 import Redis from "ioredis";
 import { env } from "../env.js";
 import { db } from "../lib/db.js";
-import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
 
 const BATCH_SIZE = 1000;
@@ -151,12 +149,6 @@ export async function processSurveyRetention(
   deps: SurveyRetentionDeps = {},
 ): Promise<void> {
   const log = jobLogger({ jobId: job.id, tenantId: "system" });
-
-  const flagOn = await isFlagEnabled(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD);
-  if (!flagOn) {
-    log.info("admin.finance_dashboard flag is off, skipping survey retention sweep");
-    return;
-  }
 
   // CROSS-TENANT INTENTIONAL: retention sweep spans every tenant —
   // owner-pool UPDATE scoped by the age + soft-delete predicate.

--- a/packages/worker/src/processors/finance-survey-send.ts
+++ b/packages/worker/src/processors/finance-survey-send.ts
@@ -21,14 +21,10 @@
  *     are left with their `next_scheduled_at` in the past so they
  *     don't re-trigger.
  *
- * Gated by `admin.finance_dashboard` — no-op when flag is off (the
- * survey infrastructure ships dark with the dashboard).
- *
  * Cohort matcher (the MVP shape, intentionally tiny — extend in docs/31):
  *   { "roles": ["org_admin"], "orgIds": ["..."], "excludeUserIds": ["..."] }
  */
 
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import { SURVEY_EVENT_TYPES } from "@givernance/shared/jobs";
 import {
   outboxEvents,
@@ -40,7 +36,6 @@ import {
 import type { Job } from "bullmq";
 import { and, eq, inArray, isNull, not, sql } from "drizzle-orm";
 import { db } from "../lib/db.js";
-import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
 
 /** JSONB matcher shape for `surveys.cohort_rule`. */
@@ -112,12 +107,6 @@ function inviteExpiresAt(now: Date, cadenceDays: number | null): Date {
 
 export async function processSurveySend(job: Job): Promise<void> {
   const log = jobLogger({ jobId: job.id, tenantId: "system" });
-
-  const flagOn = await isFlagEnabled(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD);
-  if (!flagOn) {
-    log.info("admin.finance_dashboard flag is off, skipping survey send loop");
-    return;
-  }
 
   const now = new Date();
 

--- a/packages/worker/src/processors/notifications-email-digest.ts
+++ b/packages/worker/src/processors/notifications-email-digest.ts
@@ -13,11 +13,6 @@
  * from the preferences page before any email is sent. This matches
  * `feedback_feature_flag_first` defence-in-depth posture.
  *
- * Feature-flag-first: every invocation checks
- * `communication.notifications_center` and short-circuits if off. If
- * a tenant's flag was flipped off mid-cycle the worker silently
- * skips them.
- *
  * Out of scope (deferred):
  *   - Per-tenant DKIM / sending domain (depends on Epic #279) —
  *     today the digest goes from the platform-default `from` address.
@@ -36,7 +31,6 @@
  */
 
 import {
-  FEATURE_FLAG_KEYS,
   getNotificationDescriptor,
   isNotificationType,
   type NotificationType,
@@ -47,7 +41,6 @@ import { and, eq, gt, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { env } from "../env.js";
 import { db, withWorkerContext } from "../lib/db.js";
 import { defaultEmailSender, type EmailSender } from "../lib/email.js";
-import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
 
 /** Per-tenant work budget — Worker SRE MED-1. A pathological tenant
@@ -67,9 +60,9 @@ export interface EmailDigestDeps {
 }
 
 /**
- * Process one tick of the daily digest. Iterates tenants the
- * notifications flag is on for, and for each, collects unread rows
- * since the cursor and sends one digest per recipient.
+ * Process one tick of the daily digest. Iterates active tenants and,
+ * for each, collects unread rows since the cursor and sends one digest
+ * per recipient.
  */
 export async function processNotificationsEmailDigest(
   job: Job<EmailDigestJobData>,
@@ -77,13 +70,6 @@ export async function processNotificationsEmailDigest(
 ): Promise<void> {
   const log = jobLogger({ jobId: job.id });
   const sender = deps.sender ?? defaultEmailSender;
-
-  // Feature-flag-first defence in depth — see file header.
-  const enabled = await isFlagEnabled(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER);
-  if (!enabled) {
-    log.info("Notifications flag off — skipping digest");
-    return;
-  }
 
   // Default cursor: 24h ago. If the caller passes an older value
   // we clamp to MAX_SINCE_WINDOW_MS so a hand-enqueued job can't

--- a/packages/worker/src/processors/notifications-fanout.ts
+++ b/packages/worker/src/processors/notifications-fanout.ts
@@ -30,11 +30,6 @@
  * `ON CONFLICT DO NOTHING` and silently no-ops rather than producing
  * a duplicate row per recipient.
  *
- * Feature-flag-first: every call gates on
- * `communication.notifications_center` per `feedback_feature_flag_first`.
- * Defence in depth — even if a request slipped past the API gate the
- * worker is the second wall.
- *
  * Critical-path budget — the fanout runs inside the existing
  * `processDomainEvent` switch, ahead of receipt-PDF and postal-export
  * routing. We wrap the work in a 2 s `Promise.race` budget so a slow
@@ -46,11 +41,7 @@
  * UX. A future Phase moves fanout to a dedicated retry-bearing queue.
  */
 
-import {
-  FEATURE_FLAG_KEYS,
-  getNotificationDescriptor,
-  type NotificationType,
-} from "@givernance/shared/constants";
+import { getNotificationDescriptor, type NotificationType } from "@givernance/shared/constants";
 import { BRANDING_EVENT_TYPES } from "@givernance/shared/jobs";
 import {
   type NewNotification,
@@ -60,7 +51,6 @@ import {
 } from "@givernance/shared/schema";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import { withWorkerContext } from "../lib/db.js";
-import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
 
 export interface FanoutInput {
@@ -207,21 +197,6 @@ const FANOUT_TIMEOUT_MS = 2_000;
 
 export async function fanoutNotifications(input: FanoutInput): Promise<void> {
   const log = jobLogger({ tenantId: input.tenantId, jobId: input.outboxId });
-
-  // Feature-flag-first per `feedback_feature_flag_first`. Cheap query,
-  // run before any tenant-scoped DB work so the cost of a flagged-off
-  // tenant is minimised. `isFlagEnabled` reads the platform default —
-  // correct today because the flag has `tenant_override_allowed=false`.
-  // When tenant overrides land, swap to the tenant-aware evaluator
-  // (PR #393 Security M3 follow-up).
-  const enabled = await isFlagEnabled(FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER);
-  if (!enabled) {
-    log.info(
-      { event: "notifications.fanout_skipped_flag_off", eventType: input.type },
-      "Notifications flag off — skipping fanout",
-    );
-    return;
-  }
 
   const plan = planFanout(input);
   if (plan.length === 0) {

--- a/packages/worker/src/processors/platform-report-trigger.test.ts
+++ b/packages/worker/src/processors/platform-report-trigger.test.ts
@@ -3,10 +3,9 @@
  * adapter around the shared monthly-report request flow (issue #443).
  *
  * No DB / Redis / BullMQ: the shared `requestMonthlyReport` /
- * `backfillLast12Months` and the `isFlagEnabled` gate are mocked so the
- * adapter's branching (flag-gate, single vs. backfill mode) is verified
- * in isolation. `previousMonth` is kept real (it's pure) so the
- * single-mode month assertion is meaningful.
+ * `backfillLast12Months` are mocked so the adapter's branching (single
+ * vs. backfill mode) is verified in isolation. `previousMonth` is kept
+ * real (it's pure) so the single-mode month assertion is meaningful.
  */
 
 import type { Job } from "bullmq";
@@ -23,9 +22,6 @@ vi.mock("@givernance/shared/finance/reporting", async (importOriginal) => {
     backfillLast12Months,
   };
 });
-
-const isFlagEnabled = vi.fn();
-vi.mock("../lib/flags.js", () => ({ isFlagEnabled }));
 
 // Imported AFTER the mocks are registered (vi.mock is hoisted, but the
 // dynamic import keeps intent explicit).
@@ -47,18 +43,7 @@ describe("processPlatformReportAutoTrigger", () => {
     backfillLast12Months.mockResolvedValue({ enqueued: [], skipped: [] });
   });
 
-  it("flag off → no-op (neither request nor backfill called)", async () => {
-    isFlagEnabled.mockResolvedValue(false);
-
-    await processPlatformReportAutoTrigger(jobFor({ mode: "single" }));
-
-    expect(requestMonthlyReport).not.toHaveBeenCalled();
-    expect(backfillLast12Months).not.toHaveBeenCalled();
-  });
-
-  it("single mode (flag on) → requestMonthlyReport once for the previous month", async () => {
-    isFlagEnabled.mockResolvedValue(true);
-
+  it("single mode → requestMonthlyReport once for the previous month", async () => {
     await processPlatformReportAutoTrigger(jobFor({ mode: "single" }));
 
     expect(requestMonthlyReport).toHaveBeenCalledTimes(1);
@@ -73,17 +58,13 @@ describe("processPlatformReportAutoTrigger", () => {
   });
 
   it("default mode (no mode field) → treated as single", async () => {
-    isFlagEnabled.mockResolvedValue(true);
-
     await processPlatformReportAutoTrigger(jobFor({}));
 
     expect(requestMonthlyReport).toHaveBeenCalledTimes(1);
     expect(backfillLast12Months).not.toHaveBeenCalled();
   });
 
-  it("backfill mode (flag on) → backfillLast12Months once", async () => {
-    isFlagEnabled.mockResolvedValue(true);
-
+  it("backfill mode → backfillLast12Months once", async () => {
     await processPlatformReportAutoTrigger(jobFor({ mode: "backfill" }));
 
     expect(backfillLast12Months).toHaveBeenCalledTimes(1);

--- a/packages/worker/src/processors/platform-report-trigger.ts
+++ b/packages/worker/src/processors/platform-report-trigger.ts
@@ -13,18 +13,14 @@
  *     startup with `{ mode: "backfill" }` walks the last 12 calendar
  *     months and idempotently triggers any that are missing.
  *
- * Both paths are gated by the `admin.finance_dashboard` feature flag —
- * the same early-return posture as every other cron-gated processor.
- *
  * De-dup (issue #443): the request flow lives in the shared
  * `@givernance/shared/finance/reporting` module so the API (manual
  * report + dashboard) and this cron drive the SAME idempotent
  * `requestMonthlyReport` / `backfillLast12Months`. This processor is
- * the thin worker adapter — it gates on the flag, then injects the
- * worker's owner-pool `db` and a PLATFORM_REPORTS enqueue closure.
+ * the thin worker adapter — it injects the worker's owner-pool `db`
+ * and a PLATFORM_REPORTS enqueue closure.
  */
 
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import {
   backfillLast12Months,
   type MonthlyReportDeps,
@@ -39,7 +35,6 @@ import { env } from "../env.js";
 // Owner pool — `platform_finance_reports` is a platform-level table
 // (no org_id, no RLS), same as `generate-monthly-finance-report.ts`.
 import { db as systemDb } from "../lib/db.js";
-import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
 
 export interface PlatformReportTriggerPayload {
@@ -80,12 +75,6 @@ export async function processPlatformReportAutoTrigger(
   job: Job<PlatformReportTriggerPayload>,
 ): Promise<void> {
   const log = jobLogger({ jobId: job.id });
-
-  const flagOn = await isFlagEnabled(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD);
-  if (!flagOn) {
-    log.info("platform_report_trigger: flag admin.finance_dashboard off — no-op");
-    return;
-  }
 
   const mode = job.data?.mode ?? "single";
 

--- a/packages/worker/src/processors/stripe-webhook.ts
+++ b/packages/worker/src/processors/stripe-webhook.ts
@@ -1,7 +1,6 @@
 /** Job processor — handle Stripe webhook events asynchronously */
 
 import { ExchangeRateService } from "@givernance/shared";
-import { FEATURE_FLAG_KEYS } from "@givernance/shared/constants";
 import type { ProcessStripeWebhookJob } from "@givernance/shared/jobs";
 import {
   auditLogs,
@@ -19,7 +18,6 @@ import { and, eq, sql } from "drizzle-orm";
 import Stripe from "stripe";
 import { env } from "../env.js";
 import { db, withWorkerContext } from "../lib/db.js";
-import { isFlagEnabled } from "../lib/flags.js";
 import { jobLogger } from "../lib/logger.js";
 
 /**
@@ -395,13 +393,12 @@ async function handlePaymentIntentSucceeded(
       });
     }
 
-    // #436 — Stripe BalanceTransaction fee enrichment. Gated by the
-    // `admin.finance_dashboard` flag: when off, we still process the
-    // donation normally — the column `donations.stripe_fee_cents`
-    // simply stays NULL and the dashboard's "Revenu Givernance" KPI
-    // falls back to the platform-fee accumulator without the
-    // Stripe-side processing-fee deduction. The Stripe SDK call is
-    // wrapped in try/catch — enrichment is best-effort, not
+    // #436 — Stripe BalanceTransaction fee enrichment. Best-effort:
+    // when the Stripe SDK call fails (or `STRIPE_SECRET_KEY` is unset),
+    // the column `donations.stripe_fee_cents` simply stays NULL and the
+    // dashboard's "Revenu Givernance" KPI falls back to the platform-fee
+    // accumulator without the Stripe-side processing-fee deduction. The
+    // call is wrapped in try/catch — enrichment is best-effort, not
     // transactional.
     await maybeEnrichStripeFee(tx, {
       orgId,
@@ -677,7 +674,7 @@ async function handlePaymentIntentFailed(
 /**
  * Lazy-initialised Stripe SDK singleton. Built once on first BT fetch so
  * the worker boot path doesn't crash when `STRIPE_SECRET_KEY` is unset
- * (tests, dev without the dashboard flag flipped on).
+ * (tests, dev without Stripe configured).
  */
 let _stripeClient: Stripe | null = null;
 function getStripeClient(): Stripe | null {
@@ -800,9 +797,9 @@ async function fetchStripeFeeBaseCents(args: FetchStripeFeeArgs): Promise<number
 }
 
 /**
- * Feature-flag-gated, best-effort enrichment of `donations.stripe_fee_cents`.
- * Extracted out of `handlePaymentIntentSucceeded` so that function stays
- * under the cognitive-complexity threshold. Errors are logged + swallowed —
+ * Best-effort enrichment of `donations.stripe_fee_cents`. Extracted out
+ * of `handlePaymentIntentSucceeded` so that function stays under the
+ * cognitive-complexity threshold. Errors are logged + swallowed —
  * enrichment must never roll back the donation write.
  */
 async function maybeEnrichStripeFee(
@@ -817,9 +814,6 @@ async function maybeEnrichStripeFee(
     log: ReturnType<typeof jobLogger>;
   },
 ): Promise<void> {
-  if (!(await isFlagEnabled(FEATURE_FLAG_KEYS.ADMIN_FINANCE_DASHBOARD))) {
-    return;
-  }
   try {
     const fee = await fetchStripeFeeBaseCents({
       intent: args.intent,

--- a/packages/worker/src/tests/integration/finance-constituent-count-refresh.test.ts
+++ b/packages/worker/src/tests/integration/finance-constituent-count-refresh.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { featureFlags, tenants } from "@givernance/shared/schema";
+import { tenants } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
 import { eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -23,23 +23,6 @@ function mockJob(): Job {
 }
 
 beforeAll(async () => {
-  // Ensure the feature flag is on for these tests (the cron is a no-op
-  // when off). Restore default-off in afterAll.
-  await db
-    .insert(featureFlags)
-    .values({
-      key: "admin.finance_dashboard",
-      enabled: true,
-      label: "finance",
-      description: "finance",
-      scope: "platform",
-      public: true,
-    })
-    .onConflictDoUpdate({
-      target: featureFlags.key,
-      set: { enabled: true },
-    });
-
   await db.execute(sql`
     INSERT INTO tenants (id, name, slug, status)
     VALUES
@@ -78,10 +61,6 @@ afterAll(async () => {
   await db.execute(
     sql`DELETE FROM tenants WHERE id IN (${TENANT_EMPTY}, ${TENANT_WITH_THREE}, ${TENANT_ARCHIVED})`,
   );
-  await db
-    .update(featureFlags)
-    .set({ enabled: false })
-    .where(eq(featureFlags.key, "admin.finance_dashboard"));
 });
 
 describe("processConstituentCountRefresh", () => {
@@ -117,36 +96,5 @@ describe("processConstituentCountRefresh", () => {
       .from(tenants)
       .where(eq(tenants.id, TENANT_ARCHIVED));
     expect(arch?.ts).toBeNull();
-  });
-
-  it("no-op when the admin.finance_dashboard flag is off", async () => {
-    await db
-      .update(featureFlags)
-      .set({ enabled: false })
-      .where(eq(featureFlags.key, "admin.finance_dashboard"));
-    // Mark a sentinel timestamp; if the job no-ops the column should
-    // stay NULL.
-    await db
-      .update(tenants)
-      .set({ constituentCountCached: 99, constituentCountRefreshedAt: null })
-      .where(eq(tenants.id, TENANT_WITH_THREE));
-
-    await processConstituentCountRefresh(mockJob());
-
-    const [three] = await db
-      .select({
-        count: tenants.constituentCountCached,
-        ts: tenants.constituentCountRefreshedAt,
-      })
-      .from(tenants)
-      .where(eq(tenants.id, TENANT_WITH_THREE));
-    expect(three?.count).toBe(99);
-    expect(three?.ts).toBeNull();
-
-    // Restore for the next test in the file (if any).
-    await db
-      .update(featureFlags)
-      .set({ enabled: true })
-      .where(eq(featureFlags.key, "admin.finance_dashboard"));
   });
 });

--- a/packages/worker/src/tests/integration/finance-survey-send.test.ts
+++ b/packages/worker/src/tests/integration/finance-survey-send.test.ts
@@ -8,13 +8,7 @@
  *   - reschedules cyclical surveys per cadence_days.
  */
 
-import {
-  featureFlags,
-  outboxEvents,
-  surveyInvitations,
-  surveys,
-  users,
-} from "@givernance/shared/schema";
+import { outboxEvents, surveyInvitations, surveys, users } from "@givernance/shared/schema";
 import type { Job } from "bullmq";
 import { and, eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -31,21 +25,6 @@ function mockJob(): Job {
 }
 
 beforeAll(async () => {
-  await db
-    .insert(featureFlags)
-    .values({
-      key: "admin.finance_dashboard",
-      enabled: true,
-      label: "finance",
-      description: "finance",
-      scope: "platform",
-      public: true,
-    })
-    .onConflictDoUpdate({
-      target: featureFlags.key,
-      set: { enabled: true },
-    });
-
   await db.execute(sql`
     INSERT INTO tenants (id, name, slug, status)
     VALUES (${TENANT_ID}, 'Survey Test NPO', 'survey-test-npo-436', 'active')
@@ -98,10 +77,6 @@ afterAll(async () => {
   await db.execute(sql`DELETE FROM surveys WHERE id = ${SURVEY_QUARTERLY}`);
   await db.execute(sql`DELETE FROM users WHERE id IN (${ORG_ADMIN_ID}, ${REGULAR_USER_ID})`);
   await db.execute(sql`DELETE FROM tenants WHERE id = ${TENANT_ID}`);
-  await db
-    .update(featureFlags)
-    .set({ enabled: false })
-    .where(eq(featureFlags.key, "admin.finance_dashboard"));
 });
 
 describe("resolveCohort", () => {
@@ -225,32 +200,5 @@ describe("processSurveySend", () => {
       );
 
     expect(after.length).toBe(before.length);
-  });
-
-  it("no-op when admin.finance_dashboard flag is off", async () => {
-    await db
-      .update(featureFlags)
-      .set({ enabled: false })
-      .where(eq(featureFlags.key, "admin.finance_dashboard"));
-    await db
-      .update(surveys)
-      .set({ nextScheduledAt: new Date(Date.now() - 60 * 1000) })
-      .where(eq(surveys.id, SURVEY_QUARTERLY));
-    const sentinelTime = Date.now();
-
-    await processSurveySend(mockJob());
-
-    // next_scheduled_at unchanged (still in the past, not bumped by
-    // cadence).
-    const [s] = await db
-      .select({ next: surveys.nextScheduledAt })
-      .from(surveys)
-      .where(eq(surveys.id, SURVEY_QUARTERLY));
-    expect(s?.next?.getTime()).toBeLessThan(sentinelTime);
-
-    await db
-      .update(featureFlags)
-      .set({ enabled: true })
-      .where(eq(featureFlags.key, "admin.finance_dashboard"));
   });
 });

--- a/packages/worker/src/tests/integration/notifications-fanout-isolation.test.ts
+++ b/packages/worker/src/tests/integration/notifications-fanout-isolation.test.ts
@@ -22,14 +22,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { FEATURE_FLAG_KEYS, type FeatureFlagKey } from "@givernance/shared/constants";
-import {
-  featureFlags,
-  notifications,
-  outboxEvents,
-  tenants,
-  users,
-} from "@givernance/shared/schema";
+import { notifications, outboxEvents, tenants, users } from "@givernance/shared/schema";
 import { and, eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { db } from "../../lib/db.js";
@@ -42,25 +35,7 @@ const ADMIN_B_ID = "00000000-0000-0000-0000-00000000a431";
 const OUTBOX_ID = "00000000-0000-0000-0000-00000000e430";
 const DONATION_ID = "00000000-0000-0000-0000-00000000d430";
 
-const FLAG_KEY: FeatureFlagKey = FEATURE_FLAG_KEYS.COMMUNICATION_NOTIFICATIONS_CENTER;
-
 beforeAll(async () => {
-  // Flag must be on; otherwise `fanoutNotifications` returns early. We
-  // toggle it explicitly here rather than depend on seed state because
-  // the test must be deterministic against any prior CI run.
-  await db
-    .insert(featureFlags)
-    .values({
-      key: FLAG_KEY,
-      label: "Notifications center",
-      description: "Test toggle for #430 regression.",
-      enabled: true,
-    })
-    .onConflictDoUpdate({
-      target: featureFlags.key,
-      set: { enabled: true },
-    });
-
   // Tenant A + tenant B, each with one org_admin.
   await db.execute(
     sql`INSERT INTO tenants (id, name, slug, status, created_via)

--- a/packages/worker/src/tests/integration/stripe-webhook.test.ts
+++ b/packages/worker/src/tests/integration/stripe-webhook.test.ts
@@ -797,15 +797,7 @@ describe("processStripeWebhook", () => {
 
   // ─── #436: BT enrichment stamps stripe_fee_cents (mocked Stripe SDK) ──
 
-  it("populates donations.stripe_fee_cents from BalanceTransaction when flag is on", async () => {
-    // Flip the flag on for this test. The seed migration inserts the
-    // row default-off; we toggle and revert.
-    await db.execute(
-      sql`INSERT INTO feature_flags (key, enabled, label, description, scope, public)
-          VALUES ('admin.finance_dashboard', true, 'finance', 'finance', 'platform', true)
-          ON CONFLICT (key) DO UPDATE SET enabled = true`,
-    );
-
+  it("populates donations.stripe_fee_cents from BalanceTransaction", async () => {
     // Stub the BT fetcher to return a 175 cents fee — bypasses the
     // real Stripe SDK call. Same currency as the donation (EUR) so the
     // 1:1 fee → base mapping holds.
@@ -848,10 +840,6 @@ describe("processStripeWebhook", () => {
         .where(and(eq(donations.orgId, ORG_ID), eq(donations.paymentRef, paymentRef)));
       expect(don?.stripeFeeCents).toBe(175);
     } finally {
-      // Restore default-off so other tests run with the flag off.
-      await db.execute(
-        sql`UPDATE feature_flags SET enabled = false WHERE key = 'admin.finance_dashboard'`,
-      );
       setStripeFeeFetcher(null);
     }
   });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -149,9 +149,8 @@ async function scheduleRepeatableJobs() {
   );
 
   // #436 — Super-admin finance dashboard enrichment crons. All three are
-  // platform-wide sweeps; each respects the `admin.finance_dashboard`
-  // feature flag and early-returns when off. `jobId` is fixed per
-  // schedule so worker restarts don't fan out duplicates.
+  // platform-wide sweeps. `jobId` is fixed per schedule so worker
+  // restarts don't fan out duplicates.
 
   // Daily constituent-count refresh at 03:00 UTC — pre-EU morning so
   // the dashboard's per-tenant tile is fresh by the time super-admins


### PR DESCRIPTION
## What & why

Five feature flags have been validated in production and are permanently on. Per the flag lifecycle in [`docs/18-feature-flags.md` §8](docs/18-feature-flags.md) (`GA → DEPRECATED → REMOVED`), the gating code was pure tech debt — dead "flag off" branches, `requireFlag` 404 walls that never fire, worker `isFlagEnabled` no-ops, SSR `xEnabled` plumbing, and off-state tests asserting behaviour that can no longer happen.

This PR retires the flags and keeps **only the enabled code path**. Each feature is now simply part of the product — no gate, no registry entry, no DB row.

| Operator label | Key | Scope |
|---|---|---|
| Per-organisation feature flag controls | `admin.feature_flags_phase2` | platform |
| Admin · Platform finance dashboard | `admin.finance_dashboard` | platform |
| One-click Replicate (Back Office) | `admin.impersonation_replicate` | platform |
| In-app notification centre | `communication.notifications_center` | tenant |
| Keyboard quick search (Cmd+K) | `productivity.command_palette` | tenant |

> ⚠️ **`admin.feature_flags_phase2` is special** — it gated the per-org flag *administration tooling itself*. Only its own gate is removed; the tooling (override endpoints, org-admin `/settings/feature-flags`, the per-tenant tab, `overrideStats`) **stays**, because the surviving flags still rely on it.

## How

- **API** — dropped `requireFlag` preHandlers; routes keep their role guards (`requireSuperAdmin` / `requireAuth`). The admin per-org flag tooling's `isEnabled(PHASE2)` checks are now unconditional (`overrideStats` always computed).
- **Worker** — dropped `isFlagEnabled` early-returns (finance crons, stripe-fee enrichment, notifications fanout + digest).
- **Web** — the bell, Cmd+K palette, and finance sidebar entry now key off `isSuperAdmin` (tenant-vs-platform chrome) instead of a flag; the finance route, Replicate column, notification-prefs page, and per-org flag tooling pages render unconditionally; the settings nav always shows the Feature flags entry.
- **Registry** — removed the 5 `FEATURE_FLAG_KEYS` + `FEATURE_FLAG_REGISTRY` entries (the shrinking `FeatureFlagKey` union was the find-list).
- **DB** — new migration `0082_retire_validated_feature_flags.sql` deletes `tenant_flag_overrides` rows **before** the `feature_flags` rows (FK order), after the consumers are gone; journal updated. Original seed migrations stay immutable.
- **Docs** — updated `docs/18` §0 + §8 (added a worked REMOVED example) and the per-domain docs (`19`, `27`, `29`, `33`).

## Tests

- Deleted "flag off → 404 / hidden / no-op" assertions; un-gated the on-state coverage so it runs without seeding the flag.
- The phase2 suite now uses a test-only platform-scoped fixture (`test.scope_platform_demo`) since no production platform-scoped flag survives.
- **Green under both `api-tests-owner` and `api-tests-app` (RLS role)** locally (issue #455 gate).

## Acceptance checklist

- [x] All 5 keys gone from `FEATURE_FLAG_KEYS` + `FEATURE_FLAG_REGISTRY`; `pnpm typecheck` clean.
- [x] No `requireFlag` / `isFlagEnabled` / `xEnabled` references to the 5 keys remain (grep empty; one historical comment retained intentionally).
- [x] Retirement migration + journal applied; `feature_flags` / `tenant_flag_overrides` have no rows for the 5 keys (verified on default + test DBs).
- [x] Parity + journal-parity integration tests green under both roles.
- [x] All 5 features render/behave unconditionally; the admin flag tooling still works for the remaining flags.
- [x] Docs updated in the same PR.
- [x] Full pipeline green: `pnpm build && pnpm typecheck && pnpm test && pnpm biome check .`

close #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)