### PR TITLE
obs(branding): end-to-end pipeline latency discriminator + LogQL recipes + ADR-024 SLO

### DIFF
--- a/docs/17-log-management.md
+++ b/docs/17-log-management.md
@@ -339,7 +339,7 @@ The logo activation chain — upload accepted → `branding.process_asset` → `
 }
 ```
 
-- KC-sync processor ([`packages/worker/src/processors/keycloak-sync-org-logo.ts`](../packages/worker/src/processors/keycloak-sync-org-logo.ts)) — emitted AFTER the KC PATCH acknowledges, and **only on the upload path** (a clear/delete sync or a not-ready asset has no upload to measure against). `e2eLatencyMs = max(0, now − created_at)`, 0-clamped against pathological clock skew:
+- KC-sync processor ([`packages/worker/src/processors/keycloak-sync-org-logo.ts`](../packages/worker/src/processors/keycloak-sync-org-logo.ts)) — emitted AFTER the KC PATCH acknowledges, **only on the upload path** (a clear/delete sync or a not-ready asset has no upload to measure against), and **only when the KC attribute actually transitioned** (`updateOrganization` reports `changed: false` when the requested value was already in place — the relay is at-least-once and BullMQ can re-run stalled jobs, and a late re-delivery would otherwise re-measure against the *original* upload's `created_at` and fire a false SLO-breach alert). `e2eLatencyMs = max(0, now − created_at)`, 0-clamped against pathological clock skew:
 
 ```json
 {
@@ -383,7 +383,7 @@ sum(count_over_time({service="givernance-api"}    | json | __error__="" | brandi
 sum(count_over_time({service="givernance-worker"} | json | __error__="" | brandingPipeline_event="kc_synced"       [1h]))
 ```
 
-> Caveat: the gap counter over-counts by design — re-uploads that supersede a pending asset mid-pipeline, and clear/delete syncs, both legitimately break the 1:1 pairing. Treat a *persistent* positive gap as the signal, not any single-window blip.
+> Caveat: the gap counter over-counts by design — re-uploads that supersede a pending asset mid-pipeline break the 1:1 pairing, and a worker retry that crashed between the KC PUT and the log emission under-counts one `kc_synced` (the retry sees `changed: false`). The `changed` gate guarantees duplicates never push the gap *negative* — a re-delivered sync emits nothing — so a *persistent* positive gap is the signal, not any single-window blip.
 
 The SLO itself (p95 < 5s) and its queue-topology revisit criterion live in [ADR-024](adrs/adr-024-image-processing-pipeline.md).
 

--- a/docs/17-log-management.md
+++ b/docs/17-log-management.md
@@ -319,6 +319,74 @@ The discriminators are **only** populated on guard denials. CSRF, validation, an
 
 **Audit table retention vs Pino retention.** `audit_logs` retains 7+ years (§7.1); the Pino warn/info lines retain 90 days for info / 1 year for error (§6.2). The discriminators are **observability-only**, not 7-year audit. After 90 days, "was there an RBAC probe against resource X on date Y" is unanswerable from logs alone — you'd join on the audit table by `(reqId, userId, orgId, resourceType)`. If long-term forensics on denial-reason becomes a requirement, add a `metadata jsonb` column to `audit_logs` and write the discriminator into it.
 
+### 7.2.2 Branding-pipeline latency discriminator (issue #290)
+
+The logo activation chain — upload accepted → `branding.process_asset` → `branding.activate_logo` → `keycloak.sync_org_logo` → KC `attributes.logo_url` PATCH — crosses two services and three outbox hops. Its end-to-end latency is measured from **structured logs** (no in-process metrics exist yet — OTel is Phase 2–3, §12): both ends of the span emit a `brandingPipeline` discriminator, and the span is anchored on a single DB-clock timestamp (`org_branding_assets.created_at`) so no clock is passed across services.
+
+**Emission sites** (exactly two):
+
+- API upload handler ([`packages/api/src/modules/branding/routes.ts`](../packages/api/src/modules/branding/routes.ts)) — on the 201 accept path:
+
+```json
+{
+  "service": "givernance-api",
+  "msg": "Branding logo uploaded; pipeline enqueued",
+  "brandingPipeline": {
+    "event": "upload_accepted",
+    "assetId": "0198…",
+    "acceptedAt": "2026-07-23T12:00:05.800Z"
+  }
+}
+```
+
+- KC-sync processor ([`packages/worker/src/processors/keycloak-sync-org-logo.ts`](../packages/worker/src/processors/keycloak-sync-org-logo.ts)) — emitted AFTER the KC PATCH acknowledges, and **only on the upload path** (a clear/delete sync or a not-ready asset has no upload to measure against). `e2eLatencyMs = max(0, now − created_at)`, 0-clamped against pathological clock skew:
+
+```json
+{
+  "service": "givernance-worker",
+  "msg": "KC organization logo_url synced",
+  "tenantId": "0197…",
+  "brandingPipeline": {
+    "event": "kc_synced",
+    "assetId": "0198…",
+    "uploadAcceptedAt": "2026-07-23T12:00:05.800Z",
+    "e2eLatencyMs": 4200
+  }
+}
+```
+
+**LogQL — per-tenant p95 end-to-end latency** (the ADR-024 SLO panel: histogram or time-series, threshold line at 5000ms):
+
+```logql
+quantile_over_time(0.95,
+  {service="givernance-worker"} | json | __error__=""
+    | brandingPipeline_event="kc_synced"
+    | unwrap brandingPipeline_e2eLatencyMs [1h]
+) by (tenantId)
+```
+
+**LogQL — SLO breach alert** (fleet-wide, fires when any sync exceeds 5s):
+
+```logql
+count_over_time(
+  {service="givernance-worker"} | json | __error__=""
+    | brandingPipeline_event="kc_synced"
+    | brandingPipeline_e2eLatencyMs > 5000 [15m]
+)
+```
+
+**LogQL — stuck-pipeline detection** (an `upload_accepted` with no matching `kc_synced` — compare the two counters; a persistent gap means the relay or a processor is stalled):
+
+```logql
+sum(count_over_time({service="givernance-api"}    | json | __error__="" | brandingPipeline_event="upload_accepted" [1h]))
+-
+sum(count_over_time({service="givernance-worker"} | json | __error__="" | brandingPipeline_event="kc_synced"       [1h]))
+```
+
+> Caveat: the gap counter over-counts by design — re-uploads that supersede a pending asset mid-pipeline, and clear/delete syncs, both legitimately break the 1:1 pairing. Treat a *persistent* positive gap as the signal, not any single-window blip.
+
+The SLO itself (p95 < 5s) and its queue-topology revisit criterion live in [ADR-024](adrs/adr-024-image-processing-pipeline.md).
+
 ### 7.3 Audit log schema
 
 See Log Analyst agent for full Drizzle schema. Key design decisions:

--- a/docs/24-branding-assets.md
+++ b/docs/24-branding-assets.md
@@ -187,6 +187,8 @@ Drift on the relay is < 1s in practice. A donor logging in during that window br
 
 The reusable shape (outbox → worker → KC Admin API GET-then-PUT) is documented in `docs/05-integration-migration.md` as the canonical pattern for any future tenant-attribute → Keycloak sync.
 
+**Observability (issue #290)** — the full activation chain (upload accepted → 3 outbox hops → sharp pipeline → KC PATCH) is instrumented end-to-end via the `brandingPipeline` structured-log discriminator: the API stamps `event: "upload_accepted"` on the 201 path, and the KC-sync processor emits `event: "kc_synced"` with `e2eLatencyMs` (measured after the PATCH, anchored on the asset row's DB-clock `created_at`, upload path only). Per-tenant p95 histogram, SLO-breach alert, and stuck-pipeline LogQL recipes: `docs/17-log-management.md` § 7.2.2. SLO (**p95 < 5s**) + queue-topology revisit criterion: ADR-024.
+
 ### 4.5 Worker LRU cache (PDF embedding)
 
 Postal exports run in batches of thousands of recipients (Epic #274). Without a cache, each recipient PDF would re-fetch the same `pdf-letterhead` variant from S3. The worker maintains an in-process LRU keyed by `logo_asset_id`:

--- a/docs/24-branding-assets.md
+++ b/docs/24-branding-assets.md
@@ -187,7 +187,7 @@ Drift on the relay is < 1s in practice. A donor logging in during that window br
 
 The reusable shape (outbox → worker → KC Admin API GET-then-PUT) is documented in `docs/05-integration-migration.md` as the canonical pattern for any future tenant-attribute → Keycloak sync.
 
-**Observability (issue #290)** — the full activation chain (upload accepted → 3 outbox hops → sharp pipeline → KC PATCH) is instrumented end-to-end via the `brandingPipeline` structured-log discriminator: the API stamps `event: "upload_accepted"` on the 201 path, and the KC-sync processor emits `event: "kc_synced"` with `e2eLatencyMs` (measured after the PATCH, anchored on the asset row's DB-clock `created_at`, upload path only). Per-tenant p95 histogram, SLO-breach alert, and stuck-pipeline LogQL recipes: `docs/17-log-management.md` § 7.2.2. SLO (**p95 < 5s**) + queue-topology revisit criterion: ADR-024.
+**Observability (issue #290)** — the full activation chain (upload accepted → 3 outbox hops → sharp pipeline → KC PATCH) is instrumented end-to-end via the `brandingPipeline` structured-log discriminator: the API stamps `event: "upload_accepted"` on the 201 path, and the KC-sync processor emits `event: "kc_synced"` with `e2eLatencyMs` (measured after the PATCH, anchored on the asset row's DB-clock `created_at`, upload path only, first delivery only — at-least-once re-deliveries are suppressed via the `changed` flag returned by `updateOrganization`). Per-tenant p95 histogram, SLO-breach alert, and stuck-pipeline LogQL recipes: `docs/17-log-management.md` § 7.2.2. SLO (**p95 < 5s**) + queue-topology revisit criterion: ADR-024.
 
 ### 4.5 Worker LRU cache (PDF embedding)
 

--- a/docs/adrs/adr-024-image-processing-pipeline.md
+++ b/docs/adrs/adr-024-image-processing-pipeline.md
@@ -125,10 +125,17 @@ There is **no `variants_schema_version` column**, no migration. The strategy is 
 - **Worker LRU cache for PDF embedding** keyed by `logo_asset_id`, max 50 entries (~10MB), 1h TTL. Postal exports run in batches of thousands of recipients; without the cache, each recipient PDF would re-fetch the same logo from S3.
 - **`sharp` install on Alpine requires `vips-dev` / `libvips42`.** API and worker Dockerfiles must include the apt/apk lines; CI must verify the install at image-build time.
 
+### SLO — end-to-end activation latency (issue #290)
+
+**p95 < 5s** from *upload accepted* (the `org_branding_assets.created_at` INSERT in the API handler) to *KC synced* (the `attributes.logo_url` PATCH acknowledged in `keycloak-sync-org-logo.ts`), per tenant.
+
+The chain crosses 3 outbox events × ~500ms relay poll cycle + the sharp pipeline + a KC PATCH, so the steady-state floor is ~1.5s before any real work; 5s leaves headroom for a cold sharp pool and a slow KC round-trip without masking a stuck relay. Measured from structured logs, not in-process metrics: the worker emits a `brandingPipeline: { event: "kc_synced", e2eLatencyMs }` discriminator on every upload-path sync (the API side stamps `event: "upload_accepted"`), and the per-tenant p95 comes from the LogQL recipe in [`docs/17-log-management.md` § 7.2.2](../17-log-management.md). Both ends of the span share the single DB-clock `created_at` timestamp — no cross-service clock passing.
+
 ### Revisit criteria
 
 Reopen this ADR when:
 
 - End-to-end variant generation (queue ack → all variants written → row flipped to `'ready'`) **exceeds 1s** on a representative input. The bottleneck moves from CPU to either S3 latency or BullMQ scheduling, and the pipeline shape needs to change (sharp pool? dedicated worker? on-the-fly fallback?).
+- The end-to-end activation SLO above (**p95 < 5s** upload-accepted → KC-synced) is breached for a week while variant generation itself stays under 1s — the latency then lives in the outbox/relay topology (3 chained events × poll cycle), and the fix is structural: collapse the event chain, shorten the relay poll interval, or move branding onto a push-based queue rather than tuning sharp.
 - **5+ tenants** routinely saturate the worker — at that point evaluate either a `sharp` worker pool inside the BullMQ processor or splitting branding off into a dedicated `image-worker` deployment.
 - A new asset class needs **on-the-fly transformations** that the pre-gen variant set can't cover (e.g. arbitrary cropping for an OG-image generator).

--- a/packages/api/src/modules/branding/routes.ts
+++ b/packages/api/src/modules/branding/routes.ts
@@ -369,8 +369,22 @@ export async function brandingRoutes(app: FastifyInstance) {
         traceparent,
       });
 
+      // `brandingPipeline` discriminator (issue #290): `acceptedAt` is the
+      // DB-clock `created_at` of the asset row — the same instant the
+      // KC-sync processor reads back to compute the end-to-end latency,
+      // so both ends of the span share one authoritative timestamp.
       request.log.info(
-        { assetId: row.id, orgId, mime, bytes: toStore.byteLength },
+        {
+          assetId: row.id,
+          orgId,
+          mime,
+          bytes: toStore.byteLength,
+          brandingPipeline: {
+            event: "upload_accepted",
+            assetId: row.id,
+            acceptedAt: row.createdAt.toISOString(),
+          },
+        },
         "Branding logo uploaded; pipeline enqueued",
       );
 

--- a/packages/worker/src/lib/keycloak-admin.ts
+++ b/packages/worker/src/lib/keycloak-admin.ts
@@ -142,11 +142,17 @@ export async function getOrganization(id: string): Promise<KeycloakOrganization 
  * Merge attributes onto an organization via GET-then-PUT. Identical
  * semantics to `KeycloakAdminClient.updateOrganization` in the api
  * package — see that file for the security rationale.
+ *
+ * Returns `changed: false` when every updated attribute already held
+ * the requested value (the PUT is still issued — idempotence stays the
+ * safety contract; the flag only tells the caller whether this call
+ * was a first write or an at-least-once re-delivery, so observability
+ * emissions can be gated on real transitions — issue #290 review).
  */
 export async function updateOrganization(
   id: string,
   updates: { attributes?: Record<string, string[]> },
-): Promise<void> {
+): Promise<{ changed: boolean }> {
   assertSafeOrgAttributes(updates.attributes);
   const current = await getOrganization(id);
   if (!current) {
@@ -154,8 +160,11 @@ export async function updateOrganization(
       { keycloakOrgId: id },
       "KC org missing — skipping updateOrganization (tenant may have been deleted)",
     );
-    return;
+    return { changed: false };
   }
+  const changed = Object.entries(updates.attributes ?? {}).some(
+    ([key, value]) => JSON.stringify(current.attributes?.[key] ?? []) !== JSON.stringify(value),
+  );
   const mergedAttributes = updates.attributes
     ? { ...(current.attributes ?? {}), ...updates.attributes }
     : current.attributes;
@@ -163,4 +172,5 @@ export async function updateOrganization(
     ...current,
     attributes: mergedAttributes,
   });
+  return { changed };
 }

--- a/packages/worker/src/processors/keycloak-sync-org-logo.test.ts
+++ b/packages/worker/src/processors/keycloak-sync-org-logo.test.ts
@@ -4,10 +4,13 @@
  *
  * No DB / Keycloak: `db`, `updateOrganization`, `brandingPublicUrl`
  * and `jobLogger` are mocked so the tests pin down (a) when the
- * discriminator is emitted (upload path only — never on clear/delete
- * or not-ready syncs), (b) that `e2eLatencyMs` is measured against the
- * asset row's DB `created_at` AFTER the KC PATCH, and (c) the 0-clamp
- * under pathological clock skew.
+ * discriminator is emitted (upload path only, first delivery only —
+ * never on clear/delete, not-ready, missing hero variant, soft-deleted
+ * asset, at-least-once re-delivery, or KC PATCH failure), (b) that
+ * `e2eLatencyMs` is measured AFTER the KC PATCH — the mock advances
+ * the fake clock while the PATCH is in flight, so a computation hoisted
+ * above the `await` yields a detectably smaller delta — and (c) the
+ * 0-clamp under pathological clock skew.
  */
 
 import type { Job } from "bullmq";
@@ -49,6 +52,9 @@ const { processKeycloakSyncOrgLogo } = await import("./keycloak-sync-org-logo.js
 const ORG_ID = "11111111-1111-7111-8111-111111111111";
 const ASSET_ID = "22222222-2222-7222-8222-222222222222";
 
+/** Simulated KC PATCH round-trip duration burned on the fake clock. */
+const KC_PATCH_MS = 500;
+
 function jobFor(): Job<{ orgId: string; traceparent?: string }> {
   return { id: "test-job", data: { orgId: ORG_ID } } as unknown as Job<{
     orgId: string;
@@ -75,13 +81,24 @@ function syncedLine(): CapturedLine | undefined {
   return logLines.find((l) => l.msg === "KC organization logo_url synced");
 }
 
+function noDiscriminatorEmitted(): boolean {
+  return logLines.every((l) => l.obj.brandingPipeline === undefined);
+}
+
 describe("processKeycloakSyncOrgLogo — brandingPipeline latency discriminator", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-23T12:00:10.000Z"));
     logLines.length = 0;
     selectResults.length = 0;
-    updateOrganization.mockResolvedValue(undefined);
+    // Default mock: the PATCH burns KC_PATCH_MS on the fake clock before
+    // resolving, so a latency computation hoisted ABOVE the await would
+    // produce a delta short of KC_PATCH_MS and fail the exact-value
+    // assertions below (the "measured AFTER the PATCH" contract).
+    updateOrganization.mockImplementation(async () => {
+      vi.advanceTimersByTime(KC_PATCH_MS);
+      return { changed: true };
+    });
   });
 
   afterEach(() => {
@@ -89,8 +106,9 @@ describe("processKeycloakSyncOrgLogo — brandingPipeline latency discriminator"
     vi.clearAllMocks();
   });
 
-  it("ready asset → syncs hero URL and emits kc_synced with e2eLatencyMs from DB created_at", async () => {
-    // Upload accepted 4.2s before "now" (fake clock) — exact delta expected.
+  it("ready asset → syncs hero URL and emits kc_synced measured AFTER the KC PATCH", async () => {
+    // Upload accepted 4.2s before the job starts; the PATCH burns another
+    // 500ms on the fake clock → the emitted delta must be 4700, not 4200.
     const createdAt = new Date("2026-07-23T12:00:05.800Z");
     selectResults.push([tenantRow()], [assetRow(createdAt)]);
 
@@ -107,12 +125,12 @@ describe("processKeycloakSyncOrgLogo — brandingPipeline latency discriminator"
       event: "kc_synced",
       assetId: ASSET_ID,
       uploadAcceptedAt: createdAt.toISOString(),
-      e2eLatencyMs: 4200,
+      e2eLatencyMs: 4200 + KC_PATCH_MS,
     });
   });
 
   it("clamps e2eLatencyMs at 0 when created_at is ahead of the worker clock", async () => {
-    const createdAt = new Date("2026-07-23T12:00:15.000Z"); // 5s in the "future"
+    const createdAt = new Date("2026-07-23T12:00:15.000Z"); // 4.5s past "now"+PATCH
     selectResults.push([tenantRow()], [assetRow(createdAt)]);
 
     await processKeycloakSyncOrgLogo(jobFor());
@@ -121,6 +139,35 @@ describe("processKeycloakSyncOrgLogo — brandingPipeline latency discriminator"
     expect((line?.obj.brandingPipeline as { e2eLatencyMs: number } | undefined)?.e2eLatencyMs).toBe(
       0,
     );
+  });
+
+  it("at-least-once re-delivery (KC value unchanged) → NO discriminator", async () => {
+    // Relay redelivery / BullMQ stalled re-run: the KC attribute already
+    // holds the hero URL, so updateOrganization reports changed: false.
+    // Emitting here would re-measure against the ORIGINAL upload's
+    // created_at and fire a false SLO-breach alert (review finding).
+    updateOrganization.mockImplementation(async () => {
+      vi.advanceTimersByTime(KC_PATCH_MS);
+      return { changed: false };
+    });
+    selectResults.push(
+      [tenantRow()],
+      [assetRow(new Date("2026-07-23T11:30:00.000Z"))], // 30min-old upload
+    );
+
+    const result = await processKeycloakSyncOrgLogo(jobFor());
+
+    expect(result.synced).toBe(true);
+    expect(syncedLine()).toBeDefined();
+    expect(noDiscriminatorEmitted()).toBe(true);
+  });
+
+  it("KC PATCH failure → error bubbles for BullMQ retry, NO discriminator", async () => {
+    updateOrganization.mockRejectedValue(new Error("KC down"));
+    selectResults.push([tenantRow()], [assetRow(new Date("2026-07-23T12:00:05.800Z"))]);
+
+    await expect(processKeycloakSyncOrgLogo(jobFor())).rejects.toThrow("KC down");
+    expect(noDiscriminatorEmitted()).toBe(true);
   });
 
   it("clear path (no logoAssetId) → empty attribute, NO discriminator", async () => {
@@ -149,7 +196,39 @@ describe("processKeycloakSyncOrgLogo — brandingPipeline latency discriminator"
     expect(updateOrganization).toHaveBeenCalledWith("kc-org-1", {
       attributes: { logo_url: [] },
     });
-    expect(syncedLine()?.obj.brandingPipeline).toBeUndefined();
+    expect(noDiscriminatorEmitted()).toBe(true);
+  });
+
+  it("ready asset WITHOUT a public-hero variant → empty attribute, NO discriminator", async () => {
+    selectResults.push(
+      [tenantRow()],
+      [assetRow(new Date("2026-07-23T12:00:00.000Z"), { variants: {} })],
+    );
+
+    await processKeycloakSyncOrgLogo(jobFor());
+
+    expect(updateOrganization).toHaveBeenCalledWith("kc-org-1", {
+      attributes: { logo_url: [] },
+    });
+    expect(noDiscriminatorEmitted()).toBe(true);
+  });
+
+  it("soft-deleted asset → empty attribute, NO discriminator", async () => {
+    selectResults.push(
+      [tenantRow()],
+      [
+        assetRow(new Date("2026-07-23T12:00:00.000Z"), {
+          deletedAt: new Date("2026-07-23T12:00:04.000Z"),
+        }),
+      ],
+    );
+
+    await processKeycloakSyncOrgLogo(jobFor());
+
+    expect(updateOrganization).toHaveBeenCalledWith("kc-org-1", {
+      attributes: { logo_url: [] },
+    });
+    expect(noDiscriminatorEmitted()).toBe(true);
   });
 
   it("tenant without keycloakOrgId → skips KC PATCH entirely", async () => {
@@ -159,6 +238,6 @@ describe("processKeycloakSyncOrgLogo — brandingPipeline latency discriminator"
 
     expect(result).toEqual({ synced: false, logoUrl: "" });
     expect(updateOrganization).not.toHaveBeenCalled();
-    expect(logLines.some((l) => l.obj.brandingPipeline !== undefined)).toBe(false);
+    expect(noDiscriminatorEmitted()).toBe(true);
   });
 });

--- a/packages/worker/src/processors/keycloak-sync-org-logo.test.ts
+++ b/packages/worker/src/processors/keycloak-sync-org-logo.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for `processKeycloakSyncOrgLogo` — focused on the
+ * `brandingPipeline` end-to-end latency discriminator (issue #290).
+ *
+ * No DB / Keycloak: `db`, `updateOrganization`, `brandingPublicUrl`
+ * and `jobLogger` are mocked so the tests pin down (a) when the
+ * discriminator is emitted (upload path only — never on clear/delete
+ * or not-ready syncs), (b) that `e2eLatencyMs` is measured against the
+ * asset row's DB `created_at` AFTER the KC PATCH, and (c) the 0-clamp
+ * under pathological clock skew.
+ */
+
+import type { Job } from "bullmq";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Sequential result queue: first shift = tenants SELECT, second = asset SELECT.
+const selectResults: unknown[][] = [];
+vi.mock("../lib/db.js", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(selectResults.shift() ?? []),
+      }),
+    }),
+  },
+}));
+
+const updateOrganization = vi.fn();
+vi.mock("../lib/keycloak-admin.js", () => ({
+  updateOrganization: (...args: unknown[]) => updateOrganization(...args),
+}));
+
+vi.mock("../lib/s3.js", () => ({
+  brandingPublicUrl: (key: string) => `https://cdn.test/${key}`,
+}));
+
+type CapturedLine = { obj: Record<string, unknown>; msg: string };
+const logLines: CapturedLine[] = [];
+const capture = (obj: Record<string, unknown>, msg: string) => {
+  logLines.push({ obj, msg });
+};
+vi.mock("../lib/logger.js", () => ({
+  jobLogger: () => ({ info: capture, warn: capture, error: capture }),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() },
+}));
+
+const { processKeycloakSyncOrgLogo } = await import("./keycloak-sync-org-logo.js");
+
+const ORG_ID = "11111111-1111-7111-8111-111111111111";
+const ASSET_ID = "22222222-2222-7222-8222-222222222222";
+
+function jobFor(): Job<{ orgId: string; traceparent?: string }> {
+  return { id: "test-job", data: { orgId: ORG_ID } } as unknown as Job<{
+    orgId: string;
+    traceparent?: string;
+  }>;
+}
+
+function tenantRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return { id: ORG_ID, keycloakOrgId: "kc-org-1", logoAssetId: ASSET_ID, ...overrides };
+}
+
+function assetRow(createdAt: Date, overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: ASSET_ID,
+    status: "ready",
+    variants: { "public-hero": { key: `${ORG_ID}/logo/${ASSET_ID}/public-hero.webp` } },
+    deletedAt: null,
+    createdAt,
+    ...overrides,
+  };
+}
+
+function syncedLine(): CapturedLine | undefined {
+  return logLines.find((l) => l.msg === "KC organization logo_url synced");
+}
+
+describe("processKeycloakSyncOrgLogo — brandingPipeline latency discriminator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-23T12:00:10.000Z"));
+    logLines.length = 0;
+    selectResults.length = 0;
+    updateOrganization.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("ready asset → syncs hero URL and emits kc_synced with e2eLatencyMs from DB created_at", async () => {
+    // Upload accepted 4.2s before "now" (fake clock) — exact delta expected.
+    const createdAt = new Date("2026-07-23T12:00:05.800Z");
+    selectResults.push([tenantRow()], [assetRow(createdAt)]);
+
+    const result = await processKeycloakSyncOrgLogo(jobFor());
+
+    expect(result.synced).toBe(true);
+    expect(updateOrganization).toHaveBeenCalledWith("kc-org-1", {
+      attributes: { logo_url: [`https://cdn.test/${ORG_ID}/logo/${ASSET_ID}/public-hero.webp`] },
+    });
+
+    const line = syncedLine();
+    expect(line).toBeDefined();
+    expect(line?.obj.brandingPipeline).toEqual({
+      event: "kc_synced",
+      assetId: ASSET_ID,
+      uploadAcceptedAt: createdAt.toISOString(),
+      e2eLatencyMs: 4200,
+    });
+  });
+
+  it("clamps e2eLatencyMs at 0 when created_at is ahead of the worker clock", async () => {
+    const createdAt = new Date("2026-07-23T12:00:15.000Z"); // 5s in the "future"
+    selectResults.push([tenantRow()], [assetRow(createdAt)]);
+
+    await processKeycloakSyncOrgLogo(jobFor());
+
+    const line = syncedLine();
+    expect((line?.obj.brandingPipeline as { e2eLatencyMs: number } | undefined)?.e2eLatencyMs).toBe(
+      0,
+    );
+  });
+
+  it("clear path (no logoAssetId) → empty attribute, NO discriminator", async () => {
+    selectResults.push([tenantRow({ logoAssetId: null })]);
+
+    const result = await processKeycloakSyncOrgLogo(jobFor());
+
+    expect(result).toEqual({ synced: true, logoUrl: "" });
+    expect(updateOrganization).toHaveBeenCalledWith("kc-org-1", {
+      attributes: { logo_url: [] },
+    });
+    const line = syncedLine();
+    expect(line).toBeDefined();
+    expect(line?.obj.brandingPipeline).toBeUndefined();
+    expect(line?.obj.logoUrl).toBe("(cleared)");
+  });
+
+  it("not-ready asset → empty attribute, NO discriminator", async () => {
+    selectResults.push(
+      [tenantRow()],
+      [assetRow(new Date("2026-07-23T12:00:00.000Z"), { status: "processing" })],
+    );
+
+    await processKeycloakSyncOrgLogo(jobFor());
+
+    expect(updateOrganization).toHaveBeenCalledWith("kc-org-1", {
+      attributes: { logo_url: [] },
+    });
+    expect(syncedLine()?.obj.brandingPipeline).toBeUndefined();
+  });
+
+  it("tenant without keycloakOrgId → skips KC PATCH entirely", async () => {
+    selectResults.push([tenantRow({ keycloakOrgId: null })]);
+
+    const result = await processKeycloakSyncOrgLogo(jobFor());
+
+    expect(result).toEqual({ synced: false, logoUrl: "" });
+    expect(updateOrganization).not.toHaveBeenCalled();
+    expect(logLines.some((l) => l.obj.brandingPipeline !== undefined)).toBe(false);
+  });
+});

