### PR TITLE
feat(finance): render report-archive period as a translated readable month

### DIFF
--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -9,7 +9,7 @@
  * will follow in a separate PR once visual fidelity is validated.
  */
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { createClientApiClient } from "@/lib/api/client-browser";
+import { formatMonthYear } from "@/lib/format";
 import type {
   FinancePeriod,
   FinanceSummary,
@@ -131,6 +132,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   const [error, setError] = useState<boolean>(initialError);
   const [flushing, setFlushing] = useState(false);
   const t = useTranslations("admin.finance");
+  const locale = useLocale();
 
   const periodOptions: Array<{ value: FinancePeriod; label: string }> = PERIOD_VALUES.map(
     ({ value, key }) => ({ value, label: t(key) }),
@@ -805,7 +807,9 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                     fontSize: 13,
                   }}
                 >
-                  <strong style={{ color: "var(--color-on-surface)" }}>{r.month}</strong>
+                  <strong style={{ color: "var(--color-on-surface)" }}>
+                    {formatMonthYear(r.month, locale)}
+                  </strong>
                   <span
                     style={{
                       fontSize: 11,

--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { createClientApiClient } from "@/lib/api/client-browser";
-import { formatMonthYear } from "@/lib/format";
+import { formatMonthName, formatMonthYear } from "@/lib/format";
 import type {
   FinancePeriod,
   FinanceSummary,
@@ -132,7 +132,6 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   const [error, setError] = useState<boolean>(initialError);
   const [flushing, setFlushing] = useState(false);
   const t = useTranslations("admin.finance");
-  const locale = useLocale();
 
   const periodOptions: Array<{ value: FinancePeriod; label: string }> = PERIOD_VALUES.map(
     ({ value, key }) => ({ value, label: t(key) }),
@@ -228,6 +227,26 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   // Single-slot — only one regeneration can be running at a time
   // (gated by `reportBusy`).
   const [reportToRegenerate, setReportToRegenerate] = useState<MonthlyReport | null>(null);
+
+  // Group the archive rows by calendar year for a scannable, sectioned list.
+  // The API returns rows already ordered `month DESC` (newest first), so a
+  // single linear pass yields year buckets in descending order with months
+  // descending inside each — no re-sort, the existing chronological order is
+  // preserved exactly. Grouping by the `YYYY` prefix avoids any timezone /
+  // Date parsing.
+  const reportsByYear = useMemo(() => {
+    const groups: Array<{ year: string; items: MonthlyReport[] }> = [];
+    for (const report of reports) {
+      const year = report.month.slice(0, 4);
+      const last = groups.at(-1);
+      if (last && last.year === year) {
+        last.items.push(report);
+      } else {
+        groups.push({ year, items: [report] });
+      }
+    }
+    return groups;
+  }, [reports]);
 
   const refreshReports = useCallback(async () => {
     try {
@@ -793,102 +812,75 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
               {t("reports.archive.empty")}
             </p>
           ) : (
-            <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-              {reports.map((r) => (
-                <li
-                  key={r.id}
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: "120px 100px 1fr auto",
-                    gap: 12,
-                    alignItems: "center",
-                    padding: "8px 0",
-                    borderBottom: "1px solid var(--color-outline-variant)",
-                    fontSize: 13,
-                  }}
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {reportsByYear.map(({ year, items }, groupIndex) => (
+                <section
+                  key={year}
+                  aria-label={t("reports.archive.yearGroupLabel", {
+                    year,
+                    count: items.length,
+                  })}
+                  style={{ marginTop: groupIndex === 0 ? 0 : 14 }}
                 >
-                  <strong style={{ color: "var(--color-on-surface)" }}>
-                    {formatMonthYear(r.month, locale)}
-                  </strong>
-                  <span
+                  {/* Year band — section divider with the year on the left, a
+                      connecting rule, and a report-count pill on the right. */}
+                  <div
                     style={{
-                      fontSize: 11,
-                      fontWeight: 500,
-                      color:
-                        r.status === "ready"
-                          ? "var(--color-primary)"
-                          : r.status === "failed"
-                            ? "var(--color-error)"
-                            : "var(--color-on-surface-variant)",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      padding: "2px 0 6px",
                     }}
                   >
-                    {r.status === "ready"
-                      ? t("reports.archive.statusReady")
-                      : r.status === "pending"
-                        ? t("reports.archive.statusPending")
-                        : t("reports.archive.statusFailed")}
-                  </span>
-                  <span
-                    style={{ fontSize: 11, color: "var(--color-on-surface-variant)" }}
-                    title={r.failureReason ?? undefined}
-                  >
-                    {r.readyAt
-                      ? t("reports.archive.generatedAt", {
-                          date: new Date(r.readyAt).toLocaleString("fr-FR", {
-                            day: "numeric",
-                            month: "short",
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          }),
-                        })
-                      : r.status === "failed"
-                        ? (r.failureReason ?? t("reports.archive.errorPlaceholder"))
-                        : "—"}
-                  </span>
-                  <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
-                    {r.status === "ready" && r.pdfUrl ? (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          const api = createClientApiClient();
-                          window.location.assign(api.resolveBrowserUrl(r.pdfUrl ?? ""));
-                        }}
-                      >
-                        <span
-                          className="material-symbols-outlined"
-                          style={{ fontSize: 14 }}
-                          aria-hidden
-                        >
-                          download
-                        </span>
-                        {t("reports.archive.downloadPdf")}
-                      </Button>
-                    ) : null}
-                    {r.status !== "pending" && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => requestRegenerate(r)}
-                        disabled={reportBusy}
-                        title={t("reports.archive.regenerateTitle")}
-                      >
-                        <span
-                          className="material-symbols-outlined"
-                          style={{ fontSize: 14 }}
-                          aria-hidden
-                        >
-                          refresh
-                        </span>
-                        {t("reports.archive.regenerate")}
-                      </Button>
-                    )}
+                    <span
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 700,
+                        letterSpacing: "0.04em",
+                        color: "var(--color-primary)",
+                        fontVariantNumeric: "tabular-nums",
+                      }}
+                    >
+                      {year}
+                    </span>
+                    <span
+                      aria-hidden
+                      style={{
+                        flex: 1,
+                        height: 1,
+                        background: "var(--color-outline-variant)",
+                      }}
+                    />
+                    <span
+                      style={{
+                        fontSize: 10,
+                        fontWeight: 600,
+                        color: "var(--color-on-surface-variant)",
+                        background: "var(--color-surface-container-low, #f9f8f6)",
+                        padding: "2px 8px",
+                        borderRadius: 999,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {t("reports.archive.yearCount", { count: items.length })}
+                    </span>
                   </div>
-                </li>
+                  {/* Months are indented under the year band to signal the
+                      year → months hierarchy. */}
+                  <ul style={{ listStyle: "none", padding: 0, margin: 0, paddingLeft: 18 }}>
+                    {items.map((r, idx) => (
+                      <ReportArchiveRow
+                        key={r.id}
+                        report={r}
+                        isLast={idx === items.length - 1}
+                        reportBusy={reportBusy}
+                        onRegenerate={requestRegenerate}
+                      />
+                    ))}
+                  </ul>
+                </section>
               ))}
-            </ul>
+            </div>
           )}
         </section>
       )}
