### PR TITLE
ci: cancel superseded PR runs via concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs of the same PR when new commits are pushed. On push
+# events (main) there is no PR number, so runs group by ref and are queued —
+# never cancelled — to keep every main commit verified.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Static gate: lint, types, i18n parity, build. No database — fast feedback
   # that's independent of which Postgres role the tests run under.


### PR DESCRIPTION
## Summary

Adds a `concurrency` block to the CI workflow so that pushing new commits to a PR cancels the still-in-progress run of the previous push, saving runner minutes (the `api-tests` matrix spins up Postgres + Redis twice per run, so superseded runs are relatively expensive).

## Related Issue

None — small CI optimization.

## Changes

- Group PR runs by `github.event.pull_request.number` with `cancel-in-progress` on, so only the latest push per PR runs to completion.
- Push events on `main` have no PR number, so they fall back to grouping by `github.ref` with cancellation **off** — back-to-back merges queue instead of killing each other's runs, keeping every main commit verified.

## Testing

- [x] YAML parses cleanly; workflow-only change — no application code touched
- [ ] `pnpm lint` passes (n/a — no lintable files changed; `biome check` on `packages/` verified clean)
- [ ] `pnpm typecheck` passes (n/a)
- [ ] `pnpm build` passes (n/a)
- [ ] `pnpm test` passes (n/a)

## Notes

The naive form `group: ci-${{ github.event.pull_request.number }}` with unconditional cancellation would be a footgun here: on `push` events the expression is empty, so every main-branch run would share the literal group `ci-` and a merge landing mid-run would cancel the previous merge's CI, leaving unverified commits on main. The `|| github.ref` fallback plus the conditional `cancel-in-progress` avoids that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)