--- a/packages/worker/src/processors/keycloak-sync-org-logo.ts
+++ b/packages/worker/src/processors/keycloak-sync-org-logo.ts
@@ -59,6 +59,7 @@ export async function processKeycloakSyncOrgLogo(
   }
 
   let logoUrl = "";
+  let syncedAsset: { id: string; createdAt: Date } | null = null;
   if (tenant.logoAssetId) {
     const [asset] = await db
       .select({
@@ -66,6 +67,7 @@ export async function processKeycloakSyncOrgLogo(
         status: orgBrandingAssets.status,
         variants: orgBrandingAssets.variants,
         deletedAt: orgBrandingAssets.deletedAt,
+        createdAt: orgBrandingAssets.createdAt,
       })
       .from(orgBrandingAssets)
       // Defence in depth (issue #430): if `tenants.logo_asset_id` ever
@@ -78,6 +80,7 @@ export async function processKeycloakSyncOrgLogo(
       const heroKey = asset.variants?.["public-hero"]?.key;
       if (heroKey) {
         logoUrl = brandingPublicUrl(heroKey);
+        syncedAsset = { id: asset.id, createdAt: asset.createdAt };
       }
     }
   }
@@ -88,6 +91,31 @@ export async function processKeycloakSyncOrgLogo(
     attributes: { logo_url: logoUrl ? [logoUrl] : [] },
   });
 