@@ -1662,6 +1654,108 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
         </AlertDialogContent>
       </AlertDialog>
     </main>
+  );
+}
+
+interface ReportArchiveRowProps {
+  report: MonthlyReport;
+  /** Last row of its year group — drops the bottom border (the next year
+      band already provides the separation, avoiding a doubled divider). */
+  isLast: boolean;
+  reportBusy: boolean;
+  onRegenerate: (report: MonthlyReport) => void;
+}
+
+function ReportArchiveRow({ report: r, isLast, reportBusy, onRegenerate }: ReportArchiveRowProps) {
+  const t = useTranslations("admin.finance");
+  const locale = useLocale();
+
+  return (
+    <li
+      style={{
+        display: "grid",
+        gridTemplateColumns: "120px 100px 1fr auto",
+        gap: 12,
+        alignItems: "center",
+        padding: "8px 0",
+        borderBottom: isLast ? "none" : "1px solid var(--color-outline-variant)",
+        fontSize: 13,
+      }}
+    >
+      {/* The year lives in the band above, so each row shows only the month
+          name; the full "Mai 2026" stays available as a hover title. */}
+      <strong style={{ color: "var(--color-on-surface)" }} title={formatMonthYear(r.month, locale)}>
+        {formatMonthName(r.month, locale)}
+      </strong>
+      <span
+        style={{
+          fontSize: 11,
+          fontWeight: 500,
+          color:
+            r.status === "ready"
+              ? "var(--color-primary)"
+              : r.status === "failed"
+                ? "var(--color-error)"
+                : "var(--color-on-surface-variant)",
+        }}
+      >
+        {r.status === "ready"
+          ? t("reports.archive.statusReady")
+          : r.status === "pending"
+            ? t("reports.archive.statusPending")
+            : t("reports.archive.statusFailed")}
+      </span>
+      <span
+        style={{ fontSize: 11, color: "var(--color-on-surface-variant)" }}
+        title={r.failureReason ?? undefined}
+      >
+        {r.readyAt
+          ? t("reports.archive.generatedAt", {
+              date: new Date(r.readyAt).toLocaleString("fr-FR", {
+                day: "numeric",
+                month: "short",
+                hour: "2-digit",
+                minute: "2-digit",
+              }),
+            })
+          : r.status === "failed"
+            ? (r.failureReason ?? t("reports.archive.errorPlaceholder"))
+            : "—"}
+      </span>
+      <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
+        {r.status === "ready" && r.pdfUrl ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              const api = createClientApiClient();
+              window.location.assign(api.resolveBrowserUrl(r.pdfUrl ?? ""));
+            }}
+          >
+            <span className="material-symbols-outlined" style={{ fontSize: 14 }} aria-hidden>
+              download
+            </span>
+            {t("reports.archive.downloadPdf")}
+          </Button>
+        ) : null}
+        {r.status !== "pending" && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onRegenerate(r)}
+            disabled={reportBusy}
+            title={t("reports.archive.regenerateTitle")}
+          >
+            <span className="material-symbols-outlined" style={{ fontSize: 14 }} aria-hidden>
+              refresh
+            </span>
+            {t("reports.archive.regenerate")}
+          </Button>
+        )}
+      </div>
+    </li>
   );
 }
 

