### PR TITLE
fix(finance): a11y + robustness follow-ups for the report-archive year grouping

### DIFF
--- a/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
+++ b/packages/web/src/app/(admin)/admin/finance/finance-dashboard.tsx
@@ -37,6 +37,7 @@ import type {
   SurveyCadence,
 } from "@/models/superadmin-finance";
 import { SuperAdminFinanceService } from "@/services/SuperAdminFinanceService";
+import { groupReportsByYear } from "./report-archive-grouping";
 
 import "./finance-mockup.css";
 
@@ -229,24 +230,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
   const [reportToRegenerate, setReportToRegenerate] = useState<MonthlyReport | null>(null);
 
   // Group the archive rows by calendar year for a scannable, sectioned list.
-  // The API returns rows already ordered `month DESC` (newest first), so a
-  // single linear pass yields year buckets in descending order with months
-  // descending inside each — no re-sort, the existing chronological order is
-  // preserved exactly. Grouping by the `YYYY` prefix avoids any timezone /
-  // Date parsing.
-  const reportsByYear = useMemo(() => {
-    const groups: Array<{ year: string; items: MonthlyReport[] }> = [];
-    for (const report of reports) {
-      const year = report.month.slice(0, 4);
-      const last = groups.at(-1);
-      if (last && last.year === year) {
-        last.items.push(report);
-      } else {
-        groups.push({ year, items: [report] });
-      }
-    }
-    return groups;
-  }, [reports]);
+  const reportsByYear = useMemo(() => groupReportsByYear(reports), [reports]);
 
   const refreshReports = useCallback(async () => {
     try {
@@ -814,16 +798,12 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
           ) : (
             <div style={{ display: "flex", flexDirection: "column" }}>
               {reportsByYear.map(({ year, items }, groupIndex) => (
-                <section
-                  key={year}
-                  aria-label={t("reports.archive.yearGroupLabel", {
-                    year,
-                    count: items.length,
-                  })}
-                  style={{ marginTop: groupIndex === 0 ? 0 : 14 }}
-                >
-                  {/* Year band — section divider with the year on the left, a
-                      connecting rule, and a report-count pill on the right. */}
+                <div key={year} style={{ marginTop: groupIndex === 0 ? 0 : 14 }}>
+                  {/* Year band — a real <h3> (reachable by screen-reader
+                      heading navigation) on the left, a decorative connecting
+                      rule, and a report-count pill on the right. The h3 carries
+                      a descriptive accessible name ("Année 2026 · N rapports")
+                      while showing just the year visually. */}
                   <div
                     style={{
                       display: "flex",
@@ -832,8 +812,13 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                       padding: "2px 0 6px",
                     }}
                   >
-                    <span
+                    <h3
+                      aria-label={t("reports.archive.yearGroupLabel", {
+                        year,
+                        count: items.length,
+                      })}
                       style={{
+                        margin: 0,
                         fontSize: 13,
                         fontWeight: 700,
                         letterSpacing: "0.04em",
@@ -842,7 +827,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                       }}
                     >
                       {year}
-                    </span>
+                    </h3>
                     <span
                       aria-hidden
                       style={{
@@ -878,7 +863,7 @@ export function FinanceDashboard({ initialSummary, initialError }: FinanceDashbo
                       />
                     ))}
                   </ul>
-                </section>
+                </div>
               ))}
             </div>
           )}
@@ -1711,7 +1696,7 @@ function ReportArchiveRow({ report: r, isLast, reportBusy, onRegenerate }: Repor
       >
         {r.readyAt
           ? t("reports.archive.generatedAt", {
-              date: new Date(r.readyAt).toLocaleString("fr-FR", {
+              date: new Date(r.readyAt).toLocaleString(locale, {
                 day: "numeric",
                 month: "short",
                 hour: "2-digit",

--- a/packages/web/src/app/(admin)/admin/finance/report-archive-grouping.test.ts
+++ b/packages/web/src/app/(admin)/admin/finance/report-archive-grouping.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { MonthlyReport } from "@/models/superadmin-finance";
+import { groupReportsByYear } from "./report-archive-grouping";
+
+function report(month: string): MonthlyReport {
+  return {
+    id: `id-${month}`,
+    month,
+    status: "ready",
+    failureReason: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    readyAt: "2026-06-01T00:00:00.000Z",
+    pdfUrl: `/v1/superadmin/finance/reports/id-${month}/pdf`,
+  };
+}
+
+describe("groupReportsByYear", () => {
+  it("buckets reports into descending year groups with months descending inside", () => {
+    const groups = groupReportsByYear([report("2026-05"), report("2026-01"), report("2025-12")]);
+
+    expect(groups.map((g) => g.year)).toEqual(["2026", "2025"]);
+    expect(groups[0]?.items.map((r) => r.month)).toEqual(["2026-05", "2026-01"]);
+    expect(groups[1]?.items.map((r) => r.month)).toEqual(["2025-12"]);
+  });
+
+  it("preserves chronological order, never alphabetical-by-month-name", () => {
+    // Avril (04) must come before Janvier (01) within 2026 — a name-based
+    // sort would invert them.
+    const groups = groupReportsByYear([report("2026-04"), report("2026-01")]);
+    expect(groups[0]?.items.map((r) => r.month)).toEqual(["2026-04", "2026-01"]);
+  });
+
+  it("defensively re-sorts so a year never splits into two bands when input is unordered", () => {
+    // Upstream contract is `month DESC`; if it ever drifts, a naive linear
+    // pass would emit 2026 → 2025 → 2026. The defensive sort prevents that.
+    const groups = groupReportsByYear([report("2026-05"), report("2025-12"), report("2026-03")]);
+
+    expect(groups.map((g) => g.year)).toEqual(["2026", "2025"]);
+    expect(groups[0]?.items.map((r) => r.month)).toEqual(["2026-05", "2026-03"]);
+  });
+
+  it("returns an empty array for no reports", () => {
+    expect(groupReportsByYear([])).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [report("2025-01"), report("2026-01")];
+    const snapshot = input.map((r) => r.month);
+    groupReportsByYear(input);
+    expect(input.map((r) => r.month)).toEqual(snapshot);
+  });
+});

--- a/packages/web/src/app/(admin)/admin/finance/report-archive-grouping.ts
+++ b/packages/web/src/app/(admin)/admin/finance/report-archive-grouping.ts
@@ -1,0 +1,33 @@
+import type { MonthlyReport } from "@/models/superadmin-finance";
+
+export interface ReportYearGroup {
+  /** `YYYY` */
+  year: string;
+  /** Reports for that year, newest month first. */
+  items: MonthlyReport[];
+}
+
+/**
+ * Group monthly reports by calendar year for the sectioned archive list.
+ *
+ * The API returns rows ordered `month DESC`, but we sort a copy defensively
+ * by the `YYYY-MM` string (descending — `localeCompare` is exact for the
+ * zero-padded `YYYY-MM` shape) before bucketing, so a year can never render
+ * as two separate bands if the upstream order ever drifts. Bucketing is then
+ * a single linear pass; years come out descending and months stay descending
+ * within each. The `YYYY` prefix split avoids any timezone / Date parsing.
+ */
+export function groupReportsByYear(reports: MonthlyReport[]): ReportYearGroup[] {
+  const sorted = [...reports].sort((a, b) => b.month.localeCompare(a.month));
+  const groups: ReportYearGroup[] = [];
+  for (const report of sorted) {
+    const year = report.month.slice(0, 4);
+    const last = groups.at(-1);
+    if (last && last.year === year) {
+      last.items.push(report);
+    } else {
+      groups.push({ year, items: [report] });
+    }
+  }
+  return groups;
+}

--- a/packages/web/src/lib/format.test.ts
+++ b/packages/web/src/lib/format.test.ts
@@ -26,6 +26,9 @@ describe("formatMonthYear", () => {
     expect(formatMonthYear("2026-00", "fr")).toBe("2026-00");
     expect(formatMonthYear("not-a-month", "fr")).toBe("not-a-month");
     expect(formatMonthYear("", "fr")).toBe("");
+    // The regex is anchored, so surrounding whitespace falls through to the
+    // safe passthrough rather than being silently trimmed-and-parsed.
+    expect(formatMonthYear(" 2026-05", "fr")).toBe(" 2026-05");
   });
 });
 


### PR DESCRIPTION
## Follow-up to #503 — review fixes that missed the merge window

PR #503 (readable translated month + year-grouped report archive) was merged before the multi-agent review (UX · Frontend · QA) fixes finished landing. This PR carries those fixes onto the current `main`. No new behaviour beyond polishing what #503 shipped.

### Changes

- **a11y (major, UX reviewer)** — the year band was a `<span>` inside a `<section aria-label>`, creating an anonymous landmark region per year and leaving the year unreachable by screen-reader heading navigation. The year is now a real `<h3>` (descriptive accessible name "Année 2026 · N rapports", year shown visually) and the wrapper is a plain `<div>` — no per-year landmark noise.
- **robustness (Frontend reviewer)** — grouping silently depended on the API's `month DESC` order; an unsorted response would split a year into two bands. Extracted `groupReportsByYear` as a pure module that defensively re-sorts before bucketing. Unit-tested: order preservation, defensive re-sort, no-mutation, empty.
- **consistency (Frontend reviewer)** — the "generated at" timestamp hardcoded `fr-FR`; it now uses the active `locale`, so an `en` row no longer mixes "May" with a French date.
- **tests (QA reviewer)** — added `report-archive-grouping.test.ts` + a whitespace passthrough case for `formatMonthYear`.

### Coverage note
A render test of the count pill would assert against the raw ICU string under the global next-intl test mock (interpolates `{key}` but does not evaluate plurals), so the high-value coverage lives in the pure `groupReportsByYear` test instead.

### Validation
Verified on the source branch before this cherry-pick: `typecheck` ✓, `biome check .` ✓ (extraction removed the pre-existing `FinanceDashboard` complexity warning — one fewer than `main`), 16 unit tests ✓, `build` ✓. Cherry-pick onto current `main` was clean.

Refs #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