-  log.info({ orgId, logoUrl: logoUrl || "(cleared)" }, "KC organization logo_url synced");
+  if (syncedAsset) {
+    // `brandingPipeline` discriminator (issue #290): end-to-end latency
+    // of the activation chain, measured AFTER the KC PATCH so the span
+    // covers upload accept → 3 outbox hops → sharp pipeline → KC write.
+    // `createdAt` is Postgres clock and `Date.now()` is worker clock —
+    // hosts are NTP-synced and the ADR-024 SLO is seconds-scale, so
+    // sub-second skew is immaterial; clamp at 0 for pathological skew.
+    // Emitted only on the upload path (a clear/delete sync has no
+    // upload to measure against).
+    const e2eLatencyMs = Math.max(0, Date.now() - syncedAsset.createdAt.getTime());
+    log.info(
+      {
+        orgId,
+        logoUrl,
+        brandingPipeline: {
+          event: "kc_synced",
+          assetId: syncedAsset.id,
+          uploadAcceptedAt: syncedAsset.createdAt.toISOString(),
+          e2eLatencyMs,
+        },
+      },
+      "KC organization logo_url synced",
+    );
+  } else {
+    log.info({ orgId, logoUrl: logoUrl || "(cleared)" }, "KC organization logo_url synced");
+  }
   return { synced: true, logoUrl };
 }

