### PR TITLE
feat(campaigns): give postal-export "Actualiser" button visible feedback

### DIFF
--- a/packages/web/src/components/campaigns/postal-campaign-section.test.tsx
+++ b/packages/web/src/components/campaigns/postal-campaign-section.test.tsx
@@ -459,4 +459,60 @@ describe("PostalCampaignSection", () => {
       vi.unstubAllGlobals();
     });
   });
+
+  describe('Refresh ("Actualiser") button', () => {
+    it("re-fetches the export list and confirms with a success toast", async () => {
+      const user = userEvent.setup();
+
+      const fresh: PostalExport = {
+        id: "33333333-3333-4333-8333-333333333333",
+        campaignId: CAMPAIGN_ID,
+        mode: "personalized",
+        format: "zip",
+        status: "completed",
+        totalCount: 2,
+        progressCount: 2,
+        zipS3Path: "campaigns/export.zip",
+        error: null,
+        requestedBy: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      };
+      vi.spyOn(PostalCampaignService, "listExports").mockResolvedValue([fresh]);
+
+      renderSection({ initialMemberTotal: 2 });
+
+      await user.click(screen.getByRole("button", { name: /Refresh/i }));
+
+      await waitFor(() =>
+        expect(PostalCampaignService.listExports).toHaveBeenCalledWith(
+          expect.anything(),
+          CAMPAIGN_ID,
+        ),
+      );
+      // The whole point of the change: a click must produce visible feedback
+      // even when the list is unchanged. The success toast is that signal.
+      expect(mockToast.success).toHaveBeenCalledWith("Export list up to date.");
+    });
+
+    it("surfaces an error toast when the refresh fetch fails", async () => {
+      const user = userEvent.setup();
+
+      vi.spyOn(PostalCampaignService, "listExports").mockRejectedValue(
+        new ApiProblem({
+          type: "https://givernance.test/problems/internal",
+          title: "internal_error",
+          status: 500,
+          detail: "Upstream unavailable.",
+        }),
+      );
+
+      renderSection({ initialMemberTotal: 2 });
+
+      await user.click(screen.getByRole("button", { name: /Refresh/i }));
+
+      await waitFor(() => expect(mockToast.error).toHaveBeenCalledWith("Upstream unavailable."));
+    });
+  });
 });

--- a/packages/web/src/components/campaigns/postal-export-panel.tsx
+++ b/packages/web/src/components/campaigns/postal-export-panel.tsx
@@ -129,24 +129,30 @@ export function PostalExportPanel({
   const [exports, setExports] = useState<PostalExport[]>(initialExports);
   const [isStarting, setIsStarting] = useState(false);
   const [isPreviewing, setIsPreviewing] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   const activeJob = exports.find((e) => e.status === "pending" || e.status === "processing");
 
   useExportPolling({ activeJob, campaignId, setExports, t });
 
   const refreshList = useCallback(async () => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
     const client = createClientApiClient();
     try {
       const fresh = await PostalCampaignService.listExports(client, campaignId);
       setExports(fresh);
+      toast.success(t("toast.refreshed"));
     } catch (err) {
       const message =
         err instanceof ApiProblem
           ? (err.detail ?? err.title ?? t("toast.refreshFailed"))
           : t("toast.refreshFailed");
       toast.error(message);
+    } finally {
+      setIsRefreshing(false);
     }
-  }, [campaignId, t]);
+  }, [campaignId, isRefreshing, t]);
 
   const handleStart = useCallback(async () => {
     if (isStarting) return;
@@ -238,10 +244,15 @@ export function PostalExportPanel({
           variant="ghost"
           size="sm"
           onClick={() => void refreshList()}
+          disabled={isRefreshing}
           aria-label={t("refresh")}
         >
-          <RefreshCcw size={16} aria-hidden="true" />
-          {t("refresh")}
+          <RefreshCcw
+            size={16}
+            className={isRefreshing ? "animate-spin" : undefined}
+            aria-hidden="true"
+          />
+          {isRefreshing ? t("refreshing") : t("refresh")}
         </Button>
       </CardHeader>
       <CardContent className="space-y-5">

--- a/packages/web/src/messages/en.json
+++ b/packages/web/src/messages/en.json
@@ -2764,6 +2764,7 @@
         "blocked": "Postal export is not configured yet — link a Swiss bank account or publish a public donation page to start."
       },
       "refresh": "Refresh",
+      "refreshing": "Refreshing…",
       "modes": {
         "personalized": {
           "title": "Personalized",
@@ -2853,6 +2854,7 @@
         "exportReady": "Postal export ready for download.",
         "exportFailed": "Postal export failed.",
         "startFailed": "Could not start the export. Please try again.",
+        "refreshed": "Export list up to date.",
         "refreshFailed": "Could not refresh the export list.",
         "previewFailed": "Could not load the preview."
       },

--- a/packages/web/src/messages/fr.json
+++ b/packages/web/src/messages/fr.json
@@ -2764,6 +2764,7 @@
         "blocked": "L'export postal n'est pas encore configuré — liez un compte bancaire suisse ou publiez une page de don publique pour commencer."
       },
       "refresh": "Actualiser",
+      "refreshing": "Actualisation…",
       "modes": {
         "personalized": {
           "title": "Personnalisé",
@@ -2853,6 +2854,7 @@
         "exportReady": "Export postal prêt au téléchargement.",
         "exportFailed": "L'export postal a échoué.",
         "startFailed": "Impossible de démarrer l'export. Veuillez réessayer.",
+        "refreshed": "Liste des exports à jour.",
         "refreshFailed": "Impossible d'actualiser la liste des exports.",
         "previewFailed": "Impossible de charger l'aperçu."
       },


### PR DESCRIPTION
Fixes the "dead button" UX on the campaign **Export postal** panel — the top-right **Actualiser** control.

## Problem
The Refresh button was already wired (`refreshList()` re-fetches the "Exports récents" list), but it gave **no feedback on success** — no spinner, no toast. When the list was unchanged (the common case) the screen looked identical, so it read as a control that does nothing. See #505 for the full diagnosis.

## Change
- New `isRefreshing` state in `PostalExportPanel`: the button is disabled and the `RefreshCcw` icon spins (`animate-spin`) with an **Actualisation…** label while the fetch is in flight — mirrors the existing `isStarting` / `isPreviewing` spinner pattern.
- A **success toast** fires on completion (`toast.refreshed`), so a click always produces a visible signal even when nothing changed.
- Re-entrancy guard (`if (isRefreshing) return`) so double-clicks can't stack fetches.
- New i18n keys `campaigns.postal.refreshing` and `campaigns.postal.toast.refreshed` (fr + en).
- Confirmed the auto-poll (`useExportPolling`) uses its own `getExport` tick and does **not** call `refreshList`, so the new success toast cannot spam during an active job.

## Tests
Two new cases in `postal-campaign-section.test.tsx`:
- click Refresh → `listExports` called + success toast "Export list up to date."
- refresh fetch rejects → error toast with the problem detail.

## Manual acceptance
- [x] With no active job, clicking **Actualiser** shows the spinning icon + "Actualisation…", then a success toast.
- [ ] Button is disabled while refreshing; double-click does not stack requests.
- [x] On a network/API error, an error toast appears (no silent failure).
- [x] During an active export job, the 2s auto-poll still works and no refresh toast spam occurs.

close #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)