--- a/packages/web/src/lib/format.test.ts
+++ b/packages/web/src/lib/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatMonthYear } from "./format";
+import { formatMonthName, formatMonthYear } from "./format";
 
 describe("formatMonthYear", () => {
   it("renders a YYYY-MM period as a capitalized French month + year", () => {
@@ -26,5 +26,28 @@ describe("formatMonthYear", () => {
     expect(formatMonthYear("2026-00", "fr")).toBe("2026-00");
     expect(formatMonthYear("not-a-month", "fr")).toBe("not-a-month");
     expect(formatMonthYear("", "fr")).toBe("");
+  });
+});
+
+describe("formatMonthName", () => {
+  it("renders a YYYY-MM period as just the capitalized localized month name", () => {
+    expect(formatMonthName("2026-05", "fr")).toBe("Mai");
+    expect(formatMonthName("2026-01", "fr")).toBe("Janvier");
+    expect(formatMonthName("2026-12", "fr")).toBe("Décembre");
+  });
+
+  it("translates the month name to the active locale", () => {
+    expect(formatMonthName("2026-05", "en")).toBe("May");
+    expect(formatMonthName("2026-03", "en")).toBe("March");
+  });
+
+  it("is independent of the year (year-grouped lists carry the year in the heading)", () => {
+    expect(formatMonthName("2024-07", "fr")).toBe(formatMonthName("2030-07", "fr"));
+  });
+
+  it("returns the input unchanged when it is not a well-formed YYYY-MM string", () => {
+    expect(formatMonthName("2026", "fr")).toBe("2026");
+    expect(formatMonthName("2026-13", "fr")).toBe("2026-13");
+    expect(formatMonthName("nope", "fr")).toBe("nope");
   });
 });

--- a/packages/web/src/lib/format.test.ts
+++ b/packages/web/src/lib/format.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMonthYear } from "./format";
+
+describe("formatMonthYear", () => {
+  it("renders a YYYY-MM period as a capitalized French month + year", () => {
+    expect(formatMonthYear("2026-05", "fr")).toBe("Mai 2026");
+    expect(formatMonthYear("2026-01", "fr")).toBe("Janvier 2026");
+    expect(formatMonthYear("2026-12", "fr")).toBe("Décembre 2026");
+  });
+
+  it("translates the month name to the active locale", () => {
+    expect(formatMonthYear("2026-05", "en")).toBe("May 2026");
+    expect(formatMonthYear("2026-01", "en")).toBe("January 2026");
+  });
+
+  it("does not drift across timezone boundaries (constructs midday UTC)", () => {
+    // A naive `new Date("2026-03-01")` parses as UTC midnight, which in a
+    // negative-offset timezone would render as February — guard against it.
+    expect(formatMonthYear("2026-03", "fr")).toBe("Mars 2026");
+  });
+
+  it("returns the input unchanged when it is not a well-formed YYYY-MM string", () => {
+    expect(formatMonthYear("2026", "fr")).toBe("2026");
+    expect(formatMonthYear("2026-13", "fr")).toBe("2026-13");
+    expect(formatMonthYear("2026-00", "fr")).toBe("2026-00");
+    expect(formatMonthYear("not-a-month", "fr")).toBe("not-a-month");
+    expect(formatMonthYear("", "fr")).toBe("");
+  });
+});

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -50,6 +50,37 @@ export function formatDate(
   return new Intl.DateTimeFormat(locale, options).format(d);
 }
 
+/**
+ * Format a `YYYY-MM` period string to a localized, capitalized month + year
+ * label — `2026-05` → `Mai 2026` (fr) / `May 2026` (en).
+ *
+ * Used for operator-facing period labels (e.g. the finance report archive)
+ * where the raw `YYYY-MM` reads as machine-oriented. The underlying value is
+ * kept for sorting; only the display text is humanized here.
+ *
+ * Constructs the date at midday UTC of the 1st so the rendered month never
+ * drifts across a timezone boundary. Returns the input unchanged if it is not
+ * a well-formed `YYYY-MM` string.
+ */
+export function formatMonthYear(month: string, locale: string): string {
+  const match = /^(\d{4})-(\d{2})$/.exec(month);
+  if (!match) return month;
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  if (monthIndex < 0 || monthIndex > 11) return month;
+
+  const formatted = new Intl.DateTimeFormat(locale, {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(Date.UTC(year, monthIndex, 1, 12)));
+
+  // Intl lowercases the month name in some locales (fr: "mai 2026"); the
+  // archive list wants a capitalized leading letter ("Mai 2026").
+  return formatted.charAt(0).toUpperCase() + formatted.slice(1);
+}
+
 /** Format a number with locale-appropriate thousands separators. */
 export function formatNumber(value: number, locale: string): string {
   return new Intl.NumberFormat(locale).format(value);

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -81,6 +81,28 @@ export function formatMonthYear(month: string, locale: string): string {
   return formatted.charAt(0).toUpperCase() + formatted.slice(1);
 }
 
+/**
+ * Format a `YYYY-MM` period string to just the localized, capitalized month
+ * name — `2026-05` → `Mai` (fr) / `May` (en). Intended for lists already
+ * grouped under a year heading, where repeating the year on every row is
+ * redundant. Returns the input unchanged if it is not a well-formed
+ * `YYYY-MM` string.
+ */
+export function formatMonthName(month: string, locale: string): string {
+  const match = /^(\d{4})-(\d{2})$/.exec(month);
+  if (!match) return month;
+
+  const monthIndex = Number(match[2]) - 1;
+  if (monthIndex < 0 || monthIndex > 11) return month;
+
+  const formatted = new Intl.DateTimeFormat(locale, {
+    month: "long",
+    timeZone: "UTC",
+  }).format(new Date(Date.UTC(2000, monthIndex, 1, 12)));
+
+  return formatted.charAt(0).toUpperCase() + formatted.slice(1);
+}
+
 /** Format a number with locale-appropriate thousands separators. */
 export function formatNumber(value: number, locale: string): string {
   return new Intl.NumberFormat(locale).format(value);

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -1080,6 +1080,8 @@
           "ariaLabel": "Monthly reports archive",
           "title": "Archive · recent reports",
           "subtitle": "One report per month · most recent first",
+          "yearCount": "{count, plural, one {# report} other {# reports}}",
+          "yearGroupLabel": "Year {year} · {count, plural, one {# report} other {# reports}}",
           "empty": "No report yet. Click \"Monthly report\" or \"Backfill 12 months\".",
           "rgpdNoticeTitle": "Regeneration & GDPR compliance",
           "rgpdNoticeBody": "Each report is frozen at generation time (Art. 5.2, accuracy and traceability principle). Regenerating creates a new document; the previous one is kept in the system and remains accessible via the audit log. Every action is tracked (who, when, from which IP).",

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -1080,6 +1080,8 @@
           "ariaLabel": "Archive des rapports mensuels",
           "title": "Archive · derniers rapports",
           "subtitle": "Un rapport par mois · le plus récent en premier",
+          "yearCount": "{count, plural, one {# rapport} other {# rapports}}",
+          "yearGroupLabel": "Année {year} · {count, plural, one {# rapport} other {# rapports}}",
           "empty": "Aucun rapport pour l'instant. Clique « Rapport mensuel » ou « Backfill 12 mois ».",
           "rgpdNoticeTitle": "Régénération & conformité RGPD",
           "rgpdNoticeBody": "Chaque rapport est figé au moment de sa génération (Art. 5.2, principe d'exactitude et de traçabilité). Une régénération crée un nouveau document ; l'ancien est conservé dans le système et reste consultable via le journal d'audit. Toute action est tracée (qui, quand, depuis quelle IP).",


### PR DESCRIPTION
## What & why

On `/admin/finance`, the **report archive** ("derniers rapports") listed each monthly PDF report's period as the raw `YYYY-MM` string (`2026-05`) in a flat, ungrouped list. That reads as machine-oriented for an operator-facing artefact (board pack, accounting reconciliation) and is hard to scan across many months.

This PR makes it readable **and** scannable:
1. **Readable, translated month** — `2026-05` renders as `Mai 2026` (fr) / `May 2026` (en).
2. **Year grouping** — rows are grouped under per-year section headers.

Closes #502.

## How

### Readable month
- New helpers in [`packages/web/src/lib/format.ts`](packages/web/src/lib/format.ts), alongside `formatDate` / `formatCurrency`, driven by `Intl.DateTimeFormat` for translation:
  - `formatMonthYear("2026-05", locale)` → `Mai 2026` (used for the hover title / full label).
  - `formatMonthName("2026-05", locale)` → `Mai` (used inside year groups, where the year is redundant).
  - Both capitalize the leading letter (Intl renders `mai` lowercase in fr), build the date at **midday UTC** to avoid timezone month-drift, and return the input unchanged for malformed input.

### Year grouping
- A single linear pass over the API's `month DESC` ordering buckets rows by their `YYYY` prefix — years descend, months descend within — so the existing chronological **sort is preserved exactly** (no re-sort, no alphabetical-by-month-name).
- Each year renders as a **section divider**: year label (accent colour, `tabular-nums`) on the left, a connecting rule, and a **pluralised report-count pill** on the right (ICU plural via new i18n keys).
- UX polish per review on the live dashboard:
  - Month rows are **indented** under the year band to signal the hierarchy.
  - Rows show **only the month name**; full `Mai 2026` stays available as a hover `title`.
  - The **last row of each year drops its bottom border** — the next year band already separates the groups, so the divider would otherwise double up.
- Accessibility: each year group is a `<section>` with an `aria-label` ("Année 2026 · 5 rapports").

### Refactor
- Extracted [`ReportArchiveRow`](packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx) so the per-row markup lives in its own component. This pulls the archive's cognitive complexity out of the 1.8k-line `FinanceDashboard` function (which was already over Biome's threshold) — the repo now has **one fewer** complexity warning than before this branch.

## Sort order preserved

Only grouping + rendered text changed. `MonthlyReport.month` stays `YYYY-MM` in the model, API, and storage; the list order is identical to before.

## Scope notes

- No backend / schema / API change.
- No feature flag — display-format tweak to an already-shipped feature, not net-new behaviour.
- The toast / regenerate-dialog copy still interpolates the raw `{month}`; left as a deliberate out-of-scope follow-up.

## Acceptance checklist

- [ ] `/admin/finance` → report archive → rows grouped under `2026`, `2025`, … year headers with a "N rapports" pill
- [ ] Each row shows the translated month name (`Mai`), full `Mai 2026` on hover
- [ ] Switch locale to `en` → `May`, "N reports"
- [ ] Months are indented under the year band; the last row of each year has no divider
- [ ] Reports remain in chronological order (newest first), unchanged
- [ ] Malformed period input renders unchanged (no crash)

## Tests

- [`packages/web/src/lib/format.test.ts`](packages/web/src/lib/format.test.ts) — fr/en translation, capitalization, timezone-drift guard, malformed-input passthrough, year-independence of `formatMonthName`.
- Existing finance page test still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