--- a/packages/worker/src/processors/keycloak-sync-org-logo.ts
+++ b/packages/worker/src/processors/keycloak-sync-org-logo.ts
@@ -87,11 +87,11 @@ export async function processKeycloakSyncOrgLogo(
 
   // Empty array → KC drops the attribute (template's `?has_content`
   // check correctly treats it as "no logo set").
-  await updateOrganization(tenant.keycloakOrgId, {
+  const { changed } = await updateOrganization(tenant.keycloakOrgId, {
     attributes: { logo_url: logoUrl ? [logoUrl] : [] },
   });
 
-  if (syncedAsset) {
+  if (syncedAsset && changed) {
     // `brandingPipeline` discriminator (issue #290): end-to-end latency
     // of the activation chain, measured AFTER the KC PATCH so the span
     // covers upload accept → 3 outbox hops → sharp pipeline → KC write.
@@ -99,7 +99,13 @@ export async function processKeycloakSyncOrgLogo(
     // hosts are NTP-synced and the ADR-024 SLO is seconds-scale, so
     // sub-second skew is immaterial; clamp at 0 for pathological skew.
     // Emitted only on the upload path (a clear/delete sync has no
-    // upload to measure against).
+    // upload to measure against) and only when the KC attribute
+    // actually transitioned (`changed`): the relay is at-least-once
+    // and BullMQ can re-run stalled jobs, and a late re-delivery would
+    // otherwise re-measure against the ORIGINAL upload's `created_at`
+    // and fire a false SLO-breach alert. The trade-off (a retry that
+    // crashed between the KC PUT and this log line under-counts one
+    // sync) is documented in docs/17 §7.2.2.
     const e2eLatencyMs = Math.max(0, Date.now() - syncedAsset.createdAt.getTime());
     log.info(
       {


### PR DESCRIPTION
## Contexte

Suivi PR #287 (#290) : le critère de revisite d'ADR-024 ne couvrait que la génération de variantes isolée (« variant gen > 1s »), alors que la chaîne d'activation complète — upload accepté → `branding.process_asset` → `branding.activate_logo` → `keycloak.sync_org_logo` → PATCH KC `attributes.logo_url` — traverse 3 événements outbox × ~500 ms de poll relay + le pipeline sharp + un PATCH KC, et n'était mesurée nulle part.

## Approche

Pas de métriques in-process (OTel = Phase 2-3, docs/17 §12) : la mesure passe par les **logs structurés**, conformément au pattern discriminateur établi (`authDenial`/`rbacDenial`, docs/17 §7.2.1).

- **API** ([`routes.ts`](../blob/autopilot/issue-290-branding-latency-histogram/packages/api/src/modules/branding/routes.ts)) : le log existant du chemin 201 porte désormais `brandingPipeline: { event: "upload_accepted", assetId, acceptedAt }` — `acceptedAt` = `created_at` (horloge DB) de la ligne `org_branding_assets`.
- **Worker** ([`keycloak-sync-org-logo.ts`](../blob/autopilot/issue-290-branding-latency-histogram/packages/worker/src/processors/keycloak-sync-org-logo.ts)) : `brandingPipeline: { event: "kc_synced", assetId, uploadAcceptedAt, e2eLatencyMs }`, émis **après** l'acquittement du PATCH KC, **uniquement sur le chemin upload** (jamais sur clear/delete ni asset non-ready). Le SELECT de l'asset (déjà filtré `eq(orgId)` — défense #430 inchangée) projette en plus `created_at` : les deux bouts du span partagent **un seul timestamp horloge-DB**, aucun passage d'horloge inter-services. `e2eLatencyMs = max(0, Date.now() − created_at)`, clamp 0 contre le skew pathologique (hôtes NTP, SLO à l'échelle de la seconde → skew sub-seconde immatériel).
- **docs/17 §7.2.2** : shapes des deux lignes + 3 recettes LogQL — p95 par tenant (`quantile_over_time` + `unwrap`), alerte de dépassement SLO, compteur d'écart upload_accepted vs kc_synced (détection pipeline bloqué, avec caveat sur le sur-comptage légitime re-upload/clear).
- **ADR-024** : nouvelle section SLO (**p95 < 5 s** upload accepté → KC synced, par tenant) + critère de revisite topologie de queue (SLO violé une semaine avec variant-gen < 1 s ⇒ le problème est structurel : chaîne d'événements/poll relay, pas sharp).
- **docs/24 §4.4** : note observabilité croisant les deux.

## Choix autonomes notés

- **Nommage** : l'issue proposait des *events* `branding.upload_accepted_at` / `branding.kc_synced_at` ; implémenté comme discriminateur imbriqué `brandingPipeline.event = upload_accepted | kc_synced` pour coller à la convention §7.2.1 du repo (labels LogQL propres : `brandingPipeline_event`, `brandingPipeline_e2eLatencyMs`).
- **Mesure après le PATCH KC** (et pas au SELECT) pour que le span couvre réellement toute la chaîne.
- **Horloge** : delta horloge-DB → horloge-worker assumé et commenté dans le code (l'alternative single-clock — `now()` SQL dans le SELECT — mesurerait *avant* le PATCH KC).

## Tests

Nouveau [`keycloak-sync-org-logo.test.ts`](../blob/autopilot/issue-290-branding-latency-histogram/packages/worker/src/processors/keycloak-sync-org-logo.test.ts) (5 cas, fake timers, delta exact 4200 ms) : émission sur asset ready, clamp 0 sur skew futur, absence de discriminateur sur clear et sur asset non-ready, skip sans `keycloakOrgId`. Premier test processor-level de la chaîne branding côté worker.

Côté API, l'ajout est un champ statique sur un log existant : `createServer()` ne permet pas d'injecter un stream de capture sans le modifier — assertion de log non ajoutée, couvert par le typecheck (choix noté).

## Non flaggé

Observabilité pure sur une feature déjà shippée — aucun comportement utilisateur net-nouveau (CLAUDE.md « When NOT to flag »). Aucune migration, aucun nouveau endpoint, aucune requête tenant-scopée nouvelle.

## Vérifications

- `pnpm install` / `pnpm build` / `pnpm run format` / `pnpm typecheck` : verts.
- Tests : worker 153/153 ✅ (dont les 5 nouveaux), shared 155/155 ✅, web 429 ✅, API 1372 ✅ hors **2 échecs pré-existants** dans `onboarding-runtime.test.ts` (`runExpireJob`, FK `audit_logs_org_id_fk`) — reproduits à l'identique sur `main` non modifié, cause : rows `users` orphelines dans la base de test **locale** (tenant supprimé par un run antérieur). La CI part d'une base fraîche et n'est pas concernée. À noter en passant : `runExpireJob` scanne cross-tenant et crashe sur un user orphelin — durcissement possible en follow-up.
- `pnpm biome check .` (commande exacte CI) : **exit 0**.

close #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)