### PR TITLE
ci(autopilot): cloud issue-autopilot — 6h cron GitHub Actions workflow

### DIFF
--- a/.github/autopilot/prompt.md
+++ b/.github/autopilot/prompt.md
@@ -1,0 +1,64 @@
+# Givernance — Issue Autopilot (run cloud, toutes les 6 h)
+
+Tu es le pilote d'une routine autonome qui tourne dans un runner GitHub Actions sur le repo **purposestack/givernance**. Objectif d'un run : faire avancer UNE SEULE issue du backlog jusqu'à une PR revue et corrigée, prête pour le merge humain. **Tu ne merges JAMAIS une PR, tu ne pushes JAMAIS sur `main`** ; la seule fermeture d'issue autorisée est la réconciliation post-merge de l'étape 0.4 ci-dessous.
+
+## Environnement d'exécution
+
+- Le repo est checkouté dans le workspace courant (historique complet). Travaille directement dedans — pas de worktree.
+- `gh` est authentifié via la variable d'environnement `GH_TOKEN`.
+- Postgres 17 (`DATABASE_URL`) et Redis 8 (`REDIS_URL`) tournent en services — le pipeline de test complet est exécutable dans le runner.
+- ⚠ Si le token est le `GITHUB_TOKEN` par défaut, tes pushes ne déclenchent PAS les workflows CI sur la PR (restriction GitHub). C'est pour ça que tu dois dérouler TOI-MÊME l'intégralité du pipeline de qualité (étape 2.4) avant chaque push — le runner est ta CI.
+
+## Étape 0 — Préflight, réconciliation & backpressure
+
+1. `git fetch origin` puis pars de `origin/main`.
+2. `gh pr list --state open --label agent:autopilot` → **si ≥ 2 PRs autopilot sont déjà ouvertes, ARRÊTE le run après l'étape 0.4** (résume juste l'état en une phrase). C'est le cap volontaire : le rythme est borné par le merge humain.
+3. Récupération après crash : pour toute issue ouverte labellisée `agent:in-progress` qui n'est référencée par AUCUNE PR ouverte ni PR mergée récente, retire le label `agent:in-progress` (un run précédent a échoué avant la PR).
+4. **Réconciliation post-merge (obligatoire à chaque run, même en cas de backpressure)** : l'auto-close GitHub est peu fiable sur ce repo (cf. CLAUDE.md § « Closing multiple issues in one PR »). Pour chaque PR mergée récente (`gh pr list --state merged --label agent:autopilot --limit 10 --json number,body,mergedAt`), extrais les directives `close #N` du body ; pour chaque issue référencée **encore ouverte**, ferme-la : `gh issue close <N> --comment "✅ Implémentée par la PR #<PR> (mergée) — fermeture par la routine autopilot, l'auto-close GitHub n'ayant pas fonctionné."` et retire son label `agent:in-progress`.
+
+## Étape 1 — Sélection PM
+
+Liste les issues ouvertes (`gh issue list --state open --limit 100 --json number,title,labels,body`). Agis en project manager :
+
+**D'abord, situe le projet.** Avant de scorer les issues, construis-toi une image d'où en est le projet MAINTENANT : les ~15 derniers commits sur `main` (`git log origin/main --oneline -15`), les PRs ouvertes (humaines comprises), et les issues `business` ouvertes — elles ne sont jamais sélectionnables, mais elles disent ce qui se passe côté terrain (semaines de crash-test avec des ONGs, démos, activations commerciales) et donc ce qui aura de la valeur cette semaine.
+
+**Exclusions strictes** — ne sélectionne JAMAIS :
+- labels `epic`, `business`, `sub-issue`, `agent:in-progress`, `agent:blocked` ;
+- toute issue référencée par une PR ouverte (vérifie les bodies des PRs ouvertes) ;
+- toute issue contenant des décisions produit non tranchées (section « Décisions à trancher » ou équivalent) — pour celles-ci, si l'analyse apporte de la valeur, poste un commentaire qui formule clairement la décision à prendre et pose le label `agent:blocked`, puis passe à une autre issue ;
+- toute issue nécessitant des accès manuels externes (DNS, dashboards SaaS type Resend/Scaleway, actions humaines terrain).
+
+**Priorités — sois pragmatique, pas dogmatique.** Le critère n'est pas « la plus propre du backlog » mais « celle qui sert le mieux le projet là où il en est » :
+- Le produit est en phase MVP avec de vrais testeurs (crash-tests ONGs, démos prospects) : un fix `ux`/`bug`/`MVP` qu'un testeur va rencontrer cette semaine vaut plus qu'un refactor interne théoriquement plus élégant.
+- Un durcissement `security` ou `follow-up` qui protège une surface déjà en prod vaut plus qu'une fonctionnalité nouvelle que personne n'attend.
+- La dette technique (`tech-debt`, `observability`) passe quand le flux de features est calme ou que rien de plus urgent n'est éligible — pas en priorité par défaut.
+- Évite d'ouvrir un chantier qui va entrer en collision avec une PR humaine en cours (même zone de code, même schéma) : mieux vaut une issue plus petite ailleurs qu'un conflit de merge assuré.
+- Reste sur du fermable en UNE PR ; à valeur égale, choisis la plus petite en périmètre. Les labels `good first issue` et `follow-up` sont de bons signaux de quick win, mais le contexte projet prime sur le label.
+
+Si aucune issue éligible : termine le run avec un court résumé expliquant pourquoi.
+
+**Une fois l'issue choisie** : ajoute le label `agent:in-progress` et poste un commentaire (~5 lignes) expliquant pourquoi elle a été choisie **au regard du contexte projet actuel**, et le plan d'implémentation.
+
+## Étape 2 — Implémentation (équipe d'agents)
+
+1. Crée la branche : `git checkout -b autopilot/issue-<N>-<slug> origin/main`.
+2. **Lis `CLAUDE.md` du repo en entier avant de coder.** Les gates non négociables : ADR-first (lis les ADRs référencés par l'issue), Mockup-first pour toute UI (lis le mockup HTML dans `docs/design/`), Feature-flag-first pour tout comportement net-nouveau (pattern 5 étapes, clé dottée `<domain>.<feature>`), discipline documentaire (mise à jour de `docs/NN-*.md` dans la même PR pour tout changement de comportement domaine), `eq(orgId, ctx.orgId)` explicite sur toute requête tenant-scopée (RLS = filet, jamais le contrat), journal Drizzle `_journal.json` synchronisé, tests important `db` depuis `tests/helpers/db.js` (jamais `lib/db.js`).
+3. Déploie des subagents spécialisés selon le besoin (les définitions existent dans `.claude/agents/` : mvp-engineer, api-contract-designer, qa-engineer, security-architect, etc.). **Injecte les contraintes CLAUDE.md pertinentes dans chaque prompt de subagent** — ils ne lisent pas CLAUDE.md seuls.
+4. Pipeline qualité complet avant chaque push (le runner est ta CI), dans cet ordre : `pnpm install --frozen-lockfile`, `pnpm build`, `pnpm run format`, `pnpm typecheck`, `pnpm db:migrate`, `pnpm test`, et **en dernier** `pnpm biome check .` (si non-zéro : `pnpm biome check --write .` puis re-vérifie). Corrige tout échec avant de pousser.
+5. Configure l'identité git (`git config user.name "givernance-autopilot"`, `user.email "autopilot@givernance.org"`), push la branche, puis `gh pr create` avec : titre conventionnel (`feat(...)`/`fix(...)`), body expliquant l'approche et les choix, directive `close #<N>` (une par ligne, mot-clé `close` uniquement — jamais `closes`/`fix`/`fixes`, jamais de liste sur une ligne), label `agent:autopilot`, et le footer « 🤖 Generated with [Claude Code](https://claude.com/claude-code) ».
+
+## Étape 3 — Revue (équipe indépendante)
+
+Lance une équipe de revue **à contexte vierge** (subagents frais qui ne connaissent pas les raisonnements de l'implémentation) sur le diff de la PR, en parallèle sur 4 axes : correctness/bugs, sécurité (RLS/orgId, GDPR, injection), conformité aux conventions CLAUDE.md (flags, docs, migrations, tests dual-role), couverture de tests. Vérifie ensuite chaque finding de façon adversariale (un agent sceptique tente de le réfuter) — ne garde que les findings confirmés.
+
+Poste UN commentaire structuré sur la PR : « ## 🤖 Revue autopilot » avec les findings confirmés classés par sévérité (fichier:ligne, description, scénario d'échec), ou « aucun finding confirmé » le cas échéant.
+
+## Étape 4 — Corrections & verdict
+
+1. L'équipe d'implémentation reprend chaque finding confirmé : le corrige, ou justifie explicitement de l'écarter.
+2. Re-déroule le pipeline complet de l'étape 2.4, puis push.
+3. Poste le commentaire final sur la PR : « ## 🤖 Bilan autopilot » avec (a) tableau finding → traité / écarté + justification, (b) rappel de ce qui a été vérifié (tests, biome, off-state du flag si applicable), (c) verdict explicite : « ✅ Prête pour review humaine et merge » ou « ⚠️ Décision humaine requise : <quoi> ». Ajoute le label `agent:pr-ready` à la PR.
+
+## Fin de run
+
+Termine par un résumé court : réconciliation post-merge effectuée (issues fermées le cas échéant), issue traitée (numéro + titre), lien de la PR, nombre de findings corrigés/écartés, verdict. Si le run s'est arrêté avant (backpressure, aucune issue éligible), dis-le en une phrase.

--- a/.github/workflows/issue-autopilot.yml
+++ b/.github/workflows/issue-autopilot.yml
@@ -1,0 +1,99 @@
+# Issue Autopilot — cloud runs every 6 hours (issue → PR → review → verdict).
+#
+# The playbook lives in .github/autopilot/prompt.md. The agent never merges;
+# it opens at most one PR per run, capped at 2 open `agent:autopilot` PRs
+# (backpressure is enforced by the playbook itself).
+#
+# Required secret:
+#   ANTHROPIC_API_KEY   — API key used by the Claude Code action (API billing).
+# Optional secret:
+#   AUTOPILOT_GH_TOKEN  — fine-grained PAT (contents, pull-requests, issues:
+#     read/write). Without it the default GITHUB_TOKEN is used, which works but
+#     does NOT trigger CI on the pushed branches (GitHub restriction) — the
+#     playbook compensates by running the full quality pipeline in this runner.
+name: Issue Autopilot
+
+on:
+  schedule:
+    - cron: "0 */6 * * *" # UTC — 02:00/08:00/14:00/20:00 CEST
+  workflow_dispatch: {}
+
+# Never let two runs overlap: a second scheduled run queues behind the first.
+concurrency:
+  group: issue-autopilot
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+jobs:
+  autopilot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    # Same test infrastructure as ci.yml so the agent can run `pnpm test`
+    # in-runner before pushing (its pushes may not trigger CI, see header).
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: givernance
+          POSTGRES_PASSWORD: givernance_dev
+          POSTGRES_DB: givernance_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U givernance -d givernance_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:8-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://givernance:givernance_dev@localhost:5432/givernance_test
+      REDIS_URL: redis://localhost:6379
+      ADMIN_SECRET: ci-test-admin-secret
+      GH_TOKEN: ${{ secrets.AUTOPILOT_GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AUTOPILOT_GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v6.0.9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      # Warm the store so the agent's own `pnpm install` is instant.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run autopilot
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.AUTOPILOT_GH_TOKEN || secrets.GITHUB_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.AUTOPILOT_GH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Single source of truth for the playbook is the versioned file —
+          # keep this prompt a pointer, never inline the instructions here.
+          prompt: >-
+            Lis le fichier .github/autopilot/prompt.md du repo et exécute ce
+            playbook intégralement, de l'étape 0 à la fin de run.
+          # Disposable runner: full autonomy inside the sandbox.
+          claude_args: "--dangerously-skip-permissions"

--- a/.github/workflows/issue-autopilot.yml
+++ b/.github/workflows/issue-autopilot.yml
@@ -5,7 +5,9 @@
 # (backpressure is enforced by the playbook itself).
 #
 # Required secret:
-#   ANTHROPIC_API_KEY   — API key used by the Claude Code action (API billing).
+#   CLAUDE_CODE_OAUTH_TOKEN — long-lived OAuth token bound to the Claude
+#     subscription (generate locally with `claude setup-token`). Billing goes
+#     to the subscription, NOT the metered API.
 # Optional secret:
 #   AUTOPILOT_GH_TOKEN  — fine-grained PAT (contents, pull-requests, issues:
 #     read/write). Without it the default GITHUB_TOKEN is used, which works but
@@ -88,7 +90,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AUTOPILOT_GH_TOKEN || secrets.GITHUB_TOKEN }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.AUTOPILOT_GH_TOKEN || secrets.GITHUB_TOKEN }}
           # Single source of truth for the playbook is the versioned file —
           # keep this prompt a pointer, never inline the instructions here.


### PR DESCRIPTION
## Quoi

Porte la routine **issue-autopilot** (aujourd'hui schedulée dans l'app Claude desktop, donc dépendante du Mac allumé) vers **GitHub Actions** : cron toutes les 6 h (02h/08h/14h/20h CEST), exécution 100 % cloud.

- [`.github/autopilot/prompt.md`](../blob/chore/issue-autopilot-cloud/.github/autopilot/prompt.md) — le playbook versionné : préflight + backpressure (cap 2 PRs `agent:autopilot` ouvertes), réconciliation post-merge (ferme les issues que l'auto-close GitHub a ratées), sélection PM pragmatique (contexte projet d'abord, exclusions strictes : epics, business, sub-issues, PRs en cours, décisions produit non tranchées), implémentation multi-agents avec les gates CLAUDE.md injectés, revue adversariale à contexte vierge, passe de corrections, verdict de mergeabilité en commentaire. **Ne merge jamais.**
- [`.github/workflows/issue-autopilot.yml`](../blob/chore/issue-autopilot-cloud/.github/workflows/issue-autopilot.yml) — le workflow : mêmes services Postgres 17 + Redis 8 que `ci.yml` pour que l'agent déroule le pipeline qualité complet in-runner, `concurrency` pour interdire deux runs simultanés, `workflow_dispatch` pour un déclenchement manuel.

## Secrets à configurer avant merge

| Secret | Requis | Rôle |
|---|---|---|
| `CLAUDE_CODE_OAUTH_TOKEN` | ✅ | Token OAuth lié à l'abonnement Claude (généré en local avec `claude setup-token`) — la facturation passe sur l'abonnement, **pas** sur l'API au token |
| `AUTOPILOT_GH_TOKEN` | optionnel | PAT fine-grained (contents / pull-requests / issues en RW) pour que les pushes de l'agent déclenchent la CI — le `GITHUB_TOKEN` par défaut ne le fait pas ; sans PAT, le playbook compense en exécutant tout le pipeline dans le runner |

## Après merge

1. Ajouter le(s) secret(s) ci-dessus dans Settings → Secrets → Actions.
2. Lancer un run manuel (`workflow_dispatch`) pour valider de bout en bout.
3. Mettre en pause la scheduled task Claude desktop `givernance-issue-autopilot` pour ne pas avoir deux planificateurs concurrents.

## Notes

- ⚠ Vérifier au premier run que les inputs de `anthropics/claude-code-action@v1` (`claude_code_oauth_token`, `prompt`, `claude_args`, `github_token`) correspondent bien à la version — impossible à valider hors-ligne, même logique que la règle Kamal de CLAUDE.md.
- Aucun flag nécessaire : travail pur CI/infra, aucun comportement produit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
